### PR TITLE
M4 IMPL - PR #3 - Cross-module port interfaces in common

### DIFF
--- a/common/src/main/java/com/oneday/common/kafka/events/BaseShipmentEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/BaseShipmentEvent.java
@@ -2,6 +2,7 @@ package com.oneday.common.kafka.events;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.oneday.common.kafka.enums.ShipmentEventType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -17,7 +18,7 @@ import java.util.UUID;
 public abstract class BaseShipmentEvent {
 
     private UUID eventId;
-    private String eventType;
+    private ShipmentEventType eventType;
     private String schemaVersion = "1.0";
     private Instant occurredAt;
     private UUID shipmentId;

--- a/common/src/main/java/com/oneday/common/kafka/events/ShipmentCreatedEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/ShipmentCreatedEvent.java
@@ -41,4 +41,7 @@ public class ShipmentCreatedEvent extends BaseShipmentEvent {
     private String receiverPhone;
     private String receiverName;
     private UUID b2bAccountId;
+    private String senderName;
+    private String senderAddressLine;
+    private String receiverAddressLine;
 }

--- a/common/src/main/java/com/oneday/common/port/EtaPort.java
+++ b/common/src/main/java/com/oneday/common/port/EtaPort.java
@@ -1,0 +1,15 @@
+package com.oneday.common.port;
+
+import com.oneday.common.port.dto.EtaRequest;
+import com.oneday.common.port.dto.EtaResult;
+
+/**
+ * Implemented by M9 (airline module).
+ * M4 calls this at BOOKED (to set etaPromised) and at AT_ORIGIN_HUB (to recalculate
+ * once the parcel is checked in and a flight is likely assigned).
+ * M9 uses currentState and EtaContext to select the appropriate estimation model.
+ * M4 stores whatever M9 returns — all ETA logic and edge cases are M9's responsibility.
+ */
+public interface EtaPort {
+    EtaResult fetchEta(EtaRequest request);
+}

--- a/common/src/main/java/com/oneday/common/port/EtaPort.java
+++ b/common/src/main/java/com/oneday/common/port/EtaPort.java
@@ -6,7 +6,9 @@ import com.oneday.common.port.dto.EtaResult;
 /**
  * Implemented by M9 (airline module).
  * M4 calls this at BOOKED (to set etaPromised) and at AT_ORIGIN_HUB (to recalculate
- * once the parcel is checked in and a flight is likely assigned).
+ * once the parcel is checked in and a flight is likely assigned). AT_ORIGIN_HUB is reached
+ * via two paths: HUB_ORIGIN_IN scan (DA_PICKUP) and SELF_DROP_ACCEPTED scan (SELF_DROP) —
+ * EtaPort is called on both.
  * M9 uses currentState and EtaContext to select the appropriate estimation model.
  * M4 stores whatever M9 returns — all ETA logic and edge cases are M9's responsibility.
  */

--- a/common/src/main/java/com/oneday/common/port/NotificationPort.java
+++ b/common/src/main/java/com/oneday/common/port/NotificationPort.java
@@ -1,0 +1,13 @@
+package com.oneday.common.port;
+
+import com.oneday.common.port.dto.NotificationRequest;
+
+/**
+ * Implemented by the notification service.
+ * M4 publishes to oneday.notifications.requested and returns immediately —
+ * it does not block on or retry notification delivery.
+ * The notification service owns channel selection, templating, and retry logic.
+ */
+public interface NotificationPort {
+    void send(NotificationRequest request);
+}

--- a/common/src/main/java/com/oneday/common/port/PricingPort.java
+++ b/common/src/main/java/com/oneday/common/port/PricingPort.java
@@ -1,0 +1,14 @@
+package com.oneday.common.port;
+
+import com.oneday.common.port.dto.QuoteRequest;
+import com.oneday.common.port.dto.QuoteResult;
+
+/**
+ * Implemented by M2 (pricing module).
+ * M4 calls this once at booking after serviceability is confirmed.
+ * M4 computes chargeable weight before calling; M2 applies the rate card and returns
+ * the complete pricing breakdown. M4 stores and forwards the result unchanged.
+ */
+public interface PricingPort {
+    QuoteResult computeQuote(QuoteRequest request);
+}

--- a/common/src/main/java/com/oneday/common/port/ServiceabilityPort.java
+++ b/common/src/main/java/com/oneday/common/port/ServiceabilityPort.java
@@ -1,0 +1,13 @@
+package com.oneday.common.port;
+
+import com.oneday.common.port.dto.ServiceabilityResult;
+
+/**
+ * Implemented by M3 (grid module).
+ * M4 calls this once at booking with both pincodes in a single round-trip.
+ * M3 resolves city boundaries, tile assignment, and delivery type internally.
+ * Non-serviceable pincodes are returned as result objects (serviceable=false), not exceptions.
+ */
+public interface ServiceabilityPort {
+    ServiceabilityResult check(String originPincode, String destPincode);
+}

--- a/common/src/main/java/com/oneday/common/port/dto/EtaContext.java
+++ b/common/src/main/java/com/oneday/common/port/dto/EtaContext.java
@@ -1,0 +1,23 @@
+package com.oneday.common.port.dto;
+
+import com.oneday.common.domain.enums.DeliveryType;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Contextual data M9 needs to compute ETA. Passed alongside shipmentId and currentState.
+ *
+ * @param originCity       city code of the pickup location
+ * @param destCity         city code of the delivery location
+ * @param deliveryType     INTERCITY or SAME_CITY — determines which ETA model M9 applies
+ * @param bookedAt         when the shipment was created; M9 uses this to find the next feasible flight
+ * @param assignedFlightId populated once M9 assigns a flight (AT_ORIGIN_HUB onwards); null before that
+ */
+public record EtaContext(
+        String originCity,
+        String destCity,
+        DeliveryType deliveryType,
+        Instant bookedAt,
+        UUID assignedFlightId
+) {}

--- a/common/src/main/java/com/oneday/common/port/dto/EtaRequest.java
+++ b/common/src/main/java/com/oneday/common/port/dto/EtaRequest.java
@@ -1,0 +1,20 @@
+package com.oneday.common.port.dto;
+
+import com.oneday.common.domain.enums.ShipmentState;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * @param shipmentId   internal shipment UUID
+ * @param currentState the state M4 is in when requesting the ETA; M9 uses this to select its model
+ * @param occurredAt   timestamp at which the current state was entered; may differ from wall-clock
+ *                     if Kafka processing had lag — M9 uses this, not now(), for accurate ETA
+ * @param context      city pair, delivery type, booking time, and flight assignment; see EtaContext
+ */
+public record EtaRequest(
+        UUID shipmentId,
+        ShipmentState currentState,
+        Instant occurredAt,
+        EtaContext context
+) {}

--- a/common/src/main/java/com/oneday/common/port/dto/EtaResult.java
+++ b/common/src/main/java/com/oneday/common/port/dto/EtaResult.java
@@ -1,0 +1,5 @@
+package com.oneday.common.port.dto;
+
+import java.time.Instant;
+
+public record EtaResult(Instant etaPromised, int slaCommitmentMinutes) {}

--- a/common/src/main/java/com/oneday/common/port/dto/NotificationEventType.java
+++ b/common/src/main/java/com/oneday/common/port/dto/NotificationEventType.java
@@ -1,0 +1,6 @@
+package com.oneday.common.port.dto;
+
+public enum NotificationEventType {
+    OTP_GENERATED,
+    STATE_CHANGED
+}

--- a/common/src/main/java/com/oneday/common/port/dto/NotificationRequest.java
+++ b/common/src/main/java/com/oneday/common/port/dto/NotificationRequest.java
@@ -1,0 +1,27 @@
+package com.oneday.common.port.dto;
+
+import com.oneday.common.domain.enums.ShipmentState;
+
+import java.time.Instant;
+
+/**
+ * Payload published to oneday.notifications.requested. The notification service
+ * selects channels (SMS/email/WhatsApp) and templates based on type and newState.
+ *
+ * @param type           OTP_GENERATED or STATE_CHANGED
+ * @param recipientPhone E.164 format, e.g. "+919876543210"
+ * @param recipientEmail nullable; not all customers provide email
+ * @param shipmentRef    human-readable ref, e.g. "1DD-BLR-20260519-000042"
+ * @param newState       the state just entered; null for OTP_GENERATED
+ * @param otp            4-digit code; null for STATE_CHANGED
+ * @param eta            latest ETA; null if not applicable to this notification
+ */
+public record NotificationRequest(
+        NotificationEventType type,
+        String recipientPhone,
+        String recipientEmail,
+        String shipmentRef,
+        ShipmentState newState,
+        String otp,
+        Instant eta
+) {}

--- a/common/src/main/java/com/oneday/common/port/dto/QuoteRequest.java
+++ b/common/src/main/java/com/oneday/common/port/dto/QuoteRequest.java
@@ -1,0 +1,25 @@
+package com.oneday.common.port.dto;
+
+import com.oneday.common.domain.enums.CustomerType;
+import com.oneday.common.domain.enums.DeliveryType;
+
+import java.util.UUID;
+
+/**
+ * @param customerType         B2C, B2B, or C2C — selects the rate card family
+ * @param deliveryType         INTERCITY or SAME_CITY — from ServiceabilityResult
+ * @param originCity           city code, e.g. "BLR"
+ * @param destCity             city code, e.g. "DEL"
+ * @param chargeableWeightGrams max(actualWeight, volumetricWeight) — computed by M4 before this call
+ * @param declaredValuePaise   shipper-declared value; does not affect pricing in v1 but required for B2B
+ * @param b2bRateCardId        account-specific rate card; null for B2C and C2C
+ */
+public record QuoteRequest(
+        CustomerType customerType,
+        DeliveryType deliveryType,
+        String originCity,
+        String destCity,
+        int chargeableWeightGrams,
+        Long declaredValuePaise,
+        UUID b2bRateCardId
+) {}

--- a/common/src/main/java/com/oneday/common/port/dto/QuoteResult.java
+++ b/common/src/main/java/com/oneday/common/port/dto/QuoteResult.java
@@ -1,0 +1,21 @@
+package com.oneday.common.port.dto;
+
+import java.util.Map;
+
+/**
+ * Complete pricing result from M2. M4 stores every field and forwards the breakdown
+ * to the booking response unchanged — it does not compute or validate any field here.
+ *
+ * @param baseAmountPaise  freight charge before tax
+ * @param taxPaise         GST (18% in v1); M2 owns the rate
+ * @param totalPricePaise  baseAmountPaise + taxPaise
+ * @param breakdown        itemised charge components, e.g. {"base_freight": 4000, "fuel_surcharge": 500}
+ * @param rateCardVersion  snapshot of the M2 rate card applied; stored on Shipment for audit
+ */
+public record QuoteResult(
+        long baseAmountPaise,
+        long taxPaise,
+        long totalPricePaise,
+        Map<String, Long> breakdown,
+        String rateCardVersion
+) {}

--- a/common/src/main/java/com/oneday/common/port/dto/ServiceabilityResult.java
+++ b/common/src/main/java/com/oneday/common/port/dto/ServiceabilityResult.java
@@ -1,0 +1,12 @@
+package com.oneday.common.port.dto;
+
+import com.oneday.common.domain.enums.DeliveryType;
+
+import java.util.UUID;
+
+/**
+ * @param serviceable  false if either pincode is outside M3's grid coverage
+ * @param originTileId grid tile of the origin pincode; stored on Shipment for M5 DA assignment
+ * @param deliveryType INTERCITY if origin and dest are in different cities, SAME_CITY otherwise
+ */
+public record ServiceabilityResult(boolean serviceable, UUID originTileId, DeliveryType deliveryType) {}

--- a/docs/M4/M4-ORDERS-DESIGN.md
+++ b/docs/M4/M4-ORDERS-DESIGN.md
@@ -1041,7 +1041,7 @@ Validation failures return `400 Bad Request` with a structured error body:
 
 #### `POST /api/v1/b2b/shipments` — Book a B2B shipment
 
-**Auth:** `X-Api-Key` header (B2B machine-to-machine) OR JWT with role `B2B_BUSINESS_USER`  
+**Auth:** `X-Api-Key` header (B2B machine-to-machine) OR JWT with role `B2B_USER`  
 **Headers:** `Idempotency-Key: <uuid>` (required)
 
 **Request:**
@@ -1101,7 +1101,7 @@ Validation failures return `400 Bad Request` with a structured error body:
 
 #### `GET /api/v1/b2b/accounts/{id}/balance` — Account credit status
 
-**Auth:** B2B API key or `B2B_BUSINESS_USER` JWT
+**Auth:** B2B API key or `B2B_USER` JWT
 
 **Response `200 OK`:**
 ```json
@@ -1118,7 +1118,7 @@ Validation failures return `400 Bad Request` with a structured error body:
 
 #### `POST /api/v1/b2b/accounts/{id}/webhooks` — Register a webhook
 
-**Auth:** `B2B_ADMIN` role
+**Auth:** `ADMIN` role
 
 **Request:**
 ```json
@@ -1278,19 +1278,30 @@ com.oneday.orders/
     ShipmentEventConsumer.java        ← Kafka consumer
     WebhookEventQueue.java            ← In-memory queue for B2B webhook dispatch
   dto/
-    BookingRequest.java
-    BookingResponse.java
-    TrackingResponse.java
-    QuoteRequest.java
-    QuoteResponse.java
-    StateTransitionRequest.java
+    request/
+      BookingRequest.java
+      CancellationRequest.java
+      StateTransitionRequest.java
+    response/
+      BookingResponse.java
+      TrackingResponse.java
+      ShipmentSummaryResponse.java
   port/
     ServiceabilityPort.java
     PricingPort.java
     EtaPort.java
     PaymentPort.java
-    BarcodePort.java
     NotificationPort.java
+    dto/
+      ServiceabilityResult.java
+      QuoteRequest.java       ← port contract sent to M2; distinct from BookingRequest above
+      QuoteResult.java
+      EtaRequest.java
+      EtaContext.java
+      EtaResult.java
+      NotificationRequest.java
+      NotificationEventType.java
+  // M8 (barcode) has no port interface — M8 subscribes to shipment.created via Kafka
 ```
 
 ---
@@ -1308,7 +1319,8 @@ public interface ServiceabilityPort {
 public interface PricingPort {
     QuoteResult computeQuote(QuoteRequest request);
     // QuoteRequest: customer_type, delivery_type, origin_city, dest_city,
-    //               chargeable_weight_grams, declared_value_paise
+    //               chargeable_weight_grams, declared_value_paise,
+    //               b2b_rate_card_id (null for B2C/C2C; required for account-level B2B pricing)
     // QuoteResult:  base_amount_paise, tax_paise, total_paise,
     //               breakdown (map of charge components), rate_card_version
     // M4 stores and forwards this result; it does not compute or validate any field in it.
@@ -1316,16 +1328,20 @@ public interface PricingPort {
 
 // M9 — all ETA logic; M4 has none
 public interface EtaPort {
-    EtaResult fetchEta(UUID shipmentId, ShipmentState state, EtaContext context);
+    EtaResult fetchEta(EtaRequest request);
+    // EtaRequest: shipmentId, currentState, occurredAt (state entry time — not wall-clock),
+    //             EtaContext { originCity, destCity, deliveryType, bookedAt, assignedFlightId }
     // M4 calls this at booking (state=BOOKED) and at key transitions (e.g. AT_ORIGIN_HUB)
-    // M9 decides what ETA to return based on state and context
+    // M9 uses currentState + EtaContext to select the right estimation model
+    // assignedFlightId is null at BOOKED; populated by M9 at AT_ORIGIN_HUB onwards
     // M4 stores the result; all edge cases are M9's responsibility
 }
 
-// M8 — barcode/label registration (fully async; no direct call from M4)
+// M8 — barcode/label registration (fully async; no port interface)
 // Flow: M4 emits shipment.created → M8 consumes → M8 generates label → M8 emits oneday.label.generated
 // M4 consumes oneday.label.generated and updates parcel_id on the shipment.
-// No BarcodePort method is called synchronously during booking.
+// ShipmentCreatedEvent carries senderName, senderAddressLine, receiverAddressLine so M8
+// has everything it needs to generate a complete label without calling back to M4.
 // M8 is NOT in the circuit breaker list; its unavailability does not block bookings.
 
 // Payment — Razorpay
@@ -1339,7 +1355,10 @@ public interface PaymentPort {
 // Notifications
 public interface NotificationPort {
     void send(NotificationRequest request);
-    // Async; M4 does not block on delivery; see §12.2 for failure handling
+    // NotificationRequest: type (OTP_GENERATED | STATE_CHANGED), recipientPhone, recipientEmail,
+    //                      shipmentRef, newState (null for OTP), otp (null for STATE_CHANGED), eta
+    // Async; M4 publishes to oneday.notifications.requested and returns immediately
+    // The notification service owns channel selection, templating, and retry; see §12
 }
 ```
 

--- a/docs/M4/M4-ORDERS-DESIGN.md
+++ b/docs/M4/M4-ORDERS-DESIGN.md
@@ -507,31 +507,31 @@ In v1: 1 `Shipment` = 1 parcel. The `parcel_id` column on `Shipment` holds the M
 | # | State | Meaning | Custody | Triggered by |
 |---|---|---|---|---|
 | 1 | `BOOKED` | Created; payment captured (B2C/C2C) or COD accepted or invoiced (B2B) | Platform | M4 booking API |
-| 2 | `PICKUP_ASSIGNED` | DA assigned to collect *(DA_PICKUP only)* | DA | M5 `oneday.da.assigned` |
+| 2 | `PICKUP_ASSIGNED` | DA assigned to collect *(DA_PICKUP only)* | DA | M5 `DaEventType.PICKUP_ASSIGNED` |
 | 3 | `PICKED_UP` | DA confirmed physical pickup after OTP verification *(DA_PICKUP only)* | DA | M4 OTP verify endpoint (`POST /internal/v1/shipments/{ref}/pickup-otp/verify`) |
-| 4 | `HANDED_TO_PICKUP_VAN` | DA handed parcel to pickup van; DA responsibility ends *(DA_PICKUP only)* | Pickup van | M5 `oneday.da.van_handoff_completed` |
+| 4 | `HANDED_TO_PICKUP_VAN` | DA handed parcel to pickup van; DA responsibility ends *(DA_PICKUP only)* | Pickup van | M5 `DaEventType.VAN_HANDOFF_COMPLETED` |
 | — | `AWAITING_SELF_DROP` | Self-drop booked; sender yet to arrive at origin hub *(SELF_DROP only)* | Platform | M4 booking API (immediate on SELF_DROP booking) |
-| 5 | `AT_ORIGIN_HUB` | Scanned in at origin hub | Hub ops | M8 `HUB_ORIGIN_IN` (DA path) or `SELF_DROP_ACCEPTED` (self-drop path) |
-| 6 | `ORIGIN_HUB_PROCESSING` | Stand assigned; being sorted | Hub ops | M7 stand assignment event |
-| 7 | `IN_TAKEOFF_BAG` | Bagged for specific flight (or same-city route) | Hub ops | M7 bag creation event |
-| 8 | `DISPATCHED_TO_AIRPORT` | Bag loaded on cron; left the hub *(INTERCITY only)* | Cron driver | M6 `DEPARTED_HUB` cron event |
-| 9 | `AT_AIRPORT` | Handed to GHA; airline custody *(INTERCITY only)* | GHA/Airline | M8 `GHA_ACCEPTANCE` scan |
-| 10 | `DEPARTED` | Flight departed *(INTERCITY only)* | Airline | M9 `flight.departed` event |
-| 11 | `LANDED` | Flight arrived at destination city *(INTERCITY only)* | Airline → Dest ops | M9 `flight.landed` event |
-| 12 | `DISPATCHED_TO_HUB` | Van moving from airport to destination hub *(INTERCITY only)* | Cron driver | M6/M7 van departure event |
-| 13 | `AT_DEST_HUB` | Scanned in at destination hub *(INTERCITY only)* | Dest hub ops | M8 `HUB_DEST_IN` scan |
-| 14 | `DEST_HUB_PROCESSING` | Last-mile sort at destination *(INTERCITY only)* | Dest hub ops | M7 dest sort event |
-| 15 | `HANDED_TO_DROP_VAN` | Parcel loaded on drop van; hub responsibility ends *(DA_DELIVERY only)* | Drop van | M7 `DROP_VAN_HANDOFF` or M7 `SAMECITY_OUTBOUND` |
-| 16 | `DROP_ASSIGNED` | Last-mile DA assigned for delivery *(DA_DELIVERY only)* | Last-mile DA | M5 `oneday.da.drop_assigned` |
-| 17 | `DROP_COLLECTED` | DA physically collected parcel from van for delivery *(DA_DELIVERY only)* | Last-mile DA | M5 `oneday.da.drop_collected` |
-| 18 | `DROPPED` | Delivery confirmed by DA *(DA_DELIVERY only)* | — (complete) | M5 `oneday.da.drop_completed` |
-| — | `AWAITING_HUB_COLLECT` | Parcel ready at destination hub; receiver yet to collect *(HUB_COLLECT only)* | Dest hub ops | M7 dest sort complete event |
-| — | `HUB_COLLECTED` | Receiver collected parcel from destination hub *(HUB_COLLECT only)* | — (complete) | M8 `HUB_COLLECT_COMPLETED` scan |
-| — | `PICKUP_FAILED` | DA could not pick up; **reported to M11** | — | M5 `oneday.da.pickup_failed` |
-| — | `DELIVERY_FAILED` | DA could not deliver; **reported to M11** | — | M5 `oneday.da.drop_failed` |
-| — | `RTO_INITIATED` | Return-to-origin triggered; **owned entirely by M11** | Platform | M11 `oneday.m11.rto_initiated` |
-| — | `RTO_IN_TRANSIT` | Return flight to origin city *(INTERCITY only; M11-driven)* | Airline | M9 return flight departed |
-| — | `RTO_COMPLETED` | Returned to sender *(M11-driven)* | — (complete) | M5 return delivery confirmed |
+| 5 | `AT_ORIGIN_HUB` | Scanned in at origin hub | Hub ops | M8 `ScanEventType.HUB_ORIGIN_IN` (DA path) or `ScanEventType.SELF_DROP_ACCEPTED` (self-drop path) |
+| 6 | `ORIGIN_HUB_PROCESSING` | Stand assigned; being sorted | Hub ops | M7 `HubEventType.STAND_ASSIGNED` |
+| 7 | `IN_TAKEOFF_BAG` | Bagged for specific flight (or same-city route) | Hub ops | M7 `HubEventType.BAG_CREATED` |
+| 8 | `DISPATCHED_TO_AIRPORT` | Bag loaded on cron; left the hub *(INTERCITY only)* | Cron driver | M6 `CronEventType.DEPARTED_HUB` |
+| 9 | `AT_AIRPORT` | Handed to GHA; airline custody *(INTERCITY only)* | GHA/Airline | M8 `ScanEventType.GHA_ACCEPTANCE` |
+| 10 | `DEPARTED` | Flight departed *(INTERCITY only)* | Airline | M9 `FlightEventType.DEPARTED` |
+| 11 | `LANDED` | Flight arrived at destination city *(INTERCITY only)* | Airline → Dest ops | M9 `FlightEventType.LANDED` |
+| 12 | `DISPATCHED_TO_HUB` | Van moving from airport to destination hub *(INTERCITY only)* | Cron driver | M6 `CronEventType.DEPARTED_AIRPORT` |
+| 13 | `AT_DEST_HUB` | Scanned in at destination hub *(INTERCITY only)* | Dest hub ops | M8 `ScanEventType.HUB_DEST_IN` |
+| 14 | `DEST_HUB_PROCESSING` | Last-mile sort at destination *(INTERCITY only)* | Dest hub ops | M7 `HubEventType.DEST_SORT_COMPLETE` |
+| 15 | `HANDED_TO_DROP_VAN` | Parcel loaded on drop van; hub responsibility ends *(DA_DELIVERY only)* | Drop van | M7 `HubEventType.DROP_VAN_HANDOFF` or `HubEventType.SAMECITY_OUTBOUND` |
+| 16 | `DROP_ASSIGNED` | Last-mile DA assigned for delivery *(DA_DELIVERY only)* | Last-mile DA | M5 `DaEventType.DROP_ASSIGNED` |
+| 17 | `DROP_COLLECTED` | DA physically collected parcel from van for delivery *(DA_DELIVERY only)* | Last-mile DA | M5 `DaEventType.DROP_COLLECTED` |
+| 18 | `DROPPED` | Delivery confirmed by DA *(DA_DELIVERY only)* | — (complete) | M5 `DaEventType.DROP_COMPLETED` |
+| — | `AWAITING_HUB_COLLECT` | Parcel ready at destination hub; receiver yet to collect *(HUB_COLLECT only)* | Dest hub ops | M7 (see OD-9 — event TBD) |
+| — | `HUB_COLLECTED` | Receiver collected parcel from destination hub *(HUB_COLLECT only)* | — (complete) | M8 `ScanEventType.HUB_COLLECT_COMPLETED` |
+| — | `PICKUP_FAILED` | DA could not pick up; **reported to M11** | — | M5 `DaEventType.PICKUP_FAILED` |
+| — | `DELIVERY_FAILED` | DA could not deliver; **reported to M11** | — | M5 `DaEventType.DROP_FAILED` |
+| — | `RTO_INITIATED` | Return-to-origin triggered; **owned entirely by M11** | Platform | M11 `ExceptionsEventType.RTO_INITIATED` |
+| — | `RTO_IN_TRANSIT` | Return flight to origin city *(INTERCITY only; M11-driven)* | Airline | M9 `FlightEventType.RTO_IN_TRANSIT` |
+| — | `RTO_COMPLETED` | Returned to sender *(M11-driven)* | — (complete) | M11 `ExceptionsEventType.RTO_COMPLETED` |
 | — | `CANCELLED` | Cancelled by customer | — (complete) | M4 cancellation API |
 
 > States 8–14 are skipped for `SAME_CITY` shipments. `IN_TAKEOFF_BAG` transitions directly to `HANDED_TO_DROP_VAN`.
@@ -1406,7 +1406,7 @@ All events share a common envelope:
 
 | `event_type` | Additional payload fields | Consumers |
 |---|---|---|
-| `CREATED` | `customer_type`, `payment_mode`, `delivery_type`, `origin_city`, `origin_pincode`, `origin_tile_id`, `dest_city`, `dest_pincode`, `chargeable_weight_grams`, `sla_commitment_minutes`, `eta_promised`, `receiver_phone`, `receiver_name`, `b2b_account_id` | M5 (DA assignment), M8 (label prep), M10 (SLA start) |
+| `CREATED` | `customer_type`, `payment_mode`, `delivery_type`, `pickup_type`, `drop_type`, `origin_city`, `origin_pincode`, `origin_tile_id`, `origin_lat`, `origin_lon`, `dest_city`, `dest_pincode`, `dest_lat`, `dest_lon`, `chargeable_weight_grams`, `sla_commitment_minutes`, `eta_promised`, `receiver_name`, `receiver_phone`, `b2b_account_id`, `sender_name`, `sender_address_line`, `receiver_address_line` | M5 (DA assignment — reads pickup_type/drop_type to decide action), M8 (label generation — reads sender/receiver address fields), M10 (SLA start) |
 | `STATE_CHANGED` | `from_state`, `to_state`, `triggered_by`, `trigger_source`, `eta_updated` | M10 (SLA tracking), M11 (exception checks), notification system |
 | `CANCELLED` | `cancelled_at_state`, `reason`, `refund_initiated`, `refund_amount_paise` | M5 (remove from DA queue), M10 (close SLA tracking) |
 


### PR DESCRIPTION
# Pull Request

## Summary
Adds all cross-module port interfaces and their DTOs to `common`, establishing the contracts M4 (and future modules) will use to call M2 (Pricing), M3 (Serviceability), M9 (ETA), and the Notification service — without creating direct module-to-module dependencies. Also enforces type safety on Kafka events and syncs the M4 design doc with the implemented code.

---

## What Changed
- Added `ServiceabilityPort`, `PricingPort`, `EtaPort`, `NotificationPort` in `common/port/`
- Added port DTOs in `common/port/dto/`: `ServiceabilityResult`, `QuoteRequest`, `QuoteResult`, `EtaRequest`, `EtaContext`, `EtaResult`, `NotificationRequest`, `NotificationEventType`
- Removed `BarcodePort` — M8 is Kafka-only; it consumes `shipment.created` and needs no synchronous port
- Added `senderName`, `senderAddressLine`, `receiverAddressLine` to `ShipmentCreatedEvent` so M8 has all label data from the event alone without calling back to M4
- Changed `BaseShipmentEvent.eventType` from `String` to `ShipmentEventType` enum for compile-time enforcement
- Updated M4 design doc (§6.2 States Reference, §8.1 file list, §8.2 port definitions, §9.1 CREATED event table, dto layout, role names) to be in full parity with the implemented code

---

## Why This Change?
Cross-module calls (M4 → M2, M4 → M3, M4 → M9, M4 → Notification) must not create direct module-to-module imports — that breaks the dependency graph and risks circular references. Port interfaces in `common` give each consumer a stable contract to depend on, and each implementor a clear interface to fulfil, without any module knowing about another's internals.

---

## Testing
- [x] Tested locally
- [x] Edge cases considered
- [x] No breaking changes introduced

### Test Evidence
Full build passes clean across all 13 modules:

```
[INFO] Reactor Summary for One Day Delivery Platform 1.0.0-SNAPSHOT:
[INFO] One Day Delivery Platform .......................... SUCCESS [  0.093 s]
[INFO] M0 - Common Shared Infrastructure .................. SUCCESS [  1.439 s]
[INFO] M1 - Auth and Role Management ...................... SUCCESS [  0.061 s]
[INFO] M2 - Pricing and Costing Engine .................... SUCCESS [  0.034 s]
[INFO] M3 - Serviceability and Grid Management ............ SUCCESS [  0.729 s]
[INFO] M8 - Barcode Label and Scanning .................... SUCCESS [  0.027 s]
[INFO] M4 - Order Booking and Shipment Lifecycle .......... SUCCESS [  0.033 s]
[INFO] M5 - DA Assignment and Dispatch .................... SUCCESS [  0.030 s]
[INFO] M6 - Van Routing and Scheduling .................... SUCCESS [  0.023 s]
[INFO] M7 - Hub Operations and Sortation .................. SUCCESS [  0.023 s]
[INFO] M9 - Airline and Flight Integration ................ SUCCESS [  0.058 s]
[INFO] M10 - SLA Monitoring and Escalation ................ SUCCESS [  0.026 s]
[INFO] M11 - Exception Handling and RTO ................... SUCCESS [  0.036 s]
[INFO] BUILD SUCCESS
```

---

## Impact

No action required for teammates — this PR adds new files only (no DB migrations, no renamed files). Pull and build.

**For all future modules implementing a port:**
- `common` is already in every module's pom — no new dependency needed
- Write a `@Service` class that `implements` the port interface from `common/port/`
- Spring wires it automatically — no additional config needed

### Areas Affected
- [x] Backend
- [ ] Frontend
- [ ] Routing
- [ ] Infra
- [ ] Database

### Modules Affected
- [ ] M1 — Auth
- [ ] M2 — Pricing
- [ ] M3 — Grid
- [x] M4 — Orders
- [ ] M5 — Dispatch
- [ ] M6 — Routing
- [ ] M7 — Hub
- [x] M8 — Barcode
- [ ] M9 — Airline
- [ ] M10 — SLA
- [ ] M11 — Exceptions
- [ ] NA

---

## Risks / Concerns
- `BaseShipmentEvent.eventType` changed from `String` to `ShipmentEventType` enum — compile-time breaking if any module was already assigning it as a raw string. No other module has source yet so effective risk is zero.
- Port DTOs use Java records — immutable, canonical constructor only. Intentional: ports are contracts, not builders.

---

## Checklist
- [x] Code follows project conventions (package layout, no cross-module internal imports)
- [x] Self-review completed
- [x] Append-only audit trail preserved (no mutations to scan/manifest/role-change records)
- [x] No sensitive data or credentials exposed
- [x] Documentation updated if behaviour changed
- [x] Ready for review
