### PR TITLE
M3 IMPL: PR Number 3 - DTO: Request and response

### DIFF
--- a/docs/M3-GRID-DESIGN.md
+++ b/docs/M3-GRID-DESIGN.md
@@ -638,6 +638,7 @@ CREATE TABLE assignment_proposal (
     city_id               UUID NOT NULL,
     valid_for_date        DATE NOT NULL,
     status                VARCHAR(20) NOT NULL,  -- PROPOSED | APPROVED | REJECTED | SUPERSEDED
+    proposal_type         VARCHAR(30) NOT NULL DEFAULT 'NIGHTLY',  -- NIGHTLY | INTRADAY_OVERRIDE | INTRADAY_SUGGESTION | INTRADAY_SHARE
     solver_type           VARCHAR(30) NOT NULL,  -- CP_SAT | BFS_FALLBACK
     adjacency_source      VARCHAR(30) NOT NULL,  -- OSRM | GEOMETRIC_FALLBACK
     optimality_gap_pct    DOUBLE PRECISION,      -- null for BFS_FALLBACK
@@ -742,9 +743,16 @@ GET  /grid/proposals/{proposal_id}
 POST /grid/proposals/{proposal_id}/approve
 POST /grid/proposals/{proposal_id}/reject
 PUT  /grid/proposals/{proposal_id}/regions/{region_id}/override
+POST /grid/assignments/intraday-override
+POST /grid/assignments/tile-share
+POST /grid/proposals/{proposal_id}/approve-intraday
 ```
 
 The `GET /{proposal_id}` response includes `solver_type`, `adjacency_source`, `optimality_gap_pct`, and per-region `has_bootstrapped_tiles` so reviewers see metadata about the quality of the proposal they're approving.
+
+**Tile-share endpoint** (`POST /grid/assignments/tile-share`): adds a DA to a tile without removing the existing DA. The body is `{ city_id, da_id, tile_id, requested_by }`. The system validates (a) the DA is not already assigned to this tile and (b) the tile is road-adjacent to at least one tile already in the DA's territory. Creates an `INTRADAY_SHARE` proposal pending approval. Response returns a `TileShareResponse` with the new `proposal_id` for the approval screen.
+
+Unlike `intraday-override` (Scenario B), tile-share does not supersede the existing DA's assignment — both DAs end up with `n_das_on_tile = 2` for that tile.
 
 ### 7.7 No-DA alert (Kafka, produced by M3, consumed by M10)
 
@@ -973,6 +981,11 @@ If the station manager does not act within the approval window:
 - Log the auto-fallback as an audit event visible to admin
 
 Intraday changes (station manager splits or merges a DA territory mid-day) also go through the approval flow with an immediate confirmation window. Every intraday change is audit-logged with approver ID, timestamp, and before/after tile sets. Contiguity is re-validated using the road-adjacency graph on every intraday override.
+
+Two intraday assignment patterns are supported:
+
+- **Intraday override** (`proposal_type = INTRADAY_OVERRIDE`): exclusive tile move — tiles are transferred from one DA to another. The source DA's assignments for those tiles are superseded. Both territories must remain contiguous after the move.
+- **Tile share** (`proposal_type = INTRADAY_SHARE`): additive overlay — a second DA is added to a tile without removing the existing DA. `n_das_on_tile` becomes 2. Only one contiguity check is needed: the shared tile must be road-adjacent to at least one tile already in the new DA's territory. Use this when a tile is overloaded intraday and a nearby DA has spare capacity.
 
 ---
 

--- a/docs/M3-IMPLEMENTATION-PLAN.md
+++ b/docs/M3-IMPLEMENTATION-PLAN.md
@@ -211,6 +211,8 @@ Package: `com.oneday.grid.dto`
 | `ProposalRejectRequest` | POST /grid/proposals/{id}/reject (optional notes field) |
 | `IntradayReassignmentRequest` | POST /grid/assignments/intraday-override |
 | `IntradayReassignmentResponse` | response for the above — includes new proposal_id for tracking |
+| `TileShareRequest` | POST /grid/assignments/tile-share |
+| `TileShareResponse` | response for the above — includes new proposal_id for approval screen |
 
 Use Java records for all DTOs (Java 21).
 
@@ -364,6 +366,10 @@ public interface ProposalService {
     ProposalDto requestIntradayReassignment(UUID cityId, UUID fromDaId, UUID toDaId,
                                             List<UUID> tileIdsToMove, UUID requestedBy);
     void approveIntradayReassignment(UUID proposalId, UUID reviewerId);
+
+    // Tile share: add a second DA to a tile without removing the existing DA
+    TileShareResponse requestTileShare(UUID cityId, UUID daId, UUID tileId, UUID requestedBy);
+    void approveTileShare(UUID proposalId, UUID reviewerId);
 }
 ```
 
@@ -565,6 +571,8 @@ Package: `com.oneday.grid.api`
 | PUT | `/grid/proposals/{id}/regions/{regionId}/edit` | `proposalService.editRegionInProposal(...)` | Scenario A |
 | POST | `/grid/assignments/intraday-override` | `proposalService.requestIntradayReassignment(...)` | Scenario B |
 | POST | `/grid/proposals/{id}/approve-intraday` | `proposalService.approveIntradayReassignment(id, reviewerId)` | Scenario B |
+| POST | `/grid/assignments/tile-share` | `proposalService.requestTileShare(...)` | Tile share |
+| POST | `/grid/proposals/{id}/approve-tile-share` | `proposalService.approveTileShare(id, reviewerId)` | Tile share |
 
 **Scenario B request body:**
 ```json

--- a/grid/src/main/java/com/oneday/grid/domain/ProposalType.java
+++ b/grid/src/main/java/com/oneday/grid/domain/ProposalType.java
@@ -1,5 +1,5 @@
 package com.oneday.grid.domain;
 
 public enum ProposalType {
-    NIGHTLY, INTRADAY_OVERRIDE, INTRADAY_SUGGESTION
+    NIGHTLY, INTRADAY_OVERRIDE, INTRADAY_SUGGESTION, INTRADAY_SHARE
 }

--- a/grid/src/main/java/com/oneday/grid/dto/request/IntradayReassignmentRequest.java
+++ b/grid/src/main/java/com/oneday/grid/dto/request/IntradayReassignmentRequest.java
@@ -1,0 +1,14 @@
+package com.oneday.grid.dto.request;
+
+import java.util.List;
+import java.util.UUID;
+
+// Scenario B only: tile move on an already-ACTIVE plan.
+// Creates a brand-new INTRADAY_OVERRIDE proposal that requires its own approval.
+public record IntradayReassignmentRequest(
+        UUID cityId,
+        UUID fromDaId,
+        UUID toDaId,
+        List<UUID> tileIdsToMove,
+        UUID requestedBy
+) {}

--- a/grid/src/main/java/com/oneday/grid/dto/request/ProposalRejectRequest.java
+++ b/grid/src/main/java/com/oneday/grid/dto/request/ProposalRejectRequest.java
@@ -1,0 +1,8 @@
+package com.oneday.grid.dto.request;
+
+import java.util.UUID;
+
+public record ProposalRejectRequest(
+        UUID reviewerId,
+        String notes
+) {}

--- a/grid/src/main/java/com/oneday/grid/dto/request/RegionEditRequest.java
+++ b/grid/src/main/java/com/oneday/grid/dto/request/RegionEditRequest.java
@@ -1,0 +1,11 @@
+package com.oneday.grid.dto.request;
+
+import java.util.List;
+import java.util.UUID;
+
+// Scenario A only: pre-approval edit inside an existing PROPOSED proposal.
+// Does NOT create a new proposal — modifies the existing one in place.
+public record RegionEditRequest(
+        List<UUID> newTileIds,
+        UUID reviewerId
+) {}

--- a/grid/src/main/java/com/oneday/grid/dto/request/TileShareRequest.java
+++ b/grid/src/main/java/com/oneday/grid/dto/request/TileShareRequest.java
@@ -1,0 +1,10 @@
+package com.oneday.grid.dto.request;
+
+import java.util.UUID;
+
+public record TileShareRequest(
+        UUID cityId,
+        UUID daId,
+        UUID tileId,
+        UUID requestedBy
+) {}

--- a/grid/src/main/java/com/oneday/grid/dto/response/AssignmentResponse.java
+++ b/grid/src/main/java/com/oneday/grid/dto/response/AssignmentResponse.java
@@ -1,0 +1,20 @@
+package com.oneday.grid.dto.response;
+
+import com.oneday.grid.domain.AssignmentStatus;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record AssignmentResponse(
+        UUID id,
+        UUID proposalId,
+        UUID daId,
+        UUID tileId,
+        LocalDate validDate,
+        int nDasOnTile,
+        AssignmentStatus status,
+        Instant proposedAt,
+        UUID approvedBy,
+        Instant approvedAt
+) {}

--- a/grid/src/main/java/com/oneday/grid/dto/response/DaAssignmentResponse.java
+++ b/grid/src/main/java/com/oneday/grid/dto/response/DaAssignmentResponse.java
@@ -1,0 +1,15 @@
+package com.oneday.grid.dto.response;
+
+import com.oneday.grid.domain.AssignmentStatus;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+public record DaAssignmentResponse(
+        UUID daId,
+        LocalDate validDate,
+        UUID proposalId,
+        List<UUID> tileIds,
+        AssignmentStatus status
+) {}

--- a/grid/src/main/java/com/oneday/grid/dto/response/GridVertexResponse.java
+++ b/grid/src/main/java/com/oneday/grid/dto/response/GridVertexResponse.java
@@ -1,0 +1,11 @@
+package com.oneday.grid.dto.response;
+
+import java.util.UUID;
+
+public record GridVertexResponse(
+        UUID id,
+        int rowIdx,
+        int colIdx,
+        double lat,
+        double lon
+) {}

--- a/grid/src/main/java/com/oneday/grid/dto/response/IntradayReassignmentResponse.java
+++ b/grid/src/main/java/com/oneday/grid/dto/response/IntradayReassignmentResponse.java
@@ -1,0 +1,17 @@
+package com.oneday.grid.dto.response;
+
+import com.oneday.grid.domain.ProposalStatus;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record IntradayReassignmentResponse(
+        UUID proposalId,
+        UUID cityId,
+        UUID fromDaId,
+        UUID toDaId,
+        List<UUID> tilesMoved,
+        ProposalStatus status,
+        Instant proposedAt
+) {}

--- a/grid/src/main/java/com/oneday/grid/dto/response/ProposalResponse.java
+++ b/grid/src/main/java/com/oneday/grid/dto/response/ProposalResponse.java
@@ -1,0 +1,30 @@
+package com.oneday.grid.dto.response;
+
+import com.oneday.grid.domain.AdjacencySource;
+import com.oneday.grid.domain.ProposalStatus;
+import com.oneday.grid.domain.ProposalType;
+import com.oneday.grid.domain.SolverType;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+public record ProposalResponse(
+        UUID id,
+        UUID cityId,
+        LocalDate validForDate,
+        ProposalStatus status,
+        ProposalType proposalType,
+        SolverType solverType,
+        AdjacencySource adjacencySource,
+        Double optimalityGapPct,
+        int totalDas,
+        Double coveragePct,
+        List<UUID> understaffedTileIds,
+        Instant proposedAt,
+        UUID reviewedBy,
+        Instant reviewedAt,
+        String notes,
+        List<RegionResponse> regions
+) {}

--- a/grid/src/main/java/com/oneday/grid/dto/response/RegionResponse.java
+++ b/grid/src/main/java/com/oneday/grid/dto/response/RegionResponse.java
@@ -1,0 +1,14 @@
+package com.oneday.grid.dto.response;
+
+import java.util.List;
+import java.util.UUID;
+
+public record RegionResponse(
+        UUID id,
+        UUID daId,
+        int nDasRequired,
+        double estimatedDemandMin,
+        double estimatedUtilPct,
+        boolean hasBootstrappedTiles,
+        List<UUID> tileIds
+) {}

--- a/grid/src/main/java/com/oneday/grid/dto/response/ServiceabilityResponse.java
+++ b/grid/src/main/java/com/oneday/grid/dto/response/ServiceabilityResponse.java
@@ -1,0 +1,10 @@
+package com.oneday.grid.dto.response;
+
+import java.util.UUID;
+
+public record ServiceabilityResponse(
+        UUID cityId,
+        String pincode,
+        boolean serviceable,
+        UUID tileId
+) {}

--- a/grid/src/main/java/com/oneday/grid/dto/response/TileAtResponse.java
+++ b/grid/src/main/java/com/oneday/grid/dto/response/TileAtResponse.java
@@ -1,0 +1,10 @@
+package com.oneday.grid.dto.response;
+
+import java.util.UUID;
+
+public record TileAtResponse(
+        UUID tileId,
+        int rowIdx,
+        int colIdx,
+        boolean active
+) {}

--- a/grid/src/main/java/com/oneday/grid/dto/response/TileLoadScoreResponse.java
+++ b/grid/src/main/java/com/oneday/grid/dto/response/TileLoadScoreResponse.java
@@ -1,0 +1,12 @@
+package com.oneday.grid.dto.response;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record TileLoadScoreResponse(
+        UUID tileId,
+        LocalDate date,
+        int unservedOrders,
+        double adjustedLoadScore,
+        String severity
+) {}

--- a/grid/src/main/java/com/oneday/grid/dto/response/TileShareResponse.java
+++ b/grid/src/main/java/com/oneday/grid/dto/response/TileShareResponse.java
@@ -1,0 +1,14 @@
+package com.oneday.grid.dto.response;
+
+import com.oneday.grid.domain.ProposalStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record TileShareResponse(
+        UUID proposalId,
+        UUID daId,
+        UUID tileId,
+        ProposalStatus status,
+        Instant proposedAt
+) {}


### PR DESCRIPTION
  # Pull Request
  
  ## Summary
  Implements Phase 4 of M3: 14 Java record DTOs for the grid module, split into
  `dto/request/` and `dto/response/` subpackages with clarified naming for all
  proposal and override types.
  
  ---
  
  ## What Changed
  - Added `dto/request/` with 4 records: `RegionEditRequest`, `ProposalRejectRequest`,
    `IntradayReassignmentRequest`, `TileShareRequest`
  - Added `dto/response/` with 10 records: `ProposalResponse`, `RegionResponse`,
    `AssignmentResponse`, `DaAssignmentResponse`, `IntradayReassignmentResponse`,
    `TileShareResponse`, `GridVertexResponse`, `ServiceabilityResponse`,
    `TileAtResponse`, `TileLoadScoreResponse`
  - Renamed `OverrideRequest` → `RegionEditRequest` to distinguish Scenario A
    (pre-approval region edit) from `INTRADAY_OVERRIDE` proposals (Scenario B)
  - Renamed `ProposalDto` → `ProposalResponse`, `RegionDto` → `RegionResponse`
    for naming consistency
  - Added `INTRADAY_SHARE` to `ProposalType` enum (required for tile-share proposal
    lifecycle — creates a distinct proposal type from `INTRADAY_OVERRIDE`) 
  - Updated `M3-GRID-DESIGN.md` and `M3-IMPLEMENTATION-PLAN.md` to reflect the
    two intraday assignment patterns (override vs. tile share)
    
  ---
  
  ## Why This Change?
  Phase 5 service interfaces (`ProposalService`, `GridService`, etc.) return and
  accept these DTOs. Establishing request/response separation now prevents
  rename churn once services are wired to controllers in Phase 8. The
  `RegionEditRequest` rename eliminates a naming collision — "override" was being
  used for both Scenario A (in-place edit of a not-yet-approved proposal) and
  Scenario B (new `INTRADAY_OVERRIDE` proposal on an active plan), which are
  meaningfully different operations.
  
  ---
  
  ## Testing
  - [x] Tested locally
  - [x] Edge cases considered
  - [x] No breaking changes introduced
  
  ### Test Evidence
  $ mvn clean install -pl common,grid -am -q
  BUILD SUCCESS
  No compilation errors. Phase 5 service layer not yet started so no downstream
  breakage possible.
  
  ---
  
  ## Impact
  
  ### Areas Affected
  - [x] Backend
  - [ ] Frontend
  - [ ] Routing
  - [ ] Infra
  - [ ] Database
  - [ ] NA
  
  ### Modules Affected
  - [ ] M1 — Auth
  - [ ] M2 — Pricing
  - [x] M3 — Grid
  - [ ] M4 — Orders
  - [ ] M5 — Dispatch
  - [ ] M6 — Routing
  - [ ] M7 — Hub
  - [ ] M8 — Barcode
  - [ ] M9 — Airline
  - [ ] M10 — SLA
  - [ ] M11 — Exceptions
  - [ ] NA
  
  ---
  
  ## Risks / Concerns
  - None. Phase 5 (service layer) hasn't started so there are no callers of these
    DTOs yet. The rename from `OverrideRequest` to `RegionEditRequest` carries zero
    breakage risk at this stage.
    
  ---
  
  ## Checklist
  - [x] Code follows project conventions (package layout, no cross-module internal imports)
  - [x] Self-review completed
  - [x] Append-only audit trail preserved (no mutations to scan/manifest/role-change records)
  - [x] No sensitive data or credentials exposed
  - [x] Documentation updated if behaviour changed
  - [x] Ready for review