### PR TITLE
M4 IMPL - PR #9 - Shipment reference generation and internal utility services

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ com.oneday.{module}/
 |--------|--------|
 | `common` | `BaseEntity` + `MutableBaseEntity` (@MappedSuperclass, UUID id + audit timestamps) — done |
 | `grid` (M3) | **Phases 1–8 done.** Phase 9 (integration tests) is next. See `docs/M3/M3-IMPLEMENTATION-PLAN.md` for full phase plan. |
-| `orders` (M4) | PRs 1–7 merged + architect-review fixes applied. Flyway migrations (V4_1–V4_9), JPA entities, Spring Data repositories, and service layer (ShipmentStateMachine, TransitionRegistry, TransitionContext, CustomerVisibleStateMapper) — all done. 949 tests passing. REST API (PR8) not yet started. |
+| `orders` (M4) | PRs 1–8 merged + architect-review fixes applied. Flyway migrations (V4_1–V4_10), JPA entities, Spring Data repositories, service layer (ShipmentStateMachine, TransitionRegistry, TransitionContext, CustomerVisibleStateMapper), and idempotency infrastructure (IdempotencyFilter, IdempotencyKeyPurgeJob, IdempotencyProperties, V4_10 fingerprint migration) — all done. REST API booking endpoints (PR9) not yet started. |
 | All others | Not started |
 
 ## Local Dev Setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ com.oneday.{module}/
 |--------|--------|
 | `common` | `BaseEntity` + `MutableBaseEntity` (@MappedSuperclass, UUID id + audit timestamps) — done |
 | `grid` (M3) | **Phases 1–8 done.** Phase 9 (integration tests) is next. See `docs/M3/M3-IMPLEMENTATION-PLAN.md` for full phase plan. |
-| `orders` (M4) | PRs 1–8 merged + architect-review fixes applied. Flyway migrations (V4_1–V4_10), JPA entities, Spring Data repositories, service layer (ShipmentStateMachine, TransitionRegistry, TransitionContext, CustomerVisibleStateMapper), and idempotency infrastructure (IdempotencyFilter, IdempotencyKeyPurgeJob, IdempotencyProperties, V4_10 fingerprint migration) — all done. REST API booking endpoints (PR9) not yet started. |
+| `orders` (M4) | PRs 1–9 merged + architect-review fixes applied. Flyway migrations (V4_1–V4_11), JPA entities (Shipment, ShipmentStateHistory, PaymentTransaction, B2bAccount, IdempotencyKey, ShipmentRefCounter, PickupOtp), Spring Data repositories (including PickupOtpRepository with pessimistic-lock verify), service layer (ShipmentStateMachine, TransitionRegistry, TransitionContext, CustomerVisibleStateMapper, ShipmentRefService, DeliveryTypeResolver, PaymentPort, PickupOtpService), idempotency infrastructure (IdempotencyFilter, IdempotencyKeyPurgeJob, IdempotencyProperties, V4_10 fingerprint migration), OTP infrastructure (PickupOtpService/Impl with BCrypt(4), PickupOtpProperties, PickupOtpController, V4_11 migration) — all done. B2C booking API (PR #10) not yet started. |
 | All others | Not started |
 
 ## Local Dev Setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ com.oneday.{module}/
 |--------|--------|
 | `common` | `BaseEntity` + `MutableBaseEntity` (@MappedSuperclass, UUID id + audit timestamps) — done |
 | `grid` (M3) | **Phases 1–8 done.** Phase 9 (integration tests) is next. See `docs/M3/M3-IMPLEMENTATION-PLAN.md` for full phase plan. |
-| `orders` (M4) | PRs 1–6 merged. Flyway migrations (V4_1–V4_8), JPA entities (Shipment, ShipmentStateHistory, IdempotencyKey, ShipmentRefCounter, B2bAccount, PaymentTransaction), Spring Data repositories with `@DataJpaTest` integration tests — all done. Service layer and REST API not yet started. |
+| `orders` (M4) | PRs 1–7 merged + architect-review fixes applied. Flyway migrations (V4_1–V4_9), JPA entities, Spring Data repositories, and service layer (ShipmentStateMachine, TransitionRegistry, TransitionContext, CustomerVisibleStateMapper) — all done. 949 tests passing. REST API (PR8) not yet started. |
 | All others | Not started |
 
 ## Local Dev Setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,8 +64,9 @@ com.oneday.{module}/
 
 | Module | Status |
 |--------|--------|
-| `common` | `BaseEntity` (@MappedSuperclass, UUID id + createdAt) — done |
+| `common` | `BaseEntity` + `MutableBaseEntity` (@MappedSuperclass, UUID id + audit timestamps) — done |
 | `grid` (M3) | **Phases 1–8 done.** Phase 9 (integration tests) is next. See `docs/M3/M3-IMPLEMENTATION-PLAN.md` for full phase plan. |
+| `orders` (M4) | PRs 1–6 merged. Flyway migrations (V4_1–V4_8), JPA entities (Shipment, ShipmentStateHistory, IdempotencyKey, ShipmentRefCounter, B2bAccount, PaymentTransaction), Spring Data repositories with `@DataJpaTest` integration tests — all done. Service layer and REST API not yet started. |
 | All others | Not started |
 
 ## Local Dev Setup

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -79,10 +79,11 @@
                 <configuration>
                     <url>jdbc:postgresql://localhost:5432/oneday</url>
                     <user>oneday</user>
-                    <password>oneday</password>
+                    <password>secret</password>
                     <locations>
                         <location>filesystem:src/main/resources/db/migration/auth</location>
                         <location>filesystem:${project.basedir}/../grid/src/main/resources/db/migration/grid</location>
+                        <location>filesystem:${project.basedir}/../orders/src/main/resources/db/migration/orders</location>
                     </locations>
                 </configuration>
             </plugin>

--- a/app/src/main/java/com/oneday/app/OneDayDeliveryApplication.java
+++ b/app/src/main/java/com/oneday/app/OneDayDeliveryApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = "com.oneday")
 @EnableJpaRepositories(basePackages = "com.oneday")
 @EntityScan(basePackages = "com.oneday")
+@EnableScheduling
 public class OneDayDeliveryApplication {
 
     public static void main(String[] args) {

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -676,7 +676,7 @@ Network retries and client-side double-taps are inevitable. Without idempotency,
 - `idempotency_keys` table: `(key, user_id, response_status, response_body, expires_at)`
 - Key is scoped to the authenticated user to prevent cross-user collision
 - Nightly job purges expired rows (`expires_at < NOW()`)
-- Missing header returns `400 MISSING_IDEMPOTENCY_KEY`
+- Missing header returns `400 IDEMPOTENCY_KEY_REQUIRED`
 
 **Change log:**  
 _(First entry)_

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -667,16 +667,18 @@ _(First entry)_
 | **Source** | docs/M4/M4-ORDERS-DESIGN.md §4 (KDD-6) |
 
 **Decision:**  
-`POST /api/v1/b2c/shipments` and `POST /api/v1/b2b/shipments` require an `Idempotency-Key: <uuid>` header. Duplicate requests with the same key within 24 hours return the original response (HTTP 200 + original body).
+`POST /api/v1/b2c/shipments` and `POST /api/v1/b2b/shipments` require an `Idempotency-Key: <uuid>` header. Duplicate requests with the same key within 24 hours return the original response (original HTTP status + original body).
 
 **Rationale:**  
 Network retries and client-side double-taps are inevitable. Without idempotency, a Razorpay capture could succeed while the DB write fails, leaving the customer charged but without a shipment.
 
 **Implications:**
 - `idempotency_keys` table: `(key, user_id, response_status, response_body, expires_at)`
+- `request_fingerprint VARCHAR(64)` stores SHA-256 of the canonicalised request body (JSON keys sorted alphabetically); NULL for rows created before V4_10 (treated as match-all on replay)
+- Body mismatch (same key + same user + different body within TTL) returns `422 IDEMPOTENCY_KEY_BODY_MISMATCH`
 - Key is scoped to the authenticated user to prevent cross-user collision
-- Nightly job purges expired rows (`expires_at < NOW()`)
-- Missing header returns `400 IDEMPOTENCY_KEY_REQUIRED`
+- Nightly job purges expired rows (`expires_at < NOW()`); TTL also enforced at hit time
+- Missing header returns `400 IDEMPOTENCY_KEY_REQUIRED`; header > 100 chars returns `400 IDEMPOTENCY_KEY_TOO_LONG`
 
 **Change log:**  
 _(First entry)_

--- a/docs/M4/M4-ER-DIAGRAM.md
+++ b/docs/M4/M4-ER-DIAGRAM.md
@@ -104,6 +104,7 @@ erDiagram
     IDEMPOTENCY_KEYS {
         varchar key PK
         uuid user_id PK
+        varchar request_fingerprint
         smallint response_status
         jsonb response_body
         timestamptz expires_at
@@ -116,9 +117,20 @@ erDiagram
         integer next_val
     }
 
+    PICKUP_OTPS {
+        uuid id PK
+        uuid shipment_id FK
+        varchar otp_hash
+        timestamptz expires_at
+        boolean used
+        smallint resend_count
+        timestamptz created_at
+    }
+
     SHIPMENTS ||--o{ SHIPMENT_STATE_HISTORY : "has history"
     SHIPMENTS ||--o| PAYMENT_TRANSACTIONS : "paid via"
     SHIPMENTS }o--o| B2B_ACCOUNTS : "billed to"
+    SHIPMENTS ||--o| PICKUP_OTPS : "has active OTP"
 ```
 
 ## Notes
@@ -126,7 +138,8 @@ erDiagram
 - `SHIPMENT_STATE_HISTORY` is append-only — rows are never updated or deleted.
 - `PAYMENT_TRANSACTIONS` has one row per payment attempt; a COD shipment has no row until delivery is confirmed by M5.
 - `B2B_ACCOUNTS.outstanding_balance_paise` is incremented atomically with each B2B booking (same DB transaction, `SELECT FOR UPDATE`).
-- `IDEMPOTENCY_KEYS` rows are purged nightly when `expires_at < NOW()`. The `request_fingerprint` column (SHA-256 of canonicalised request body) is **not in this migration** — it is added in PR #8 (Idempotency infrastructure) alongside the fingerprinting logic that writes it.
+- `IDEMPOTENCY_KEYS` rows are purged nightly when `expires_at < NOW()`. The `request_fingerprint` column (SHA-256 of canonicalised request body) was added in V4_10 (PR #8) alongside the fingerprinting logic that writes it.
+- `PICKUP_OTPS` stores BCrypt-hashed OTPs for DA pickup verification. At most one row exists per shipment at any time (unique index on `shipment_id`). On resend the old row is deleted and a new one is inserted. Rows are not archived — they can be purged after expiry.
 - `SHIPMENT_REF_COUNTERS` is a per-city-per-day sequence counter; see design doc §5.1 for the Redis INCR upgrade path at high volume.
 - `assigned_flight_id` references M9's flight table (cross-module, not a DB foreign key — enforced at application level).
 - `origin_tile_id` references M3's grid tile table (same cross-module rule).

--- a/docs/M4/M4-ER-DIAGRAM.md
+++ b/docs/M4/M4-ER-DIAGRAM.md
@@ -104,7 +104,6 @@ erDiagram
     IDEMPOTENCY_KEYS {
         varchar key PK
         uuid user_id PK
-        varchar request_fingerprint
         smallint response_status
         jsonb response_body
         timestamptz expires_at
@@ -127,7 +126,7 @@ erDiagram
 - `SHIPMENT_STATE_HISTORY` is append-only — rows are never updated or deleted.
 - `PAYMENT_TRANSACTIONS` has one row per payment attempt; a COD shipment has no row until delivery is confirmed by M5.
 - `B2B_ACCOUNTS.outstanding_balance_paise` is incremented atomically with each B2B booking (same DB transaction, `SELECT FOR UPDATE`).
-- `IDEMPOTENCY_KEYS` rows are purged nightly when `expires_at < NOW()`.
+- `IDEMPOTENCY_KEYS` rows are purged nightly when `expires_at < NOW()`. The `request_fingerprint` column (SHA-256 of canonicalised request body) is **not in this migration** — it is added in PR #8 (Idempotency infrastructure) alongside the fingerprinting logic that writes it.
 - `SHIPMENT_REF_COUNTERS` is a per-city-per-day sequence counter; see design doc §5.1 for the Redis INCR upgrade path at high volume.
 - `assigned_flight_id` references M9's flight table (cross-module, not a DB foreign key — enforced at application level).
 - `origin_tile_id` references M3's grid tile table (same cross-module rule).

--- a/docs/M4/M4-IMPL-PLAN.md
+++ b/docs/M4/M4-IMPL-PLAN.md
@@ -3,9 +3,9 @@
 | Field | Value |
 |---|---|
 | **Module** | M4 — Orders |
-| **Plan version** | 1.3 |
+| **Plan version** | 1.4 |
 | **Author** | Satvik |
-| **Last updated** | 2026-05-29 |
+| **Last updated** | 2026-05-30 |
 | **Total PRs** | 21 |
 | **Design doc** | [M4-ORDERS-DESIGN.md](M4-ORDERS-DESIGN.md) |
 
@@ -21,7 +21,8 @@
 | #6 | Spring Data repositories and custom query methods | ✅ Merged |
 | #7 | Shipment state machine with full transition coverage | ✅ Merged |
 | #8 | Idempotency infrastructure (IdempotencyFilter, IdempotencyKeyPurgeJob, V4_10 fingerprint migration) | ✅ Merged |
-| #9–#21 | Ref gen + utility services, booking APIs, Kafka wiring, supporting APIs, resilience, observability | 🔲 Not started |
+| #9 | Ref gen + utility services: ShipmentRefService, DeliveryTypeResolver, PaymentPort, PickupOtpService, PickupOtpController, V4_11 pickup_otps migration, PickupOtpProperties | ✅ Merged |
+| #10–#21 | Booking APIs, Kafka wiring, supporting APIs, resilience, observability | 🔲 Not started |
 
 ---
 
@@ -243,18 +244,21 @@ NotificationPort     → notification service implements; M4 calls on every stat
 
 ---
 
-### `M4 IMPL - PR #9 - Shipment reference generation and internal utility services`
+### `M4 IMPL - PR #9 - Shipment reference generation and internal utility services` ✅ Merged
 
 **Module:** `orders`
 
-**What:**
-- `ShipmentRefService`: generates `1DD-{CITY}-{YYYYMMDD}-{NNNNN}` using `SELECT FOR UPDATE` on `ShipmentRefCounter`; documents the Redis upgrade path at high volume
-- `DeliveryTypeResolver`: `origin_city == dest_city` → `SAME_CITY`, else `INTERCITY` — pure function, zero DB calls
-- `PaymentPort` (local to `orders`): `verifySignature()`, `capture()`, `initiateRefund()` — Razorpay-specific, not in `common` since no other module touches payments
-- `PickupOtpService`: generates 4-digit OTP, stores hashed in `pickup_otps` table with 10-minute TTL; exposes `generate()`, `verify()`, `resend()` (max 3); called as a side-effect when state machine enters `PICKUP_ASSIGNED`
-- `POST /internal/v1/shipments/{ref}/pickup-otp/verify` — on success, directly transitions `PICKUP_ASSIGNED → PICKED_UP`; returns `422` on wrong OTP or expired; returns `409` if state is not `PICKUP_ASSIGNED`
-- `POST /internal/v1/shipments/{ref}/pickup-otp/resend` — invalidates previous OTP; generates fresh one; returns `429` after 3 resends
-- Flyway migration for `pickup_otps` table: `(id, shipment_id, otp_hash, expires_at, used, resend_count, created_at)`
+**What (all implemented):**
+- `ShipmentRefService` interface + `ShipmentRefServiceImpl`: generates `1DD-{CITY}-{YYYYMMDD}-{NNNNN}` using `insertIfAbsent` + `SELECT FOR UPDATE` on `ShipmentRefCounter`; `Propagation.MANDATORY` — counter increment rolls back with the caller's transaction; documents the Redis upgrade path at high volume
+- `DeliveryTypeResolver` (`@Component`): `resolve(origin, dest)` → `SAME_CITY` if equal ignoring case, else `INTERCITY` — pure function, zero DB calls
+- `PaymentPort` interface (local to `orders/service/` — not in `common`): `verifySignature(orderId, paymentId, signature)`, `void capture(paymentId, amountPaise)`, `String initiateRefund(paymentId, amountPaise)` — Razorpay-specific; inner unchecked exceptions `PaymentVerificationException`, `PaymentCaptureException`, `PaymentRefundException`
+- `PickupOtpService` interface + `PickupOtpServiceImpl`: generates 4-digit OTP using `SecureRandom`, stores BCrypt(cost=4) hash in `pickup_otps` table; exposes `generate()`, `verify()` (pessimistic-lock), `resend()` (max 3, driven by `PickupOtpProperties`); inner exceptions `OtpVerificationException`, `ResendLimitExceededException`
+- `PickupOtpProperties` (`@ConfigurationProperties(prefix="orders.otp")`): `ttlMinutes=10`, `maxResendCount=3`
+- `PickupOtpRepository`: `findByShipmentId`, `findByShipmentIdWithLock` (`SELECT FOR UPDATE`), `deleteByShipmentId`
+- `PickupOtp` JPA entity: `pickup_otps` table; only `used` is mutable after creation
+- `PickupOtpController`: `POST /internal/v1/shipments/{ref}/pickup-otp/verify` → `204 No Content` on success (transitions `PICKUP_ASSIGNED → PICKED_UP`), `409` if wrong state, `422` on wrong/expired OTP; `POST /internal/v1/shipments/{ref}/pickup-otp/resend` → `200 {"otp": "..."}` on success, `429` after 3 resends
+- `OtpVerifyRequest` DTO: `@NotBlank @Pattern(regexp="\\d{4}") String otp`
+- `V4_11__create_pickup_otps.sql`: `pickup_otps` table with unique index on `shipment_id` and expiry index; `ShipmentRefCounterRepository` extended with `insertIfAbsent` native query
 
 ---
 
@@ -469,8 +473,8 @@ NotificationPort     → notification service implements; M4 calls on every stat
                 └─► #5 (JPA entities)
                      └─► #6 (Repositories)
                           └─► #7 (State machine)
-                               ├─► #8 (Idempotency)
-                               └─► #9 (Ref gen + PaymentPort)
+                               ├─► #8 (Idempotency) ✅
+                               └─► #9 (Ref gen + PaymentPort + PickupOtpService) ✅
                                     └─► #10 (B2C/C2C PREPAID booking + circuit breakers)
                                          ├─► #11 (COD path)         ← parallel
                                          ├─► #12 (B2B booking)      ← parallel

--- a/docs/M4/M4-IMPL-PLAN.md
+++ b/docs/M4/M4-IMPL-PLAN.md
@@ -3,11 +3,24 @@
 | Field | Value |
 |---|---|
 | **Module** | M4 — Orders |
-| **Plan version** | 1.1 |
+| **Plan version** | 1.2 |
 | **Author** | Satvik |
-| **Last updated** | 2026-05-16 |
+| **Last updated** | 2026-05-28 |
 | **Total PRs** | 21 |
 | **Design doc** | [M4-ORDERS-DESIGN.md](M4-ORDERS-DESIGN.md) |
+
+## Progress
+
+| PR | Title | Status |
+|----|-------|--------|
+| #1 | MutableBaseEntity + Flyway multi-module strategy | ✅ Merged |
+| #2 | Kafka event POJOs, topic constants in common | ✅ Merged |
+| #3 | Cross-module port interfaces in common | ✅ Merged |
+| #4 | Flyway migrations for all M4 tables and enums (V4_1–V4_9) | ✅ Merged |
+| #5 | JPA entities for M4 domain model | ✅ Merged |
+| #6 | Spring Data repositories and custom query methods | ✅ Merged |
+| #7 | Shipment state machine with full transition coverage | 🔄 Open — pending review |
+| #8–#21 | Idempotency, booking APIs, Kafka wiring, supporting APIs, resilience, observability | 🔲 Not started |
 
 ---
 
@@ -148,8 +161,9 @@ NotificationPort     → notification service implements; M4 calls on every stat
 - PostgreSQL ENUMs: `shipment_state` (27 values — includes `AWAITING_SELF_DROP`, `AWAITING_HUB_COLLECT`, `HUB_COLLECTED`), `customer_type`, `delivery_type`, `payment_mode`, `pickup_type` (`DA_PICKUP`, `SELF_DROP`), `drop_type` (`DA_DELIVERY`, `HUB_COLLECT`)
 - `trigger_source` is **not** a PG ENUM — stored as `VARCHAR(20)` in `shipment_state_history`. It is an M4-internal audit classification (API, KAFKA_EVENT, SYSTEM), not a shared business domain type. Adding a new source requires only a Java enum value, not a DB migration.
 - Tables: `shipments` (with `pickup_type` and `drop_type` columns, both NOT NULL DEFAULT), `shipment_state_history`, `payment_transactions`, `b2b_accounts`, `idempotency_keys`, `shipment_ref_counters`
-- All indexes (shipment_ref, parcel_id, state, b2b_account_id, origin_tile_id)
+- All indexes (shipment_ref, parcel_id, state, b2b_account_id, origin_tile_id, city_id+state composite, assigned_flight_id, origin_city, dest_city)
 - DB trigger for `updated_at` auto-management on `shipments`, `payment_transactions`, `b2b_accounts`
+- **V4_9 (added during architect review):** `UNIQUE` constraint on `shipments.idempotency_key` — prevents TOCTOU duplicate-creation race under concurrent order requests; NULLs permitted for B2B batch imports
 - No Java code in this PR
 
 **Note:** SQL-only PR. Reviewer should check:
@@ -178,13 +192,13 @@ NotificationPort     → notification service implements; M4 calls on every stat
 **Module:** `orders`
 
 **What:**
-- `ShipmentRepository`: `findByShipmentRef`, `findByIdWithLock` (`@Lock(PESSIMISTIC_WRITE)`), `findByB2bAccountIdAndStateIn`
+- `ShipmentRepository`: `findByIdWithLock` (`@Lock(PESSIMISTIC_WRITE)`), `findByShipmentRef`, `findByState` (list + paginated), `findByStateAndCityId` (list + paginated), `existsByIdempotencyKey`, `findByCustomerType`, `findByAssignedFlightId`
 - `ShipmentStateHistoryRepository`: `findByShipmentIdOrderByOccurredAtAsc`
 - `PaymentTransactionRepository`: `findByShipmentId`, `findByRazorpayOrderId`
-- `B2bAccountRepository`: `findByIdWithLock` (`@Lock(PESSIMISTIC_WRITE)`)
-- `IdempotencyKeyRepository`: `findByKeyAndUserId`, `deleteByExpiresAtBefore`
-- `ShipmentRefCounterRepository`: `findByCityCodeAndDateKeyWithLock`
-- `@DataJpaTest` integration tests for all custom queries
+- `B2bAccountRepository`: `findByCityId`, `findByIsActive`, `findByBillingEmail` — **Note:** `findByIdWithLock` not yet added; needed for B2B credit check in PR #12
+- `IdempotencyKeyRepository`: `deleteExpired(Instant now)` (`@Transactional @Modifying @Query`)
+- `ShipmentRefCounterRepository`: `findByIdWithLock(@Param("id") ShipmentRefCounterId id)` (`@Lock(PESSIMISTIC_WRITE)`)
+- `@DataJpaTest` integration tests against local PostgreSQL (`@AutoConfigureTestDatabase(replace=NONE)`) — see testing strategy note below
 
 ---
 
@@ -491,8 +505,8 @@ NotificationPort     → notification service implements; M4 calls on every stat
 | Layer | Tool | When |
 |---|---|---|
 | Unit | JUnit 5 + Mockito | Every PR |
-| Repository | `@DataJpaTest` + Testcontainers (PostgreSQL) | PR #6 onwards |
-| State machine | Parameterized JUnit5 (all 27×27 transition matrix) | PR #7 |
+| Repository | `@DataJpaTest` + `@AutoConfigureTestDatabase(replace=NONE)` + `@Import(FlywayAutoConfiguration.class)` against **local PostgreSQL 16** (Docker/Testcontainers blocked by Docker Engine API version mismatch in dev environment) | PR #6 onwards |
+| State machine | Parameterized JUnit5 (all 27×27 transition matrix — 841 parameterized + 108 named tests = 949 total in PR #7) | PR #7 |
 | Kafka | `@EmbeddedKafka` | PR #14 onwards |
 | API | `@SpringBootTest` + MockMvc + stub ports via `@TestConfiguration` | PR #10 onwards |
 | Concurrency | `CountDownLatch` multi-thread test for B2B credit check | PR #12 |

--- a/docs/M4/M4-IMPL-PLAN.md
+++ b/docs/M4/M4-IMPL-PLAN.md
@@ -3,9 +3,9 @@
 | Field | Value |
 |---|---|
 | **Module** | M4 — Orders |
-| **Plan version** | 1.2 |
+| **Plan version** | 1.3 |
 | **Author** | Satvik |
-| **Last updated** | 2026-05-28 |
+| **Last updated** | 2026-05-29 |
 | **Total PRs** | 21 |
 | **Design doc** | [M4-ORDERS-DESIGN.md](M4-ORDERS-DESIGN.md) |
 
@@ -19,8 +19,9 @@
 | #4 | Flyway migrations for all M4 tables and enums (V4_1–V4_9) | ✅ Merged |
 | #5 | JPA entities for M4 domain model | ✅ Merged |
 | #6 | Spring Data repositories and custom query methods | ✅ Merged |
-| #7 | Shipment state machine with full transition coverage | 🔄 Open — pending review |
-| #8–#21 | Idempotency, booking APIs, Kafka wiring, supporting APIs, resilience, observability | 🔲 Not started |
+| #7 | Shipment state machine with full transition coverage | ✅ Merged |
+| #8 | Idempotency infrastructure (IdempotencyFilter, IdempotencyKeyPurgeJob, V4_10 fingerprint migration) | ✅ Merged |
+| #9–#21 | Ref gen + utility services, booking APIs, Kafka wiring, supporting APIs, resilience, observability | 🔲 Not started |
 
 ---
 

--- a/docs/M4/M4-IMPL-PLAN.md
+++ b/docs/M4/M4-IMPL-PLAN.md
@@ -145,7 +145,8 @@ NotificationPort     → notification service implements; M4 calls on every stat
 **Module:** `orders` (`db/migration/orders/`)
 
 **What:**
-- PostgreSQL ENUMs: `shipment_state` (27 values — includes `AWAITING_SELF_DROP`, `AWAITING_HUB_COLLECT`, `HUB_COLLECTED`), `customer_type`, `delivery_type`, `payment_mode`, `pickup_type` (`DA_PICKUP`, `SELF_DROP`), `drop_type` (`DA_DELIVERY`, `HUB_COLLECT`), `trigger_source`
+- PostgreSQL ENUMs: `shipment_state` (27 values — includes `AWAITING_SELF_DROP`, `AWAITING_HUB_COLLECT`, `HUB_COLLECTED`), `customer_type`, `delivery_type`, `payment_mode`, `pickup_type` (`DA_PICKUP`, `SELF_DROP`), `drop_type` (`DA_DELIVERY`, `HUB_COLLECT`)
+- `trigger_source` is **not** a PG ENUM — stored as `VARCHAR(20)` in `shipment_state_history`. It is an M4-internal audit classification (API, KAFKA_EVENT, SYSTEM), not a shared business domain type. Adding a new source requires only a Java enum value, not a DB migration.
 - Tables: `shipments` (with `pickup_type` and `drop_type` columns, both NOT NULL DEFAULT), `shipment_state_history`, `payment_transactions`, `b2b_accounts`, `idempotency_keys`, `shipment_ref_counters`
 - All indexes (shipment_ref, parcel_id, state, b2b_account_id, origin_tile_id)
 - DB trigger for `updated_at` auto-management on `shipments`, `payment_transactions`, `b2b_accounts`
@@ -165,7 +166,7 @@ NotificationPort     → notification service implements; M4 calls on every stat
 
 **What:**
 - Remaining enums local to `orders`: `PaymentStatus`, `RefundStatus`, `TriggerSource`
-- JPA entities: `Shipment` (extends `MutableBaseEntity`), `ShipmentStateHistory` (extends `BaseEntity`), `PaymentTransaction` (extends `MutableBaseEntity`), `B2bAccount` (extends `MutableBaseEntity`), `IdempotencyKey` (extends `BaseEntity`), `ShipmentRefCounter`
+- JPA entities: `Shipment` (extends `MutableBaseEntity`), `ShipmentStateHistory` (standalone — has `occurred_at` not `created_at`; extending `BaseEntity` would fail schema validation), `PaymentTransaction` (extends `MutableBaseEntity`), `B2bAccount` (extends `MutableBaseEntity`), `IdempotencyKey` (standalone with `@EmbeddedId` for composite PK `(key, user_id)` — cannot extend `BaseEntity`), `ShipmentRefCounter` (standalone with `@EmbeddedId` for composite PK `(city_code, date_key)`)
 - `ShipmentState`, `PickupType`, `DropType`, and customer/delivery/payment enums imported from `common` (defined in PR #2)
 - `@Column(updatable = false)` on all immutable fields; `@Column(name = "created_at", updatable = false)` inherited
 - No repositories, no services

--- a/docs/M4/M4-INTEGRATION-CONTRACTS.md
+++ b/docs/M4/M4-INTEGRATION-CONTRACTS.md
@@ -4,7 +4,7 @@
 |---|---|
 | **Module** | M4 — Orders |
 | **Author** | Satvik |
-| **Last updated** | 2026-05-24 |
+| **Last updated** | 2026-05-30 |
 | **Status** | Authoritative — must be kept in sync with M4-ORDERS-DESIGN.md |
 
 This document is the single reference for every other module team integrating with M4. It covers exactly what M4 needs from you, what M4 gives you, and the precise contracts (types, fields, topics, endpoints) for both directions.
@@ -584,10 +584,10 @@ M9 uses this to bulk-update states on flight departure and arrival.
 ```
 
 **Behaviour:**
-- Success (`200`): transitions `PICKUP_ASSIGNED → PICKED_UP`; OTP is consumed and invalidated.
-- Wrong OTP (`422 INVALID_OTP`): no state change; DA must retry or call resend.
-- Expired OTP (`422 OTP_EXPIRED`): DA must call the resend endpoint.
-- Wrong state (`409 INVALID_STATE`): shipment is not in `PICKUP_ASSIGNED`.
+- Success (`204 No Content`): transitions `PICKUP_ASSIGNED → PICKED_UP`; OTP is consumed and invalidated.
+- Wrong OTP (`422`): no state change; DA must retry or call resend.
+- Expired OTP (`422`): DA must call the resend endpoint.
+- Wrong state (`409`): shipment is not in `PICKUP_ASSIGNED`.
 
 ---
 

--- a/docs/M4/M4-INTEGRATION-CONTRACTS.md
+++ b/docs/M4/M4-INTEGRATION-CONTRACTS.md
@@ -1,0 +1,780 @@
+# M4 — Integration Contracts
+
+| Field | Value |
+|---|---|
+| **Module** | M4 — Orders |
+| **Author** | Satvik |
+| **Last updated** | 2026-05-24 |
+| **Status** | Authoritative — must be kept in sync with M4-ORDERS-DESIGN.md |
+
+This document is the single reference for every other module team integrating with M4. It covers exactly what M4 needs from you, what M4 gives you, and the precise contracts (types, fields, topics, endpoints) for both directions.
+
+---
+
+## Table of Contents
+
+1. [What M4 Needs From Other Modules (Inbound)](#1-what-m4-needs-from-other-modules-inbound)
+   - 1.1 [M3 — Serviceability Check (Sync Port)](#11-m3--serviceability-check-sync-port)
+   - 1.2 [M2 — Pricing Quote (Sync Port)](#12-m2--pricing-quote-sync-port)
+   - 1.3 [M9 — ETA Calculation (Sync Port)](#13-m9--eta-calculation-sync-port)
+   - 1.4 [Notification Service — Send Notification (Async Port)](#14-notification-service--send-notification-async-port)
+   - 1.5 [M5 — DA Events (Kafka)](#15-m5--da-events-kafka)
+   - 1.6 [M7 — Hub Events (Kafka)](#16-m7--hub-events-kafka)
+   - 1.7 [M8 — Scan Events (Kafka)](#17-m8--scan-events-kafka)
+   - 1.8 [M9 — Flight Events (Kafka)](#18-m9--flight-events-kafka)
+   - 1.9 [M6 — Cron Events (Kafka)](#19-m6--cron-events-kafka)
+   - 1.10 [M11 — Exception Events (Kafka)](#110-m11--exception-events-kafka)
+2. [What M4 Exposes to Other Modules (Outbound)](#2-what-m4-exposes-to-other-modules-outbound)
+   - 2.1 [Kafka Events Produced by M4](#21-kafka-events-produced-by-m4)
+   - 2.2 [Internal REST APIs](#22-internal-rest-apis)
+3. [Shared Types Reference](#3-shared-types-reference)
+   - 3.1 [ShipmentState Enum (27 values)](#31-shipmentstate-enum-27-values)
+   - 3.2 [Other Domain Enums](#32-other-domain-enums)
+   - 3.3 [Kafka Topics](#33-kafka-topics)
+4. [Event Routing: What Triggers What](#4-event-routing-what-triggers-what)
+5. [Critical Rules All Teams Must Follow](#5-critical-rules-all-teams-must-follow)
+6. [Open Decisions Blocking Integration](#6-open-decisions-blocking-integration)
+
+---
+
+## 1. What M4 Needs From Other Modules (Inbound)
+
+M4 integrates with other modules in two ways:
+- **Synchronous port interfaces** — M4 calls these in-process during the booking request. Latency directly impacts booking response time. Failures may block the booking.
+- **Kafka event consumption** — M4 subscribes to topics produced by other modules and drives its state machine from them. These are fully decoupled and async.
+
+---
+
+### 1.1 M3 — Serviceability Check (Sync Port)
+
+**Implemented by:** M3 (grid module)  
+**Called at:** Booking time, once per booking, synchronously  
+**Circuit-broken:** Yes — M3 unavailability fails the booking  
+**Latency budget:** < 500ms (booking must complete sub-2s end-to-end)
+
+**Interface (already in `common`):**
+
+```java
+// com.oneday.common.port.ServiceabilityPort
+public interface ServiceabilityPort {
+    ServiceabilityResult check(String originPincode, String destPincode);
+}
+```
+
+**Input:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `originPincode` | `String` | Sender's pincode — as entered by customer at booking |
+| `destPincode` | `String` | Receiver's pincode — as entered by customer at booking |
+
+**Output (`ServiceabilityResult` record in `common/port/dto/`):**
+
+```java
+public record ServiceabilityResult(
+    boolean serviceable,   // false if either pincode is outside M3's grid coverage
+    UUID originTileId,     // grid tile of origin; M4 stores this on Shipment for M5 DA assignment
+    DeliveryType deliveryType  // INTERCITY if different cities, SAME_CITY if same
+)
+```
+
+**Rules M3 must follow:**
+- Return `serviceable=false` for unsupported pincodes — **do not throw an exception**. M4 maps this to a `422 PINCODE_NOT_SERVICEABLE` response.
+- `originTileId` must be non-null when `serviceable=true`. M4 stores it on the `Shipment` record; M5 reads it for DA assignment. A null tile ID when serviceable=true will cause M5 to fail assignment.
+- `deliveryType` must be non-null when `serviceable=true`. M4 uses it to determine which state machine path applies (INTERCITY skips states 8–14 for SAME_CITY).
+- M3 owns all city boundary logic — M4 never passes a cityCode; it only passes raw pincodes.
+
+---
+
+### 1.2 M2 — Pricing Quote (Sync Port)
+
+**Implemented by:** M2 (pricing module)  
+**Called at:** Booking time, once per booking, synchronously, after serviceability check passes  
+**Circuit-broken:** Yes — M2 unavailability fails the booking  
+**Latency budget:** < 500ms
+
+**Interface (already in `common`):**
+
+```java
+// com.oneday.common.port.PricingPort
+public interface PricingPort {
+    QuoteResult computeQuote(QuoteRequest request);
+}
+```
+
+**Input (`QuoteRequest` record in `common/port/dto/`):**
+
+```java
+public record QuoteRequest(
+    CustomerType customerType,      // B2C, B2B, or C2C — selects the rate card family
+    DeliveryType deliveryType,      // INTERCITY or SAME_CITY — from ServiceabilityResult
+    String originCity,              // city code, e.g. "BLR"
+    String destCity,                // city code, e.g. "DEL"
+    int chargeableWeightGrams,      // max(actualWeight, volumetricWeight) — M4 computes this before calling
+    Long declaredValuePaise,        // shipper-declared value; nullable; no pricing effect in v1
+    UUID b2bRateCardId              // account-specific rate card; null for B2C and C2C
+)
+```
+
+**M4 computes `chargeableWeightGrams` itself** before this call:
+```
+volumetricWeightGrams = (length_cm × width_cm × height_cm) / 5
+chargeableWeightGrams = max(actualWeightGrams, volumetricWeightGrams)
+```
+
+**Output (`QuoteResult` record in `common/port/dto/`):**
+
+```java
+public record QuoteResult(
+    long baseAmountPaise,           // freight charge before tax
+    long taxPaise,                  // GST 18% in v1; M2 owns the rate
+    long totalPricePaise,           // baseAmountPaise + taxPaise
+    Map<String, Long> breakdown,    // e.g. {"base_freight": 4000, "fuel_surcharge": 500}
+    String rateCardVersion          // snapshot of which rate card was applied; stored for audit
+)
+```
+
+**Rules M2 must follow:**
+- `totalPricePaise` must equal `baseAmountPaise + taxPaise` exactly. M4 stores all three independently.
+- `rateCardVersion` must be non-null. M4 stores it on `Shipment.rate_card_version` for billing reconciliation.
+- M4 forwards the entire result to the customer unchanged — it does not validate, adjust, or recompute any field.
+- Throw a runtime exception on pricing failure (unsupported city pair, disabled rate card, etc.) — M4's circuit breaker will catch it and fail the booking with `503`.
+
+---
+
+### 1.3 M9 — ETA Calculation (Sync Port)
+
+**Implemented by:** M9 (airline module)  
+**Called at:** Two points in the shipment lifecycle (see below)  
+**Circuit-broken:** No — ETA failure does not block state transitions. M4 proceeds with null ETA and logs a warning.
+
+**Interface (already in `common`):**
+
+```java
+// com.oneday.common.port.EtaPort
+public interface EtaPort {
+    EtaResult fetchEta(EtaRequest request);
+}
+```
+
+**Input (`EtaRequest` + `EtaContext` records in `common/port/dto/`):**
+
+```java
+public record EtaRequest(
+    UUID shipmentId,
+    ShipmentState currentState,   // the state M4 is currently entering; M9 uses this to select its model
+    Instant occurredAt,           // when this state was entered; use this, not now(), for accurate ETA
+    EtaContext context
+)
+
+public record EtaContext(
+    String originCity,            // e.g. "BLR"
+    String destCity,              // e.g. "DEL"
+    DeliveryType deliveryType,    // INTERCITY or SAME_CITY
+    Instant bookedAt,             // when the shipment was created; M9 uses this to find next feasible flight
+    UUID assignedFlightId         // null at BOOKED; populated once M9 has assigned a flight
+)
+```
+
+**Output (`EtaResult` record in `common/port/dto/`):**
+
+```java
+public record EtaResult(
+    Instant etaPromised,          // absolute timestamp of expected delivery; M4 stores + sends to customer
+    int slaCommitmentMinutes      // total minutes committed; stored on Shipment.sla_commitment_minutes
+)
+```
+
+**When M4 calls EtaPort:**
+
+| Call point | `currentState` | What M4 does with result |
+|---|---|---|
+| After booking | `BOOKED` | Stores as `eta_promised`; included in booking response to customer |
+| On `AT_ORIGIN_HUB` (both DA_PICKUP and SELF_DROP paths) | `AT_ORIGIN_HUB` | Stores as `eta_updated`; triggers customer notification with updated ETA |
+
+**Rules M9 must follow:**
+- All ETA logic, edge cases, and fallbacks are M9's sole responsibility. M4 stores whatever M9 returns.
+- If M9 cannot compute an ETA, return `null` fields rather than throwing — M4 treats nulls as "ETA unavailable" and does not fail the state transition.
+- `occurredAt` in `EtaRequest` may lag behind wall-clock time due to Kafka processing delay. Always use `occurredAt`, not `Instant.now()`, as the reference point.
+- `assignedFlightId` will be null on the `BOOKED` call; M9 must handle this gracefully with a best-estimate.
+
+---
+
+### 1.4 Notification Service — Send Notification (Async Port)
+
+**Implemented by:** Notification service (separate service, not a numbered module)  
+**Called at:** Multiple state transitions — OTP generation, state changes  
+**Circuit-broken:** No — M4 publishes to Kafka topic `oneday.notifications.requested` and returns immediately. Notification failures do not affect shipment state.
+
+**Interface (already in `common`):**
+
+```java
+// com.oneday.common.port.NotificationPort
+public interface NotificationPort {
+    void send(NotificationRequest request);
+}
+```
+
+**Input (`NotificationRequest` record in `common/port/dto/`):**
+
+```java
+public record NotificationRequest(
+    NotificationEventType type,   // OTP_GENERATED or STATE_CHANGED
+    String recipientPhone,        // E.164 format, e.g. "+919876543210"
+    String recipientEmail,        // nullable; not all customers provide email
+    String shipmentRef,           // human-readable, e.g. "1DD-BLR-20260519-000042"
+    ShipmentState newState,       // the state just entered; null for OTP_GENERATED
+    String otp,                   // 4-digit code; null for STATE_CHANGED
+    Instant eta                   // latest ETA; null if not applicable
+)
+```
+
+**`NotificationEventType` enum (in `common/port/dto/`):**
+
+```java
+public enum NotificationEventType {
+    OTP_GENERATED,   // M4 generated OTP for pickup verification
+    STATE_CHANGED    // shipment entered a new state
+}
+```
+
+**When M4 sends notifications:**
+
+| Trigger | `type` | `otp` | `newState` | `eta` |
+|---|---|---|---|---|
+| DA assigned (entering `PICKUP_ASSIGNED`) | `OTP_GENERATED` | 4-digit OTP | null | null |
+| OTP resend request | `OTP_GENERATED` | fresh 4-digit OTP | null | null |
+| `AT_ORIGIN_HUB` entered (ETA recalculated) | `STATE_CHANGED` | null | `AT_ORIGIN_HUB` | updated ETA |
+| Every other state transition | `STATE_CHANGED` | null | the new state | null |
+| Cancellation | `STATE_CHANGED` | null | `CANCELLED` | null |
+
+**Rules the notification service must follow:**
+- Select channels (SMS/WhatsApp/email) and templates based on `type` and `newState` — M4 does not dictate channel.
+- Own retry logic — M4 fires and forgets on `oneday.notifications.requested`.
+- Mask PII in all logs.
+
+---
+
+### 1.5 M5 — DA Events (Kafka)
+
+**Topic:** `oneday.da.events`  
+**Partition key:** `shipment_id`  
+**Enum class:** `com.oneday.common.kafka.enums.DaEventType`
+
+M4 consumes the following `DaEventType` values and drives state transitions from them:
+
+| `event_type` | State transition M4 performs | Side-effects |
+|---|---|---|
+| `PICKUP_ASSIGNED` | `BOOKED → PICKUP_ASSIGNED` | Generates 4-digit OTP (10-min TTL); sends via `NotificationPort` (type=`OTP_GENERATED`) |
+| `PICKUP_FAILED` | `PICKUP_ASSIGNED → PICKUP_FAILED` | Publishes `STATE_CHANGED` event to `oneday.shipments.events`; M11 will pick it up |
+| `VAN_HANDOFF_COMPLETED` | `PICKED_UP → HANDED_TO_PICKUP_VAN` | None |
+| `DROP_ASSIGNED` | `HANDED_TO_DROP_VAN → DROP_ASSIGNED` | None |
+| `DROP_COLLECTED` | `DROP_ASSIGNED → DROP_COLLECTED` | None |
+| `DROP_COMPLETED` | `DROP_COLLECTED → DROPPED` | None |
+| `DROP_FAILED` | `DROP_COLLECTED → DELIVERY_FAILED` | Publishes `STATE_CHANGED` event; M11 will pick it up |
+
+> **`PICKUP_COMPLETED` is NOT consumed by M4.** M5 may produce it for other consumers (M10), but M4 has no handler for it. `PICKED_UP` is triggered exclusively by the OTP verify HTTP endpoint.
+
+**Minimum required fields M5 must include in every event:**
+
+```json
+{
+  "shipment_id": "<uuid>",
+  "event_type": "<DaEventType value>",
+  "occurred_at": "<ISO 8601 UTC>"
+}
+```
+
+---
+
+### 1.6 M7 — Hub Events (Kafka)
+
+**Topic:** `oneday.hub.events`  
+**Partition key:** `shipment_id`  
+**Enum class:** `com.oneday.common.kafka.enums.HubEventType`
+
+| `event_type` | State transition M4 performs | Applicable path |
+|---|---|---|
+| `STAND_ASSIGNED` | `AT_ORIGIN_HUB → ORIGIN_HUB_PROCESSING` | All |
+| `BAG_CREATED` | `ORIGIN_HUB_PROCESSING → IN_TAKEOFF_BAG` | All |
+| `SAMECITY_OUTBOUND` | `IN_TAKEOFF_BAG → HANDED_TO_DROP_VAN` | SAME_CITY only |
+| `DEST_SORT_COMPLETE` | `AT_DEST_HUB → DEST_HUB_PROCESSING` | INTERCITY only |
+| `DROP_VAN_HANDOFF` | `DEST_HUB_PROCESSING → HANDED_TO_DROP_VAN` | DA_DELIVERY only |
+
+> **OD-9 (open):** The event triggering `DEST_HUB_PROCESSING → AWAITING_HUB_COLLECT` (HUB_COLLECT path) is not yet decided. Recommended: a new `HUB_COLLECT_STAGED` value in `HubEventType`. Team must agree before M7 implementation. M4 will add the handler once the event type is confirmed.
+
+**Minimum required fields per event:**
+
+```json
+{
+  "shipment_id": "<uuid>",
+  "event_type": "<HubEventType value>",
+  "occurred_at": "<ISO 8601 UTC>"
+}
+```
+
+---
+
+### 1.7 M8 — Scan Events (Kafka)
+
+**Topic:** `oneday.scan.events`  
+**Partition key:** `shipment_id`  
+**Enum class:** `com.oneday.common.kafka.enums.ScanEventType`
+
+| `event_type` | State transition M4 performs | Side-effects |
+|---|---|---|
+| `HUB_ORIGIN_IN` | `HANDED_TO_PICKUP_VAN → AT_ORIGIN_HUB` | Calls `EtaPort.fetchEta(AT_ORIGIN_HUB)`; stores as `eta_updated`; sends customer notification with updated ETA |
+| `SELF_DROP_ACCEPTED` | `AWAITING_SELF_DROP → AT_ORIGIN_HUB` | Same side-effects as `HUB_ORIGIN_IN` above |
+| `GHA_ACCEPTANCE` | `DISPATCHED_TO_AIRPORT → AT_AIRPORT` | None |
+| `HUB_DEST_IN` | `DISPATCHED_TO_HUB → AT_DEST_HUB` | None |
+| `LABEL_GENERATED` | **No state transition** | Updates `Shipment.parcel_id` with value from event; sets `label_status = READY` |
+| `HUB_COLLECT_COMPLETED` | `AWAITING_HUB_COLLECT → HUB_COLLECTED` | None |
+
+**Special requirement for `LABEL_GENERATED`:**
+
+M4 emits `ShipmentCreatedEvent` on `oneday.shipments.events` immediately after booking. M8 consumes this event and generates the barcode label. When done, M8 must produce a `LABEL_GENERATED` event on `oneday.scan.events` with the following fields:
+
+```json
+{
+  "shipment_id": "<uuid>",
+  "event_type": "LABEL_GENERATED",
+  "parcel_id": "<M8-assigned barcode string, e.g. '1DDBLR00042'>",
+  "occurred_at": "<ISO 8601 UTC>"
+}
+```
+
+M4 will update `shipments.parcel_id` with this value. **`parcel_id` must be non-null before a shipment reaches `PICKUP_ASSIGNED`** — M4 will fire an ops alert if it is null at that state. This gives M8 the window between booking and DA assignment (typically minutes) to generate the label.
+
+**Minimum required fields per scan event:**
+
+```json
+{
+  "shipment_id": "<uuid>",
+  "event_type": "<ScanEventType value>",
+  "occurred_at": "<ISO 8601 UTC>"
+}
+```
+
+---
+
+### 1.8 M9 — Flight Events (Kafka)
+
+**Topic:** `oneday.flight.events`  
+**Partition key:** `shipment_id`  
+**Enum class:** `com.oneday.common.kafka.enums.FlightEventType`
+
+| `event_type` | State transition M4 performs | Applicable path |
+|---|---|---|
+| `DEPARTED` | `AT_AIRPORT → DEPARTED` | INTERCITY only |
+| `LANDED` | `DEPARTED → LANDED` | INTERCITY only |
+| `RTO_IN_TRANSIT` | `RTO_INITIATED → RTO_IN_TRANSIT` | INTERCITY only |
+
+> M9 produces flight events per shipment (partitioned on `shipment_id`), not per flight. If a single flight carries 200 shipments, M9 must emit 200 individual events — one per shipment.
+
+**Minimum required fields:**
+
+```json
+{
+  "shipment_id": "<uuid>",
+  "event_type": "<FlightEventType value>",
+  "occurred_at": "<ISO 8601 UTC>"
+}
+```
+
+---
+
+### 1.9 M6 — Cron Events (Kafka)
+
+**Topic:** `oneday.cron.events`  
+**Partition key:** `shipment_id`  
+**Enum class:** `com.oneday.common.kafka.enums.CronEventType`
+
+| `event_type` | State transition M4 performs | Applicable path |
+|---|---|---|
+| `DEPARTED_HUB` | `IN_TAKEOFF_BAG → DISPATCHED_TO_AIRPORT` | INTERCITY only |
+| `DEPARTED_AIRPORT` | `LANDED → DISPATCHED_TO_HUB` | INTERCITY only |
+
+> Same as M9: M6 must emit one event per shipment in the bag/van, not one event per van/bag.
+
+**Minimum required fields:**
+
+```json
+{
+  "shipment_id": "<uuid>",
+  "event_type": "<CronEventType value>",
+  "occurred_at": "<ISO 8601 UTC>"
+}
+```
+
+---
+
+### 1.10 M11 — Exception Events (Kafka)
+
+**Topic:** `oneday.exceptions.events`  
+**Partition key:** `shipment_id`  
+**Enum class:** `com.oneday.common.kafka.enums.ExceptionsEventType`
+
+| `event_type` | State transition M4 performs | Notes |
+|---|---|---|
+| `RTO_INITIATED` | `DELIVERY_FAILED → RTO_INITIATED` | M11 triggers this after deciding no further delivery attempt is viable |
+| `PICKUP_RESCHEDULED` | `PICKUP_FAILED → PICKUP_ASSIGNED` | M11 reschedules a failed pickup attempt |
+| `DELIVERY_RESCHEDULED` | `DELIVERY_FAILED → DROP_ASSIGNED` | M11 reschedules a failed delivery attempt |
+| `RTO_COMPLETED` | `RTO_IN_TRANSIT → RTO_COMPLETED` | Terminal state — parcel returned to sender |
+
+> M4 **never self-initiates RTO**. M11 owns the entire failure escalation lifecycle. M4 only records the transitions M11 instructs.
+
+**Minimum required fields:**
+
+```json
+{
+  "shipment_id": "<uuid>",
+  "event_type": "<ExceptionsEventType value>",
+  "occurred_at": "<ISO 8601 UTC>"
+}
+```
+
+---
+
+## 2. What M4 Exposes to Other Modules (Outbound)
+
+---
+
+### 2.1 Kafka Events Produced by M4
+
+**Topic:** `oneday.shipments.events`  
+**Partition key:** `shipment_id`  
+**Serialization:** JSON, snake_case field names (Jackson `SNAKE_CASE` strategy configured globally)
+
+All events share a common envelope:
+
+```json
+{
+  "event_id": "<uuid>",
+  "event_type": "CREATED | STATE_CHANGED | CANCELLED",
+  "schema_version": "1.0",
+  "occurred_at": "<ISO 8601 UTC>",
+  "shipment_id": "<uuid>",
+  "shipment_ref": "1DD-BLR-20260524-000042"
+}
+```
+
+---
+
+#### Event: `CREATED`
+
+Emitted immediately after a successful booking.
+
+**Consumers:** M5 (DA assignment), M8 (label generation), M10 (SLA start)
+
+**Additional fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `customer_type` | `B2C \| B2B \| C2C` | Drives pricing and auth |
+| `payment_mode` | `PREPAID \| COD \| null` | Null for B2B (credit); M5 DA must collect cash for COD at delivery |
+| `delivery_type` | `INTERCITY \| SAME_CITY` | M5 uses this to decide routing logic |
+| `pickup_type` | `DA_PICKUP \| SELF_DROP` | M5 uses this to decide whether to assign a DA |
+| `drop_type` | `DA_DELIVERY \| HUB_COLLECT` | M5 uses this to decide last-mile action |
+| `origin_city` | `String` | City code, e.g. `"BLR"` |
+| `origin_pincode` | `String` | |
+| `origin_tile_id` | `UUID` | Grid tile from M3; M5 uses for DA assignment |
+| `origin_lat` | `Double` | |
+| `origin_lon` | `Double` | |
+| `dest_city` | `String` | |
+| `dest_pincode` | `String` | |
+| `dest_lat` | `Double` | |
+| `dest_lon` | `Double` | |
+| `chargeable_weight_grams` | `Integer` | As computed by M4 and confirmed by M2 |
+| `sla_commitment_minutes` | `Integer` | From M9 EtaResult |
+| `eta_promised` | `Instant` | From M9 EtaResult; M10 uses as SLA deadline |
+| `receiver_name` | `String` | |
+| `receiver_phone` | `String` | |
+| `b2b_account_id` | `UUID \| null` | Null for B2C and C2C |
+| `sender_name` | `String` | M8 uses for label printing |
+| `sender_address_line` | `String` | M8 uses for label printing |
+| `receiver_address_line` | `String` | M8 uses for label printing |
+
+**Java class:** `com.oneday.common.kafka.events.ShipmentCreatedEvent` (extends `BaseShipmentEvent`)
+
+---
+
+#### Event: `STATE_CHANGED`
+
+Emitted on every state transition.
+
+**Consumers:** M10 (SLA tracking), M11 (exception checks), Notification service
+
+**Additional fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `from_state` | `ShipmentState \| null` | Null only for the initial `BOOKED` entry |
+| `to_state` | `ShipmentState` | The new state |
+| `triggered_by` | `String` | Identifier of the actor/service that caused the transition |
+| `trigger_source` | `String` | `API`, `KAFKA_EVENT`, or `SYSTEM` |
+| `eta_updated` | `Instant \| null` | Populated only when EtaPort was called on this transition (at `AT_ORIGIN_HUB`) |
+
+**Java class:** `com.oneday.common.kafka.events.ShipmentStateChangedEvent` (extends `BaseShipmentEvent`)
+
+---
+
+#### Event: `CANCELLED`
+
+Emitted when a shipment is cancelled via the cancellation API.
+
+**Consumers:** M5 (remove from DA queue), M10 (close SLA tracking)
+
+**Additional fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `cancelled_at_state` | `ShipmentState` | The state the shipment was in when cancelled |
+| `reason` | `String` | Customer-provided cancellation reason |
+| `refund_initiated` | `Boolean` | True if a Razorpay refund was triggered |
+| `refund_amount_paise` | `Long \| null` | Null if no refund (COD or B2B) |
+
+**Java class:** `com.oneday.common.kafka.events.ShipmentCancelledEvent` (extends `BaseShipmentEvent`)
+
+---
+
+### 2.2 Internal REST APIs
+
+These endpoints are **not on the public load balancer**. Auth requires an internal service token.
+
+---
+
+#### `GET /internal/v1/shipments/{id}` — Full shipment record
+
+**Used by:** M5, M7, M9, M10, M11
+
+Returns the full `Shipment` entity including all fields. Use this when you need current state or metadata about a shipment identified by its UUID.
+
+---
+
+#### `GET /internal/v1/shipments/by-ref/{ref}` — Lookup by human-readable ref
+
+**Used by:** M7, M8
+
+Example: `GET /internal/v1/shipments/by-ref/1DD-BLR-20260524-000042`
+
+Use when you have a scan event or manifest entry with the human-readable ref but not the UUID.
+
+---
+
+#### `GET /internal/v1/shipments?flight_id={uuid}&state={state}` — Shipments on a flight
+
+**Used by:** M9
+
+| Param | Type | Required | Description |
+|---|---|---|---|
+| `flight_id` | UUID | Yes | Assigned flight UUID |
+| `state` | String | No | Filter by current `ShipmentState` |
+
+M9 uses this to bulk-update states on flight departure and arrival.
+
+---
+
+#### `POST /internal/v1/shipments/{ref}/pickup-otp/verify` — Verify pickup OTP
+
+**Used by:** M5 (DA app calls this after customer provides OTP to DA)
+
+**Request body:**
+```json
+{ "otp": "4821" }
+```
+
+**Behaviour:**
+- Success (`200`): transitions `PICKUP_ASSIGNED → PICKED_UP`; OTP is consumed and invalidated.
+- Wrong OTP (`422 INVALID_OTP`): no state change; DA must retry or call resend.
+- Expired OTP (`422 OTP_EXPIRED`): DA must call the resend endpoint.
+- Wrong state (`409 INVALID_STATE`): shipment is not in `PICKUP_ASSIGNED`.
+
+---
+
+#### `POST /internal/v1/shipments/{ref}/pickup-otp/resend` — Resend pickup OTP
+
+**Used by:** M5 (when DA requests a fresh OTP)
+
+**Behaviour:**
+- Invalidates previous OTP; generates a fresh 4-digit OTP with a new 10-minute TTL.
+- Sends to customer's registered phone via `NotificationPort`.
+- Maximum **3 resends** per pickup attempt; returns `429 RESEND_LIMIT_EXCEEDED` beyond that.
+
+---
+
+#### `PATCH /internal/v1/shipments/{id}/state` — Force state transition
+
+**Used by:** M7 only (for synchronous hub flows — prefer Kafka events in all other cases)
+
+**Request body:**
+```json
+{
+  "target_state": "AT_ORIGIN_HUB",
+  "trigger_source": "KAFKA_EVENT",
+  "event_ref": "kafka-msg-key-abc123",
+  "triggered_by": "m7-hub-service",
+  "notes": "Hub in-scan confirmed at stand 4B"
+}
+```
+
+M4's state machine validates the transition. Returns `409` if the transition is illegal from the current state.
+
+---
+
+## 3. Shared Types Reference
+
+All types below live in the `common` module (`com.oneday.common.*`). Every other module already depends on `common`.
+
+---
+
+### 3.1 ShipmentState Enum (27 values)
+
+```java
+// com.oneday.common.domain.enums.ShipmentState
+BOOKED
+PICKUP_ASSIGNED         // DA_PICKUP only
+PICKED_UP               // DA_PICKUP only
+HANDED_TO_PICKUP_VAN    // DA_PICKUP only
+AWAITING_SELF_DROP      // SELF_DROP only
+AT_ORIGIN_HUB
+ORIGIN_HUB_PROCESSING
+IN_TAKEOFF_BAG
+DISPATCHED_TO_AIRPORT   // INTERCITY only
+AT_AIRPORT              // INTERCITY only
+DEPARTED                // INTERCITY only
+LANDED                  // INTERCITY only
+DISPATCHED_TO_HUB       // INTERCITY only
+AT_DEST_HUB             // INTERCITY only
+DEST_HUB_PROCESSING     // INTERCITY only
+HANDED_TO_DROP_VAN
+DROP_ASSIGNED           // DA_DELIVERY only
+DROP_COLLECTED          // DA_DELIVERY only
+DROPPED                 // DA_DELIVERY only (terminal success)
+AWAITING_HUB_COLLECT    // HUB_COLLECT only
+HUB_COLLECTED           // HUB_COLLECT only (terminal success)
+PICKUP_FAILED
+DELIVERY_FAILED
+RTO_INITIATED
+RTO_IN_TRANSIT          // INTERCITY only
+RTO_COMPLETED           // terminal success (returned to sender)
+CANCELLED               // terminal
+```
+
+**SQL ENUM** (`shipment_state` in PostgreSQL) has the same 27 values in the same order.
+
+---
+
+### 3.2 Other Domain Enums
+
+```java
+// com.oneday.common.domain.enums.CustomerType
+B2C, B2B, C2C
+
+// com.oneday.common.domain.enums.DeliveryType
+INTERCITY, SAME_CITY
+
+// com.oneday.common.domain.enums.PaymentMode
+PREPAID, COD
+
+// com.oneday.common.domain.enums.PickupType
+DA_PICKUP, SELF_DROP
+
+// com.oneday.common.domain.enums.DropType
+DA_DELIVERY, HUB_COLLECT
+```
+
+---
+
+### 3.3 Kafka Topics
+
+```java
+// com.oneday.common.kafka.KafkaTopics
+SHIPMENTS_EVENTS        = "oneday.shipments.events"       // produced by M4
+DA_EVENTS               = "oneday.da.events"              // produced by M5, consumed by M4
+HUB_EVENTS              = "oneday.hub.events"             // produced by M7, consumed by M4
+SCAN_EVENTS             = "oneday.scan.events"            // produced by M8, consumed by M4
+FLIGHT_EVENTS           = "oneday.flight.events"          // produced by M9, consumed by M4
+CRON_EVENTS             = "oneday.cron.events"            // produced by M6, consumed by M4
+EXCEPTIONS_EVENTS       = "oneday.exceptions.events"      // produced by M11, consumed by M4
+NOTIFICATIONS_REQUESTED = "oneday.notifications.requested"// consumed by notification service
+SHIPMENTS_DLQ           = "oneday.shipments.dlq"          // M4 dead-letter queue
+```
+
+---
+
+## 4. Event Routing: What Triggers What
+
+Complete mapping of every incoming Kafka event to the state transition M4 performs:
+
+| Source module | `event_type` | From state | To state |
+|---|---|---|---|
+| M5 | `PICKUP_ASSIGNED` | `BOOKED` | `PICKUP_ASSIGNED` + OTP sent |
+| M5 | `PICKUP_FAILED` | `PICKUP_ASSIGNED` | `PICKUP_FAILED` |
+| M5 | `VAN_HANDOFF_COMPLETED` | `PICKED_UP` | `HANDED_TO_PICKUP_VAN` |
+| M5 | `DROP_ASSIGNED` | `HANDED_TO_DROP_VAN` | `DROP_ASSIGNED` |
+| M5 | `DROP_COLLECTED` | `DROP_ASSIGNED` | `DROP_COLLECTED` |
+| M5 | `DROP_COMPLETED` | `DROP_COLLECTED` | `DROPPED` |
+| M5 | `DROP_FAILED` | `DROP_COLLECTED` | `DELIVERY_FAILED` |
+| M7 | `STAND_ASSIGNED` | `AT_ORIGIN_HUB` | `ORIGIN_HUB_PROCESSING` |
+| M7 | `BAG_CREATED` | `ORIGIN_HUB_PROCESSING` | `IN_TAKEOFF_BAG` |
+| M7 | `SAMECITY_OUTBOUND` | `IN_TAKEOFF_BAG` | `HANDED_TO_DROP_VAN` *(SAME_CITY only)* |
+| M7 | `DEST_SORT_COMPLETE` | `AT_DEST_HUB` | `DEST_HUB_PROCESSING` |
+| M7 | `DROP_VAN_HANDOFF` | `DEST_HUB_PROCESSING` | `HANDED_TO_DROP_VAN` |
+| M7 | *(TBD — OD-9)* | `DEST_HUB_PROCESSING` | `AWAITING_HUB_COLLECT` *(HUB_COLLECT only)* |
+| M8 | `HUB_ORIGIN_IN` | `HANDED_TO_PICKUP_VAN` | `AT_ORIGIN_HUB` + ETA recalculated |
+| M8 | `SELF_DROP_ACCEPTED` | `AWAITING_SELF_DROP` | `AT_ORIGIN_HUB` + ETA recalculated |
+| M8 | `GHA_ACCEPTANCE` | `DISPATCHED_TO_AIRPORT` | `AT_AIRPORT` |
+| M8 | `HUB_DEST_IN` | `DISPATCHED_TO_HUB` | `AT_DEST_HUB` |
+| M8 | `LABEL_GENERATED` | *(no transition)* | Updates `parcel_id` only |
+| M8 | `HUB_COLLECT_COMPLETED` | `AWAITING_HUB_COLLECT` | `HUB_COLLECTED` |
+| M9 | `DEPARTED` | `AT_AIRPORT` | `DEPARTED` |
+| M9 | `LANDED` | `DEPARTED` | `LANDED` |
+| M9 | `RTO_IN_TRANSIT` | `RTO_INITIATED` | `RTO_IN_TRANSIT` *(INTERCITY only)* |
+| M6 | `DEPARTED_HUB` | `IN_TAKEOFF_BAG` | `DISPATCHED_TO_AIRPORT` *(INTERCITY only)* |
+| M6 | `DEPARTED_AIRPORT` | `LANDED` | `DISPATCHED_TO_HUB` |
+| M11 | `RTO_INITIATED` | `DELIVERY_FAILED` | `RTO_INITIATED` |
+| M11 | `PICKUP_RESCHEDULED` | `PICKUP_FAILED` | `PICKUP_ASSIGNED` |
+| M11 | `DELIVERY_RESCHEDULED` | `DELIVERY_FAILED` | `DROP_ASSIGNED` |
+| M11 | `RTO_COMPLETED` | `RTO_IN_TRANSIT` | `RTO_COMPLETED` |
+
+**Any transition not in this table will be rejected with a `409` and the event will be parked on `oneday.shipments.dlq`.**
+
+---
+
+## 5. Critical Rules All Teams Must Follow
+
+**1. Always use `shipment_id` as the Kafka partition key.**  
+M4 processes events per-shipment serially on a single partition. If you use a different key (e.g. DA ID, flight ID), M4 may receive events for the same shipment out of order, causing DLQ parking and requiring manual ops replay.
+
+**2. Always include `shipment_id`, `event_type`, and `occurred_at` in every event.**  
+These are the minimum fields M4 requires to route and process the event. Missing any of these will cause M4 to park the event on DLQ.
+
+**3. Use `occurred_at` for the timestamp of the physical event, not `Instant.now()` at publish time.**  
+M4 and M9 use `occurred_at` for ETA calculations and audit history. Publish lag must not contaminate event timestamps.
+
+**4. Produce one event per shipment, not one event per bag/flight/van.**  
+M5, M6, M7, and M9 all handle batches (bags, flights, van loads). For any batch operation that affects multiple shipments, you must emit one Kafka event per shipment. M4 has no concept of batches.
+
+**5. Do not call M4's internal HTTP endpoints for state transitions that have a corresponding Kafka event.**  
+`PATCH /internal/v1/shipments/{id}/state` exists for M7 synchronous hub flows only. Every other module must drive state changes via Kafka. HTTP state-patch bypasses the consumer group, breaks replay capabilities, and creates split audit trails.
+
+**6. `parcel_id` must be populated before `PICKUP_ASSIGNED`.**  
+M8 must emit `LABEL_GENERATED` (with `parcel_id`) before a DA is assigned. M4 fires an ops alert if `parcel_id` is null when `PICKUP_ASSIGNED` arrives.
+
+**7. Respect the `serviceable=false` contract in `ServiceabilityResult`.**  
+M3 must never throw an exception for an unserviceable pincode — return a result object with `serviceable=false`. M4 maps this to a user-facing `422`.
+
+**8. Jackson `SNAKE_CASE` is configured globally.**  
+All Kafka events produced by M4 use snake_case JSON field names (e.g. `shipment_id`, not `shipmentId`). Consumers must deserialize accordingly.
+
+---
+
+## 6. Open Decisions Blocking Integration
+
+| ID | Decision | Blocks | Status |
+|---|---|---|---|
+| OD-8 | Delivery verification mechanism — OTP (recommended, mirrors pickup) or QR scan | M5 DA app, M4 `DROP_COMPLETED` handler | Open |
+| OD-9 | Event that triggers `DEST_HUB_PROCESSING → AWAITING_HUB_COLLECT` | M7, M4 hub consumer | Open — recommended: new `HUB_COLLECT_STAGED` in `HubEventType` |
+| OD-2 | ETA circuit breaking — fail booking or proceed with null ETA if M9 is down | M9 integration | Open — M9 team to decide |
+
+Teams blocked by these decisions should not begin implementation of the affected flows until the decisions are resolved and this document is updated.

--- a/docs/M4/M4-ORDERS-DESIGN.md
+++ b/docs/M4/M4-ORDERS-DESIGN.md
@@ -142,10 +142,11 @@ Every other module either feeds state into M4 via Kafka or reads shipment data f
 **EtaPort interface:**
 ```java
 public interface EtaPort {
-    EtaResult fetchEta(UUID shipmentId, ShipmentState state, EtaContext context);
-    // state: the current or target state at the time of the call
-    // context: origin_city, dest_city, delivery_type, booked_at, assigned_flight_id (if known)
-    // M9 interprets state and context to decide which ETA logic to apply
+    EtaResult fetchEta(EtaRequest request);
+    // EtaRequest: shipmentId, currentState, occurredAt, EtaContext
+    // occurredAt: when the current state was entered — NOT wall-clock now; critical when Kafka has lag
+    // EtaContext: origin_city, dest_city, delivery_type, booked_at, assigned_flight_id (if known)
+    // M9 interprets currentState and context to decide which ETA logic to apply
 }
 ```
 

--- a/docs/M4/M4-ORDERS-DESIGN.md
+++ b/docs/M4/M4-ORDERS-DESIGN.md
@@ -3,10 +3,10 @@
 | Field | Value |
 |---|---|
 | **Module** | M4 — Orders |
-| **Version** | 0.3 |
-| **Status** | Draft — pending ops sign-off on state machine |
+| **Version** | 0.4 |
+| **Status** | Draft — PRs #1–8 complete; REST API (PR #9+) next |
 | **Author** | Satvik |
-| **Last updated** | 2026-05-12 |
+| **Last updated** | 2026-05-29 |
 | **Depends on** | M1 (auth/JWT), M2 (pricing — sync), M3 (grid/serviceability — sync), M8 (barcode/label — async via Kafka) |
 | **Consumed by** | M5 (dispatch), M6 (routing), M7 (hub), M9 (airline), M10 (SLA), M11 (exceptions) |
 | **Related docs** | [MODULES.md](../MODULES.md) · [DECISIONS.md](../DECISIONS.md) · [M8-BARCODE-DESIGN.md](../M8-BARCODE-DESIGN.md) · [PRD-ONE-DAY-DELIVERY.md](../PRD-ONE-DAY-DELIVERY.md) |
@@ -836,7 +836,7 @@ Validation failures return `400 Bad Request` with a structured error body:
 
 **Booking flow (synchronous):**
 ```
-1.  Check Idempotency-Key → if exists, return cached response (200)
+1.  Check Idempotency-Key → if exists, return cached response (original HTTP status + original body)
 2.  Validate all fields (see §7.2)
 3.  Call M3 ServiceabilityPort.check(originPincode, destPincode)
      → 422 UNSERVICEABLE if either pincode is not covered
@@ -1508,6 +1508,8 @@ Files follow the `V4_N__description.sql` convention (M4 = module 4). Location re
 | `V4_6__create_b2b_accounts.sql` | `b2b_accounts` table, `trg_b2b_accounts_updated_at` trigger |
 | `V4_7__create_idempotency_keys.sql` | `idempotency_keys` table, expiry index |
 | `V4_8__create_shipment_ref_counters.sql` | `shipment_ref_counters` table |
+| `V4_9__add_idempotency_key_unique.sql` | `UNIQUE` constraint on `shipments.idempotency_key`; NULLs permitted for B2B batch imports |
+| `V4_10__add_request_fingerprint_to_idempotency_keys.sql` | `request_fingerprint VARCHAR(64) NULL` column on `idempotency_keys`; SHA-256 of canonical request body for body-mismatch detection |
 
 Full SQL for reference:
 
@@ -1889,13 +1891,26 @@ All M4 log entries include:
 
 ## 14. Configuration Reference
 
-All properties under namespace `oneday.orders.*` in `application.yml`:
+### 14.1 Idempotency (implemented — PR #8)
+
+Bound by `IdempotencyProperties` under `orders.idempotency.*`:
+
+```yaml
+orders:
+  idempotency:
+    ttl: 24h                          # Idempotency key retention period (default: 24h)
+    apply-to-path-pattern: /api/v1/** # Ant path pattern — filter only applies to matching URLs
+    purge-cron: "0 0 2 * * *"         # Nightly purge schedule (default: 02:00 IST)
+```
+
+### 14.2 Planned configuration (future PRs)
+
+All planned properties under namespace `oneday.orders.*` in `application.yml` (not yet implemented):
 
 ```yaml
 oneday:
   orders:
     booking:
-      idempotency-key-ttl-hours: 24       # Idempotency key expiry
       max-weight-grams: 70000             # Hard upper limit; rejects bookings above
     state-machine:
       kafka-consumer-group: m4-shipment-state-consumer

--- a/docs/M4/M4-ORDERS-DESIGN.md
+++ b/docs/M4/M4-ORDERS-DESIGN.md
@@ -3,10 +3,10 @@
 | Field | Value |
 |---|---|
 | **Module** | M4 — Orders |
-| **Version** | 0.4 |
-| **Status** | Draft — PRs #1–8 complete; REST API (PR #9+) next |
+| **Version** | 0.5 |
+| **Status** | Draft — PRs #1–9 complete; B2C booking API (PR #10+) next |
 | **Author** | Satvik |
-| **Last updated** | 2026-05-29 |
+| **Last updated** | 2026-05-30 |
 | **Depends on** | M1 (auth/JWT), M2 (pricing — sync), M3 (grid/serviceability — sync), M8 (barcode/label — async via Kafka) |
 | **Consumed by** | M5 (dispatch), M6 (routing), M7 (hub), M9 (airline), M10 (SLA), M11 (exceptions) |
 | **Related docs** | [MODULES.md](../MODULES.md) · [DECISIONS.md](../DECISIONS.md) · [M8-BARCODE-DESIGN.md](../M8-BARCODE-DESIGN.md) · [PRD-ONE-DAY-DELIVERY.md](../PRD-ONE-DAY-DELIVERY.md) |
@@ -427,6 +427,24 @@ Atomic sequence for generating human-readable shipment references.
 | `next_val` | INTEGER | Incremented with `SELECT ... FOR UPDATE` |
 
 > **Known bottleneck:** Row-level lock on `(city_code, date_key)` serialises concurrent bookings per city per day. At volumes above ~500 bookings/min per city, consider migrating to Redis `INCR` with a Lua script that atomically increments and returns the counter, syncing to DB asynchronously. See §15.5.
+
+---
+
+#### `PickupOtp`
+
+Stores the BCrypt-hashed OTP for DA pickup verification. Exactly one row exists per shipment while an OTP is active. On resend the old row is deleted and a new one inserted — the unique index on `shipment_id` enforces this at the DB level.
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | UUID | PK |
+| `shipment_id` | UUID | FK to `shipments`; UNIQUE index (one active OTP per shipment) |
+| `otp_hash` | VARCHAR(60) | BCrypt hash of the 4-digit OTP (cleartext is never stored) |
+| `expires_at` | TIMESTAMPTZ | 10 minutes from generation; checked at verify time |
+| `used` | BOOLEAN | Set to `true` on first successful verification; prevents replay within TTL |
+| `resend_count` | SMALLINT | How many times `/resend` has been called; capped at 3 by application logic |
+| `created_at` | TIMESTAMPTZ | |
+
+> Rows are deleted on resend (not updated). This is the only entity in M4 with a delete-on-replace pattern.
 
 ---
 
@@ -1177,10 +1195,10 @@ Called by M5 DA app after customer provides OTP to DA.
 
 **Behaviour:**
 - Looks up active OTP for this shipment; verifies value and TTL
-- On success: transitions `PICKUP_ASSIGNED → PICKED_UP`; marks OTP consumed; returns `200`
-- On wrong OTP: returns `422 INVALID_OTP`
-- On expired OTP: returns `422 OTP_EXPIRED` — DA must call resend endpoint
-- On state not `PICKUP_ASSIGNED`: returns `409 INVALID_STATE`
+- On success: transitions `PICKUP_ASSIGNED → PICKED_UP`; marks OTP consumed; returns `204 No Content`
+- On wrong OTP: returns `422`
+- On expired OTP: returns `422` — DA must call resend endpoint
+- On state not `PICKUP_ASSIGNED`: returns `409`
 
 ---
 
@@ -1241,68 +1259,67 @@ When a B2B account has a registered webhook URL:
 
 ### 8.1 Package Structure
 
+The listing below shows what exists in the codebase as of PR #9. Files without a suffix note are fully implemented. Future PRs add to this structure.
+
 ```
 com.oneday.orders/
   api/
-    B2cShipmentController.java
-    B2bShipmentController.java
-    TrackingController.java
-    InternalShipmentController.java
-    RazorpayWebhookController.java
-  service/
-    ShipmentService.java              ← public interface
-    impl/
-      ShipmentServiceImpl.java        ← package-private
-      ShipmentStateMachine.java       ← package-private
-      CancellationService.java        ← package-private
-      IdempotencyService.java         ← package-private
-      B2bCreditService.java           ← package-private
-      WebhookDeliveryService.java     ← package-private
+    PickupOtpController.java          ← POST /internal/v1/shipments/{ref}/pickup-otp/verify|resend
+    filter/
+      IdempotencyFilter.java          ← OncePerRequestFilter; idempotency header enforcement
+  config/
+    IdempotencyProperties.java        ← @ConfigurationProperties(prefix="orders.idempotency")
+    PickupOtpProperties.java          ← @ConfigurationProperties(prefix="orders.otp")
   domain/
     Shipment.java
-    ShipmentState.java
-    DeliveryType.java
-    CustomerType.java
     ShipmentStateHistory.java
     PaymentTransaction.java
     B2bAccount.java
     IdempotencyKey.java
+    IdempotencyKeyId.java             ← @EmbeddedId for composite PK (key, user_id)
+    ShipmentRefCounter.java
+    ShipmentRefCounterId.java         ← @EmbeddedId for composite PK (city_code, date_key)
+    PickupOtp.java                    ← OTP hash storage; BCrypt; one row per shipment
+    enums/
+      PaymentStatus.java
+      RefundStatus.java
+      TriggerSource.java
+  dto/
+    OtpVerifyRequest.java             ← @NotBlank @Pattern(regexp="\\d{4}") String otp
   repository/
     ShipmentRepository.java
     ShipmentStateHistoryRepository.java
     PaymentTransactionRepository.java
     B2bAccountRepository.java
     IdempotencyKeyRepository.java
-    ShipmentRefCounterRepository.java
-  events/
-    ShipmentEventProducer.java        ← Kafka producer
-    ShipmentEventConsumer.java        ← Kafka consumer
-    WebhookEventQueue.java            ← In-memory queue for B2B webhook dispatch
-  dto/
-    request/
-      BookingRequest.java
-      CancellationRequest.java
-      StateTransitionRequest.java
-    response/
-      BookingResponse.java
-      TrackingResponse.java
-      ShipmentSummaryResponse.java
-  port/
-    ServiceabilityPort.java
-    PricingPort.java
-    EtaPort.java
-    PaymentPort.java
-    NotificationPort.java
-    dto/
-      ServiceabilityResult.java
-      QuoteRequest.java       ← port contract sent to M2; distinct from BookingRequest above
-      QuoteResult.java
-      EtaRequest.java
-      EtaContext.java
-      EtaResult.java
-      NotificationRequest.java
-      NotificationEventType.java
-  // M8 (barcode) has no port interface — M8 subscribes to shipment.created via Kafka
+    ShipmentRefCounterRepository.java ← includes insertIfAbsent native query
+    PickupOtpRepository.java          ← findByShipmentId, findByShipmentIdWithLock, deleteByShipmentId
+  service/
+    ShipmentStateMachine.java         ← public interface
+    TransitionRegistry.java           ← extensible transition map
+    TransitionRegistryConfigurer.java ← configures all legal transitions at startup
+    TransitionContext.java            ← value object: triggeredBy, triggerSource, eventRef
+    CustomerVisibleStateMapper.java   ← maps ShipmentState → customer-facing label
+    IdempotencyKeyPurgeJob.java       ← @Scheduled nightly purge of expired idempotency_keys rows
+    ShipmentRefService.java           ← public interface: generateRef(originCityCode)
+    DeliveryTypeResolver.java         ← @Component; origin==dest → SAME_CITY, else INTERCITY
+    PaymentPort.java                  ← Razorpay port (orders-local; not in common)
+    PickupOtpService.java             ← public interface: generate, verify, resend
+    service/exception/
+      IllegalStateTransitionException.java
+    impl/
+      ShipmentStateMachineImpl.java   ← package-private
+      ShipmentRefServiceImpl.java     ← package-private; Propagation.MANDATORY
+      PickupOtpServiceImpl.java       ← package-private; BCrypt(4); pessimistic-lock verify
+  // Cross-module port interfaces live in common, not here:
+  //   common.port.ServiceabilityPort (M3 implements)
+  //   common.port.PricingPort        (M2 implements)
+  //   common.port.EtaPort            (M9 implements)
+  //   common.port.NotificationPort   (notification service implements)
+  // M8 (barcode) has no port interface — M8 subscribes to shipment.created via Kafka.
+  // Future PRs add: B2cShipmentController, B2bShipmentController, TrackingController,
+  //   InternalShipmentController, RazorpayWebhookController, ShipmentEventProducer,
+  //   ShipmentEventConsumer, WebhookDeliveryService, and all booking/tracking DTOs.
 ```
 
 ---
@@ -1345,12 +1362,18 @@ public interface EtaPort {
 // has everything it needs to generate a complete label without calling back to M4.
 // M8 is NOT in the circuit breaker list; its unavailability does not block bookings.
 
-// Payment — Razorpay
+// Payment — Razorpay (local to orders module — not in common)
+// com.oneday.orders.service.PaymentPort
 public interface PaymentPort {
-    void verifySignature(String orderId, String paymentId, String signature);
-    // Throws PaymentVerificationException on mismatch
-    CaptureResult capture(String paymentId, long amountPaise);
-    RefundResult initiateRefund(String paymentId, long amountPaise, String reason);
+    void verifySignature(String razorpayOrderId, String razorpayPaymentId, String signature);
+    // Throws PaymentPort.PaymentVerificationException on mismatch
+
+    void capture(String razorpayPaymentId, long amountPaise);
+    // Throws PaymentPort.PaymentCaptureException on failure
+
+    String initiateRefund(String razorpayPaymentId, long amountPaise);
+    // Returns Razorpay refund ID (e.g. "rfnd_xxxxxxxx"); throws PaymentPort.PaymentRefundException on failure
+    // Inner unchecked exceptions: PaymentVerificationException, PaymentCaptureException, PaymentRefundException
 }
 
 // Notifications
@@ -1510,6 +1533,7 @@ Files follow the `V4_N__description.sql` convention (M4 = module 4). Location re
 | `V4_8__create_shipment_ref_counters.sql` | `shipment_ref_counters` table |
 | `V4_9__add_idempotency_key_unique.sql` | `UNIQUE` constraint on `shipments.idempotency_key`; NULLs permitted for B2B batch imports |
 | `V4_10__add_request_fingerprint_to_idempotency_keys.sql` | `request_fingerprint VARCHAR(64) NULL` column on `idempotency_keys`; SHA-256 of canonical request body for body-mismatch detection |
+| `V4_11__create_pickup_otps.sql` | `pickup_otps` table (`id`, `shipment_id` FK, `otp_hash`, `expires_at`, `used`, `resend_count`, `created_at`); unique index on `shipment_id`; expiry index |
 
 Full SQL for reference:
 
@@ -1692,6 +1716,22 @@ CREATE TABLE shipment_ref_counters (
   next_val   INTEGER     NOT NULL DEFAULT 1,
   PRIMARY KEY (city_code, date_key)
 );
+
+-- Pickup OTPs (V4_11 — PR #9)
+CREATE TABLE pickup_otps (
+  id             UUID         NOT NULL DEFAULT gen_random_uuid(),
+  shipment_id    UUID         NOT NULL REFERENCES shipments(id),
+  otp_hash       VARCHAR(60)  NOT NULL,   -- BCrypt output is always 60 chars
+  expires_at     TIMESTAMPTZ  NOT NULL,
+  used           BOOLEAN      NOT NULL DEFAULT FALSE,
+  resend_count   SMALLINT     NOT NULL DEFAULT 0,
+  created_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  CONSTRAINT pk_pickup_otps PRIMARY KEY (id)
+);
+
+-- One active OTP row per shipment; deleted and re-inserted on resend.
+CREATE UNIQUE INDEX uq_pickup_otps_shipment ON pickup_otps(shipment_id);
+CREATE INDEX idx_pickup_otps_expires ON pickup_otps(expires_at);
 ```
 
 ---
@@ -1903,7 +1943,18 @@ orders:
     purge-cron: "0 0 2 * * *"         # Nightly purge schedule (default: 02:00 IST)
 ```
 
-### 14.2 Planned configuration (future PRs)
+### 14.2 Pickup OTP (implemented — PR #9)
+
+Bound by `PickupOtpProperties` under `orders.otp.*`:
+
+```yaml
+orders:
+  otp:
+    ttl-minutes: 10       # How long a generated OTP is valid (default: 10 minutes)
+    max-resend-count: 3   # Maximum resend attempts before 429 is returned (default: 3)
+```
+
+### 14.3 Planned configuration (future PRs)
 
 All planned properties under namespace `oneday.orders.*` in `application.yml` (not yet implemented):
 

--- a/docs/M4/M4-ORDERS-DESIGN.md
+++ b/docs/M4/M4-ORDERS-DESIGN.md
@@ -169,7 +169,7 @@ public interface EtaPort {
 
 ### KDD-6: Idempotency on the booking endpoint
 
-**Decision:** `POST /api/v1/b2c/shipments` and `POST /api/v1/b2b/shipments` accept an `Idempotency-Key` header. Duplicate requests with the same key within 24 hours return the original response (HTTP 200 + original body).
+**Decision:** `POST /api/v1/b2c/shipments` and `POST /api/v1/b2b/shipments` accept an `Idempotency-Key` header. Duplicate requests with the same key within 24 hours return the original response (original HTTP status + original body).
 
 **Rationale:** Network retries and client-side double-clicks are inevitable. Without idempotency, a Razorpay capture could succeed while the DB write fails, leaving the customer charged but without a shipment.
 
@@ -1999,7 +1999,7 @@ oneday:
 
 | ID | Edge Case | How M4 Handles It |
 |---|---|---|
-| E1 | Client submits duplicate booking with same Idempotency-Key | Return original response (200 + original body); no duplicate Shipment created |
+| E1 | Client submits duplicate booking with same Idempotency-Key | Return original response (original HTTP status + original body); no duplicate Shipment created |
 | E2 | Razorpay captured but DB write failed | See §15.4 — retry with same idempotency key; Razorpay idempotency absorbs duplicate capture |
 | E3 | Same pincode for origin and dest | `delivery_type = SAME_CITY`; air leg states are skipped |
 | E4 | Kafka event arrives out of order | State machine rejects; event parked to DLQ with `OUT_OF_ORDER` reason |

--- a/orders/pom.xml
+++ b/orders/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>test</scope>

--- a/orders/pom.xml
+++ b/orders/pom.xml
@@ -40,5 +40,15 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/orders/pom.xml
+++ b/orders/pom.xml
@@ -36,5 +36,9 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/orders/src/main/java/com/oneday/orders/api/PickupOtpController.java
+++ b/orders/src/main/java/com/oneday/orders/api/PickupOtpController.java
@@ -1,0 +1,136 @@
+package com.oneday.orders.api;
+
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.dto.OtpVerifyRequest;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.service.PickupOtpService;
+import com.oneday.orders.service.ShipmentStateMachine;
+import com.oneday.orders.service.TransitionContext;
+import com.oneday.common.domain.enums.ShipmentState;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Map;
+
+/**
+ * Internal endpoints for DA pickup OTP verification.
+ *
+ * <p>These endpoints are on {@code /internal/v1/} and are called by the DA mobile
+ * app (not exposed to end customers). Full {@code X-Service-Token} authentication
+ * is added in PR #18 when the internal-endpoint auth infrastructure is built.
+ * Until then these paths must be behind the existing JWT security filter —
+ * only authenticated principals can reach them.</p>
+ */
+@RestController
+@RequestMapping("/internal/v1/shipments")
+public class PickupOtpController {
+
+    private final ShipmentRepository shipmentRepository;
+    private final PickupOtpService pickupOtpService;
+    private final ShipmentStateMachine stateMachine;
+
+    public PickupOtpController(ShipmentRepository shipmentRepository,
+                               PickupOtpService pickupOtpService,
+                               ShipmentStateMachine stateMachine) {
+        this.shipmentRepository = shipmentRepository;
+        this.pickupOtpService   = pickupOtpService;
+        this.stateMachine       = stateMachine;
+    }
+
+    /**
+     * DA submits the OTP shown by the sender. On success the shipment transitions
+     * {@code PICKUP_ASSIGNED → PICKED_UP}.
+     *
+     * <pre>
+     * POST /internal/v1/shipments/{ref}/pickup-otp/verify
+     * Body: { "otp": "4821" }
+     *
+     * 204 No Content — OTP correct; state transitioned
+     * 409 Conflict   — shipment is not in PICKUP_ASSIGNED state
+     * 422 Unprocessable Entity — OTP wrong / expired / already used
+     * 404 Not Found  — shipment ref does not exist
+     * </pre>
+     */
+    @Transactional
+    @PostMapping("/{ref}/pickup-otp/verify")
+    public ResponseEntity<Void> verifyOtp(@PathVariable String ref,
+                                          @Valid @RequestBody OtpVerifyRequest request) {
+        Shipment shipment = resolveShipment(ref);
+
+        if (shipment.getState() != ShipmentState.PICKUP_ASSIGNED) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Shipment is not in PICKUP_ASSIGNED state");
+        }
+
+        try {
+            pickupOtpService.verify(shipment.getId(), request.getOtp());
+        } catch (PickupOtpService.OtpVerificationException e) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, e.getMessage());
+        }
+
+        // OTP verified — transition state.
+        // triggeredBy = "da-app" (internal caller); eventRef = ref for correlation.
+        // TODO (PR #18): replace "da-app" with the authenticated DA user ID from the service token.
+        TransitionContext ctx = TransitionContext.fromApi("da-app", ref);
+        stateMachine.transition(shipment.getId(), ShipmentState.PICKED_UP, ctx);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * DA requests a fresh OTP (e.g. sender did not receive the SMS). Invalidates
+     * the previous OTP and generates a new one. The new cleartext OTP is returned
+     * to the caller who must forward it via the notification service.
+     *
+     * <p><strong>Note:</strong> In the full flow the notification is triggered here
+     * server-side (calling {@code NotificationPort}). That wiring is added in PR #10
+     * alongside the booking flow. For now the OTP is returned in the response body
+     * so the DA app can display it as a fallback.</p>
+     *
+     * <pre>
+     * POST /internal/v1/shipments/{ref}/pickup-otp/resend
+     * Body: (empty)
+     *
+     * 200 OK         — { "otp": "3902" }   new OTP (sent to sender; also returned for DA display)
+     * 404 Not Found  — shipment ref does not exist
+     * 429 Too Many Requests — resend limit (3) reached
+     * </pre>
+     */
+    @PostMapping("/{ref}/pickup-otp/resend")
+    public ResponseEntity<Map<String, String>> resendOtp(@PathVariable String ref) {
+        Shipment shipment = resolveShipment(ref);
+
+        if (shipment.getState() != ShipmentState.PICKUP_ASSIGNED) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Shipment is not in PICKUP_ASSIGNED state");
+        }
+
+        try {
+            String newOtp = pickupOtpService.resend(shipment.getId());
+            // TODO (PR #10): call NotificationPort to SMS the new OTP to the sender.
+            return ResponseEntity.ok(Map.of("otp", newOtp));
+        } catch (PickupOtpService.ResendLimitExceededException e) {
+            throw new ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS, e.getMessage());
+        } catch (PickupOtpService.OtpVerificationException e) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, e.getMessage());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private Shipment resolveShipment(String ref) {
+        return shipmentRepository.findByShipmentRef(ref)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Shipment not found: " + ref));
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/api/filter/IdempotencyFilter.java
+++ b/orders/src/main/java/com/oneday/orders/api/filter/IdempotencyFilter.java
@@ -97,12 +97,10 @@ public class IdempotencyFilter extends OncePerRequestFilter {
     /** Maximum allowed length for the Idempotency-Key header value (matches DB column). */
     private static final int MAX_KEY_LENGTH = 100;
 
-    /**
-     * ObjectMapper configured to write JSON with keys sorted alphabetically.
-     * Used to produce the canonical form for fingerprinting.
-     * {@link ObjectMapper} is thread-safe after configuration and safe to share.
-     */
-    /** Shared mapper for reading and writing canonical JSON. Thread-safe after construction. */
+    // Deliberately a bare ObjectMapper (no custom serializers) so the fingerprint is
+    // unaffected by application-level Jackson configuration on the injected objectMapper.
+    // Key sorting is done explicitly in sortKeysRecursively(), not via a mapper feature.
+    // ObjectMapper is thread-safe after construction and safe to share.
     private static final ObjectMapper CANONICAL_MAPPER = new ObjectMapper();
 
     private final IdempotencyKeyRepository repository;
@@ -209,7 +207,9 @@ public class IdempotencyFilter extends OncePerRequestFilter {
                 wrappedResponse.copyBodyToResponse();
                 return;
             }
-            // Key is present but expired — fall through and treat as a miss
+            // Key is present but expired — delete it so the subsequent save() performs
+            // an INSERT rather than a no-op merge() against the updatable=false columns.
+            repository.deleteById(keyId);
         }
 
         // 9. Miss — let the handler run
@@ -266,7 +266,7 @@ public class IdempotencyFilter extends OncePerRequestFilter {
      */
     static String sha256HexCanonical(byte[] bytes) {
         if (bytes == null || bytes.length == 0) {
-            return sha256Hex(bytes != null ? bytes : new byte[0]);
+            return sha256Hex(new byte[0]);
         }
         try {
             JsonNode tree = CANONICAL_MAPPER.readTree(bytes);

--- a/orders/src/main/java/com/oneday/orders/api/filter/IdempotencyFilter.java
+++ b/orders/src/main/java/com/oneday/orders/api/filter/IdempotencyFilter.java
@@ -1,0 +1,217 @@
+package com.oneday.orders.api.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.orders.config.IdempotencyProperties;
+import com.oneday.orders.domain.IdempotencyKey;
+import com.oneday.orders.domain.IdempotencyKeyId;
+import com.oneday.orders.repository.IdempotencyKeyRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Servlet filter that enforces idempotency for non-safe HTTP methods (POST).
+ *
+ * <h2>Protocol</h2>
+ * <ol>
+ *   <li>Client sends {@code Idempotency-Key: <uuid-or-any-string>} header on every POST.</li>
+ *   <li>First request (miss): the request is passed to the handler. When the response
+ *       comes back with a non-5xx status, the key + SHA-256 body fingerprint + response
+ *       are stored in {@code idempotency_keys}.</li>
+ *   <li>Repeat request with matching body (hit): the cached response is returned
+ *       immediately with {@code Idempotency-Replayed: true} header. The handler is
+ *       not invoked.</li>
+ *   <li>Repeat request with different body (mismatch): {@code 422 Unprocessable Entity}
+ *       with error code {@code IDEMPOTENCY_KEY_BODY_MISMATCH}.</li>
+ * </ol>
+ *
+ * <h2>Scoping</h2>
+ * Keys are scoped to {@code (key, user_id)} — two users with the same key string
+ * are independent. The {@code user_id} is extracted from the Spring Security
+ * {@link AuthUserDetails} principal set by M1's JWT filter.
+ *
+ * <h2>TTL</h2>
+ * Keys expire after {@link IdempotencyProperties#getTtl()} (default 24 h) and are
+ * purged nightly by {@link com.oneday.orders.service.IdempotencyKeyPurgeJob}.
+ */
+public class IdempotencyFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(IdempotencyFilter.class);
+
+    static final String HEADER_IDEMPOTENCY_KEY = "Idempotency-Key";
+    static final String HEADER_IDEMPOTENCY_REPLAYED = "Idempotency-Replayed";
+    static final String ERROR_CODE_MISSING_HEADER = "IDEMPOTENCY_KEY_MISSING";
+    static final String ERROR_CODE_BODY_MISMATCH = "IDEMPOTENCY_KEY_BODY_MISMATCH";
+
+    private final IdempotencyKeyRepository repository;
+    private final IdempotencyProperties properties;
+    private final ObjectMapper objectMapper;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    public IdempotencyFilter(IdempotencyKeyRepository repository,
+                             IdempotencyProperties properties,
+                             ObjectMapper objectMapper) {
+        this.repository = repository;
+        this.properties = properties;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Skip the filter for:
+     * <ul>
+     *   <li>Non-POST methods (GET, PUT, DELETE are naturally idempotent or handled differently)</li>
+     *   <li>Paths that do not match {@link IdempotencyProperties#getApplyToPathPattern()}</li>
+     * </ul>
+     */
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        if (!HttpMethod.POST.matches(request.getMethod())) {
+            return true;
+        }
+        String path = request.getRequestURI();
+        return !pathMatcher.match(properties.getApplyToPathPattern(), path);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+
+        // 1. Header presence check
+        String key = request.getHeader(HEADER_IDEMPOTENCY_KEY);
+        if (key == null || key.isBlank()) {
+            writeError(response, HttpServletResponse.SC_BAD_REQUEST, ERROR_CODE_MISSING_HEADER,
+                    "Idempotency-Key header is required for POST requests");
+            return;
+        }
+
+        // 2. Extract authenticated user id
+        UUID userId = extractUserId();
+        if (userId == null) {
+            // Should not happen — JWT filter runs first; but be defensive
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        IdempotencyKeyId keyId = new IdempotencyKeyId(key, userId);
+
+        // 3. Wrap request/response so the body can be read multiple times
+        ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(request);
+        ContentCachingResponseWrapper wrappedResponse = new ContentCachingResponseWrapper(response);
+
+        // 4. Eagerly read the body so the fingerprint is available before the chain runs
+        //    (ContentCachingRequestWrapper caches on first getInputStream() / getReader() call)
+        wrappedRequest.getInputStream().readAllBytes();
+
+        String incomingFingerprint = sha256Hex(wrappedRequest.getContentAsByteArray());
+
+        // 5. DB lookup
+        Optional<IdempotencyKey> existing = repository.findById(keyId);
+
+        if (existing.isPresent()) {
+            IdempotencyKey cached = existing.get();
+
+            // Mismatch: same key, different body
+            if (cached.getRequestFingerprint() != null
+                    && !cached.getRequestFingerprint().equals(incomingFingerprint)) {
+                writeError(wrappedResponse, 422,
+                        ERROR_CODE_BODY_MISMATCH,
+                        "A different request body was previously sent with this Idempotency-Key");
+                wrappedResponse.copyBodyToResponse();
+                return;
+            }
+
+            // Hit: replay cached response
+            log.debug("Idempotency hit — replaying key={} userId={}", key, userId);
+            wrappedResponse.setStatus(cached.getResponseStatus());
+            wrappedResponse.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            wrappedResponse.addHeader(HEADER_IDEMPOTENCY_REPLAYED, "true");
+            wrappedResponse.getWriter().write(cached.getResponseBody());
+            wrappedResponse.copyBodyToResponse();
+            return;
+        }
+
+        // 6. Miss — let the handler run
+        chain.doFilter(wrappedRequest, wrappedResponse);
+
+        // 7. Persist only if the response is not a server error (5xx)
+        int status = wrappedResponse.getStatus();
+        if (status < 500) {
+            String responseBody = new String(wrappedResponse.getContentAsByteArray(), StandardCharsets.UTF_8);
+            IdempotencyKey record = new IdempotencyKey();
+            record.setId(keyId);
+            record.setRequestFingerprint(incomingFingerprint);
+            record.setResponseStatus((short) status);
+            record.setResponseBody(responseBody);
+            record.setExpiresAt(Instant.now().plus(properties.getTtl()));
+            try {
+                repository.save(record);
+            } catch (Exception e) {
+                // Concurrent duplicate insert — the unique PK constraint will reject one;
+                // the winning thread already persisted the record. Log and continue.
+                log.warn("Idempotency key already persisted by concurrent request: key={} userId={}", key, userId);
+            }
+        }
+
+        // 8. Always copy the real response body back to the client
+        wrappedResponse.copyBodyToResponse();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private UUID extractUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null && auth.getPrincipal() instanceof AuthUserDetails details) {
+            return details.getUserId();
+        }
+        return null;
+    }
+
+    /**
+     * Computes SHA-256 of {@code bytes} and returns it as a 64-character lowercase hex string.
+     */
+    static String sha256Hex(byte[] bytes) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(bytes);
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is guaranteed by the JVM spec — never thrown
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    private void writeError(HttpServletResponse response, int status,
+                            String errorCode, String message) throws IOException {
+        response.setStatus(status);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        String body = objectMapper.writeValueAsString(
+                Map.of("error", errorCode, "message", message));
+        response.getWriter().write(body);
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/api/filter/IdempotencyFilter.java
+++ b/orders/src/main/java/com/oneday/orders/api/filter/IdempotencyFilter.java
@@ -1,14 +1,21 @@
 package com.oneday.orders.api.filter;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.oneday.auth.security.AuthUserDetails;
 import com.oneday.orders.config.IdempotencyProperties;
 import com.oneday.orders.domain.IdempotencyKey;
 import com.oneday.orders.domain.IdempotencyKeyId;
 import com.oneday.orders.repository.IdempotencyKeyRepository;
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.ReadListener;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,17 +23,23 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
-import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HexFormat;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -38,32 +51,59 @@ import java.util.UUID;
  * <ol>
  *   <li>Client sends {@code Idempotency-Key: <uuid-or-any-string>} header on every POST.</li>
  *   <li>First request (miss): the request is passed to the handler. When the response
- *       comes back with a non-5xx status, the key + SHA-256 body fingerprint + response
- *       are stored in {@code idempotency_keys}.</li>
- *   <li>Repeat request with matching body (hit): the cached response is returned
- *       immediately with {@code Idempotency-Replayed: true} header. The handler is
- *       not invoked.</li>
+ *       comes back with a non-5xx status, the key + SHA-256 canonical body fingerprint +
+ *       response are stored in {@code idempotency_keys}.</li>
+ *   <li>Repeat request with matching body (hit, within TTL): the cached response is returned
+ *       immediately with {@code Idempotency-Replayed: true} header. The handler is not invoked.</li>
  *   <li>Repeat request with different body (mismatch): {@code 422 Unprocessable Entity}
  *       with error code {@code IDEMPOTENCY_KEY_BODY_MISMATCH}.</li>
+ *   <li>Repeat request with the same key after TTL expiry: treated as a new miss.</li>
  * </ol>
  *
+ * <h2>Fingerprint</h2>
+ * The body fingerprint is SHA-256 of the <em>canonicalised</em> JSON body (all object keys
+ * sorted alphabetically, whitespace stripped). This makes the fingerprint order-independent:
+ * {@code {"a":1,"b":2}} and {@code {"b":2,"a":1}} produce the same fingerprint. If the body
+ * is not valid JSON, the fingerprint falls back to SHA-256 of the raw bytes.
+ *
+ * <h2>Body availability</h2>
+ * The filter reads the request body once into a byte array before fingerprinting, then wraps
+ * the request in a {@link ReplayableRequestWrapper} that re-serves those bytes on every
+ * {@link jakarta.servlet.http.HttpServletRequest#getInputStream()} call. This ensures
+ * {@code @RequestBody} deserialization by the downstream Spring MVC handler is unaffected.
+ *
  * <h2>Scoping</h2>
- * Keys are scoped to {@code (key, user_id)} — two users with the same key string
- * are independent. The {@code user_id} is extracted from the Spring Security
+ * Keys are scoped to {@code (key, user_id)} — two users with the same key string are
+ * independent. The {@code user_id} is extracted from the Spring Security
  * {@link AuthUserDetails} principal set by M1's JWT filter.
  *
  * <h2>TTL</h2>
- * Keys expire after {@link IdempotencyProperties#getTtl()} (default 24 h) and are
- * purged nightly by {@link com.oneday.orders.service.IdempotencyKeyPurgeJob}.
+ * Keys expire after {@link IdempotencyProperties#getTtl()} (default 24 h). Expiry is
+ * checked at hit time so clients always see the correct replay/miss behaviour regardless
+ * of when the nightly purge job last ran.
  */
+@Component
 public class IdempotencyFilter extends OncePerRequestFilter {
 
     private static final Logger log = LoggerFactory.getLogger(IdempotencyFilter.class);
 
-    static final String HEADER_IDEMPOTENCY_KEY = "Idempotency-Key";
+    static final String HEADER_IDEMPOTENCY_KEY      = "Idempotency-Key";
     static final String HEADER_IDEMPOTENCY_REPLAYED = "Idempotency-Replayed";
-    static final String ERROR_CODE_MISSING_HEADER = "IDEMPOTENCY_KEY_MISSING";
-    static final String ERROR_CODE_BODY_MISMATCH = "IDEMPOTENCY_KEY_BODY_MISMATCH";
+    /** Aligned with M4-ORDERS-DESIGN.md §4 KDD-6 and DECISIONS.md M4-D-016. */
+    static final String ERROR_CODE_MISSING_HEADER   = "IDEMPOTENCY_KEY_REQUIRED";
+    static final String ERROR_CODE_BODY_MISMATCH    = "IDEMPOTENCY_KEY_BODY_MISMATCH";
+    static final String ERROR_CODE_KEY_TOO_LONG     = "IDEMPOTENCY_KEY_TOO_LONG";
+
+    /** Maximum allowed length for the Idempotency-Key header value (matches DB column). */
+    private static final int MAX_KEY_LENGTH = 100;
+
+    /**
+     * ObjectMapper configured to write JSON with keys sorted alphabetically.
+     * Used to produce the canonical form for fingerprinting.
+     * {@link ObjectMapper} is thread-safe after configuration and safe to share.
+     */
+    /** Shared mapper for reading and writing canonical JSON. Thread-safe after construction. */
+    private static final ObjectMapper CANONICAL_MAPPER = new ObjectMapper();
 
     private final IdempotencyKeyRepository repository;
     private final IdempotencyProperties properties;
@@ -73,8 +113,8 @@ public class IdempotencyFilter extends OncePerRequestFilter {
     public IdempotencyFilter(IdempotencyKeyRepository repository,
                              IdempotencyProperties properties,
                              ObjectMapper objectMapper) {
-        this.repository = repository;
-        this.properties = properties;
+        this.repository   = repository;
+        this.properties   = properties;
         this.objectMapper = objectMapper;
     }
 
@@ -90,8 +130,7 @@ public class IdempotencyFilter extends OncePerRequestFilter {
         if (!HttpMethod.POST.matches(request.getMethod())) {
             return true;
         }
-        String path = request.getRequestURI();
-        return !pathMatcher.match(properties.getApplyToPathPattern(), path);
+        return !pathMatcher.match(properties.getApplyToPathPattern(), request.getRequestURI());
     }
 
     @Override
@@ -107,59 +146,80 @@ public class IdempotencyFilter extends OncePerRequestFilter {
             return;
         }
 
-        // 2. Extract authenticated user id
-        UUID userId = extractUserId();
-        if (userId == null) {
-            // Should not happen — JWT filter runs first; but be defensive
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        // 2. Header length guard (IdempotencyKeyId.key is VARCHAR(100))
+        if (key.length() > MAX_KEY_LENGTH) {
+            writeError(response, HttpServletResponse.SC_BAD_REQUEST, ERROR_CODE_KEY_TOO_LONG,
+                    "Idempotency-Key must be " + MAX_KEY_LENGTH + " characters or fewer");
             return;
         }
 
-        IdempotencyKeyId keyId = new IdempotencyKeyId(key, userId);
+        // 3. Extract authenticated user id
+        UUID userId = extractUserId();
+        if (userId == null) {
+            // Should not happen — JWT filter runs first; but be defensive
+            writeError(response, HttpServletResponse.SC_UNAUTHORIZED,
+                    "UNAUTHENTICATED", "Authentication required");
+            return;
+        }
 
-        // 3. Wrap request/response so the body can be read multiple times
-        ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(request);
+        // 4. Read the request body ONCE into a byte array.
+        //    We must do this before wrapping so the raw ServletInputStream is only consumed once.
+        //    The ReplayableRequestWrapper will re-serve these bytes for the downstream handler.
+        byte[] bodyBytes = request.getInputStream().readAllBytes();
+
+        // 5. Compute canonical JSON fingerprint (keys sorted, whitespace stripped).
+        //    Falls back to raw bytes for non-JSON bodies.
+        String incomingFingerprint = sha256HexCanonical(bodyBytes);
+
+        // 6. Wrap request so the handler can still read the body (@RequestBody deserialization).
+        ReplayableRequestWrapper replayableRequest = new ReplayableRequestWrapper(request, bodyBytes);
+
+        // 7. Wrap response to capture the body for caching.
         ContentCachingResponseWrapper wrappedResponse = new ContentCachingResponseWrapper(response);
 
-        // 4. Eagerly read the body so the fingerprint is available before the chain runs
-        //    (ContentCachingRequestWrapper caches on first getInputStream() / getReader() call)
-        wrappedRequest.getInputStream().readAllBytes();
+        IdempotencyKeyId keyId = new IdempotencyKeyId(key, userId);
 
-        String incomingFingerprint = sha256Hex(wrappedRequest.getContentAsByteArray());
-
-        // 5. DB lookup
+        // 8. DB lookup
         Optional<IdempotencyKey> existing = repository.findById(keyId);
 
         if (existing.isPresent()) {
             IdempotencyKey cached = existing.get();
 
-            // Mismatch: same key, different body
-            if (cached.getRequestFingerprint() != null
-                    && !cached.getRequestFingerprint().equals(incomingFingerprint)) {
-                writeError(wrappedResponse, 422,
-                        ERROR_CODE_BODY_MISMATCH,
-                        "A different request body was previously sent with this Idempotency-Key");
+            // Check TTL at hit time — the nightly purge runs only once a day, so a
+            // record that expired hours ago could still be in the table.
+            if (!cached.getExpiresAt().isBefore(Instant.now())) {
+
+                // Mismatch: same key, different canonical body
+                if (cached.getRequestFingerprint() != null
+                        && !cached.getRequestFingerprint().equals(incomingFingerprint)) {
+                    writeError(wrappedResponse, 422,
+                            ERROR_CODE_BODY_MISMATCH,
+                            "A different request body was previously sent with this Idempotency-Key");
+                    wrappedResponse.copyBodyToResponse();
+                    return;
+                }
+
+                // Hit: replay cached response
+                log.debug("Idempotency hit — replaying key={}**** userId={}",
+                        key.substring(0, Math.min(4, key.length())), userId);
+                wrappedResponse.setStatus(cached.getResponseStatus());
+                wrappedResponse.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                wrappedResponse.addHeader(HEADER_IDEMPOTENCY_REPLAYED, "true");
+                wrappedResponse.getWriter().write(cached.getResponseBody());
                 wrappedResponse.copyBodyToResponse();
                 return;
             }
-
-            // Hit: replay cached response
-            log.debug("Idempotency hit — replaying key={} userId={}", key, userId);
-            wrappedResponse.setStatus(cached.getResponseStatus());
-            wrappedResponse.setContentType(MediaType.APPLICATION_JSON_VALUE);
-            wrappedResponse.addHeader(HEADER_IDEMPOTENCY_REPLAYED, "true");
-            wrappedResponse.getWriter().write(cached.getResponseBody());
-            wrappedResponse.copyBodyToResponse();
-            return;
+            // Key is present but expired — fall through and treat as a miss
         }
 
-        // 6. Miss — let the handler run
-        chain.doFilter(wrappedRequest, wrappedResponse);
+        // 9. Miss — let the handler run
+        chain.doFilter(replayableRequest, wrappedResponse);
 
-        // 7. Persist only if the response is not a server error (5xx)
+        // 10. Persist only if the response is not a server error (5xx)
         int status = wrappedResponse.getStatus();
         if (status < 500) {
-            String responseBody = new String(wrappedResponse.getContentAsByteArray(), StandardCharsets.UTF_8);
+            String responseBody = new String(wrappedResponse.getContentAsByteArray(),
+                    StandardCharsets.UTF_8);
             IdempotencyKey record = new IdempotencyKey();
             record.setId(keyId);
             record.setRequestFingerprint(incomingFingerprint);
@@ -171,11 +231,12 @@ public class IdempotencyFilter extends OncePerRequestFilter {
             } catch (Exception e) {
                 // Concurrent duplicate insert — the unique PK constraint will reject one;
                 // the winning thread already persisted the record. Log and continue.
-                log.warn("Idempotency key already persisted by concurrent request: key={} userId={}", key, userId);
+                log.warn("Idempotency key already persisted by concurrent request: key={}**** userId={}",
+                        key.substring(0, Math.min(4, key.length())), userId);
             }
         }
 
-        // 8. Always copy the real response body back to the client
+        // 11. Always copy the real response body back to the client
         wrappedResponse.copyBodyToResponse();
     }
 
@@ -189,6 +250,59 @@ public class IdempotencyFilter extends OncePerRequestFilter {
             return details.getUserId();
         }
         return null;
+    }
+
+    /**
+     * Computes SHA-256 of the <em>canonicalised</em> JSON body and returns it as a
+     * 64-character lowercase hex string.
+     *
+     * <p>Canonicalisation: all JSON object keys are sorted alphabetically at every level,
+     * and whitespace is stripped (compact serialisation). This makes the fingerprint
+     * order-independent across client implementations:
+     * {@code {"a":1,"b":2}} and {@code {"b":2,"a":1}} produce the same fingerprint.</p>
+     *
+     * <p>Falls back to {@link #sha256Hex(byte[])} of the raw bytes if the body is empty
+     * or not valid JSON.</p>
+     */
+    static String sha256HexCanonical(byte[] bytes) {
+        if (bytes == null || bytes.length == 0) {
+            return sha256Hex(bytes != null ? bytes : new byte[0]);
+        }
+        try {
+            JsonNode tree = CANONICAL_MAPPER.readTree(bytes);
+            JsonNode sorted = sortKeysRecursively(tree);
+            byte[] canonical = CANONICAL_MAPPER.writeValueAsBytes(sorted);
+            return sha256Hex(canonical);
+        } catch (Exception e) {
+            // Non-JSON body (e.g., form-encoded or binary) — fall back to raw bytes
+            return sha256Hex(bytes);
+        }
+    }
+
+    /**
+     * Recursively sorts all object keys in a {@link JsonNode} alphabetically.
+     * Array elements and scalar nodes are returned unchanged; only {@code ObjectNode}
+     * children are reordered.
+     */
+    private static JsonNode sortKeysRecursively(JsonNode node) {
+        if (node.isObject()) {
+            List<String> keys = new ArrayList<>();
+            node.fieldNames().forEachRemaining(keys::add);
+            Collections.sort(keys);
+            ObjectNode sorted = JsonNodeFactory.instance.objectNode();
+            for (String key : keys) {
+                sorted.set(key, sortKeysRecursively(node.get(key)));
+            }
+            return sorted;
+        }
+        if (node.isArray()) {
+            ArrayNode array = JsonNodeFactory.instance.arrayNode();
+            for (JsonNode element : node) {
+                array.add(sortKeysRecursively(element));
+            }
+            return array;
+        }
+        return node;
     }
 
     /**
@@ -213,5 +327,70 @@ public class IdempotencyFilter extends OncePerRequestFilter {
         String body = objectMapper.writeValueAsString(
                 Map.of("error", errorCode, "message", message));
         response.getWriter().write(body);
+    }
+
+    // -------------------------------------------------------------------------
+    // Inner helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Wraps an {@link HttpServletRequest} and replays the given pre-read body bytes on every
+     * call to {@link #getInputStream()} or {@link #getReader()}.
+     *
+     * <p>This is necessary because the filter reads the raw {@link jakarta.servlet.ServletInputStream}
+     * to compute the fingerprint before the downstream handler runs. Without this wrapper,
+     * Spring MVC's {@code @RequestBody} deserialiser would see an exhausted stream and produce
+     * an empty or null DTO.</p>
+     */
+    private static class ReplayableRequestWrapper extends HttpServletRequestWrapper {
+
+        private final byte[] bodyBytes;
+
+        ReplayableRequestWrapper(HttpServletRequest request, byte[] bodyBytes) {
+            super(request);
+            this.bodyBytes = bodyBytes;
+        }
+
+        @Override
+        public ServletInputStream getInputStream() {
+            return new ByteArrayServletInputStream(bodyBytes);
+        }
+
+        @Override
+        public BufferedReader getReader() {
+            return new BufferedReader(new InputStreamReader(
+                    new ByteArrayInputStream(bodyBytes), StandardCharsets.UTF_8));
+        }
+
+        @Override
+        public int getContentLength() {
+            return bodyBytes.length;
+        }
+
+        @Override
+        public long getContentLengthLong() {
+            return bodyBytes.length;
+        }
+    }
+
+    /**
+     * Adapts a {@link ByteArrayInputStream} to the {@link ServletInputStream} contract.
+     * Each instance is created fresh per request (not shared), so thread safety is inherent.
+     */
+    private static class ByteArrayServletInputStream extends ServletInputStream {
+
+        private final ByteArrayInputStream bais;
+
+        ByteArrayServletInputStream(byte[] bytes) {
+            this.bais = new ByteArrayInputStream(bytes);
+        }
+
+        @Override public int read()                                  { return bais.read(); }
+        @Override public int read(byte[] b, int off, int len)        { return bais.read(b, off, len); }
+        @Override public boolean isFinished()                        { return bais.available() == 0; }
+        @Override public boolean isReady()                           { return true; }
+        @Override public void setReadListener(ReadListener listener) {
+            throw new UnsupportedOperationException("Async not supported by IdempotencyFilter");
+        }
     }
 }

--- a/orders/src/main/java/com/oneday/orders/config/IdempotencyProperties.java
+++ b/orders/src/main/java/com/oneday/orders/config/IdempotencyProperties.java
@@ -1,7 +1,10 @@
 package com.oneday.orders.config;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 
 import java.time.Duration;
 
@@ -20,6 +23,7 @@ import java.time.Duration;
  */
 @Component
 @ConfigurationProperties(prefix = "orders.idempotency")
+@Validated
 public class IdempotencyProperties {
 
     /**
@@ -28,6 +32,7 @@ public class IdempotencyProperties {
      * client that reuses the same key will be treated as a fresh request.
      * Default: 24 hours.
      */
+    @NotNull
     private Duration ttl = Duration.ofHours(24);
 
     /**
@@ -36,6 +41,7 @@ public class IdempotencyProperties {
      * without any idempotency enforcement.
      * Default: all order API paths.
      */
+    @NotBlank
     private String applyToPathPattern = "/api/v1/**";
 
     public Duration getTtl() {

--- a/orders/src/main/java/com/oneday/orders/config/IdempotencyProperties.java
+++ b/orders/src/main/java/com/oneday/orders/config/IdempotencyProperties.java
@@ -1,0 +1,56 @@
+package com.oneday.orders.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+/**
+ * Configuration properties for the idempotency infrastructure.
+ *
+ * <p>Defaults are production-safe. Override in {@code application.yml} under the
+ * {@code orders.idempotency} prefix.</p>
+ *
+ * <pre>{@code
+ * orders:
+ *   idempotency:
+ *     ttl: 24h
+ *     apply-to-path-pattern: /api/v1/**
+ * }</pre>
+ */
+@Component
+@ConfigurationProperties(prefix = "orders.idempotency")
+public class IdempotencyProperties {
+
+    /**
+     * How long an idempotency key is retained after first use.
+     * After expiry the key is removed by {@code IdempotencyKeyPurgeJob} and a
+     * client that reuses the same key will be treated as a fresh request.
+     * Default: 24 hours.
+     */
+    private Duration ttl = Duration.ofHours(24);
+
+    /**
+     * Ant-style URL pattern to which the idempotency filter applies.
+     * Requests whose path does not match this pattern are passed through
+     * without any idempotency enforcement.
+     * Default: all order API paths.
+     */
+    private String applyToPathPattern = "/api/v1/**";
+
+    public Duration getTtl() {
+        return ttl;
+    }
+
+    public void setTtl(Duration ttl) {
+        this.ttl = ttl;
+    }
+
+    public String getApplyToPathPattern() {
+        return applyToPathPattern;
+    }
+
+    public void setApplyToPathPattern(String applyToPathPattern) {
+        this.applyToPathPattern = applyToPathPattern;
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/config/PickupOtpProperties.java
+++ b/orders/src/main/java/com/oneday/orders/config/PickupOtpProperties.java
@@ -1,0 +1,36 @@
+package com.oneday.orders.config;
+
+import jakarta.validation.constraints.Positive;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Configuration properties for pickup OTP behaviour.
+ *
+ * <pre>{@code
+ * orders:
+ *   otp:
+ *     ttl-minutes: 10
+ *     max-resend-count: 3
+ * }</pre>
+ */
+@Component
+@ConfigurationProperties(prefix = "orders.otp")
+@Validated
+public class PickupOtpProperties {
+
+    /** How long a generated OTP is valid. Default: 10 minutes. */
+    @Positive
+    private int ttlMinutes = 10;
+
+    /** Maximum number of resend attempts before the endpoint returns 429. Default: 3. */
+    @Positive
+    private int maxResendCount = 3;
+
+    public int getTtlMinutes() { return ttlMinutes; }
+    public void setTtlMinutes(int ttlMinutes) { this.ttlMinutes = ttlMinutes; }
+
+    public int getMaxResendCount() { return maxResendCount; }
+    public void setMaxResendCount(int maxResendCount) { this.maxResendCount = maxResendCount; }
+}

--- a/orders/src/main/java/com/oneday/orders/domain/Address.java
+++ b/orders/src/main/java/com/oneday/orders/domain/Address.java
@@ -1,0 +1,19 @@
+package com.oneday.orders.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Address {
+    private String line1;
+    private String line2;
+    private String city;
+    private String pincode;
+    private String state;
+    private String landmark;
+}

--- a/orders/src/main/java/com/oneday/orders/domain/B2bAccount.java
+++ b/orders/src/main/java/com/oneday/orders/domain/B2bAccount.java
@@ -1,0 +1,52 @@
+package com.oneday.orders.domain;
+
+import com.oneday.common.domain.MutableBaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "b2b_accounts")
+@Getter
+@Setter
+@NoArgsConstructor
+public class B2bAccount extends MutableBaseEntity {
+
+    @Column(name = "account_name", length = 200, nullable = false)
+    private String accountName;
+
+    @Column(name = "gstin", length = 15)
+    private String gstin;
+
+    @Column(name = "billing_email", length = 254, nullable = false)
+    private String billingEmail;
+
+    @Column(name = "credit_limit_paise", nullable = false)
+    private Long creditLimitPaise;
+
+    @Column(name = "outstanding_balance_paise", nullable = false)
+    private Long outstandingBalancePaise;
+
+    @Column(name = "payment_terms_days", nullable = false)
+    private Short paymentTermsDays;
+
+    @Column(name = "rate_card_id")
+    private UUID rateCardId;
+
+    @Column(name = "webhook_url", length = 500)
+    private String webhookUrl;
+
+    @Column(name = "webhook_secret", length = 100)
+    private String webhookSecret;
+
+    @Column(name = "city_id", length = 10, nullable = false)
+    private String cityId;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive;
+}

--- a/orders/src/main/java/com/oneday/orders/domain/IdempotencyKey.java
+++ b/orders/src/main/java/com/oneday/orders/domain/IdempotencyKey.java
@@ -1,0 +1,37 @@
+package com.oneday.orders.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "idempotency_keys")
+@Getter
+@Setter
+@NoArgsConstructor
+public class IdempotencyKey {
+
+    @EmbeddedId
+    private IdempotencyKeyId id;
+
+    @Column(name = "response_status", nullable = false, updatable = false)
+    private Short responseStatus;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "response_body", nullable = false, columnDefinition = "jsonb", updatable = false)
+    private String responseBody;
+
+    @Column(name = "expires_at", nullable = false, updatable = false)
+    private Instant expiresAt;
+
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private Instant createdAt;
+}

--- a/orders/src/main/java/com/oneday/orders/domain/IdempotencyKey.java
+++ b/orders/src/main/java/com/oneday/orders/domain/IdempotencyKey.java
@@ -23,6 +23,15 @@ public class IdempotencyKey {
     @EmbeddedId
     private IdempotencyKeyId id;
 
+    /**
+     * SHA-256 hex digest of the original request body (64 lowercase hex chars).
+     * Set on first insert; used by {@link com.oneday.orders.api.filter.IdempotencyFilter}
+     * to detect body mismatches on replay (→ 422).
+     * NULL for rows created before V4_10 migration.
+     */
+    @Column(name = "request_fingerprint", length = 64, updatable = false)
+    private String requestFingerprint;
+
     @Column(name = "response_status", nullable = false, updatable = false)
     private Short responseStatus;
 

--- a/orders/src/main/java/com/oneday/orders/domain/IdempotencyKey.java
+++ b/orders/src/main/java/com/oneday/orders/domain/IdempotencyKey.java
@@ -3,6 +3,7 @@ package com.oneday.orders.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,4 +35,11 @@ public class IdempotencyKey {
 
     @Column(name = "created_at", updatable = false, nullable = false)
     private Instant createdAt;
+
+    @PrePersist
+    protected void prePersist() {
+        if (this.createdAt == null) {
+            this.createdAt = Instant.now();
+        }
+    }
 }

--- a/orders/src/main/java/com/oneday/orders/domain/IdempotencyKeyId.java
+++ b/orders/src/main/java/com/oneday/orders/domain/IdempotencyKeyId.java
@@ -1,0 +1,25 @@
+package com.oneday.orders.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class IdempotencyKeyId implements Serializable {
+
+    @Column(name = "key", length = 100, nullable = false)
+    private String key;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+}

--- a/orders/src/main/java/com/oneday/orders/domain/PaymentTransaction.java
+++ b/orders/src/main/java/com/oneday/orders/domain/PaymentTransaction.java
@@ -1,0 +1,64 @@
+package com.oneday.orders.domain;
+
+import com.oneday.common.domain.MutableBaseEntity;
+import com.oneday.orders.domain.enums.PaymentStatus;
+import com.oneday.orders.domain.enums.RefundStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "payment_transactions")
+@Getter
+@Setter
+@NoArgsConstructor
+public class PaymentTransaction extends MutableBaseEntity {
+
+    @Column(name = "shipment_id", nullable = false, updatable = false)
+    private UUID shipmentId;
+
+    @Column(name = "razorpay_order_id", length = 100, nullable = false, unique = true, updatable = false)
+    private String razorpayOrderId;
+
+    @Column(name = "razorpay_payment_id", length = 100)
+    private String razorpayPaymentId;
+
+    @Column(name = "razorpay_signature", length = 500)
+    private String razorpaySignature;
+
+    @Column(name = "amount_paise", nullable = false, updatable = false)
+    private Long amountPaise;
+
+    @Column(name = "tax_paise", nullable = false)
+    private Long taxPaise;
+
+    @Column(name = "total_paise", nullable = false, updatable = false)
+    private Long totalPaise;
+
+    @Column(name = "currency", length = 3, nullable = false)
+    private String currency;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 30, nullable = false)
+    private PaymentStatus status;
+
+    @Column(name = "refund_id", length = 100)
+    private String refundId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "refund_status", length = 20)
+    private RefundStatus refundStatus;
+
+    @Column(name = "refund_amount_paise")
+    private Long refundAmountPaise;
+
+    @Column(name = "payment_method", length = 50)
+    private String paymentMethod;
+}

--- a/orders/src/main/java/com/oneday/orders/domain/PickupOtp.java
+++ b/orders/src/main/java/com/oneday/orders/domain/PickupOtp.java
@@ -1,0 +1,97 @@
+package com.oneday.orders.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Stores the BCrypt-hashed OTP for DA pickup verification.
+ *
+ * <p>Exactly one row exists per shipment while an OTP is active. On resend the
+ * old row is deleted and a new row is inserted — the unique index on
+ * {@code shipment_id} enforces this at the DB level.</p>
+ *
+ * <p>This entity is append-only: once created, only {@code used} is ever updated
+ * (set to {@code true} on successful verification). All other fields are
+ * {@code updatable = false}.</p>
+ */
+@Entity
+@Table(name = "pickup_otps")
+public class PickupOtp {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    /**
+     * The shipment this OTP is attached to.
+     * UNIQUE index on the FK column enforces one active OTP per shipment.
+     */
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shipment_id", nullable = false, updatable = false, unique = true)
+    private Shipment shipment;
+
+    /** BCrypt hash of the 4-digit OTP (60 chars). Cleartext is never persisted. */
+    @Column(name = "otp_hash", length = 60, nullable = false, updatable = false)
+    private String otpHash;
+
+    /** Absolute timestamp after which this OTP is no longer valid (10 min from creation). */
+    @Column(name = "expires_at", nullable = false, updatable = false)
+    private Instant expiresAt;
+
+    /**
+     * Set to {@code true} on first successful verification; prevents replay
+     * of a valid OTP within the TTL window.
+     * This is the only mutable field.
+     */
+    @Column(name = "used", nullable = false)
+    private boolean used = false;
+
+    /** How many times /resend has been called for this shipment. Capped at 3. */
+    @Column(name = "resend_count", nullable = false, updatable = false)
+    private short resendCount = 0;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    private void onPersist() {
+        if (createdAt == null) {
+            createdAt = Instant.now();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Getters and setters
+    // -------------------------------------------------------------------------
+
+    public UUID getId() { return id; }
+
+    public Shipment getShipment() { return shipment; }
+    public void setShipment(Shipment shipment) { this.shipment = shipment; }
+
+    public String getOtpHash() { return otpHash; }
+    public void setOtpHash(String otpHash) { this.otpHash = otpHash; }
+
+    public Instant getExpiresAt() { return expiresAt; }
+    public void setExpiresAt(Instant expiresAt) { this.expiresAt = expiresAt; }
+
+    public boolean isUsed() { return used; }
+    public void setUsed(boolean used) { this.used = used; }
+
+    public short getResendCount() { return resendCount; }
+    public void setResendCount(short resendCount) { this.resendCount = resendCount; }
+
+    public Instant getCreatedAt() { return createdAt; }
+}

--- a/orders/src/main/java/com/oneday/orders/domain/Shipment.java
+++ b/orders/src/main/java/com/oneday/orders/domain/Shipment.java
@@ -1,0 +1,204 @@
+package com.oneday.orders.domain;
+
+import com.oneday.common.domain.MutableBaseEntity;
+import com.oneday.common.domain.enums.CustomerType;
+import com.oneday.common.domain.enums.DeliveryType;
+import com.oneday.common.domain.enums.DropType;
+import com.oneday.common.domain.enums.PaymentMode;
+import com.oneday.common.domain.enums.PickupType;
+import com.oneday.common.domain.enums.ShipmentState;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "shipments")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Shipment extends MutableBaseEntity {
+
+    @Column(name = "shipment_ref", length = 30, nullable = false, unique = true, updatable = false)
+    private String shipmentRef;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "customer_type", nullable = false, updatable = false, columnDefinition = "customer_type")
+    private CustomerType customerType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "delivery_type", nullable = false, updatable = false, columnDefinition = "delivery_type")
+    private DeliveryType deliveryType;
+
+    @Column(name = "b2b_account_id", updatable = false)
+    private UUID b2bAccountId;
+
+    // ── Sender ────────────────────────────────────────────────────────────
+
+    @Column(name = "sender_name", length = 100, nullable = false, updatable = false)
+    private String senderName;
+
+    @Column(name = "sender_phone", length = 15, nullable = false, updatable = false)
+    private String senderPhone;
+
+    @Column(name = "sender_email", length = 254, updatable = false)
+    private String senderEmail;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "origin_address", nullable = false, columnDefinition = "jsonb", updatable = false)
+    private Address originAddress;
+
+    @Column(name = "origin_city", length = 10, nullable = false, updatable = false)
+    private String originCity;
+
+    @Column(name = "origin_pincode", length = 10, nullable = false, updatable = false)
+    private String originPincode;
+
+    // ── Receiver ──────────────────────────────────────────────────────────
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "dest_address", nullable = false, columnDefinition = "jsonb", updatable = false)
+    private Address destAddress;
+
+    @Column(name = "dest_city", length = 10, nullable = false, updatable = false)
+    private String destCity;
+
+    @Column(name = "dest_pincode", length = 10, nullable = false, updatable = false)
+    private String destPincode;
+
+    @Column(name = "receiver_name", length = 100, nullable = false, updatable = false)
+    private String receiverName;
+
+    @Column(name = "receiver_phone", length = 15, nullable = false, updatable = false)
+    private String receiverPhone;
+
+    @Column(name = "receiver_email", length = 254, updatable = false)
+    private String receiverEmail;
+
+    // ── Parcel dimensions ─────────────────────────────────────────────────
+
+    @Column(name = "weight_grams", nullable = false, updatable = false)
+    private Integer weightGrams;
+
+    @Column(name = "length_cm", nullable = false, updatable = false)
+    private Short lengthCm;
+
+    @Column(name = "width_cm", nullable = false, updatable = false)
+    private Short widthCm;
+
+    @Column(name = "height_cm", nullable = false, updatable = false)
+    private Short heightCm;
+
+    @Column(name = "volumetric_weight_grams", nullable = false, updatable = false)
+    private Integer volumetricWeightGrams;
+
+    @Column(name = "chargeable_weight_grams", nullable = false, updatable = false)
+    private Integer chargeableWeightGrams;
+
+    // ── Pricing ───────────────────────────────────────────────────────────
+
+    @Column(name = "declared_value_paise", updatable = false)
+    private Long declaredValuePaise;
+
+    @Column(name = "quoted_price_paise", nullable = false, updatable = false)
+    private Long quotedPricePaise;
+
+    @Column(name = "tax_paise", nullable = false, updatable = false)
+    private Long taxPaise;
+
+    @Column(name = "total_price_paise", nullable = false, updatable = false)
+    private Long totalPricePaise;
+
+    // finalPricePaise is nullable; set after weight confirmation (post-v1)
+    @Column(name = "final_price_paise")
+    private Long finalPricePaise;
+
+    @Column(name = "rate_card_version", length = 50, nullable = false, updatable = false)
+    private String rateCardVersion;
+
+    // ── Routing ───────────────────────────────────────────────────────────
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "pickup_type", nullable = false, columnDefinition = "pickup_type", updatable = false)
+    private PickupType pickupType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "drop_type", nullable = false, columnDefinition = "drop_type", updatable = false)
+    private DropType dropType;
+
+    // ── State machine ─────────────────────────────────────────────────────
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "state", nullable = false, columnDefinition = "shipment_state")
+    private ShipmentState state;
+
+    // ── SLA and ETA ───────────────────────────────────────────────────────
+
+    @Column(name = "sla_commitment_minutes", updatable = false)
+    private Short slaCommitmentMinutes;
+
+    @Column(name = "eta_promised")
+    private Instant etaPromised;
+
+    @Column(name = "eta_updated")
+    private Instant etaUpdated;
+
+    // ── Cross-module references (not DB foreign keys) ─────────────────────
+
+    // Set by M9 once a flight is assigned
+    @Column(name = "assigned_flight_id")
+    private UUID assignedFlightId;
+
+    // Set from ServiceabilityResult at booking; used by M5 for DA assignment
+    @Column(name = "origin_tile_id", updatable = false)
+    private UUID originTileId;
+
+    // Null at booking; populated when M8 emits LABEL_GENERATED
+    @Column(name = "parcel_id", length = 30)
+    private String parcelId;
+
+    // ── Payment ───────────────────────────────────────────────────────────
+
+    // Null for B2B (credit); non-null for B2C/C2C prepaid and COD
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payment_mode", columnDefinition = "payment_mode", updatable = false)
+    private PaymentMode paymentMode;
+
+    // FK to payment_transactions; null for B2B and COD-before-delivery
+    @Column(name = "payment_id")
+    private UUID paymentId;
+
+    // ── Idempotency ───────────────────────────────────────────────────────
+
+    @Column(name = "idempotency_key", length = 100, updatable = false)
+    private String idempotencyKey;
+
+    // ── Cancellation ──────────────────────────────────────────────────────
+
+    @Column(name = "cancelled_at")
+    private Instant cancelledAt;
+
+    @Column(name = "cancellation_reason", length = 500)
+    private String cancellationReason;
+
+    // ── Archival ──────────────────────────────────────────────────────────
+
+    // Set by nightly ArchivalJob after 2 years; never deleted
+    @Column(name = "archived_at")
+    private Instant archivedAt;
+
+    // ── Auth scope ────────────────────────────────────────────────────────
+
+    // Origin city code; used for city-scoped permission enforcement
+    @Column(name = "city_id", length = 10, nullable = false, updatable = false)
+    private String cityId;
+}

--- a/orders/src/main/java/com/oneday/orders/domain/Shipment.java
+++ b/orders/src/main/java/com/oneday/orders/domain/Shipment.java
@@ -15,6 +15,7 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnTransformer;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
@@ -32,10 +33,12 @@ public class Shipment extends MutableBaseEntity {
     private String shipmentRef;
 
     @Enumerated(EnumType.STRING)
+    @ColumnTransformer(write = "CAST(? AS customer_type)")
     @Column(name = "customer_type", nullable = false, updatable = false, columnDefinition = "customer_type")
     private CustomerType customerType;
 
     @Enumerated(EnumType.STRING)
+    @ColumnTransformer(write = "CAST(? AS delivery_type)")
     @Column(name = "delivery_type", nullable = false, updatable = false, columnDefinition = "delivery_type")
     private DeliveryType deliveryType;
 
@@ -128,16 +131,19 @@ public class Shipment extends MutableBaseEntity {
     // ── Routing ───────────────────────────────────────────────────────────
 
     @Enumerated(EnumType.STRING)
+    @ColumnTransformer(write = "CAST(? AS pickup_type)")
     @Column(name = "pickup_type", nullable = false, columnDefinition = "pickup_type", updatable = false)
     private PickupType pickupType;
 
     @Enumerated(EnumType.STRING)
+    @ColumnTransformer(write = "CAST(? AS drop_type)")
     @Column(name = "drop_type", nullable = false, columnDefinition = "drop_type", updatable = false)
     private DropType dropType;
 
     // ── State machine ─────────────────────────────────────────────────────
 
     @Enumerated(EnumType.STRING)
+    @ColumnTransformer(read = "state::text", write = "CAST(? AS shipment_state)")
     @Column(name = "state", nullable = false, columnDefinition = "shipment_state")
     private ShipmentState state;
 
@@ -170,6 +176,7 @@ public class Shipment extends MutableBaseEntity {
 
     // Null for B2B (credit); non-null for B2C/C2C prepaid and COD
     @Enumerated(EnumType.STRING)
+    @ColumnTransformer(write = "CAST(? AS payment_mode)")
     @Column(name = "payment_mode", columnDefinition = "payment_mode", updatable = false)
     private PaymentMode paymentMode;
 

--- a/orders/src/main/java/com/oneday/orders/domain/Shipment.java
+++ b/orders/src/main/java/com/oneday/orders/domain/Shipment.java
@@ -33,12 +33,12 @@ public class Shipment extends MutableBaseEntity {
     private String shipmentRef;
 
     @Enumerated(EnumType.STRING)
-    @ColumnTransformer(write = "CAST(? AS customer_type)")
+    @ColumnTransformer(read = "customer_type::text", write = "CAST(? AS customer_type)")
     @Column(name = "customer_type", nullable = false, updatable = false, columnDefinition = "customer_type")
     private CustomerType customerType;
 
     @Enumerated(EnumType.STRING)
-    @ColumnTransformer(write = "CAST(? AS delivery_type)")
+    @ColumnTransformer(read = "delivery_type::text", write = "CAST(? AS delivery_type)")
     @Column(name = "delivery_type", nullable = false, updatable = false, columnDefinition = "delivery_type")
     private DeliveryType deliveryType;
 
@@ -131,12 +131,12 @@ public class Shipment extends MutableBaseEntity {
     // ── Routing ───────────────────────────────────────────────────────────
 
     @Enumerated(EnumType.STRING)
-    @ColumnTransformer(write = "CAST(? AS pickup_type)")
+    @ColumnTransformer(read = "pickup_type::text", write = "CAST(? AS pickup_type)")
     @Column(name = "pickup_type", nullable = false, columnDefinition = "pickup_type", updatable = false)
     private PickupType pickupType;
 
     @Enumerated(EnumType.STRING)
-    @ColumnTransformer(write = "CAST(? AS drop_type)")
+    @ColumnTransformer(read = "drop_type::text", write = "CAST(? AS drop_type)")
     @Column(name = "drop_type", nullable = false, columnDefinition = "drop_type", updatable = false)
     private DropType dropType;
 
@@ -176,7 +176,7 @@ public class Shipment extends MutableBaseEntity {
 
     // Null for B2B (credit); non-null for B2C/C2C prepaid and COD
     @Enumerated(EnumType.STRING)
-    @ColumnTransformer(write = "CAST(? AS payment_mode)")
+    @ColumnTransformer(read = "payment_mode::text", write = "CAST(? AS payment_mode)")
     @Column(name = "payment_mode", columnDefinition = "payment_mode", updatable = false)
     private PaymentMode paymentMode;
 

--- a/orders/src/main/java/com/oneday/orders/domain/ShipmentRefCounter.java
+++ b/orders/src/main/java/com/oneday/orders/domain/ShipmentRefCounter.java
@@ -1,0 +1,23 @@
+package com.oneday.orders.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "shipment_ref_counters")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ShipmentRefCounter {
+
+    @EmbeddedId
+    private ShipmentRefCounterId id;
+
+    @Column(name = "next_val", nullable = false)
+    private Integer nextVal;
+}

--- a/orders/src/main/java/com/oneday/orders/domain/ShipmentRefCounterId.java
+++ b/orders/src/main/java/com/oneday/orders/domain/ShipmentRefCounterId.java
@@ -1,0 +1,25 @@
+package com.oneday.orders.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class ShipmentRefCounterId implements Serializable {
+
+    @Column(name = "city_code", length = 10, nullable = false)
+    private String cityCode;
+
+    @Column(name = "date_key", nullable = false)
+    private LocalDate dateKey;
+}

--- a/orders/src/main/java/com/oneday/orders/domain/ShipmentStateHistory.java
+++ b/orders/src/main/java/com/oneday/orders/domain/ShipmentStateHistory.java
@@ -1,0 +1,59 @@
+package com.oneday.orders.domain;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.domain.enums.TriggerSource;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "shipment_state_history")
+@Getter
+@Builder
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@AllArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public class ShipmentStateHistory {
+
+    @Id
+    @UuidGenerator
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "shipment_id", nullable = false, updatable = false)
+    private UUID shipmentId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "from_state", columnDefinition = "shipment_state", updatable = false)
+    private ShipmentState fromState;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "to_state", nullable = false, columnDefinition = "shipment_state", updatable = false)
+    private ShipmentState toState;
+
+    @Column(name = "triggered_by", length = 100, nullable = false, updatable = false)
+    private String triggeredBy;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "trigger_source", length = 20, nullable = false, updatable = false)
+    private TriggerSource triggerSource;
+
+    @Column(name = "event_ref", length = 200, updatable = false)
+    private String eventRef;
+
+    @Column(name = "notes", columnDefinition = "TEXT", updatable = false)
+    private String notes;
+
+    @Column(name = "occurred_at", nullable = false, updatable = false)
+    private Instant occurredAt;
+}

--- a/orders/src/main/java/com/oneday/orders/domain/ShipmentStateHistory.java
+++ b/orders/src/main/java/com/oneday/orders/domain/ShipmentStateHistory.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -56,4 +57,11 @@ public class ShipmentStateHistory {
 
     @Column(name = "occurred_at", nullable = false, updatable = false)
     private Instant occurredAt;
+
+    @PrePersist
+    protected void prePersist() {
+        if (this.occurredAt == null) {
+            this.occurredAt = Instant.now();
+        }
+    }
 }

--- a/orders/src/main/java/com/oneday/orders/domain/ShipmentStateHistory.java
+++ b/orders/src/main/java/com/oneday/orders/domain/ShipmentStateHistory.java
@@ -13,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnTransformer;
 import org.hibernate.annotations.UuidGenerator;
 
 import java.time.Instant;
@@ -35,10 +36,12 @@ public class ShipmentStateHistory {
     private UUID shipmentId;
 
     @Enumerated(EnumType.STRING)
+    @ColumnTransformer(write = "CAST(? AS shipment_state)")
     @Column(name = "from_state", columnDefinition = "shipment_state", updatable = false)
     private ShipmentState fromState;
 
     @Enumerated(EnumType.STRING)
+    @ColumnTransformer(write = "CAST(? AS shipment_state)")
     @Column(name = "to_state", nullable = false, columnDefinition = "shipment_state", updatable = false)
     private ShipmentState toState;
 

--- a/orders/src/main/java/com/oneday/orders/domain/ShipmentStateHistory.java
+++ b/orders/src/main/java/com/oneday/orders/domain/ShipmentStateHistory.java
@@ -2,6 +2,7 @@ package com.oneday.orders.domain;
 
 import com.oneday.common.domain.enums.ShipmentState;
 import com.oneday.orders.domain.enums.TriggerSource;
+import com.oneday.orders.service.TransitionContext;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -66,5 +67,30 @@ public class ShipmentStateHistory {
         if (this.occurredAt == null) {
             this.occurredAt = Instant.now();
         }
+    }
+
+    /**
+     * Factory method used by the state machine to create a history row from a
+     * completed transition. Maps all fields from {@link TransitionContext} directly.
+     *
+     * @param shipmentId the shipment that transitioned
+     * @param fromState  the state before the transition (null only for the initial BOOKED entry)
+     * @param toState    the state after the transition
+     * @param ctx        transition metadata (who triggered it, source, event ref, notes)
+     */
+    public static ShipmentStateHistory of(UUID shipmentId,
+                                          ShipmentState fromState,
+                                          ShipmentState toState,
+                                          TransitionContext ctx) {
+        return ShipmentStateHistory.builder()
+                .shipmentId(shipmentId)
+                .fromState(fromState)
+                .toState(toState)
+                .triggeredBy(ctx.getTriggeredBy())
+                .triggerSource(ctx.getTriggerSource())
+                .eventRef(ctx.getEventRef())
+                .notes(ctx.getNotes())
+                .occurredAt(ctx.getOccurredAt())
+                .build();
     }
 }

--- a/orders/src/main/java/com/oneday/orders/domain/ShipmentStateHistory.java
+++ b/orders/src/main/java/com/oneday/orders/domain/ShipmentStateHistory.java
@@ -37,12 +37,12 @@ public class ShipmentStateHistory {
     private UUID shipmentId;
 
     @Enumerated(EnumType.STRING)
-    @ColumnTransformer(write = "CAST(? AS shipment_state)")
+    @ColumnTransformer(read = "from_state::text", write = "CAST(? AS shipment_state)")
     @Column(name = "from_state", columnDefinition = "shipment_state", updatable = false)
     private ShipmentState fromState;
 
     @Enumerated(EnumType.STRING)
-    @ColumnTransformer(write = "CAST(? AS shipment_state)")
+    @ColumnTransformer(read = "to_state::text", write = "CAST(? AS shipment_state)")
     @Column(name = "to_state", nullable = false, columnDefinition = "shipment_state", updatable = false)
     private ShipmentState toState;
 

--- a/orders/src/main/java/com/oneday/orders/domain/enums/PaymentStatus.java
+++ b/orders/src/main/java/com/oneday/orders/domain/enums/PaymentStatus.java
@@ -1,0 +1,10 @@
+package com.oneday.orders.domain.enums;
+
+public enum PaymentStatus {
+    CREATED,
+    AUTHORIZED,
+    CAPTURED,
+    FAILED,
+    REFUND_INITIATED,
+    REFUNDED
+}

--- a/orders/src/main/java/com/oneday/orders/domain/enums/RefundStatus.java
+++ b/orders/src/main/java/com/oneday/orders/domain/enums/RefundStatus.java
@@ -1,0 +1,7 @@
+package com.oneday.orders.domain.enums;
+
+public enum RefundStatus {
+    PENDING,
+    PROCESSED,
+    FAILED
+}

--- a/orders/src/main/java/com/oneday/orders/domain/enums/TriggerSource.java
+++ b/orders/src/main/java/com/oneday/orders/domain/enums/TriggerSource.java
@@ -1,0 +1,7 @@
+package com.oneday.orders.domain.enums;
+
+public enum TriggerSource {
+    API,
+    KAFKA_EVENT,
+    SYSTEM
+}

--- a/orders/src/main/java/com/oneday/orders/dto/OtpVerifyRequest.java
+++ b/orders/src/main/java/com/oneday/orders/dto/OtpVerifyRequest.java
@@ -1,0 +1,18 @@
+package com.oneday.orders.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+/**
+ * Request body for {@code POST /internal/v1/shipments/{ref}/pickup-otp/verify}.
+ */
+public class OtpVerifyRequest {
+
+    /** The 4-digit OTP entered by the DA. */
+    @NotBlank(message = "otp is required")
+    @Pattern(regexp = "\\d{4}", message = "otp must be exactly 4 digits")
+    private String otp;
+
+    public String getOtp() { return otp; }
+    public void setOtp(String otp) { this.otp = otp; }
+}

--- a/orders/src/main/java/com/oneday/orders/repository/B2bAccountRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/B2bAccountRepository.java
@@ -1,0 +1,17 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.B2bAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface B2bAccountRepository extends JpaRepository<B2bAccount, UUID> {
+
+    List<B2bAccount> findByCityId(String cityId);
+
+    List<B2bAccount> findByIsActive(boolean isActive);
+
+    Optional<B2bAccount> findByBillingEmail(String billingEmail);
+}

--- a/orders/src/main/java/com/oneday/orders/repository/IdempotencyKeyRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/IdempotencyKeyRepository.java
@@ -6,11 +6,18 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 
 public interface IdempotencyKeyRepository extends JpaRepository<IdempotencyKey, IdempotencyKeyId> {
 
+    /**
+     * Bulk-deletes all idempotency keys whose TTL has expired.
+     * Must be called in a transaction (or is self-transactional via {@code @Transactional}).
+     * Typically invoked by a nightly {@code @Scheduled} cleanup job.
+     */
+    @Transactional
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM IdempotencyKey k WHERE k.expiresAt < :now")
     int deleteExpired(@Param("now") Instant now);

--- a/orders/src/main/java/com/oneday/orders/repository/IdempotencyKeyRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/IdempotencyKeyRepository.java
@@ -1,0 +1,17 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.IdempotencyKey;
+import com.oneday.orders.domain.IdempotencyKeyId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+
+public interface IdempotencyKeyRepository extends JpaRepository<IdempotencyKey, IdempotencyKeyId> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM IdempotencyKey k WHERE k.expiresAt < :now")
+    int deleteExpired(@Param("now") Instant now);
+}

--- a/orders/src/main/java/com/oneday/orders/repository/PaymentTransactionRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/PaymentTransactionRepository.java
@@ -1,0 +1,15 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.PaymentTransaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PaymentTransactionRepository extends JpaRepository<PaymentTransaction, UUID> {
+
+    List<PaymentTransaction> findByShipmentId(UUID shipmentId);
+
+    Optional<PaymentTransaction> findByRazorpayOrderId(String razorpayOrderId);
+}

--- a/orders/src/main/java/com/oneday/orders/repository/PickupOtpRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/PickupOtpRepository.java
@@ -1,0 +1,43 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.PickupOtp;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PickupOtpRepository extends JpaRepository<PickupOtp, UUID> {
+
+    /**
+     * Finds the active OTP record for a shipment (at most one due to unique index).
+     */
+    Optional<PickupOtp> findByShipmentId(UUID shipmentId);
+
+    /**
+     * Same as {@link #findByShipmentId} but acquires a pessimistic write lock
+     * (SELECT FOR UPDATE). Use this in {@code verify()} to prevent concurrent
+     * replay of a valid OTP — two concurrent calls both see {@code used=false}
+     * without the lock; with the lock the second call blocks until the first
+     * transaction commits.
+     *
+     * <p>Caller must be inside a {@code @Transactional} method.</p>
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT o FROM PickupOtp o WHERE o.shipment.id = :shipmentId")
+    Optional<PickupOtp> findByShipmentIdWithLock(@Param("shipmentId") UUID shipmentId);
+
+    /**
+     * Deletes the OTP for a given shipment. Used on resend: delete old row, then
+     * insert a fresh one. Must run inside a transaction.
+     */
+    @Transactional
+    @Modifying
+    @Query("DELETE FROM PickupOtp o WHERE o.shipment.id = :shipmentId")
+    void deleteByShipmentId(@Param("shipmentId") UUID shipmentId);
+}

--- a/orders/src/main/java/com/oneday/orders/repository/ShipmentRefCounterRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ShipmentRefCounterRepository.java
@@ -5,9 +5,12 @@ import com.oneday.orders.domain.ShipmentRefCounterId;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 public interface ShipmentRefCounterRepository extends JpaRepository<ShipmentRefCounter, ShipmentRefCounterId> {
@@ -25,4 +28,20 @@ public interface ShipmentRefCounterRepository extends JpaRepository<ShipmentRefC
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT r FROM ShipmentRefCounter r WHERE r.id = :id")
     Optional<ShipmentRefCounter> findByIdWithLock(@Param("id") ShipmentRefCounterId id);
+
+    /**
+     * Inserts a counter row with {@code next_val = 0} if one does not already exist
+     * for the given {@code (city_code, date_key)} pair. A concurrent INSERT is handled
+     * by {@code ON CONFLICT DO NOTHING} — exactly one row wins and the others silently
+     * skip. Call this before {@link #findByIdWithLock} so that the SELECT FOR UPDATE
+     * always finds an existing row (SELECT FOR UPDATE cannot lock a non-existent row).
+     *
+     * <p>Caller must be inside a {@code @Transactional} method.</p>
+     */
+    @Modifying
+    @Transactional
+    @Query(value = "INSERT INTO shipment_ref_counters (city_code, date_key, next_val) " +
+                   "VALUES (:cityCode, :dateKey, 0) ON CONFLICT (city_code, date_key) DO NOTHING",
+           nativeQuery = true)
+    void insertIfAbsent(@Param("cityCode") String cityCode, @Param("dateKey") LocalDate dateKey);
 }

--- a/orders/src/main/java/com/oneday/orders/repository/ShipmentRefCounterRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ShipmentRefCounterRepository.java
@@ -2,14 +2,27 @@ package com.oneday.orders.repository;
 
 import com.oneday.orders.domain.ShipmentRefCounter;
 import com.oneday.orders.domain.ShipmentRefCounterId;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface ShipmentRefCounterRepository extends JpaRepository<ShipmentRefCounter, ShipmentRefCounterId> {
 
-    @Modifying(clearAutomatically = true)
-    @Query("UPDATE ShipmentRefCounter r SET r.nextVal = r.nextVal + 1 WHERE r.id = :id")
-    int increment(@Param("id") ShipmentRefCounterId id);
+    /**
+     * Acquires a pessimistic write lock (SELECT FOR UPDATE) on the counter row.
+     * The caller must be inside a {@code @Transactional} method and should increment
+     * {@link ShipmentRefCounter#setNextVal} in Java after calling this method; the ORM
+     * will flush the update atomically when the transaction commits.
+     *
+     * <p>Using a DB-level lock instead of a bulk UPDATE means the new value is available
+     * in the same Java call without a second round-trip, and no concurrent transaction can
+     * interleave between the read and the write.</p>
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM ShipmentRefCounter r WHERE r.id = :id")
+    Optional<ShipmentRefCounter> findByIdWithLock(@Param("id") ShipmentRefCounterId id);
 }

--- a/orders/src/main/java/com/oneday/orders/repository/ShipmentRefCounterRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ShipmentRefCounterRepository.java
@@ -1,0 +1,15 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.ShipmentRefCounter;
+import com.oneday.orders.domain.ShipmentRefCounterId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ShipmentRefCounterRepository extends JpaRepository<ShipmentRefCounter, ShipmentRefCounterId> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE ShipmentRefCounter r SET r.nextVal = r.nextVal + 1 WHERE r.id = :id")
+    int increment(@Param("id") ShipmentRefCounterId id);
+}

--- a/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
@@ -1,0 +1,20 @@
+package com.oneday.orders.repository;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.domain.Shipment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ShipmentRepository extends JpaRepository<Shipment, UUID> {
+
+    Optional<Shipment> findByShipmentRef(String shipmentRef);
+
+    List<Shipment> findByState(ShipmentState state);
+
+    List<Shipment> findByStateAndCityId(ShipmentState state, String cityId);
+
+    boolean existsByIdempotencyKey(String idempotencyKey);
+}

--- a/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
@@ -1,8 +1,15 @@
 package com.oneday.orders.repository;
 
+import com.oneday.common.domain.enums.CustomerType;
 import com.oneday.common.domain.enums.ShipmentState;
 import com.oneday.orders.domain.Shipment;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,11 +17,35 @@ import java.util.UUID;
 
 public interface ShipmentRepository extends JpaRepository<Shipment, UUID> {
 
+    /**
+     * Acquires a pessimistic write lock (SELECT FOR UPDATE) on the shipment row.
+     * Must be called from within a {@code @Transactional} method.
+     * Used by the state machine to prevent concurrent transitions on the same shipment.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM Shipment s WHERE s.id = :id")
+    Optional<Shipment> findByIdWithLock(@Param("id") UUID id);
+
     Optional<Shipment> findByShipmentRef(String shipmentRef);
 
+    /** Unbounded list — use only when result set is known to be small (e.g. admin tooling). */
     List<Shipment> findByState(ShipmentState state);
 
+    /** Paginated variant — preferred for service-layer and API use; avoids full-table loads. */
+    Page<Shipment> findByState(ShipmentState state, Pageable pageable);
+
+    /** Unbounded list — use only when result set is known to be small (e.g. admin tooling). */
     List<Shipment> findByStateAndCityId(ShipmentState state, String cityId);
 
+    /** Paginated variant — preferred for service-layer and API use; avoids full-table loads. */
+    Page<Shipment> findByStateAndCityId(ShipmentState state, String cityId, Pageable pageable);
+
     boolean existsByIdempotencyKey(String idempotencyKey);
+
+    // Used to verify that the read transformer on customer_type enables WHERE-clause filtering.
+    // Also needed by reporting and B2B billing queries in the service layer.
+    List<Shipment> findByCustomerType(CustomerType customerType);
+
+    // Used by M9 to find all shipments assigned to a specific flight.
+    List<Shipment> findByAssignedFlightId(UUID assignedFlightId);
 }

--- a/orders/src/main/java/com/oneday/orders/repository/ShipmentStateHistoryRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ShipmentStateHistoryRepository.java
@@ -1,0 +1,12 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.ShipmentStateHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ShipmentStateHistoryRepository extends JpaRepository<ShipmentStateHistory, UUID> {
+
+    List<ShipmentStateHistory> findByShipmentIdOrderByOccurredAtAsc(UUID shipmentId);
+}

--- a/orders/src/main/java/com/oneday/orders/service/CustomerVisibleStateMapper.java
+++ b/orders/src/main/java/com/oneday/orders/service/CustomerVisibleStateMapper.java
@@ -1,0 +1,68 @@
+package com.oneday.orders.service;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import org.springframework.stereotype.Component;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Maps internal {@link ShipmentState} values to the customer-visible labels
+ * shown in the tracking API and notification messages.
+ *
+ * <p>Labels are sourced from the M4 design doc (§5.4). Changing a label here
+ * automatically propagates to every place that calls {@link #labelFor(ShipmentState)}
+ * — there is no other place in the codebase where these strings should be duplicated.</p>
+ */
+@Component
+public class CustomerVisibleStateMapper {
+
+    private static final Map<ShipmentState, String> LABELS = new EnumMap<>(ShipmentState.class);
+
+    static {
+        LABELS.put(ShipmentState.BOOKED,                  "Order confirmed");
+        LABELS.put(ShipmentState.PICKUP_ASSIGNED,          "Pickup agent assigned");
+        LABELS.put(ShipmentState.PICKED_UP,                "Parcel collected");
+        LABELS.put(ShipmentState.HANDED_TO_PICKUP_VAN,     "Parcel handed to transport");
+        LABELS.put(ShipmentState.AWAITING_SELF_DROP,       "Please bring your parcel to the origin hub");
+        LABELS.put(ShipmentState.AT_ORIGIN_HUB,            "Arrived at origin hub");
+        LABELS.put(ShipmentState.ORIGIN_HUB_PROCESSING,    "Being processed at hub");
+        LABELS.put(ShipmentState.IN_TAKEOFF_BAG,           "Sorted and bagged for dispatch");
+        LABELS.put(ShipmentState.DISPATCHED_TO_AIRPORT,    "En route to airport");
+        LABELS.put(ShipmentState.AT_AIRPORT,               "At airport — airline check-in");
+        LABELS.put(ShipmentState.DEPARTED,                 "In transit by air");
+        LABELS.put(ShipmentState.LANDED,                   "Arrived at destination city");
+        LABELS.put(ShipmentState.DISPATCHED_TO_HUB,        "En route to delivery hub");
+        LABELS.put(ShipmentState.AT_DEST_HUB,              "Arrived at destination hub");
+        LABELS.put(ShipmentState.DEST_HUB_PROCESSING,      "Being sorted for last-mile delivery");
+        LABELS.put(ShipmentState.HANDED_TO_DROP_VAN,       "Out for delivery");
+        LABELS.put(ShipmentState.DROP_ASSIGNED,            "Delivery agent assigned");
+        LABELS.put(ShipmentState.DROP_COLLECTED,           "Delivery agent en route");
+        LABELS.put(ShipmentState.DROPPED,                  "Delivered");
+        LABELS.put(ShipmentState.AWAITING_HUB_COLLECT,     "Your parcel is ready — collect from the hub");
+        LABELS.put(ShipmentState.HUB_COLLECTED,            "Collected from hub");
+        LABELS.put(ShipmentState.PICKUP_FAILED,            "Pickup unsuccessful");
+        LABELS.put(ShipmentState.DELIVERY_FAILED,          "Delivery unsuccessful");
+        LABELS.put(ShipmentState.RTO_INITIATED,            "Return to sender initiated");
+        LABELS.put(ShipmentState.RTO_IN_TRANSIT,           "Returning to sender");
+        LABELS.put(ShipmentState.RTO_COMPLETED,            "Returned to sender");
+        LABELS.put(ShipmentState.CANCELLED,                "Cancelled");
+    }
+
+    /**
+     * Returns the customer-visible label for {@code state}.
+     *
+     * @throws IllegalArgumentException if {@code state} has no registered label —
+     *         indicates a new state was added to {@link ShipmentState} without
+     *         updating this mapper
+     */
+    public String labelFor(ShipmentState state) {
+        String label = LABELS.get(state);
+        if (label == null) {
+            throw new IllegalArgumentException(
+                    "No customer-visible label registered for state: " + state +
+                    ". Add an entry to CustomerVisibleStateMapper.LABELS.");
+        }
+        return label;
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/DeliveryTypeResolver.java
+++ b/orders/src/main/java/com/oneday/orders/service/DeliveryTypeResolver.java
@@ -1,0 +1,32 @@
+package com.oneday.orders.service;
+
+import com.oneday.common.domain.enums.DeliveryType;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves the {@link DeliveryType} from origin and destination city codes.
+ *
+ * <p>Pure function — zero DB calls, zero side effects. Safe to call from any
+ * context (filter, service, test) without a transaction.</p>
+ *
+ * <p>Rule: if both city codes are identical (case-insensitive) the shipment
+ * is {@link DeliveryType#SAME_CITY}; otherwise {@link DeliveryType#INTERCITY}.</p>
+ */
+@Component
+public class DeliveryTypeResolver {
+
+    /**
+     * @param originCityCode 3-letter origin city code (e.g. {@code "BLR"})
+     * @param destCityCode   3-letter destination city code (e.g. {@code "BOM"})
+     * @return {@link DeliveryType#SAME_CITY} if both codes match ignoring case;
+     *         {@link DeliveryType#INTERCITY} otherwise
+     */
+    public DeliveryType resolve(String originCityCode, String destCityCode) {
+        if (originCityCode == null || destCityCode == null) {
+            return DeliveryType.INTERCITY;
+        }
+        return originCityCode.equalsIgnoreCase(destCityCode)
+                ? DeliveryType.SAME_CITY
+                : DeliveryType.INTERCITY;
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/IdempotencyKeyPurgeJob.java
+++ b/orders/src/main/java/com/oneday/orders/service/IdempotencyKeyPurgeJob.java
@@ -1,0 +1,44 @@
+package com.oneday.orders.service;
+
+import com.oneday.orders.repository.IdempotencyKeyRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+
+/**
+ * Nightly job that deletes expired idempotency keys.
+ *
+ * <p>Keys older than {@link com.oneday.orders.config.IdempotencyProperties#getTtl()} are
+ * no longer replayable — a client reusing an expired key is treated as a fresh request.
+ * Purging expired rows keeps {@code idempotency_keys} small and the
+ * {@code idx_idempotency_expires} index lean.</p>
+ *
+ * <p>Runs at 02:00 server time every day. The exact time is low-traffic by design;
+ * adjust via {@code orders.idempotency.purge-cron} in {@code application.yml} if needed.</p>
+ */
+@Service
+public class IdempotencyKeyPurgeJob {
+
+    private static final Logger log = LoggerFactory.getLogger(IdempotencyKeyPurgeJob.class);
+
+    private final IdempotencyKeyRepository repository;
+
+    public IdempotencyKeyPurgeJob(IdempotencyKeyRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * Deletes all {@code idempotency_keys} rows whose {@code expires_at} is in the past.
+     * The underlying repository method is {@code @Modifying @Transactional} — the delete
+     * runs in its own transaction and commits before this method returns.
+     */
+    @Scheduled(cron = "${orders.idempotency.purge-cron:0 0 2 * * *}")
+    public void purgeExpiredKeys() {
+        Instant now = Instant.now();
+        int deleted = repository.deleteExpired(now);
+        log.info("IdempotencyKeyPurgeJob: deleted {} expired keys (cutoff={})", deleted, now);
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/IdempotencyKeyPurgeJob.java
+++ b/orders/src/main/java/com/oneday/orders/service/IdempotencyKeyPurgeJob.java
@@ -16,8 +16,11 @@ import java.time.Instant;
  * Purging expired rows keeps {@code idempotency_keys} small and the
  * {@code idx_idempotency_expires} index lean.</p>
  *
- * <p>Runs at 02:00 server time every day. The exact time is low-traffic by design;
+ * <p>Runs at 02:00 IST every day. The exact time is low-traffic by design;
  * adjust via {@code orders.idempotency.purge-cron} in {@code application.yml} if needed.</p>
+ *
+ * <p>Requires {@code @EnableScheduling} on a {@code @Configuration} class (provided by
+ * {@code app/OneDayDeliveryApplication}) for this method to be invoked by the scheduler.</p>
  */
 @Service
 public class IdempotencyKeyPurgeJob {
@@ -35,7 +38,7 @@ public class IdempotencyKeyPurgeJob {
      * The underlying repository method is {@code @Modifying @Transactional} — the delete
      * runs in its own transaction and commits before this method returns.
      */
-    @Scheduled(cron = "${orders.idempotency.purge-cron:0 0 2 * * *}")
+    @Scheduled(cron = "${orders.idempotency.purge-cron:0 0 2 * * *}", zone = "Asia/Kolkata")
     public void purgeExpiredKeys() {
         Instant now = Instant.now();
         int deleted = repository.deleteExpired(now);

--- a/orders/src/main/java/com/oneday/orders/service/PaymentPort.java
+++ b/orders/src/main/java/com/oneday/orders/service/PaymentPort.java
@@ -1,0 +1,63 @@
+package com.oneday.orders.service;
+
+/**
+ * Port for Razorpay payment operations.
+ *
+ * <p>This interface is intentionally local to the {@code orders} module — no other
+ * module interacts with Razorpay directly, so it does not belong in {@code common}.
+ * The production implementation ({@code RazorpayPaymentAdapter}) will live in
+ * {@code orders/service/impl/} and be wired by Spring.</p>
+ *
+ * <p>All monetary amounts are in <strong>paise</strong> (1 INR = 100 paise).</p>
+ */
+public interface PaymentPort {
+
+    /**
+     * Verifies the Razorpay HMAC-SHA256 payment signature supplied by the client
+     * after the Razorpay checkout JS SDK completes.
+     *
+     * @param razorpayOrderId   Razorpay order ID created by the client (e.g. {@code order_xxxxxxxx})
+     * @param razorpayPaymentId Razorpay payment ID returned by the checkout SDK (e.g. {@code pay_xxxxxxxx})
+     * @param signature         HMAC-SHA256 signature provided by the client
+     * @throws PaymentVerificationException if the signature does not match
+     */
+    void verifySignature(String razorpayOrderId, String razorpayPaymentId, String signature);
+
+    /**
+     * Captures a previously authorised Razorpay payment.
+     *
+     * @param razorpayPaymentId the payment to capture
+     * @param amountPaise       amount to capture in paise; must match the authorised amount
+     * @throws PaymentCaptureException if Razorpay rejects or returns an error
+     */
+    void capture(String razorpayPaymentId, long amountPaise);
+
+    /**
+     * Initiates a refund for a captured Razorpay payment.
+     *
+     * @param razorpayPaymentId the payment to refund
+     * @param amountPaise       refund amount in paise; may be partial
+     * @return the Razorpay refund ID (e.g. {@code rfnd_xxxxxxxx}) for audit trail storage
+     * @throws PaymentRefundException if Razorpay rejects or returns an error
+     */
+    String initiateRefund(String razorpayPaymentId, long amountPaise);
+
+    // -------------------------------------------------------------------------
+    // Unchecked exceptions (all extend RuntimeException — callers need not declare them)
+    // -------------------------------------------------------------------------
+
+    class PaymentVerificationException extends RuntimeException {
+        public PaymentVerificationException(String message) { super(message); }
+        public PaymentVerificationException(String message, Throwable cause) { super(message, cause); }
+    }
+
+    class PaymentCaptureException extends RuntimeException {
+        public PaymentCaptureException(String message) { super(message); }
+        public PaymentCaptureException(String message, Throwable cause) { super(message, cause); }
+    }
+
+    class PaymentRefundException extends RuntimeException {
+        public PaymentRefundException(String message) { super(message); }
+        public PaymentRefundException(String message, Throwable cause) { super(message, cause); }
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/PickupOtpService.java
+++ b/orders/src/main/java/com/oneday/orders/service/PickupOtpService.java
@@ -1,0 +1,73 @@
+package com.oneday.orders.service;
+
+import java.util.UUID;
+
+/**
+ * Manages one-time passcodes (OTPs) for DA pickup verification.
+ *
+ * <h2>Flow</h2>
+ * <ol>
+ *   <li>State machine enters {@code PICKUP_ASSIGNED} → caller invokes {@link #generate}.</li>
+ *   <li>DA presents the OTP to the sender; sender confirms on the DA app.</li>
+ *   <li>DA app calls {@code POST /internal/v1/shipments/{ref}/pickup-otp/verify}
+ *       → {@link #verify} is called → on success, state machine transitions
+ *       {@code PICKUP_ASSIGNED → PICKED_UP}.</li>
+ *   <li>If the sender did not receive the OTP, DA calls
+ *       {@code POST /internal/v1/shipments/{ref}/pickup-otp/resend}
+ *       → {@link #resend} is called (max 3 times).</li>
+ * </ol>
+ *
+ * <h2>Security</h2>
+ * Only the BCrypt hash of the OTP is ever stored in the DB. The cleartext
+ * 4-digit OTP is returned once from {@link #generate} and must be sent to
+ * the sender via the notification service immediately.
+ */
+public interface PickupOtpService {
+
+    /**
+     * Generates a fresh 4-digit OTP for the given shipment and stores its
+     * BCrypt hash in {@code pickup_otps} with a 10-minute expiry.
+     *
+     * <p>If an OTP row already exists for this shipment (e.g. called twice due
+     * to a state machine retry), the old row is deleted and a new one inserted.
+     *
+     * @param shipmentId the shipment entering {@code PICKUP_ASSIGNED}
+     * @return the cleartext 4-digit OTP string (e.g. {@code "4821"}); send to
+     *         sender immediately and do not persist
+     */
+    String generate(UUID shipmentId);
+
+    /**
+     * Verifies the OTP submitted by the DA app.
+     *
+     * @param shipmentId the shipment being picked up
+     * @param otp        the 4-digit OTP entered by the DA
+     * @throws OtpVerificationException if the OTP is wrong, expired, or already used
+     */
+    void verify(UUID shipmentId, String otp);
+
+    /**
+     * Resends the OTP by generating a new one and invalidating the previous.
+     * Increments the resend counter. After the third resend the shipment is
+     * flagged and further resends are blocked.
+     *
+     * @param shipmentId the shipment for which to resend
+     * @return the new cleartext OTP string; send to sender immediately
+     * @throws ResendLimitExceededException if {@code resend_count >= 3}
+     */
+    String resend(UUID shipmentId);
+
+    // -------------------------------------------------------------------------
+    // Exceptions
+    // -------------------------------------------------------------------------
+
+    /** Thrown when OTP verification fails for any reason (wrong, expired, used). */
+    class OtpVerificationException extends RuntimeException {
+        public OtpVerificationException(String message) { super(message); }
+    }
+
+    /** Thrown when the caller attempts a resend after the 3-resend limit. */
+    class ResendLimitExceededException extends RuntimeException {
+        public ResendLimitExceededException(String message) { super(message); }
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/ShipmentRefService.java
+++ b/orders/src/main/java/com/oneday/orders/service/ShipmentRefService.java
@@ -1,0 +1,32 @@
+package com.oneday.orders.service;
+
+/**
+ * Generates unique, human-readable shipment reference numbers.
+ *
+ * <p>Format: {@code 1DD-{CITY}-{YYYYMMDD}-{NNNNN}}
+ * <br>Example: {@code 1DD-BLR-20260530-00042}
+ *
+ * <ul>
+ *   <li>{@code CITY} — 3-letter origin city code (e.g. BLR, BOM, DEL)</li>
+ *   <li>{@code YYYYMMDD} — booking date in IST</li>
+ *   <li>{@code NNNNN} — zero-padded 5-digit sequence, resets daily per city</li>
+ * </ul>
+ *
+ * <p>The sequence counter is persisted in {@code shipment_ref_counters} using
+ * {@code SELECT FOR UPDATE} to serialise concurrent increments. At high volume
+ * (> ~500 bookings/min per city) the row-level lock becomes a bottleneck;
+ * the upgrade path is a Redis {@code INCR} + Lua script with async DB sync —
+ * documented in M4-ORDERS-DESIGN.md §15.5.</p>
+ */
+public interface ShipmentRefService {
+
+    /**
+     * Atomically generates the next reference number for the given origin city
+     * on today's date (IST). Must be called inside an active transaction so that
+     * the counter increment is rolled back if the surrounding booking fails.
+     *
+     * @param originCityCode 3-letter city code (e.g. {@code "BLR"})
+     * @return reference string, e.g. {@code "1DD-BLR-20260530-00001"}
+     */
+    String generateRef(String originCityCode);
+}

--- a/orders/src/main/java/com/oneday/orders/service/ShipmentStateMachine.java
+++ b/orders/src/main/java/com/oneday/orders/service/ShipmentStateMachine.java
@@ -1,0 +1,40 @@
+package com.oneday.orders.service;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.service.exception.IllegalStateTransitionException;
+
+import java.util.UUID;
+
+/**
+ * The canonical state machine for M4 shipment lifecycle.
+ *
+ * <p>Callers supply the target state and a {@link TransitionContext} describing
+ * who triggered the transition and why. The implementation:</p>
+ * <ol>
+ *   <li>Acquires a pessimistic write lock (SELECT FOR UPDATE) on the shipment row</li>
+ *   <li>Looks up allowed targets from {@link TransitionRegistry}</li>
+ *   <li>Applies runtime branching rules (pickup_type, drop_type, delivery_type)</li>
+ *   <li>Rejects invalid transitions with {@link IllegalStateTransitionException}</li>
+ *   <li>Updates the shipment state and appends a {@code ShipmentStateHistory} row</li>
+ * </ol>
+ *
+ * <p>Side effects (OTP generation, ETA calls, Kafka emission, notifications) are
+ * NOT performed here — they live in the calling service layer ({@code ShipmentServiceImpl})
+ * which wraps this machine.</p>
+ *
+ * <p>All callers must be inside a {@code @Transactional} method; the implementation
+ * enforces this via its own {@code @Transactional} annotation.</p>
+ */
+public interface ShipmentStateMachine {
+
+    /**
+     * Transitions {@code shipmentId} to {@code target}.
+     *
+     * @param shipmentId the shipment to transition
+     * @param target     the desired next state
+     * @param ctx        metadata about who triggered this transition and why
+     * @throws IllegalStateTransitionException if the transition is not permitted
+     * @throws jakarta.persistence.EntityNotFoundException if the shipment does not exist
+     */
+    void transition(UUID shipmentId, ShipmentState target, TransitionContext ctx);
+}

--- a/orders/src/main/java/com/oneday/orders/service/TransitionContext.java
+++ b/orders/src/main/java/com/oneday/orders/service/TransitionContext.java
@@ -1,0 +1,70 @@
+package com.oneday.orders.service;
+
+import com.oneday.orders.domain.enums.TriggerSource;
+
+import java.time.Instant;
+
+/**
+ * Carries metadata about why a state transition is happening.
+ * Passed into the state machine and written verbatim into {@code ShipmentStateHistory}.
+ *
+ * <p>Use the factory methods rather than the constructor directly:</p>
+ * <pre>
+ *   TransitionContext.fromApi(userId, requestId)
+ *   TransitionContext.fromKafka("m5-consumer", kafkaMessageKey)
+ *   TransitionContext.fromSystem("idempotency-purge-job")
+ * </pre>
+ */
+public final class TransitionContext {
+
+    private final String triggeredBy;
+    private final TriggerSource triggerSource;
+    private final String eventRef;   // nullable — Kafka message key or API request ID
+    private final String notes;      // nullable — human-readable context
+    private final Instant occurredAt;
+
+    private TransitionContext(String triggeredBy,
+                              TriggerSource triggerSource,
+                              String eventRef,
+                              String notes,
+                              Instant occurredAt) {
+        this.triggeredBy = triggeredBy;
+        this.triggerSource = triggerSource;
+        this.eventRef = eventRef;
+        this.notes = notes;
+        this.occurredAt = occurredAt;
+    }
+
+    // ── Factory methods ───────────────────────────────────────────────────────
+
+    /** Transition triggered by a customer or operator via the REST API. */
+    public static TransitionContext fromApi(String userId, String requestId) {
+        return new TransitionContext(userId, TriggerSource.API, requestId, null, Instant.now());
+    }
+
+    /**
+     * Transition triggered by a Kafka event from another module.
+     * {@code eventRef} should be the Kafka message key for correlation back to the topic log.
+     */
+    public static TransitionContext fromKafka(String consumerIdentifier, String kafkaMessageKey) {
+        return new TransitionContext(consumerIdentifier, TriggerSource.KAFKA_EVENT, kafkaMessageKey, null, Instant.now());
+    }
+
+    /** Transition triggered by an internal scheduled job or system process. */
+    public static TransitionContext fromSystem(String systemIdentifier) {
+        return new TransitionContext(systemIdentifier, TriggerSource.SYSTEM, null, null, Instant.now());
+    }
+
+    /** Builder-style notes attachment — returns a new context with the note added. */
+    public TransitionContext withNotes(String notes) {
+        return new TransitionContext(triggeredBy, triggerSource, eventRef, notes, occurredAt);
+    }
+
+    // ── Accessors ─────────────────────────────────────────────────────────────
+
+    public String getTriggeredBy() { return triggeredBy; }
+    public TriggerSource getTriggerSource() { return triggerSource; }
+    public String getEventRef() { return eventRef; }
+    public String getNotes() { return notes; }
+    public Instant getOccurredAt() { return occurredAt; }
+}

--- a/orders/src/main/java/com/oneday/orders/service/TransitionRegistry.java
+++ b/orders/src/main/java/com/oneday/orders/service/TransitionRegistry.java
@@ -1,0 +1,127 @@
+package com.oneday.orders.service;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Holds the allowed state transitions for the M4 shipment state machine.
+ *
+ * <p>The V1 base transitions are registered in {@link #initialise()}. Any Spring bean
+ * implementing {@link TransitionRegistryConfigurer} is applied afterwards, allowing
+ * future modules or V2 flows to add transitions without modifying this class.</p>
+ *
+ * <p>Runtime branching (pickup_type, drop_type, delivery_type) is handled by
+ * {@link impl.ShipmentStateMachineImpl}, which narrows the set returned here based on
+ * the shipment's own fields. The registry intentionally contains both possible targets
+ * for branching states (e.g. {@code IN_TAKEOFF_BAG} allows both
+ * {@code DISPATCHED_TO_AIRPORT} and {@code HANDED_TO_DROP_VAN}); the impl filters
+ * the set down to the one that matches the shipment's delivery_type at transition time.</p>
+ */
+@Component
+public class TransitionRegistry {
+
+    private final Map<ShipmentState, Set<ShipmentState>> transitions =
+            new EnumMap<>(ShipmentState.class);
+
+    private final List<TransitionRegistryConfigurer> configurers;
+
+    public TransitionRegistry(List<TransitionRegistryConfigurer> configurers) {
+        this.configurers = configurers;
+    }
+
+    @PostConstruct
+    public void initialise() {
+        // ── Normal pickup path (DA_PICKUP) ────────────────────────────────────
+        register(ShipmentState.BOOKED,                ShipmentState.PICKUP_ASSIGNED);
+        register(ShipmentState.BOOKED,                ShipmentState.AWAITING_SELF_DROP);
+        register(ShipmentState.BOOKED,                ShipmentState.CANCELLED);
+
+        register(ShipmentState.AWAITING_SELF_DROP,    ShipmentState.AT_ORIGIN_HUB);
+        register(ShipmentState.AWAITING_SELF_DROP,    ShipmentState.CANCELLED);
+
+        register(ShipmentState.PICKUP_ASSIGNED,       ShipmentState.PICKED_UP);
+        register(ShipmentState.PICKUP_ASSIGNED,       ShipmentState.PICKUP_FAILED);
+        register(ShipmentState.PICKUP_ASSIGNED,       ShipmentState.CANCELLED);
+
+        register(ShipmentState.PICKED_UP,             ShipmentState.HANDED_TO_PICKUP_VAN);
+        register(ShipmentState.PICKED_UP,             ShipmentState.CANCELLED);
+
+        register(ShipmentState.HANDED_TO_PICKUP_VAN,  ShipmentState.AT_ORIGIN_HUB);
+
+        // ── Hub processing ────────────────────────────────────────────────────
+        register(ShipmentState.AT_ORIGIN_HUB,         ShipmentState.ORIGIN_HUB_PROCESSING);
+        register(ShipmentState.ORIGIN_HUB_PROCESSING, ShipmentState.IN_TAKEOFF_BAG);
+
+        // ── Intercity air leg (delivery_type branching at IN_TAKEOFF_BAG) ─────
+        // Both targets are registered; ShipmentStateMachineImpl filters to one at runtime.
+        register(ShipmentState.IN_TAKEOFF_BAG,        ShipmentState.DISPATCHED_TO_AIRPORT); // INTERCITY
+        register(ShipmentState.IN_TAKEOFF_BAG,        ShipmentState.HANDED_TO_DROP_VAN);    // SAME_CITY
+
+        register(ShipmentState.DISPATCHED_TO_AIRPORT, ShipmentState.AT_AIRPORT);
+        register(ShipmentState.AT_AIRPORT,            ShipmentState.DEPARTED);
+        register(ShipmentState.DEPARTED,              ShipmentState.LANDED);
+        register(ShipmentState.LANDED,                ShipmentState.DISPATCHED_TO_HUB);
+        register(ShipmentState.DISPATCHED_TO_HUB,     ShipmentState.AT_DEST_HUB);
+        register(ShipmentState.AT_DEST_HUB,           ShipmentState.DEST_HUB_PROCESSING);
+
+        // ── Last-mile delivery (drop_type branching at DEST_HUB_PROCESSING) ───
+        // Both targets are registered; impl filters to one at runtime.
+        register(ShipmentState.DEST_HUB_PROCESSING,   ShipmentState.HANDED_TO_DROP_VAN);    // DA_DELIVERY
+        register(ShipmentState.DEST_HUB_PROCESSING,   ShipmentState.AWAITING_HUB_COLLECT);  // HUB_COLLECT
+
+        register(ShipmentState.AWAITING_HUB_COLLECT,  ShipmentState.HUB_COLLECTED);
+
+        register(ShipmentState.HANDED_TO_DROP_VAN,    ShipmentState.DROP_ASSIGNED);
+        register(ShipmentState.DROP_ASSIGNED,         ShipmentState.DROP_COLLECTED);
+        register(ShipmentState.DROP_COLLECTED,        ShipmentState.DROPPED);
+        register(ShipmentState.DROP_COLLECTED,        ShipmentState.DELIVERY_FAILED);
+
+        // ── Exception / failure paths (M11-driven) ───────────────────────────
+        register(ShipmentState.PICKUP_FAILED,         ShipmentState.PICKUP_ASSIGNED);
+        register(ShipmentState.PICKUP_FAILED,         ShipmentState.CANCELLED);
+
+        register(ShipmentState.DELIVERY_FAILED,       ShipmentState.RTO_INITIATED);
+        register(ShipmentState.DELIVERY_FAILED,       ShipmentState.DROP_ASSIGNED);
+
+        // ── RTO path (delivery_type branching at RTO_INITIATED) ──────────────
+        // Both targets registered; impl filters to one at runtime.
+        register(ShipmentState.RTO_INITIATED,         ShipmentState.RTO_IN_TRANSIT);  // INTERCITY
+        register(ShipmentState.RTO_INITIATED,         ShipmentState.RTO_COMPLETED);   // SAME_CITY
+
+        register(ShipmentState.RTO_IN_TRANSIT,        ShipmentState.RTO_COMPLETED);
+
+        // Terminal states: DROPPED, HUB_COLLECTED, RTO_COMPLETED, CANCELLED
+        // — intentionally not registered; getAllowedTargets returns empty set for them.
+
+        // Apply extension configurers (e.g. V2 flows registered by other modules)
+        configurers.forEach(c -> c.configure(this));
+    }
+
+    /**
+     * Registers a single {@code from → to} transition. Safe to call from
+     * {@link TransitionRegistryConfigurer} implementations at startup.
+     */
+    public void register(ShipmentState from, ShipmentState to) {
+        transitions.computeIfAbsent(from, k -> EnumSet.noneOf(ShipmentState.class)).add(to);
+    }
+
+    /**
+     * Returns the set of states reachable from {@code from} according to the registry.
+     * Note: this is the <em>full</em> registry set — the state machine impl narrows it
+     * further for branching states (pickup_type / drop_type / delivery_type).
+     *
+     * @return an unmodifiable view; empty if {@code from} is a terminal state
+     */
+    public Set<ShipmentState> getAllowedTargets(ShipmentState from) {
+        return Collections.unmodifiableSet(
+                transitions.getOrDefault(from, EnumSet.noneOf(ShipmentState.class)));
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/TransitionRegistryConfigurer.java
+++ b/orders/src/main/java/com/oneday/orders/service/TransitionRegistryConfigurer.java
@@ -1,0 +1,25 @@
+package com.oneday.orders.service;
+
+/**
+ * Extension point for registering additional state transitions into the
+ * {@link TransitionRegistry} at application startup.
+ *
+ * <p>Any Spring bean implementing this interface will be discovered automatically
+ * and applied by {@code TransitionRegistry} in its {@code @PostConstruct} phase,
+ * after the V1 base transitions have been registered. This allows future modules
+ * or V2 flows to contribute new transitions without modifying existing code.</p>
+ *
+ * <p>Example:</p>
+ * <pre>
+ * {@literal @}Component
+ * class V2PartialDeliveryTransitions implements TransitionRegistryConfigurer {
+ *     {@literal @}Override
+ *     public void configure(TransitionRegistry registry) {
+ *         registry.register(ShipmentState.DROPPED, ShipmentState.PARTIAL_RETURN_INITIATED);
+ *     }
+ * }
+ * </pre>
+ */
+public interface TransitionRegistryConfigurer {
+    void configure(TransitionRegistry registry);
+}

--- a/orders/src/main/java/com/oneday/orders/service/exception/IllegalStateTransitionException.java
+++ b/orders/src/main/java/com/oneday/orders/service/exception/IllegalStateTransitionException.java
@@ -1,0 +1,29 @@
+package com.oneday.orders.service.exception;
+
+import com.oneday.common.domain.enums.ShipmentState;
+
+/**
+ * Thrown by {@link com.oneday.orders.service.ShipmentStateMachine} when a requested
+ * state transition is not permitted by the transition registry or runtime branching rules.
+ *
+ * <p>Maps to {@code 409 Conflict} at the API layer.</p>
+ */
+public class IllegalStateTransitionException extends RuntimeException {
+
+    private final ShipmentState fromState;
+    private final ShipmentState toState;
+
+    public IllegalStateTransitionException(ShipmentState fromState, ShipmentState toState) {
+        super(String.format("Transition from %s to %s is not permitted", fromState, toState));
+        this.fromState = fromState;
+        this.toState = toState;
+    }
+
+    public ShipmentState getFromState() {
+        return fromState;
+    }
+
+    public ShipmentState getToState() {
+        return toState;
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/PickupOtpServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/PickupOtpServiceImpl.java
@@ -1,0 +1,142 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.config.PickupOtpProperties;
+import com.oneday.orders.domain.PickupOtp;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.repository.PickupOtpRepository;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.service.PickupOtpService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+/**
+ * BCrypt-backed OTP service. Cleartext OTP is generated per request, never stored.
+ *
+ * <p>All methods are {@code @Transactional} so that concurrent verify/resend calls
+ * are serialised at the DB level via the unique index on {@code pickup_otps.shipment_id}.</p>
+ */
+@Service
+class PickupOtpServiceImpl implements PickupOtpService {
+
+    private static final Logger log = LoggerFactory.getLogger(PickupOtpServiceImpl.class);
+
+    // BCrypt cost 4 is adequate for 4-digit OTPs — the 10-min TTL and single-use flag
+    // provide the primary security guarantee. Cost 10 adds ~100 ms per operation with
+    // no meaningful security gain for short-lived codes.
+    private static final BCryptPasswordEncoder ENCODER = new BCryptPasswordEncoder(4);
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private final PickupOtpRepository otpRepository;
+    private final ShipmentRepository shipmentRepository;
+    private final PickupOtpProperties properties;
+
+    PickupOtpServiceImpl(PickupOtpRepository otpRepository,
+                         ShipmentRepository shipmentRepository,
+                         PickupOtpProperties properties) {
+        this.otpRepository      = otpRepository;
+        this.shipmentRepository = shipmentRepository;
+        this.properties         = properties;
+    }
+
+    @Override
+    @Transactional
+    public String generate(UUID shipmentId) {
+        Shipment shipment = shipmentRepository.findById(shipmentId)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Shipment not found: " + shipmentId));
+
+        // Delete any existing OTP for this shipment (idempotent re-entry guard).
+        otpRepository.deleteByShipmentId(shipmentId);
+
+        String otp = generateFourDigitOtp();
+
+        PickupOtp record = new PickupOtp();
+        record.setShipment(shipment);
+        record.setOtpHash(ENCODER.encode(otp));
+        record.setExpiresAt(Instant.now().plus(properties.getTtlMinutes(), ChronoUnit.MINUTES));
+        record.setResendCount((short) 0);
+        record.setUsed(false);
+        otpRepository.save(record);
+
+        log.debug("OTP generated for shipmentId={}", shipmentId);
+        return otp;
+    }
+
+    @Override
+    @Transactional
+    public void verify(UUID shipmentId, String otp) {
+        // Pessimistic lock prevents two concurrent verify calls from both seeing
+        // used=false and both succeeding — the second blocks until the first commits.
+        PickupOtp record = otpRepository.findByShipmentIdWithLock(shipmentId)
+                .orElseThrow(() -> new OtpVerificationException(
+                        "No active OTP found for shipment"));
+
+        if (record.isUsed()) {
+            throw new OtpVerificationException("OTP has already been used");
+        }
+        if (record.getExpiresAt().isBefore(Instant.now())) {
+            throw new OtpVerificationException("OTP has expired");
+        }
+        if (!ENCODER.matches(otp, record.getOtpHash())) {
+            throw new OtpVerificationException("OTP is incorrect");
+        }
+
+        record.setUsed(true);
+        otpRepository.save(record);
+        log.debug("OTP verified for shipmentId={}", shipmentId);
+    }
+
+    @Override
+    @Transactional
+    public String resend(UUID shipmentId) {
+        PickupOtp existing = otpRepository.findByShipmentId(shipmentId)
+                .orElseThrow(() -> new OtpVerificationException(
+                        "No active OTP found for shipment; call generate first"));
+
+        if (existing.getResendCount() >= properties.getMaxResendCount()) {
+            throw new ResendLimitExceededException(
+                    "Resend limit (" + properties.getMaxResendCount() + ") reached for shipment " + shipmentId);
+        }
+
+        short newResendCount = (short) (existing.getResendCount() + 1);
+
+        // Delete the old row (unique index prevents inserting a new one while old exists).
+        otpRepository.deleteByShipmentId(shipmentId);
+
+        // Re-use the already-loaded shipment reference — avoids a second DB round-trip.
+        Shipment shipment = existing.getShipment();
+
+        String otp = generateFourDigitOtp();
+
+        PickupOtp record = new PickupOtp();
+        record.setShipment(shipment);
+        record.setOtpHash(ENCODER.encode(otp));
+        record.setExpiresAt(Instant.now().plus(properties.getTtlMinutes(), ChronoUnit.MINUTES));
+        record.setResendCount(newResendCount);
+        record.setUsed(false);
+        otpRepository.save(record);
+
+        log.debug("OTP resent (attempt {}/{}) for shipmentId={}",
+                newResendCount, properties.getMaxResendCount(), shipmentId);
+        return otp;
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /** Returns a zero-padded 4-digit string, e.g. "0042" or "9871". */
+    private static String generateFourDigitOtp() {
+        int value = RANDOM.nextInt(10_000); // 0–9999
+        return String.format("%04d", value);
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/ShipmentRefServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/ShipmentRefServiceImpl.java
@@ -1,0 +1,75 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.domain.ShipmentRefCounter;
+import com.oneday.orders.domain.ShipmentRefCounterId;
+import com.oneday.orders.repository.ShipmentRefCounterRepository;
+import com.oneday.orders.service.ShipmentRefService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Generates shipment reference numbers of the form {@code 1DD-{CITY}-{YYYYMMDD}-{NNNNN}}.
+ *
+ * <p>Uses {@code SELECT FOR UPDATE} via {@link ShipmentRefCounterRepository#findByIdWithLock}
+ * to serialise concurrent increments within a transaction. The caller's transaction
+ * must already be active — this method runs with {@code MANDATORY} propagation so that
+ * the counter increment is rolled back together with the surrounding booking if anything
+ * fails after ref generation.</p>
+ *
+ * <p><strong>High-volume upgrade path:</strong> At > ~500 bookings/min per city the
+ * row-level lock on {@code (city_code, date_key)} becomes a serialisation bottleneck.
+ * Migrate to a Redis {@code INCR} + Lua script that atomically increments and returns
+ * the counter, syncing to the DB asynchronously. See M4-ORDERS-DESIGN.md §15.5.</p>
+ */
+@Service
+class ShipmentRefServiceImpl implements ShipmentRefService {
+
+    private static final ZoneId IST = ZoneId.of("Asia/Kolkata");
+    private static final String PREFIX = "1DD";
+
+    private final ShipmentRefCounterRepository counterRepository;
+
+    ShipmentRefServiceImpl(ShipmentRefCounterRepository counterRepository) {
+        this.counterRepository = counterRepository;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Must be called inside an active transaction ({@code MANDATORY} propagation).
+     * The counter increment is part of the caller's transaction and will be rolled
+     * back if the surrounding booking fails.</p>
+     */
+    @Override
+    @Transactional(propagation = Propagation.MANDATORY)
+    public String generateRef(String originCityCode) {
+        String city = originCityCode.toUpperCase();
+        LocalDate today = LocalDate.now(IST);
+
+        ShipmentRefCounterId id = new ShipmentRefCounterId(city, today);
+
+        // Ensure the row exists before locking — INSERT does nothing on conflict,
+        // so only the first concurrent caller for this (city, date) pair inserts.
+        // Without this, SELECT FOR UPDATE on a missing row locks nothing, letting
+        // concurrent first-of-day callers race to INSERT and violate the PK.
+        counterRepository.insertIfAbsent(city, today);
+
+        // Lock the counter row so no other transaction can interleave.
+        ShipmentRefCounter counter = counterRepository.findByIdWithLock(id)
+                .orElseThrow(() -> new IllegalStateException(
+                        "Counter must exist after insertIfAbsent for id=" + id));
+
+        int next = counter.getNextVal() + 1;
+        counter.setNextVal(next);
+        counterRepository.save(counter);
+
+        // Format: 1DD-BLR-20260530-00042
+        String dateKey = today.format(DateTimeFormatter.BASIC_ISO_DATE); // YYYYMMDD
+        return String.format("%s-%s-%s-%05d", PREFIX, city, dateKey, next);
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/ShipmentStateMachineImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/ShipmentStateMachineImpl.java
@@ -1,0 +1,108 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.enums.DeliveryType;
+import com.oneday.common.domain.enums.DropType;
+import com.oneday.common.domain.enums.PickupType;
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.domain.ShipmentStateHistory;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.repository.ShipmentStateHistoryRepository;
+import com.oneday.orders.service.ShipmentStateMachine;
+import com.oneday.orders.service.TransitionContext;
+import com.oneday.orders.service.TransitionRegistry;
+import com.oneday.orders.service.exception.IllegalStateTransitionException;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+@Transactional
+class ShipmentStateMachineImpl implements ShipmentStateMachine {
+
+    private final ShipmentRepository shipmentRepo;
+    private final ShipmentStateHistoryRepository historyRepo;
+    private final TransitionRegistry registry;
+
+    ShipmentStateMachineImpl(ShipmentRepository shipmentRepo,
+                              ShipmentStateHistoryRepository historyRepo,
+                              TransitionRegistry registry) {
+        this.shipmentRepo = shipmentRepo;
+        this.historyRepo = historyRepo;
+        this.registry = registry;
+    }
+
+    @Override
+    public void transition(UUID shipmentId, ShipmentState target, TransitionContext ctx) {
+        // SELECT FOR UPDATE — prevents concurrent transitions on the same shipment
+        Shipment shipment = shipmentRepo.findByIdWithLock(shipmentId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Shipment not found: " + shipmentId));
+
+        ShipmentState current = shipment.getState();
+        Set<ShipmentState> allowed = computeAllowed(shipment, current);
+
+        if (!allowed.contains(target)) {
+            throw new IllegalStateTransitionException(current, target);
+        }
+
+        shipment.setState(target);
+        shipmentRepo.save(shipment);
+
+        historyRepo.save(ShipmentStateHistory.of(shipmentId, current, target, ctx));
+    }
+
+    /**
+     * Returns the set of states actually reachable from {@code current} for this
+     * specific shipment, applying pickup_type / drop_type / delivery_type branching
+     * on top of the registry's base set.
+     */
+    private Set<ShipmentState> computeAllowed(Shipment shipment, ShipmentState current) {
+        Set<ShipmentState> base = EnumSet.copyOf(
+                registry.getAllowedTargets(current).isEmpty()
+                        ? EnumSet.noneOf(ShipmentState.class)
+                        : registry.getAllowedTargets(current));
+
+        switch (current) {
+            case BOOKED -> {
+                // pickup_type determines which initial path is taken
+                if (shipment.getPickupType() == PickupType.DA_PICKUP) {
+                    base.remove(ShipmentState.AWAITING_SELF_DROP);
+                } else if (shipment.getPickupType() == PickupType.SELF_DROP) {
+                    base.remove(ShipmentState.PICKUP_ASSIGNED);
+                }
+            }
+            case IN_TAKEOFF_BAG -> {
+                // delivery_type determines whether the air leg is taken
+                if (shipment.getDeliveryType() == DeliveryType.INTERCITY) {
+                    base.remove(ShipmentState.HANDED_TO_DROP_VAN);
+                } else if (shipment.getDeliveryType() == DeliveryType.SAME_CITY) {
+                    base.remove(ShipmentState.DISPATCHED_TO_AIRPORT);
+                }
+            }
+            case DEST_HUB_PROCESSING -> {
+                // drop_type determines whether a DA delivers or customer collects from hub
+                if (shipment.getDropType() == DropType.DA_DELIVERY) {
+                    base.remove(ShipmentState.AWAITING_HUB_COLLECT);
+                } else if (shipment.getDropType() == DropType.HUB_COLLECT) {
+                    base.remove(ShipmentState.HANDED_TO_DROP_VAN);
+                }
+            }
+            case RTO_INITIATED -> {
+                // delivery_type determines whether there is a return air leg
+                if (shipment.getDeliveryType() == DeliveryType.INTERCITY) {
+                    base.remove(ShipmentState.RTO_COMPLETED);
+                } else if (shipment.getDeliveryType() == DeliveryType.SAME_CITY) {
+                    base.remove(ShipmentState.RTO_IN_TRANSIT);
+                }
+            }
+            default -> { /* no branching — base set is the full allowed set */ }
+        }
+
+        return base;
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/ShipmentStateMachineImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/ShipmentStateMachineImpl.java
@@ -51,7 +51,8 @@ class ShipmentStateMachineImpl implements ShipmentStateMachine {
         }
 
         shipment.setState(target);
-        shipmentRepo.save(shipment);
+        // No explicit save() — shipment is a managed entity; Hibernate dirty-checks
+        // and flushes the UPDATE automatically when the transaction commits.
 
         historyRepo.save(ShipmentStateHistory.of(shipmentId, current, target, ctx));
     }

--- a/orders/src/main/resources/db/migration/orders/V4_10__add_request_fingerprint_to_idempotency_keys.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_10__add_request_fingerprint_to_idempotency_keys.sql
@@ -1,0 +1,10 @@
+-- PR #8: add SHA-256 body fingerprint column to idempotency_keys.
+-- Used by IdempotencyFilter to detect key-reuse with a different request body
+-- (returns 422 IDEMPOTENCY_KEY_BODY_MISMATCH in that case).
+--
+-- VARCHAR(64) because SHA-256 always produces exactly 64 lowercase hex characters.
+-- NULLable: rows created before this migration have no fingerprint (safe — they
+-- will not be replayed; they will expire and be purged by IdempotencyKeyPurgeJob).
+
+ALTER TABLE idempotency_keys
+    ADD COLUMN request_fingerprint VARCHAR(64) NULL;

--- a/orders/src/main/resources/db/migration/orders/V4_11__create_pickup_otps.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_11__create_pickup_otps.sql
@@ -1,0 +1,32 @@
+-- PR #9: pickup OTP table for DA pickup verification.
+--
+-- Flow: when a shipment enters PICKUP_ASSIGNED, PickupOtpService generates a
+-- 4-digit OTP, stores only the BCrypt hash here, and sends the cleartext to
+-- the sender via SMS. The DA app calls POST /internal/v1/shipments/{ref}/pickup-otp/verify;
+-- on success the state machine transitions PICKUP_ASSIGNED → PICKED_UP.
+--
+-- Design choices:
+--   - otp_hash: BCrypt of the 4-digit OTP; cleartext is never stored.
+--   - expires_at: 10 minutes from generation; checked at verify time.
+--   - used: set to TRUE on first successful verify; prevents replay within TTL window.
+--   - resend_count: incremented on each /resend; capped at 3 by application logic.
+--   - One active OTP per shipment at a time (uq_pickup_otps_shipment enforces this).
+--     On resend the old row is deleted and a fresh row is inserted.
+
+CREATE TABLE pickup_otps (
+    id             UUID         NOT NULL DEFAULT gen_random_uuid(),
+    shipment_id    UUID         NOT NULL REFERENCES shipments(id),
+    otp_hash       VARCHAR(60)  NOT NULL,   -- BCrypt output is always 60 chars
+    expires_at     TIMESTAMPTZ  NOT NULL,
+    used           BOOLEAN      NOT NULL DEFAULT FALSE,
+    resend_count   SMALLINT     NOT NULL DEFAULT 0,
+    created_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT pk_pickup_otps PRIMARY KEY (id)
+);
+
+-- One active OTP row per shipment; deleted and re-inserted on resend.
+CREATE UNIQUE INDEX uq_pickup_otps_shipment ON pickup_otps(shipment_id);
+
+-- Purge job / cleanup queries filter on expires_at.
+CREATE INDEX idx_pickup_otps_expires ON pickup_otps(expires_at);

--- a/orders/src/main/resources/db/migration/orders/V4_9__add_idempotency_key_unique.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_9__add_idempotency_key_unique.sql
@@ -1,0 +1,6 @@
+-- Enforces uniqueness of idempotency_key values on shipments.
+-- Prevents duplicate shipment creation under concurrent requests with the same key.
+-- NULL values are permitted (B2B batch imports may omit idempotency keys);
+-- PostgreSQL treats each NULL as distinct, so multiple NULLs are allowed.
+ALTER TABLE shipments
+  ADD CONSTRAINT uq_shipments_idempotency_key UNIQUE (idempotency_key);

--- a/orders/src/test/java/com/oneday/orders/OrdersTestApplication.java
+++ b/orders/src/test/java/com/oneday/orders/OrdersTestApplication.java
@@ -1,0 +1,7 @@
+package com.oneday.orders;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+class OrdersTestApplication {
+}

--- a/orders/src/test/java/com/oneday/orders/api/PickupOtpControllerTest.java
+++ b/orders/src/test/java/com/oneday/orders/api/PickupOtpControllerTest.java
@@ -1,0 +1,168 @@
+package com.oneday.orders.api;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.dto.OtpVerifyRequest;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.service.PickupOtpService;
+import com.oneday.orders.service.ShipmentStateMachine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PickupOtpControllerTest {
+
+    @Mock private ShipmentRepository shipmentRepository;
+    @Mock private PickupOtpService pickupOtpService;
+    @Mock private ShipmentStateMachine stateMachine;
+
+    private PickupOtpController controller;
+
+    private static final String REF = "1DD-BLR-20260530-00001";
+    private static final UUID SHIPMENT_ID = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        controller = new PickupOtpController(shipmentRepository, pickupOtpService, stateMachine);
+    }
+
+    // -------------------------------------------------------------------------
+    // verifyOtp
+    // -------------------------------------------------------------------------
+
+    @Test
+    void verifyOtp_correctOtp_returns204AndTransitionsState() {
+        when(shipmentRepository.findByShipmentRef(REF))
+                .thenReturn(Optional.of(shipment(ShipmentState.PICKUP_ASSIGNED)));
+        doNothing().when(pickupOtpService).verify(eq(SHIPMENT_ID), any());
+        doNothing().when(stateMachine).transition(eq(SHIPMENT_ID),
+                eq(ShipmentState.PICKED_UP), any());
+
+        ResponseEntity<Void> response = controller.verifyOtp(REF, otpRequest("4821"));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        verify(pickupOtpService).verify(SHIPMENT_ID, "4821");
+        verify(stateMachine).transition(eq(SHIPMENT_ID), eq(ShipmentState.PICKED_UP), any());
+    }
+
+    @Test
+    void verifyOtp_shipmentNotInPickupAssigned_returns409() {
+        when(shipmentRepository.findByShipmentRef(REF))
+                .thenReturn(Optional.of(shipment(ShipmentState.BOOKED)));
+
+        assertThatThrownBy(() -> controller.verifyOtp(REF, otpRequest("4821")))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.CONFLICT));
+    }
+
+    @Test
+    void verifyOtp_wrongOtp_returns422() {
+        when(shipmentRepository.findByShipmentRef(REF))
+                .thenReturn(Optional.of(shipment(ShipmentState.PICKUP_ASSIGNED)));
+        doThrow(new PickupOtpService.OtpVerificationException("OTP is incorrect"))
+                .when(pickupOtpService).verify(any(), any());
+
+        assertThatThrownBy(() -> controller.verifyOtp(REF, otpRequest("9999")))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY));
+    }
+
+    @Test
+    void verifyOtp_shipmentNotFound_returns404() {
+        when(shipmentRepository.findByShipmentRef(REF)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> controller.verifyOtp(REF, otpRequest("4821")))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.NOT_FOUND));
+    }
+
+    // -------------------------------------------------------------------------
+    // resendOtp
+    // -------------------------------------------------------------------------
+
+    @Test
+    void resendOtp_belowLimit_returns200WithNewOtp() {
+        when(shipmentRepository.findByShipmentRef(REF))
+                .thenReturn(Optional.of(shipment(ShipmentState.PICKUP_ASSIGNED)));
+        when(pickupOtpService.resend(SHIPMENT_ID)).thenReturn("3902");
+
+        ResponseEntity<Map<String, String>> response = controller.resendOtp(REF);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).containsEntry("otp", "3902");
+    }
+
+    @Test
+    void resendOtp_limitExceeded_returns429() {
+        when(shipmentRepository.findByShipmentRef(REF))
+                .thenReturn(Optional.of(shipment(ShipmentState.PICKUP_ASSIGNED)));
+        doThrow(new PickupOtpService.ResendLimitExceededException("Resend limit reached"))
+                .when(pickupOtpService).resend(SHIPMENT_ID);
+
+        assertThatThrownBy(() -> controller.resendOtp(REF))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.TOO_MANY_REQUESTS));
+    }
+
+    @Test
+    void resendOtp_shipmentNotInPickupAssigned_returns409() {
+        when(shipmentRepository.findByShipmentRef(REF))
+                .thenReturn(Optional.of(shipment(ShipmentState.BOOKED)));
+
+        assertThatThrownBy(() -> controller.resendOtp(REF))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.CONFLICT));
+    }
+
+    @Test
+    void resendOtp_shipmentNotFound_returns404() {
+        when(shipmentRepository.findByShipmentRef(REF)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> controller.resendOtp(REF))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                        .isEqualTo(HttpStatus.NOT_FOUND));
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private Shipment shipment(ShipmentState state) {
+        Shipment s = new Shipment();
+        ReflectionTestUtils.setField(s, "id", SHIPMENT_ID);
+        s.setState(state);
+        return s;
+    }
+
+    private OtpVerifyRequest otpRequest(String otp) {
+        OtpVerifyRequest req = new OtpVerifyRequest();
+        req.setOtp(otp);
+        return req;
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/api/filter/IdempotencyFilterTest.java
+++ b/orders/src/test/java/com/oneday/orders/api/filter/IdempotencyFilterTest.java
@@ -1,0 +1,313 @@
+package com.oneday.orders.api.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneday.auth.domain.User;
+import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.orders.config.IdempotencyProperties;
+import com.oneday.orders.domain.IdempotencyKey;
+import com.oneday.orders.domain.IdempotencyKeyId;
+import com.oneday.orders.repository.IdempotencyKeyRepository;
+import jakarta.servlet.GenericServlet;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.oneday.orders.api.filter.IdempotencyFilter.ERROR_CODE_BODY_MISMATCH;
+import static com.oneday.orders.api.filter.IdempotencyFilter.ERROR_CODE_MISSING_HEADER;
+import static com.oneday.orders.api.filter.IdempotencyFilter.HEADER_IDEMPOTENCY_KEY;
+import static com.oneday.orders.api.filter.IdempotencyFilter.HEADER_IDEMPOTENCY_REPLAYED;
+import static com.oneday.orders.api.filter.IdempotencyFilter.sha256Hex;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("IdempotencyFilter")
+class IdempotencyFilterTest {
+
+    @Mock
+    private IdempotencyKeyRepository repository;
+
+    private IdempotencyFilter filter;
+    private ObjectMapper objectMapper;
+
+    private static final UUID USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final String IDEMPOTENCY_KEY = "test-key-abc-123";
+    private static final String REQUEST_BODY = "{\"weight\":500,\"originCity\":\"BOM\"}";
+    private static final String CACHED_BODY = "{\"shipmentRef\":\"1DD-BOM-20260529-00001\"}";
+
+    @BeforeEach
+    void setUp() {
+        IdempotencyProperties props = new IdempotencyProperties();
+        props.setTtl(Duration.ofHours(24));
+        props.setApplyToPathPattern("/api/v1/**");
+
+        objectMapper = new ObjectMapper();
+        filter = new IdempotencyFilter(repository, props, objectMapper);
+
+        // Put an authenticated user into the SecurityContext.
+        // Use a real User instance — mock(User.class) fails on Java 21 because
+        // ByteBuddy cannot instrument the BaseEntity class hierarchy.
+        User user = new User();
+        ReflectionTestUtils.setField(user, "id", USER_ID); // sets BaseEntity.id
+        AuthUserDetails principal = new AuthUserDetails(user);
+        var auth = new UsernamePasswordAuthenticationToken(principal, null, List.of());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    // -------------------------------------------------------------------------
+    // shouldNotFilter
+    // -------------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("shouldNotFilter")
+    class ShouldNotFilter {
+
+        @Test
+        @DisplayName("GET request is skipped entirely")
+        void getRequest_isSkipped() throws Exception {
+            MockHttpServletRequest request = postRequest();
+            request.setMethod("GET");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+
+            filter.doFilter(request, response, chain);
+
+            // chain was advanced — filter did not intercept
+            assertThat(chain.getRequest()).isNotNull();
+            verify(repository, never()).findById(any());
+        }
+
+        @Test
+        @DisplayName("POST to non-matching path is skipped")
+        void postToNonMatchingPath_isSkipped() throws Exception {
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/auth/login");
+            request.setContent(REQUEST_BODY.getBytes());
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+
+            filter.doFilter(request, response, chain);
+
+            assertThat(chain.getRequest()).isNotNull();
+            verify(repository, never()).findById(any());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Missing header
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("POST without Idempotency-Key header → 400")
+    void missingHeader_returns400() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/shipments");
+        request.setContent(REQUEST_BODY.getBytes());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getContentAsString()).contains(ERROR_CODE_MISSING_HEADER);
+        // chain must NOT have been advanced
+        assertThat(chain.getRequest()).isNull();
+    }
+
+    // -------------------------------------------------------------------------
+    // Miss path
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("miss — key not in DB → handler runs, 2xx response is persisted")
+    void miss_handlerRunsAndResponsePersisted() throws Exception {
+        when(repository.findById(any())).thenReturn(Optional.empty());
+
+        MockHttpServletRequest request = postRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain(new RespondingServlet(201, CACHED_BODY));
+
+        filter.doFilter(request, response, chain);
+
+        // Handler was invoked (chain advanced to servlet)
+        assertThat(chain.getRequest()).isNotNull();
+
+        // Response passed through to client
+        assertThat(response.getStatus()).isEqualTo(201);
+        assertThat(response.getContentAsString()).contains("shipmentRef");
+
+        // IdempotencyKey was saved with correct fields
+        ArgumentCaptor<IdempotencyKey> captor = ArgumentCaptor.forClass(IdempotencyKey.class);
+        verify(repository).save(captor.capture());
+
+        IdempotencyKey saved = captor.getValue();
+        assertThat(saved.getId().getKey()).isEqualTo(IDEMPOTENCY_KEY);
+        assertThat(saved.getId().getUserId()).isEqualTo(USER_ID);
+        assertThat(saved.getResponseStatus()).isEqualTo((short) 201);
+        assertThat(saved.getResponseBody()).contains("shipmentRef");
+        assertThat(saved.getRequestFingerprint()).isEqualTo(sha256Hex(REQUEST_BODY.getBytes()));
+        assertThat(saved.getExpiresAt()).isAfter(Instant.now());
+    }
+
+    @Test
+    @DisplayName("miss — 5xx response → NOT persisted, body still reaches client")
+    void miss_serverError_notPersisted() throws Exception {
+        when(repository.findById(any())).thenReturn(Optional.empty());
+
+        MockHttpServletRequest request = postRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain(new RespondingServlet(500, "{\"error\":\"internal\"}"));
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(500);
+        verify(repository, never()).save(any());
+    }
+
+    // -------------------------------------------------------------------------
+    // Hit — matching fingerprint (replay)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("hit-match — same body → cached response replayed with Idempotency-Replayed header")
+    void hitMatch_cachedResponseReplayed() throws Exception {
+        String fingerprint = sha256Hex(REQUEST_BODY.getBytes());
+        IdempotencyKey cached = cachedKey(fingerprint, (short) 201, CACHED_BODY);
+        when(repository.findById(any())).thenReturn(Optional.of(cached));
+
+        MockHttpServletRequest request = postRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        // Handler was NOT invoked
+        assertThat(chain.getRequest()).isNull();
+
+        assertThat(response.getStatus()).isEqualTo(201);
+        assertThat(response.getHeader(HEADER_IDEMPOTENCY_REPLAYED)).isEqualTo("true");
+        assertThat(response.getContentAsString()).contains("shipmentRef");
+        verify(repository, never()).save(any());
+    }
+
+    // -------------------------------------------------------------------------
+    // Hit — mismatched fingerprint
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("hit-mismatch — different body → 422 IDEMPOTENCY_KEY_BODY_MISMATCH")
+    void hitMismatch_returns422() throws Exception {
+        String differentFingerprint = sha256Hex("completely-different-body".getBytes());
+        IdempotencyKey cached = cachedKey(differentFingerprint, (short) 201, CACHED_BODY);
+        when(repository.findById(any())).thenReturn(Optional.of(cached));
+
+        MockHttpServletRequest request = postRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(chain.getRequest()).isNull();
+        assertThat(response.getStatus()).isEqualTo(422);
+        assertThat(response.getContentAsString()).contains(ERROR_CODE_BODY_MISMATCH);
+        verify(repository, never()).save(any());
+    }
+
+    // -------------------------------------------------------------------------
+    // sha256Hex helper
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sha256Hex produces a 64-char lowercase hex string")
+    void sha256Hex_produces64CharHex() {
+        String hash = sha256Hex("hello world".getBytes());
+        assertThat(hash).hasSize(64).matches("[0-9a-f]+");
+    }
+
+    @Test
+    @DisplayName("sha256Hex is deterministic")
+    void sha256Hex_isDeterministic() {
+        byte[] input = "same input".getBytes();
+        assertThat(sha256Hex(input)).isEqualTo(sha256Hex(input));
+    }
+
+    @Test
+    @DisplayName("sha256Hex differs for different inputs")
+    void sha256Hex_differsForDifferentInputs() {
+        assertThat(sha256Hex("a".getBytes())).isNotEqualTo(sha256Hex("b".getBytes()));
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private MockHttpServletRequest postRequest() {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/shipments");
+        request.addHeader(HEADER_IDEMPOTENCY_KEY, IDEMPOTENCY_KEY);
+        request.setContent(REQUEST_BODY.getBytes());
+        request.setContentType("application/json");
+        return request;
+    }
+
+    private IdempotencyKey cachedKey(String fingerprint, short status, String body) {
+        IdempotencyKey key = new IdempotencyKey();
+        key.setId(new IdempotencyKeyId(IDEMPOTENCY_KEY, USER_ID));
+        key.setRequestFingerprint(fingerprint);
+        key.setResponseStatus(status);
+        key.setResponseBody(body);
+        key.setExpiresAt(Instant.now().plusSeconds(3600));
+        return key;
+    }
+
+    /**
+     * Minimal servlet that writes a fixed status + body to simulate a downstream handler.
+     * Used only in MockFilterChain — not a Spring component.
+     */
+    @SuppressWarnings("serial")
+    private static class RespondingServlet extends GenericServlet {
+        private final int status;
+        private final String body;
+
+        RespondingServlet(int status, String body) {
+            this.status = status;
+            this.body = body;
+        }
+
+        @Override
+        public void service(ServletRequest req, ServletResponse res) throws IOException {
+            HttpServletResponse httpRes = (HttpServletResponse) res;
+            httpRes.setStatus(status);
+            httpRes.setContentType("application/json");
+            httpRes.getWriter().write(body);
+        }
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/api/filter/IdempotencyFilterTest.java
+++ b/orders/src/test/java/com/oneday/orders/api/filter/IdempotencyFilterTest.java
@@ -21,7 +21,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockFilterChain;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -29,6 +28,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -40,6 +40,7 @@ import static com.oneday.orders.api.filter.IdempotencyFilter.ERROR_CODE_MISSING_
 import static com.oneday.orders.api.filter.IdempotencyFilter.HEADER_IDEMPOTENCY_KEY;
 import static com.oneday.orders.api.filter.IdempotencyFilter.HEADER_IDEMPOTENCY_REPLAYED;
 import static com.oneday.orders.api.filter.IdempotencyFilter.sha256Hex;
+import static com.oneday.orders.api.filter.IdempotencyFilter.sha256HexCanonical;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -58,8 +59,8 @@ class IdempotencyFilterTest {
 
     private static final UUID USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
     private static final String IDEMPOTENCY_KEY = "test-key-abc-123";
-    private static final String REQUEST_BODY = "{\"weight\":500,\"originCity\":\"BOM\"}";
-    private static final String CACHED_BODY = "{\"shipmentRef\":\"1DD-BOM-20260529-00001\"}";
+    private static final String REQUEST_BODY   = "{\"weight\":500,\"originCity\":\"BOM\"}";
+    private static final String CACHED_BODY    = "{\"shipmentRef\":\"1DD-BOM-20260529-00001\"}";
 
     @BeforeEach
     void setUp() {
@@ -174,8 +175,28 @@ class IdempotencyFilterTest {
         assertThat(saved.getId().getUserId()).isEqualTo(USER_ID);
         assertThat(saved.getResponseStatus()).isEqualTo((short) 201);
         assertThat(saved.getResponseBody()).contains("shipmentRef");
-        assertThat(saved.getRequestFingerprint()).isEqualTo(sha256Hex(REQUEST_BODY.getBytes()));
+        // Fingerprint must be the canonical JSON hash (keys sorted), not raw bytes hash
+        assertThat(saved.getRequestFingerprint()).isEqualTo(sha256HexCanonical(REQUEST_BODY.getBytes()));
         assertThat(saved.getExpiresAt()).isAfter(Instant.now());
+    }
+
+    @Test
+    @DisplayName("miss — request body still available to handler after filter fingerprints it (C1 regression guard)")
+    void miss_requestBodyStillAvailableToHandler() throws Exception {
+        when(repository.findById(any())).thenReturn(Optional.empty());
+
+        MockHttpServletRequest request = postRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // Servlet that reads the request body and writes it back — verifies the
+        // ReplayableRequestWrapper correctly re-serves the bytes to the downstream handler.
+        MockFilterChain chain = new MockFilterChain(new BodyEchoServlet());
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(chain.getRequest()).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getContentAsString()).isEqualTo(REQUEST_BODY);
     }
 
     @Test
@@ -200,7 +221,8 @@ class IdempotencyFilterTest {
     @Test
     @DisplayName("hit-match — same body → cached response replayed with Idempotency-Replayed header")
     void hitMatch_cachedResponseReplayed() throws Exception {
-        String fingerprint = sha256Hex(REQUEST_BODY.getBytes());
+        // Fingerprint must use the same canonical algorithm as the filter
+        String fingerprint = sha256HexCanonical(REQUEST_BODY.getBytes());
         IdempotencyKey cached = cachedKey(fingerprint, (short) 201, CACHED_BODY);
         when(repository.findById(any())).thenReturn(Optional.of(cached));
 
@@ -226,7 +248,8 @@ class IdempotencyFilterTest {
     @Test
     @DisplayName("hit-mismatch — different body → 422 IDEMPOTENCY_KEY_BODY_MISMATCH")
     void hitMismatch_returns422() throws Exception {
-        String differentFingerprint = sha256Hex("completely-different-body".getBytes());
+        // "completely-different-body" is not valid JSON so sha256HexCanonical falls back to raw bytes
+        String differentFingerprint = sha256HexCanonical("completely-different-body".getBytes());
         IdempotencyKey cached = cachedKey(differentFingerprint, (short) 201, CACHED_BODY);
         when(repository.findById(any())).thenReturn(Optional.of(cached));
 
@@ -240,6 +263,53 @@ class IdempotencyFilterTest {
         assertThat(response.getStatus()).isEqualTo(422);
         assertThat(response.getContentAsString()).contains(ERROR_CODE_BODY_MISMATCH);
         verify(repository, never()).save(any());
+    }
+
+    // -------------------------------------------------------------------------
+    // Hit — null fingerprint (pre-V4_10 legacy rows)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("hit — null fingerprint in DB (pre-V4_10 row) → always replayed regardless of body")
+    void hitNullFingerprint_alwaysReplayed() throws Exception {
+        // Null fingerprint means the row was created before V4_10 migration.
+        // These rows must still be replayed rather than rejected.
+        IdempotencyKey cached = cachedKey(null, (short) 201, CACHED_BODY);
+        when(repository.findById(any())).thenReturn(Optional.of(cached));
+
+        MockHttpServletRequest request = postRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(chain.getRequest()).isNull();
+        assertThat(response.getStatus()).isEqualTo(201);
+        assertThat(response.getHeader(HEADER_IDEMPOTENCY_REPLAYED)).isEqualTo("true");
+        verify(repository, never()).save(any());
+    }
+
+    // -------------------------------------------------------------------------
+    // Hit — expired key
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("hit — expired key → treated as miss, handler runs")
+    void expiredKey_treatedAsMiss() throws Exception {
+        String fingerprint = sha256HexCanonical(REQUEST_BODY.getBytes());
+        IdempotencyKey expired = cachedKey(fingerprint, (short) 201, CACHED_BODY);
+        expired.setExpiresAt(Instant.now().minusSeconds(1)); // already expired
+        when(repository.findById(any())).thenReturn(Optional.of(expired));
+
+        MockHttpServletRequest request = postRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain(new RespondingServlet(201, CACHED_BODY));
+
+        filter.doFilter(request, response, chain);
+
+        // Expired key → treated as a miss → handler is invoked
+        assertThat(chain.getRequest()).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(201);
     }
 
     // -------------------------------------------------------------------------
@@ -264,6 +334,37 @@ class IdempotencyFilterTest {
     @DisplayName("sha256Hex differs for different inputs")
     void sha256Hex_differsForDifferentInputs() {
         assertThat(sha256Hex("a".getBytes())).isNotEqualTo(sha256Hex("b".getBytes()));
+    }
+
+    // -------------------------------------------------------------------------
+    // sha256HexCanonical helper
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sha256HexCanonical is order-independent for JSON objects")
+    void sha256HexCanonical_isOrderIndependent() {
+        byte[] ab = "{\"a\":1,\"b\":2}".getBytes();
+        byte[] ba = "{\"b\":2,\"a\":1}".getBytes();
+        assertThat(sha256HexCanonical(ab)).isEqualTo(sha256HexCanonical(ba));
+    }
+
+    @Test
+    @DisplayName("sha256HexCanonical differs from sha256Hex when key order differs")
+    void sha256HexCanonical_differFromRawWhenOrderDiffers() {
+        // {"weight":500,"originCity":"BOM"} — canonical form sorts keys: {"originCity":"BOM","weight":500}
+        // The two forms have different raw bytes, so sha256Hex differs but sha256HexCanonical converges
+        byte[] form1 = "{\"weight\":500,\"originCity\":\"BOM\"}".getBytes();
+        byte[] form2 = "{\"originCity\":\"BOM\",\"weight\":500}".getBytes();
+        assertThat(sha256HexCanonical(form1)).isEqualTo(sha256HexCanonical(form2));
+        assertThat(sha256Hex(form1)).isNotEqualTo(sha256Hex(form2));
+    }
+
+    @Test
+    @DisplayName("sha256HexCanonical falls back to raw bytes for non-JSON input")
+    void sha256HexCanonical_fallsBackToRawForNonJson() {
+        byte[] notJson = "not-valid-json".getBytes();
+        // Should not throw; result equals raw sha256Hex
+        assertThat(sha256HexCanonical(notJson)).isEqualTo(sha256Hex(notJson));
     }
 
     // -------------------------------------------------------------------------
@@ -308,6 +409,24 @@ class IdempotencyFilterTest {
             httpRes.setStatus(status);
             httpRes.setContentType("application/json");
             httpRes.getWriter().write(body);
+        }
+    }
+
+    /**
+     * Servlet that reads the request body and echoes it back in the response.
+     * Used to verify the ReplayableRequestWrapper correctly re-serves the body bytes
+     * to the downstream handler (C1 regression guard).
+     */
+    @SuppressWarnings("serial")
+    private static class BodyEchoServlet extends GenericServlet {
+
+        @Override
+        public void service(ServletRequest req, ServletResponse res) throws IOException {
+            byte[] body = req.getInputStream().readAllBytes();
+            HttpServletResponse httpRes = (HttpServletResponse) res;
+            httpRes.setStatus(200);
+            httpRes.setContentType("application/json");
+            httpRes.getWriter().write(new String(body, StandardCharsets.UTF_8));
         }
     }
 }

--- a/orders/src/test/java/com/oneday/orders/api/filter/IdempotencyFilterTest.java
+++ b/orders/src/test/java/com/oneday/orders/api/filter/IdempotencyFilterTest.java
@@ -125,7 +125,7 @@ class IdempotencyFilterTest {
     }
 
     // -------------------------------------------------------------------------
-    // Missing header
+    // Missing / oversized header
     // -------------------------------------------------------------------------
 
     @Test
@@ -141,6 +141,22 @@ class IdempotencyFilterTest {
         assertThat(response.getStatus()).isEqualTo(400);
         assertThat(response.getContentAsString()).contains(ERROR_CODE_MISSING_HEADER);
         // chain must NOT have been advanced
+        assertThat(chain.getRequest()).isNull();
+    }
+
+    @Test
+    @DisplayName("Idempotency-Key longer than 100 chars → 400 IDEMPOTENCY_KEY_TOO_LONG")
+    void keyTooLong_returns400() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/shipments");
+        request.addHeader(HEADER_IDEMPOTENCY_KEY, "x".repeat(101));
+        request.setContent(REQUEST_BODY.getBytes());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getContentAsString()).contains(IdempotencyFilter.ERROR_CODE_KEY_TOO_LONG);
         assertThat(chain.getRequest()).isNull();
     }
 
@@ -294,8 +310,8 @@ class IdempotencyFilterTest {
     // -------------------------------------------------------------------------
 
     @Test
-    @DisplayName("hit — expired key → treated as miss, handler runs")
-    void expiredKey_treatedAsMiss() throws Exception {
+    @DisplayName("hit — expired key → deleted, handler runs, fresh response persisted")
+    void expiredKey_deletedAndRepersisted() throws Exception {
         String fingerprint = sha256HexCanonical(REQUEST_BODY.getBytes());
         IdempotencyKey expired = cachedKey(fingerprint, (short) 201, CACHED_BODY);
         expired.setExpiresAt(Instant.now().minusSeconds(1)); // already expired
@@ -307,9 +323,17 @@ class IdempotencyFilterTest {
 
         filter.doFilter(request, response, chain);
 
-        // Expired key → treated as a miss → handler is invoked
+        // Expired key → handler is invoked
         assertThat(chain.getRequest()).isNotNull();
         assertThat(response.getStatus()).isEqualTo(201);
+
+        // Expired row must be deleted before re-insert (guards against the updatable=false silent no-op)
+        verify(repository).deleteById(any());
+
+        // New key must be persisted with a future expiresAt
+        ArgumentCaptor<IdempotencyKey> captor = ArgumentCaptor.forClass(IdempotencyKey.class);
+        verify(repository).save(captor.capture());
+        assertThat(captor.getValue().getExpiresAt()).isAfter(Instant.now());
     }
 
     // -------------------------------------------------------------------------

--- a/orders/src/test/java/com/oneday/orders/repository/AbstractRepositoryTest.java
+++ b/orders/src/test/java/com/oneday/orders/repository/AbstractRepositoryTest.java
@@ -1,0 +1,12 @@
+package com.oneday.orders.repository;
+
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(FlywayAutoConfiguration.class)
+abstract class AbstractRepositoryTest {
+}

--- a/orders/src/test/java/com/oneday/orders/repository/B2bAccountRepositoryTest.java
+++ b/orders/src/test/java/com/oneday/orders/repository/B2bAccountRepositoryTest.java
@@ -1,0 +1,66 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.B2bAccount;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("B2bAccountRepository")
+class B2bAccountRepositoryTest extends AbstractRepositoryTest {
+
+    @Autowired
+    private B2bAccountRepository repo;
+
+    @Test
+    void saveAndFindById_roundTrip() {
+        B2bAccount saved = repo.save(TestFixtures.b2bAccount("billing@test-acme.com", "DEL"));
+
+        assertThat(repo.findById(saved.getId())).isPresent();
+        assertThat(saved.getAccountName()).isEqualTo("Acme Corp");
+        assertThat(saved.getIsActive()).isTrue();
+    }
+
+    @Test
+    void findByCityId_returnsAccountsInThatCity() {
+        repo.save(TestFixtures.b2bAccount("del1@test.com", "DEL"));
+        repo.save(TestFixtures.b2bAccount("del2@test.com", "DEL"));
+        repo.save(TestFixtures.b2bAccount("bom1@test.com", "BOM"));
+
+        List<B2bAccount> delhiAccounts = repo.findByCityId("DEL");
+
+        assertThat(delhiAccounts)
+                .extracting(B2bAccount::getBillingEmail)
+                .contains("del1@test.com", "del2@test.com")
+                .doesNotContain("bom1@test.com");
+    }
+
+    @Test
+    void findByIsActive_separatesActiveFromInactive() {
+        B2bAccount active = TestFixtures.b2bAccount("active@test.com", "DEL");
+        B2bAccount inactive = TestFixtures.b2bAccount("inactive@test.com", "DEL");
+        inactive.setIsActive(false);
+
+        repo.save(active);
+        repo.save(inactive);
+
+        List<B2bAccount> activeAccounts = repo.findByIsActive(true);
+        List<B2bAccount> inactiveAccounts = repo.findByIsActive(false);
+
+        assertThat(activeAccounts).extracting(B2bAccount::getBillingEmail)
+                .contains("active@test.com");
+        assertThat(inactiveAccounts).extracting(B2bAccount::getBillingEmail)
+                .contains("inactive@test.com");
+    }
+
+    @Test
+    void findByBillingEmail_returnsMatchingAccount() {
+        repo.save(TestFixtures.b2bAccount("unique@test-corp.com", "DEL"));
+
+        assertThat(repo.findByBillingEmail("unique@test-corp.com")).isPresent();
+        assertThat(repo.findByBillingEmail("other@test.com")).isEmpty();
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/repository/IdempotencyKeyRepositoryTest.java
+++ b/orders/src/test/java/com/oneday/orders/repository/IdempotencyKeyRepositoryTest.java
@@ -1,0 +1,53 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.IdempotencyKey;
+import com.oneday.orders.domain.IdempotencyKeyId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("IdempotencyKeyRepository")
+class IdempotencyKeyRepositoryTest extends AbstractRepositoryTest {
+
+    @Autowired
+    private IdempotencyKeyRepository repo;
+
+    @Test
+    void saveAndFindById_compositeKeyRoundTrip() {
+        UUID userId = UUID.randomUUID();
+        IdempotencyKey saved = repo.save(
+                TestFixtures.idempotencyKey("test-key-001", userId, Instant.now().plus(1, ChronoUnit.HOURS)));
+
+        IdempotencyKeyId id = new IdempotencyKeyId("test-key-001", userId);
+        assertThat(repo.findById(id)).isPresent();
+        assertThat(saved.getResponseStatus()).isEqualTo((short) 200);
+    }
+
+    @Test
+    void existsById_falseForUnknownKey() {
+        IdempotencyKeyId unknown = new IdempotencyKeyId("no-such-key", UUID.randomUUID());
+        assertThat(repo.existsById(unknown)).isFalse();
+    }
+
+    @Test
+    void deleteExpired_removesOnlyExpiredKeys() {
+        UUID userId = UUID.randomUUID();
+        Instant past = Instant.now().minus(1, ChronoUnit.HOURS);
+        Instant future = Instant.now().plus(1, ChronoUnit.HOURS);
+
+        repo.save(TestFixtures.idempotencyKey("expired-key", userId, past));
+        repo.save(TestFixtures.idempotencyKey("valid-key", userId, future));
+
+        int deleted = repo.deleteExpired(Instant.now());
+
+        assertThat(deleted).isEqualTo(1);
+        assertThat(repo.existsById(new IdempotencyKeyId("expired-key", userId))).isFalse();
+        assertThat(repo.existsById(new IdempotencyKeyId("valid-key", userId))).isTrue();
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/repository/IdempotencyKeyRepositoryTest.java
+++ b/orders/src/test/java/com/oneday/orders/repository/IdempotencyKeyRepositoryTest.java
@@ -46,7 +46,9 @@ class IdempotencyKeyRepositoryTest extends AbstractRepositoryTest {
 
         int deleted = repo.deleteExpired(Instant.now());
 
-        assertThat(deleted).isEqualTo(1);
+        // isGreaterThanOrEqualTo(1): the shared DB may contain expired keys from other test runs;
+        // we only care that at least our expired key was removed, not the exact total.
+        assertThat(deleted).isGreaterThanOrEqualTo(1);
         assertThat(repo.existsById(new IdempotencyKeyId("expired-key", userId))).isFalse();
         assertThat(repo.existsById(new IdempotencyKeyId("valid-key", userId))).isTrue();
     }

--- a/orders/src/test/java/com/oneday/orders/repository/PaymentTransactionRepositoryTest.java
+++ b/orders/src/test/java/com/oneday/orders/repository/PaymentTransactionRepositoryTest.java
@@ -1,0 +1,65 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.PaymentTransaction;
+import com.oneday.orders.domain.Shipment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("PaymentTransactionRepository")
+class PaymentTransactionRepositoryTest extends AbstractRepositoryTest {
+
+    @Autowired
+    private PaymentTransactionRepository repo;
+
+    @Autowired
+    private ShipmentRepository shipmentRepository;
+
+    @Test
+    void saveAndFindById_roundTrip() {
+        Shipment shipment = shipmentRepository.save(TestFixtures.shipment("TST-PT-RND", "DEL"));
+        PaymentTransaction saved = repo.save(
+                TestFixtures.paymentTransaction(shipment.getId(), "order_tst_001"));
+
+        assertThat(repo.findById(saved.getId())).isPresent();
+        assertThat(saved.getRazorpayOrderId()).isEqualTo("order_tst_001");
+        assertThat(saved.getTotalPaise()).isEqualTo(11800L);
+    }
+
+    @Test
+    void findByShipmentId_returnsTransactionsForThatShipment() {
+        Shipment shipA = shipmentRepository.save(TestFixtures.shipment("TST-PT-A", "DEL"));
+        Shipment shipB = shipmentRepository.save(TestFixtures.shipment("TST-PT-B", "DEL"));
+
+        repo.save(TestFixtures.paymentTransaction(shipA.getId(), "order_tst_A1"));
+        repo.save(TestFixtures.paymentTransaction(shipA.getId(), "order_tst_A2"));
+        repo.save(TestFixtures.paymentTransaction(shipB.getId(), "order_tst_B1"));
+
+        List<PaymentTransaction> results = repo.findByShipmentId(shipA.getId());
+
+        assertThat(results).hasSize(2);
+        assertThat(results).extracting(PaymentTransaction::getRazorpayOrderId)
+                .containsExactlyInAnyOrder("order_tst_A1", "order_tst_A2");
+    }
+
+    @Test
+    void findByRazorpayOrderId_returnsMatchingTransaction() {
+        Shipment shipment = shipmentRepository.save(TestFixtures.shipment("TST-PT-RZP", "DEL"));
+        repo.save(TestFixtures.paymentTransaction(shipment.getId(), "order_rzp_unique"));
+
+        Optional<PaymentTransaction> found = repo.findByRazorpayOrderId("order_rzp_unique");
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getCurrency()).isEqualTo("INR");
+    }
+
+    @Test
+    void findByRazorpayOrderId_emptyForUnknownId() {
+        assertThat(repo.findByRazorpayOrderId("order_does_not_exist")).isEmpty();
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/repository/PickupOtpRepositoryTest.java
+++ b/orders/src/test/java/com/oneday/orders/repository/PickupOtpRepositoryTest.java
@@ -1,0 +1,103 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.PickupOtp;
+import com.oneday.orders.domain.Shipment;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PickupOtpRepositoryTest extends AbstractRepositoryTest {
+
+    @Autowired private PickupOtpRepository otpRepository;
+    @Autowired private ShipmentRepository shipmentRepository;
+
+    // -------------------------------------------------------------------------
+    // findByShipmentId
+    // -------------------------------------------------------------------------
+
+    @Test
+    void findByShipmentId_existingOtp_returnsIt() {
+        Shipment shipment = shipmentRepository.save(TestFixtures.shipment("1DD-BLR-20260530-00001", "city-blr"));
+        otpRepository.save(pickupOtp(shipment, "hashed-otp-1", false, (short) 0));
+
+        Optional<PickupOtp> found = otpRepository.findByShipmentId(shipment.getId());
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getOtpHash()).isEqualTo("hashed-otp-1");
+        assertThat(found.get().isUsed()).isFalse();
+    }
+
+    @Test
+    void findByShipmentId_unknownShipment_returnsEmpty() {
+        Optional<PickupOtp> found = otpRepository.findByShipmentId(java.util.UUID.randomUUID());
+        assertThat(found).isEmpty();
+    }
+
+    // -------------------------------------------------------------------------
+    // deleteByShipmentId
+    // -------------------------------------------------------------------------
+
+    @Test
+    void deleteByShipmentId_removesRow() {
+        Shipment shipment = shipmentRepository.save(TestFixtures.shipment("1DD-BLR-20260530-00002", "city-blr"));
+        otpRepository.save(pickupOtp(shipment, "hashed-otp-2", false, (short) 0));
+
+        otpRepository.deleteByShipmentId(shipment.getId());
+
+        assertThat(otpRepository.findByShipmentId(shipment.getId())).isEmpty();
+    }
+
+    @Test
+    void deleteByShipmentId_unknownShipment_noOp() {
+        // Should not throw
+        otpRepository.deleteByShipmentId(java.util.UUID.randomUUID());
+    }
+
+    // -------------------------------------------------------------------------
+    // Unique constraint: one OTP per shipment
+    // -------------------------------------------------------------------------
+
+    @Test
+    void save_duplicateOtpForSameShipment_throwsConstraintViolation() {
+        Shipment shipment = shipmentRepository.save(TestFixtures.shipment("1DD-BLR-20260530-00003", "city-blr"));
+        otpRepository.save(pickupOtp(shipment, "hash-a", false, (short) 0));
+
+        assertThatThrownBy(() -> {
+            otpRepository.saveAndFlush(pickupOtp(shipment, "hash-b", false, (short) 0));
+        }).isInstanceOf(Exception.class); // DataIntegrityViolationException or PersistenceException
+    }
+
+    // -------------------------------------------------------------------------
+    // used flag can be updated
+    // -------------------------------------------------------------------------
+
+    @Test
+    void save_updatingUsedFlag_persists() {
+        Shipment shipment = shipmentRepository.save(TestFixtures.shipment("1DD-BLR-20260530-00004", "city-blr"));
+        PickupOtp otp = otpRepository.save(pickupOtp(shipment, "hash-c", false, (short) 0));
+
+        otp.setUsed(true);
+        PickupOtp updated = otpRepository.save(otp);
+
+        assertThat(updated.isUsed()).isTrue();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private PickupOtp pickupOtp(Shipment shipment, String otpHash, boolean used, short resendCount) {
+        PickupOtp otp = new PickupOtp();
+        otp.setShipment(shipment);
+        otp.setOtpHash(otpHash);
+        otp.setExpiresAt(Instant.now().plusSeconds(600));
+        otp.setUsed(used);
+        otp.setResendCount(resendCount);
+        return otp;
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/repository/ShipmentRefCounterRepositoryTest.java
+++ b/orders/src/test/java/com/oneday/orders/repository/ShipmentRefCounterRepositoryTest.java
@@ -29,26 +29,30 @@ class ShipmentRefCounterRepositoryTest extends AbstractRepositoryTest {
     }
 
     @Test
-    void increment_incrementsNextValByOne() {
+    void findByIdWithLock_allowsSafeIncrementPattern() {
+        // Simulates what the service layer does: lock → read → increment in Java → flush
         LocalDate today = LocalDate.of(2026, 5, 27);
         ShipmentRefCounterId id = new ShipmentRefCounterId("BOM", today);
         repo.save(TestFixtures.refCounter("BOM", today, 5));
 
-        int updated = repo.increment(id);
+        ShipmentRefCounter counter = repo.findByIdWithLock(id).orElseThrow();
+        counter.setNextVal(counter.getNextVal() + 1);
+        repo.saveAndFlush(counter);
 
-        assertThat(updated).isEqualTo(1);
-        ShipmentRefCounter counter = repo.findById(id).orElseThrow();
-        assertThat(counter.getNextVal()).isEqualTo(6);
+        assertThat(repo.findById(id).orElseThrow().getNextVal()).isEqualTo(6);
     }
 
     @Test
-    void increment_isIsolatedByCityAndDate() {
+    void findByIdWithLock_isIsolatedByCityAndDate() {
         LocalDate d1 = LocalDate.of(2026, 5, 27);
         LocalDate d2 = LocalDate.of(2026, 5, 28);
         repo.save(TestFixtures.refCounter("DEL", d1, 10));
         repo.save(TestFixtures.refCounter("DEL", d2, 20));
 
-        repo.increment(new ShipmentRefCounterId("DEL", d1));
+        // Lock and increment only d1
+        ShipmentRefCounter counter = repo.findByIdWithLock(new ShipmentRefCounterId("DEL", d1)).orElseThrow();
+        counter.setNextVal(counter.getNextVal() + 1);
+        repo.saveAndFlush(counter);
 
         assertThat(repo.findById(new ShipmentRefCounterId("DEL", d1)).orElseThrow().getNextVal()).isEqualTo(11);
         assertThat(repo.findById(new ShipmentRefCounterId("DEL", d2)).orElseThrow().getNextVal()).isEqualTo(20);

--- a/orders/src/test/java/com/oneday/orders/repository/ShipmentRefCounterRepositoryTest.java
+++ b/orders/src/test/java/com/oneday/orders/repository/ShipmentRefCounterRepositoryTest.java
@@ -1,0 +1,56 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.ShipmentRefCounter;
+import com.oneday.orders.domain.ShipmentRefCounterId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ShipmentRefCounterRepository")
+class ShipmentRefCounterRepositoryTest extends AbstractRepositoryTest {
+
+    @Autowired
+    private ShipmentRefCounterRepository repo;
+
+    @Test
+    void saveAndFindById_compositeKeyRoundTrip() {
+        LocalDate today = LocalDate.of(2026, 5, 27);
+        repo.save(TestFixtures.refCounter("DEL", today, 1));
+
+        Optional<ShipmentRefCounter> found = repo.findById(new ShipmentRefCounterId("DEL", today));
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getNextVal()).isEqualTo(1);
+    }
+
+    @Test
+    void increment_incrementsNextValByOne() {
+        LocalDate today = LocalDate.of(2026, 5, 27);
+        ShipmentRefCounterId id = new ShipmentRefCounterId("BOM", today);
+        repo.save(TestFixtures.refCounter("BOM", today, 5));
+
+        int updated = repo.increment(id);
+
+        assertThat(updated).isEqualTo(1);
+        ShipmentRefCounter counter = repo.findById(id).orElseThrow();
+        assertThat(counter.getNextVal()).isEqualTo(6);
+    }
+
+    @Test
+    void increment_isIsolatedByCityAndDate() {
+        LocalDate d1 = LocalDate.of(2026, 5, 27);
+        LocalDate d2 = LocalDate.of(2026, 5, 28);
+        repo.save(TestFixtures.refCounter("DEL", d1, 10));
+        repo.save(TestFixtures.refCounter("DEL", d2, 20));
+
+        repo.increment(new ShipmentRefCounterId("DEL", d1));
+
+        assertThat(repo.findById(new ShipmentRefCounterId("DEL", d1)).orElseThrow().getNextVal()).isEqualTo(11);
+        assertThat(repo.findById(new ShipmentRefCounterId("DEL", d2)).orElseThrow().getNextVal()).isEqualTo(20);
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/repository/ShipmentRepositoryTest.java
+++ b/orders/src/test/java/com/oneday/orders/repository/ShipmentRepositoryTest.java
@@ -1,13 +1,18 @@
 package com.oneday.orders.repository;
 
+import com.oneday.common.domain.enums.CustomerType;
 import com.oneday.common.domain.enums.ShipmentState;
 import com.oneday.orders.domain.Shipment;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -65,6 +70,27 @@ class ShipmentRepositoryTest extends AbstractRepositoryTest {
     }
 
     @Test
+    void findByState_paginatedVariant_returnsCorrectPage() {
+        // Save 3 BOOKED + 1 PICKED_UP
+        repo.save(TestFixtures.shipment("TST-DEL-PG-001", "DEL"));
+        repo.save(TestFixtures.shipment("TST-DEL-PG-002", "DEL"));
+        repo.save(TestFixtures.shipment("TST-DEL-PG-003", "DEL"));
+        Shipment pickedUp = TestFixtures.shipment("TST-DEL-PG-004", "DEL");
+        pickedUp.setState(ShipmentState.PICKED_UP);
+        repo.save(pickedUp);
+
+        Page<Shipment> page = repo.findByState(
+                ShipmentState.BOOKED,
+                PageRequest.of(0, 2, Sort.by("shipmentRef")));
+
+        assertThat(page.getTotalElements()).isGreaterThanOrEqualTo(3);
+        assertThat(page.getSize()).isEqualTo(2);
+        assertThat(page.getContent())
+                .extracting(Shipment::getShipmentRef)
+                .doesNotContain("TST-DEL-PG-004");
+    }
+
+    @Test
     void findByStateAndCityId_filtersOnBothColumns() {
         Shipment delhiBooked = TestFixtures.shipment("TST-DEL-SC-001", "DEL");
         Shipment mumbaiBooked = TestFixtures.shipment("TST-BOM-SC-001", "BOM");
@@ -82,6 +108,24 @@ class ShipmentRepositoryTest extends AbstractRepositoryTest {
     }
 
     @Test
+    void findByStateAndCityId_paginatedVariant_returnsCorrectSubset() {
+        repo.save(TestFixtures.shipment("TST-DEL-SCP-001", "DEL"));
+        repo.save(TestFixtures.shipment("TST-DEL-SCP-002", "DEL"));
+        Shipment bom = TestFixtures.shipment("TST-BOM-SCP-001", "BOM");
+        bom.setOriginCity("BOM");
+        repo.save(bom);
+
+        Page<Shipment> page = repo.findByStateAndCityId(
+                ShipmentState.BOOKED, "DEL",
+                PageRequest.of(0, 10, Sort.by("shipmentRef")));
+
+        assertThat(page.getContent())
+                .extracting(Shipment::getShipmentRef)
+                .contains("TST-DEL-SCP-001", "TST-DEL-SCP-002")
+                .doesNotContain("TST-BOM-SCP-001");
+    }
+
+    @Test
     void existsByIdempotencyKey_trueWhenPresent() {
         Shipment s = TestFixtures.shipment("TST-DEL-IK-001", "DEL");
         s.setIdempotencyKey("test-idem-key-001");
@@ -89,5 +133,54 @@ class ShipmentRepositoryTest extends AbstractRepositoryTest {
 
         assertThat(repo.existsByIdempotencyKey("test-idem-key-001")).isTrue();
         assertThat(repo.existsByIdempotencyKey("no-such-key")).isFalse();
+    }
+
+    @Test
+    void findByCustomerType_filtersByPgEnumColumn() {
+        // Verifies that the read transformer on customer_type enables WHERE-clause filtering.
+        // Without read = "customer_type::text", this would throw "operator does not exist".
+        Shipment b2c = TestFixtures.shipment("TST-DEL-CT-B2C", "DEL"); // default is B2C
+        Shipment b2b = TestFixtures.shipment("TST-DEL-CT-B2B", "DEL");
+        b2b.setCustomerType(CustomerType.B2B);
+
+        repo.save(b2c);
+        repo.save(b2b);
+
+        assertThat(repo.findByCustomerType(CustomerType.B2C))
+                .extracting(Shipment::getShipmentRef)
+                .contains("TST-DEL-CT-B2C")
+                .doesNotContain("TST-DEL-CT-B2B");
+
+        assertThat(repo.findByCustomerType(CustomerType.B2B))
+                .extracting(Shipment::getShipmentRef)
+                .contains("TST-DEL-CT-B2B")
+                .doesNotContain("TST-DEL-CT-B2C");
+    }
+
+    @Test
+    void findByAssignedFlightId_returnsShipmentsForFlight() {
+        // Fix 6: Verifies M9 can query all shipments assigned to a specific flight.
+        UUID flightId = UUID.randomUUID();
+        UUID otherFlightId = UUID.randomUUID();
+
+        Shipment s1 = TestFixtures.shipment("TST-DEL-FL-001", "DEL");
+        s1.setAssignedFlightId(flightId);
+        Shipment s2 = TestFixtures.shipment("TST-DEL-FL-002", "DEL");
+        s2.setAssignedFlightId(flightId);
+        Shipment s3 = TestFixtures.shipment("TST-DEL-FL-003", "DEL");
+        s3.setAssignedFlightId(otherFlightId);
+        Shipment s4 = TestFixtures.shipment("TST-DEL-FL-004", "DEL"); // no flight assigned
+
+        repo.save(s1);
+        repo.save(s2);
+        repo.save(s3);
+        repo.save(s4);
+
+        List<Shipment> results = repo.findByAssignedFlightId(flightId);
+
+        assertThat(results)
+                .extracting(Shipment::getShipmentRef)
+                .contains("TST-DEL-FL-001", "TST-DEL-FL-002")
+                .doesNotContain("TST-DEL-FL-003", "TST-DEL-FL-004");
     }
 }

--- a/orders/src/test/java/com/oneday/orders/repository/ShipmentRepositoryTest.java
+++ b/orders/src/test/java/com/oneday/orders/repository/ShipmentRepositoryTest.java
@@ -1,0 +1,93 @@
+package com.oneday.orders.repository;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.domain.Shipment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ShipmentRepository")
+class ShipmentRepositoryTest extends AbstractRepositoryTest {
+
+    @Autowired
+    private ShipmentRepository repo;
+
+    @Test
+    void saveAndFindById_roundTrip() {
+        Shipment saved = repo.save(TestFixtures.shipment("TST-DEL-001", "DEL"));
+
+        Optional<Shipment> found = repo.findById(saved.getId());
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getShipmentRef()).isEqualTo("TST-DEL-001");
+        assertThat(found.get().getCityId()).isEqualTo("DEL");
+        assertThat(found.get().getState()).isEqualTo(ShipmentState.BOOKED);
+    }
+
+    @Test
+    void findByShipmentRef_returnsMatchingShipment() {
+        repo.save(TestFixtures.shipment("TST-DEL-REF-A", "DEL"));
+        repo.save(TestFixtures.shipment("TST-DEL-REF-B", "DEL"));
+
+        Optional<Shipment> found = repo.findByShipmentRef("TST-DEL-REF-A");
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getShipmentRef()).isEqualTo("TST-DEL-REF-A");
+    }
+
+    @Test
+    void findByShipmentRef_emptyWhenNotFound() {
+        assertThat(repo.findByShipmentRef("NONEXISTENT-REF")).isEmpty();
+    }
+
+    @Test
+    void findByState_returnsOnlyMatchingState() {
+        Shipment booked1 = TestFixtures.shipment("TST-DEL-ST-001", "DEL");
+        Shipment booked2 = TestFixtures.shipment("TST-DEL-ST-002", "DEL");
+        Shipment pickedUp = TestFixtures.shipment("TST-DEL-ST-003", "DEL");
+        pickedUp.setState(ShipmentState.PICKED_UP);
+
+        repo.save(booked1);
+        repo.save(booked2);
+        repo.save(pickedUp);
+
+        List<Shipment> bookedShipments = repo.findByState(ShipmentState.BOOKED);
+
+        assertThat(bookedShipments)
+                .extracting(Shipment::getShipmentRef)
+                .contains("TST-DEL-ST-001", "TST-DEL-ST-002")
+                .doesNotContain("TST-DEL-ST-003");
+    }
+
+    @Test
+    void findByStateAndCityId_filtersOnBothColumns() {
+        Shipment delhiBooked = TestFixtures.shipment("TST-DEL-SC-001", "DEL");
+        Shipment mumbaiBooked = TestFixtures.shipment("TST-BOM-SC-001", "BOM");
+        mumbaiBooked.setOriginCity("BOM");
+
+        repo.save(delhiBooked);
+        repo.save(mumbaiBooked);
+
+        List<Shipment> results = repo.findByStateAndCityId(ShipmentState.BOOKED, "DEL");
+
+        assertThat(results)
+                .extracting(Shipment::getShipmentRef)
+                .contains("TST-DEL-SC-001")
+                .doesNotContain("TST-BOM-SC-001");
+    }
+
+    @Test
+    void existsByIdempotencyKey_trueWhenPresent() {
+        Shipment s = TestFixtures.shipment("TST-DEL-IK-001", "DEL");
+        s.setIdempotencyKey("test-idem-key-001");
+        repo.save(s);
+
+        assertThat(repo.existsByIdempotencyKey("test-idem-key-001")).isTrue();
+        assertThat(repo.existsByIdempotencyKey("no-such-key")).isFalse();
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/repository/ShipmentStateHistoryRepositoryTest.java
+++ b/orders/src/test/java/com/oneday/orders/repository/ShipmentStateHistoryRepositoryTest.java
@@ -1,0 +1,72 @@
+package com.oneday.orders.repository;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.domain.ShipmentStateHistory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ShipmentStateHistoryRepository")
+class ShipmentStateHistoryRepositoryTest extends AbstractRepositoryTest {
+
+    @Autowired
+    private ShipmentStateHistoryRepository repo;
+
+    @Autowired
+    private ShipmentRepository shipmentRepository;
+
+    @Test
+    void saveAndFindById_roundTrip() {
+        Shipment shipment = shipmentRepository.save(TestFixtures.shipment("TST-SSH-RND", "DEL"));
+        ShipmentStateHistory saved = repo.save(
+                TestFixtures.stateHistory(shipment.getId(), ShipmentState.PICKED_UP, Instant.now()));
+
+        assertThat(repo.findById(saved.getId())).isPresent();
+        assertThat(saved.getShipmentId()).isEqualTo(shipment.getId());
+        assertThat(saved.getToState()).isEqualTo(ShipmentState.PICKED_UP);
+    }
+
+    @Test
+    void findByShipmentIdOrderByOccurredAtAsc_returnsChronologicalOrder() {
+        Shipment shipment = shipmentRepository.save(TestFixtures.shipment("TST-SSH-ORD", "DEL"));
+        UUID shipmentId = shipment.getId();
+
+        Instant t0 = Instant.now().minus(2, ChronoUnit.MINUTES);
+        Instant t1 = Instant.now().minus(1, ChronoUnit.MINUTES);
+        Instant t2 = Instant.now();
+
+        // Save out-of-order intentionally
+        repo.save(TestFixtures.stateHistory(shipmentId, ShipmentState.HANDED_TO_PICKUP_VAN, t2));
+        repo.save(TestFixtures.stateHistory(shipmentId, ShipmentState.PICKUP_ASSIGNED, t0));
+        repo.save(TestFixtures.stateHistory(shipmentId, ShipmentState.PICKED_UP, t1));
+
+        List<ShipmentStateHistory> result = repo.findByShipmentIdOrderByOccurredAtAsc(shipmentId);
+
+        assertThat(result).hasSize(3);
+        assertThat(result).extracting(ShipmentStateHistory::getToState).containsExactly(
+                ShipmentState.PICKUP_ASSIGNED,
+                ShipmentState.PICKED_UP,
+                ShipmentState.HANDED_TO_PICKUP_VAN
+        );
+    }
+
+    @Test
+    void findByShipmentIdOrderByOccurredAtAsc_doesNotReturnOtherShipments() {
+        Shipment shipA = shipmentRepository.save(TestFixtures.shipment("TST-SSH-A", "DEL"));
+        Shipment shipB = shipmentRepository.save(TestFixtures.shipment("TST-SSH-B", "DEL"));
+
+        repo.save(TestFixtures.stateHistory(shipA.getId(), ShipmentState.BOOKED, Instant.now()));
+        repo.save(TestFixtures.stateHistory(shipB.getId(), ShipmentState.PICKED_UP, Instant.now()));
+
+        assertThat(repo.findByShipmentIdOrderByOccurredAtAsc(shipA.getId())).hasSize(1);
+        assertThat(repo.findByShipmentIdOrderByOccurredAtAsc(shipB.getId())).hasSize(1);
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/repository/TestFixtures.java
+++ b/orders/src/test/java/com/oneday/orders/repository/TestFixtures.java
@@ -1,0 +1,116 @@
+package com.oneday.orders.repository;
+
+import com.oneday.common.domain.enums.CustomerType;
+import com.oneday.common.domain.enums.DeliveryType;
+import com.oneday.common.domain.enums.DropType;
+import com.oneday.common.domain.enums.PickupType;
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.domain.Address;
+import com.oneday.orders.domain.B2bAccount;
+import com.oneday.orders.domain.IdempotencyKey;
+import com.oneday.orders.domain.IdempotencyKeyId;
+import com.oneday.orders.domain.PaymentTransaction;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.domain.ShipmentRefCounter;
+import com.oneday.orders.domain.ShipmentRefCounterId;
+import com.oneday.orders.domain.ShipmentStateHistory;
+import com.oneday.orders.domain.enums.PaymentStatus;
+import com.oneday.orders.domain.enums.TriggerSource;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+class TestFixtures {
+
+    static Address address(String city) {
+        Address a = new Address();
+        a.setLine1("1 Test Street");
+        a.setCity(city);
+        a.setPincode("110001");
+        a.setState("Test State");
+        return a;
+    }
+
+    static Shipment shipment(String ref, String cityId) {
+        Shipment s = new Shipment();
+        s.setShipmentRef(ref);
+        s.setCustomerType(CustomerType.B2C);
+        s.setDeliveryType(DeliveryType.INTERCITY);
+        s.setSenderName("Alice Sender");
+        s.setSenderPhone("9000000001");
+        s.setOriginAddress(address("Delhi"));
+        s.setOriginCity("DEL");
+        s.setOriginPincode("110001");
+        s.setDestAddress(address("Mumbai"));
+        s.setDestCity("BOM");
+        s.setDestPincode("400001");
+        s.setReceiverName("Bob Receiver");
+        s.setReceiverPhone("9000000002");
+        s.setWeightGrams(500);
+        s.setLengthCm((short) 10);
+        s.setWidthCm((short) 10);
+        s.setHeightCm((short) 10);
+        s.setVolumetricWeightGrams(500);
+        s.setChargeableWeightGrams(500);
+        s.setQuotedPricePaise(10000L);
+        s.setTaxPaise(1800L);
+        s.setTotalPricePaise(11800L);
+        s.setRateCardVersion("v1.0");
+        s.setPickupType(PickupType.DA_PICKUP);
+        s.setDropType(DropType.DA_DELIVERY);
+        s.setState(ShipmentState.BOOKED);
+        s.setCityId(cityId);
+        return s;
+    }
+
+    static ShipmentStateHistory stateHistory(UUID shipmentId, ShipmentState toState, Instant occurredAt) {
+        return ShipmentStateHistory.builder()
+                .shipmentId(shipmentId)
+                .toState(toState)
+                .triggeredBy("test-user")
+                .triggerSource(TriggerSource.SYSTEM)
+                .occurredAt(occurredAt)
+                .build();
+    }
+
+    static IdempotencyKey idempotencyKey(String key, UUID userId, Instant expiresAt) {
+        IdempotencyKey ik = new IdempotencyKey();
+        ik.setId(new IdempotencyKeyId(key, userId));
+        ik.setResponseStatus((short) 200);
+        ik.setResponseBody("{\"status\":\"ok\"}");
+        ik.setExpiresAt(expiresAt);
+        return ik;
+    }
+
+    static ShipmentRefCounter refCounter(String cityCode, LocalDate dateKey, int nextVal) {
+        ShipmentRefCounter rc = new ShipmentRefCounter();
+        rc.setId(new ShipmentRefCounterId(cityCode, dateKey));
+        rc.setNextVal(nextVal);
+        return rc;
+    }
+
+    static B2bAccount b2bAccount(String email, String cityId) {
+        B2bAccount acc = new B2bAccount();
+        acc.setAccountName("Acme Corp");
+        acc.setBillingEmail(email);
+        acc.setCreditLimitPaise(1_000_000L);
+        acc.setOutstandingBalancePaise(0L);
+        acc.setPaymentTermsDays((short) 30);
+        acc.setCityId(cityId);
+        acc.setIsActive(true);
+        return acc;
+    }
+
+    static PaymentTransaction paymentTransaction(UUID shipmentId, String razorpayOrderId) {
+        PaymentTransaction tx = new PaymentTransaction();
+        tx.setShipmentId(shipmentId);
+        tx.setRazorpayOrderId(razorpayOrderId);
+        tx.setAmountPaise(10000L);
+        tx.setTaxPaise(1800L);
+        tx.setTotalPaise(11800L);
+        tx.setCurrency("INR");
+        tx.setStatus(PaymentStatus.CREATED);
+        return tx;
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/service/CustomerVisibleStateMapperTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/CustomerVisibleStateMapperTest.java
@@ -1,0 +1,56 @@
+package com.oneday.orders.service;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("CustomerVisibleStateMapper")
+class CustomerVisibleStateMapperTest {
+
+    private final CustomerVisibleStateMapper mapper = new CustomerVisibleStateMapper();
+
+    @ParameterizedTest(name = "{0} has a non-blank label")
+    @EnumSource(ShipmentState.class)
+    void everyState_hasNonBlankLabel(ShipmentState state) {
+        assertThat(mapper.labelFor(state))
+                .as("Label for %s", state)
+                .isNotNull()
+                .isNotBlank();
+    }
+
+    @Test
+    void labelFor_booked_matchesDesignDoc() {
+        assertThat(mapper.labelFor(ShipmentState.BOOKED)).isEqualTo("Order confirmed");
+    }
+
+    @Test
+    void labelFor_dropped_matchesDesignDoc() {
+        assertThat(mapper.labelFor(ShipmentState.DROPPED)).isEqualTo("Delivered");
+    }
+
+    @Test
+    void labelFor_cancelled_matchesDesignDoc() {
+        assertThat(mapper.labelFor(ShipmentState.CANCELLED)).isEqualTo("Cancelled");
+    }
+
+    @Test
+    void labelFor_rtoCompleted_matchesDesignDoc() {
+        assertThat(mapper.labelFor(ShipmentState.RTO_COMPLETED)).isEqualTo("Returned to sender");
+    }
+
+    @Test
+    void labelFor_awaitingSelfDrop_matchesDesignDoc() {
+        assertThat(mapper.labelFor(ShipmentState.AWAITING_SELF_DROP))
+                .isEqualTo("Please bring your parcel to the origin hub");
+    }
+
+    @Test
+    void labelFor_awaitingHubCollect_matchesDesignDoc() {
+        assertThat(mapper.labelFor(ShipmentState.AWAITING_HUB_COLLECT))
+                .isEqualTo("Your parcel is ready — collect from the hub");
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/service/DeliveryTypeResolverTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/DeliveryTypeResolverTest.java
@@ -1,0 +1,44 @@
+package com.oneday.orders.service;
+
+import com.oneday.common.domain.enums.DeliveryType;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DeliveryTypeResolverTest {
+
+    private final DeliveryTypeResolver resolver = new DeliveryTypeResolver();
+
+    @Test
+    void sameCityCode_returnsSameCity() {
+        assertThat(resolver.resolve("BLR", "BLR")).isEqualTo(DeliveryType.SAME_CITY);
+    }
+
+    @Test
+    void sameCityCode_caseInsensitive() {
+        assertThat(resolver.resolve("blr", "BLR")).isEqualTo(DeliveryType.SAME_CITY);
+        assertThat(resolver.resolve("BLR", "blr")).isEqualTo(DeliveryType.SAME_CITY);
+        assertThat(resolver.resolve("blr", "blr")).isEqualTo(DeliveryType.SAME_CITY);
+    }
+
+    @Test
+    void differentCityCodes_returnsIntercity() {
+        assertThat(resolver.resolve("BLR", "BOM")).isEqualTo(DeliveryType.INTERCITY);
+        assertThat(resolver.resolve("DEL", "MAA")).isEqualTo(DeliveryType.INTERCITY);
+    }
+
+    @Test
+    void nullOrigin_returnsIntercity() {
+        assertThat(resolver.resolve(null, "BLR")).isEqualTo(DeliveryType.INTERCITY);
+    }
+
+    @Test
+    void nullDest_returnsIntercity() {
+        assertThat(resolver.resolve("BLR", null)).isEqualTo(DeliveryType.INTERCITY);
+    }
+
+    @Test
+    void bothNull_returnsIntercity() {
+        assertThat(resolver.resolve(null, null)).isEqualTo(DeliveryType.INTERCITY);
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/service/IdempotencyKeyPurgeJobTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/IdempotencyKeyPurgeJobTest.java
@@ -1,0 +1,53 @@
+package com.oneday.orders.service;
+
+import com.oneday.orders.repository.IdempotencyKeyRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("IdempotencyKeyPurgeJob")
+class IdempotencyKeyPurgeJobTest {
+
+    @Mock
+    private IdempotencyKeyRepository repository;
+
+    @InjectMocks
+    private IdempotencyKeyPurgeJob purgeJob;
+
+    @Test
+    @DisplayName("purgeExpiredKeys calls deleteExpired with current time and logs deleted count")
+    void purgeExpiredKeys_callsDeleteExpiredWithNow() {
+        when(repository.deleteExpired(org.mockito.ArgumentMatchers.any())).thenReturn(42);
+
+        Instant before = Instant.now();
+        purgeJob.purgeExpiredKeys();
+        Instant after = Instant.now();
+
+        ArgumentCaptor<Instant> captor = ArgumentCaptor.forClass(Instant.class);
+        verify(repository).deleteExpired(captor.capture());
+
+        Instant cutoff = captor.getValue();
+        assertThat(cutoff)
+                .isAfterOrEqualTo(before)
+                .isBeforeOrEqualTo(after);
+    }
+
+    @Test
+    @DisplayName("purgeExpiredKeys handles zero deleted rows without error")
+    void purgeExpiredKeys_zeroDeleted_noError() {
+        when(repository.deleteExpired(org.mockito.ArgumentMatchers.any())).thenReturn(0);
+
+        purgeJob.purgeExpiredKeys(); // must not throw
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/service/impl/PickupOtpServiceTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/PickupOtpServiceTest.java
@@ -1,0 +1,208 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.config.PickupOtpProperties;
+import com.oneday.orders.domain.PickupOtp;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.repository.PickupOtpRepository;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.service.PickupOtpService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PickupOtpServiceTest {
+
+    @Mock private PickupOtpRepository otpRepository;
+    @Mock private ShipmentRepository shipmentRepository;
+
+    private PickupOtpProperties properties;
+    private PickupOtpService service;
+
+    private static final UUID SHIPMENT_ID = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        properties = new PickupOtpProperties(); // uses defaults: ttlMinutes=10, maxResendCount=3
+        service = new PickupOtpServiceImpl(otpRepository, shipmentRepository, properties);
+    }
+
+    // -------------------------------------------------------------------------
+    // generate()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void generate_createsOtpRowAndReturnsFourDigitString() {
+        when(shipmentRepository.findById(SHIPMENT_ID)).thenReturn(Optional.of(shipment()));
+        when(otpRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        String otp = service.generate(SHIPMENT_ID);
+
+        assertThat(otp).matches("\\d{4}");
+        verify(otpRepository).deleteByShipmentId(SHIPMENT_ID);
+        ArgumentCaptor<PickupOtp> captor = ArgumentCaptor.forClass(PickupOtp.class);
+        verify(otpRepository).save(captor.capture());
+        PickupOtp saved = captor.getValue();
+        assertThat(saved.isUsed()).isFalse();
+        assertThat(saved.getResendCount()).isZero();
+        assertThat(saved.getExpiresAt()).isAfter(Instant.now());
+    }
+
+    @Test
+    void generate_shipmentNotFound_throwsIllegalArgument() {
+        when(shipmentRepository.findById(SHIPMENT_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.generate(SHIPMENT_ID))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(SHIPMENT_ID.toString());
+    }
+
+    @Test
+    void generate_deletesExistingOtpFirst() {
+        when(shipmentRepository.findById(SHIPMENT_ID)).thenReturn(Optional.of(shipment()));
+        when(otpRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.generate(SHIPMENT_ID);
+
+        // deleteByShipmentId must be called before save
+        verify(otpRepository).deleteByShipmentId(SHIPMENT_ID);
+        verify(otpRepository).save(any());
+    }
+
+    // -------------------------------------------------------------------------
+    // verify()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void verify_correctOtp_setsUsedTrue() {
+        // BCrypt-encode a known OTP for the test record
+        String plainOtp = "1234";
+        PickupOtp record = otpRecord(plainOtp, Instant.now().plusSeconds(600), false, (short) 0);
+        when(otpRepository.findByShipmentIdWithLock(SHIPMENT_ID)).thenReturn(Optional.of(record));
+        when(otpRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.verify(SHIPMENT_ID, plainOtp);
+
+        ArgumentCaptor<PickupOtp> captor = ArgumentCaptor.forClass(PickupOtp.class);
+        verify(otpRepository).save(captor.capture());
+        assertThat(captor.getValue().isUsed()).isTrue();
+    }
+
+    @Test
+    void verify_wrongOtp_throwsOtpVerificationException() {
+        PickupOtp record = otpRecord("1234", Instant.now().plusSeconds(600), false, (short) 0);
+        when(otpRepository.findByShipmentIdWithLock(SHIPMENT_ID)).thenReturn(Optional.of(record));
+
+        assertThatThrownBy(() -> service.verify(SHIPMENT_ID, "9999"))
+                .isInstanceOf(PickupOtpService.OtpVerificationException.class)
+                .hasMessageContaining("incorrect");
+    }
+
+    @Test
+    void verify_expiredOtp_throwsOtpVerificationException() {
+        PickupOtp record = otpRecord("1234", Instant.now().minusSeconds(1), false, (short) 0);
+        when(otpRepository.findByShipmentIdWithLock(SHIPMENT_ID)).thenReturn(Optional.of(record));
+
+        assertThatThrownBy(() -> service.verify(SHIPMENT_ID, "1234"))
+                .isInstanceOf(PickupOtpService.OtpVerificationException.class)
+                .hasMessageContaining("expired");
+    }
+
+    @Test
+    void verify_alreadyUsedOtp_throwsOtpVerificationException() {
+        PickupOtp record = otpRecord("1234", Instant.now().plusSeconds(600), true, (short) 0);
+        when(otpRepository.findByShipmentIdWithLock(SHIPMENT_ID)).thenReturn(Optional.of(record));
+
+        assertThatThrownBy(() -> service.verify(SHIPMENT_ID, "1234"))
+                .isInstanceOf(PickupOtpService.OtpVerificationException.class)
+                .hasMessageContaining("already been used");
+    }
+
+    @Test
+    void verify_noRecord_throwsOtpVerificationException() {
+        when(otpRepository.findByShipmentIdWithLock(SHIPMENT_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.verify(SHIPMENT_ID, "1234"))
+                .isInstanceOf(PickupOtpService.OtpVerificationException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // resend()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void resend_belowLimit_generatesNewOtpAndIncrementsCount() {
+        PickupOtp existing = otpRecord("1234", Instant.now().plusSeconds(600), false, (short) 1);
+        when(otpRepository.findByShipmentId(SHIPMENT_ID)).thenReturn(Optional.of(existing));
+        when(otpRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        String newOtp = service.resend(SHIPMENT_ID);
+
+        assertThat(newOtp).matches("\\d{4}");
+        verify(otpRepository).deleteByShipmentId(SHIPMENT_ID);
+        ArgumentCaptor<PickupOtp> captor = ArgumentCaptor.forClass(PickupOtp.class);
+        verify(otpRepository).save(captor.capture());
+        assertThat(captor.getValue().getResendCount()).isEqualTo((short) 2);
+    }
+
+    @Test
+    void resend_atLimit_throwsResendLimitExceededException() {
+        PickupOtp existing = otpRecord("1234", Instant.now().plusSeconds(600), false,
+                (short) properties.getMaxResendCount());
+        when(otpRepository.findByShipmentId(SHIPMENT_ID)).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> service.resend(SHIPMENT_ID))
+                .isInstanceOf(PickupOtpService.ResendLimitExceededException.class);
+    }
+
+    @Test
+    void resend_noExistingOtp_throwsOtpVerificationException() {
+        when(otpRepository.findByShipmentId(SHIPMENT_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.resend(SHIPMENT_ID))
+                .isInstanceOf(PickupOtpService.OtpVerificationException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private Shipment shipment() {
+        Shipment s = new Shipment();
+        ReflectionTestUtils.setField(s, "id", SHIPMENT_ID);
+        s.setState(ShipmentState.PICKUP_ASSIGNED);
+        return s;
+    }
+
+    /**
+     * Builds a PickupOtp with a real BCrypt hash of {@code plainOtp} so
+     * BCryptPasswordEncoder.matches() works in verify() tests.
+     */
+    private PickupOtp otpRecord(String plainOtp, Instant expiresAt,
+                                boolean used, short resendCount) {
+        org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder encoder =
+                new org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder(4);
+        PickupOtp otp = new PickupOtp();
+        otp.setShipment(shipment());
+        otp.setOtpHash(encoder.encode(plainOtp));
+        otp.setExpiresAt(expiresAt);
+        otp.setUsed(used);
+        otp.setResendCount(resendCount);
+        return otp;
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/service/impl/ShipmentRefServiceTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/ShipmentRefServiceTest.java
@@ -1,0 +1,135 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.domain.ShipmentRefCounter;
+import com.oneday.orders.domain.ShipmentRefCounterId;
+import com.oneday.orders.repository.ShipmentRefCounterRepository;
+import com.oneday.orders.service.ShipmentRefService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ShipmentRefServiceTest {
+
+    @Mock
+    private ShipmentRefCounterRepository counterRepository;
+
+    private ShipmentRefService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ShipmentRefServiceImpl(counterRepository);
+    }
+
+    // -------------------------------------------------------------------------
+    // Format tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void generateRef_noExistingCounter_startsAt00001() {
+        // insertIfAbsent creates the row (void, no stub needed); findByIdWithLock
+        // returns it with nextVal=0 as if freshly inserted.
+        when(counterRepository.findByIdWithLock(any()))
+                .thenReturn(Optional.of(counterWithNextVal("BLR", 0)));
+        when(counterRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        String ref = service.generateRef("BLR");
+
+        String today = LocalDate.now(ZoneId.of("Asia/Kolkata"))
+                .format(DateTimeFormatter.BASIC_ISO_DATE);
+        assertThat(ref).isEqualTo("1DD-BLR-" + today + "-00001");
+    }
+
+    @Test
+    void generateRef_existingCounter_incrementsByOne() {
+        ShipmentRefCounter existing = counterWithNextVal("BLR", 41);
+        when(counterRepository.findByIdWithLock(any())).thenReturn(Optional.of(existing));
+        when(counterRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        String ref = service.generateRef("BLR");
+
+        String today = LocalDate.now(ZoneId.of("Asia/Kolkata"))
+                .format(DateTimeFormatter.BASIC_ISO_DATE);
+        assertThat(ref).isEqualTo("1DD-BLR-" + today + "-00042");
+    }
+
+    @Test
+    void generateRef_cityCodeIsUppercased() {
+        when(counterRepository.findByIdWithLock(any()))
+                .thenReturn(Optional.of(counterWithNextVal("BLR", 0)));
+        when(counterRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        String ref = service.generateRef("blr");
+
+        assertThat(ref).startsWith("1DD-BLR-");
+    }
+
+    @Test
+    void generateRef_sequenceZeroPaddedToFiveDigits() {
+        ShipmentRefCounter existing = counterWithNextVal("DEL", 99998);
+        when(counterRepository.findByIdWithLock(any())).thenReturn(Optional.of(existing));
+        when(counterRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        String ref = service.generateRef("DEL");
+
+        assertThat(ref).endsWith("-99999");
+    }
+
+    // -------------------------------------------------------------------------
+    // Persistence tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void generateRef_savesUpdatedCounter() {
+        ShipmentRefCounter existing = counterWithNextVal("BOM", 10);
+        when(counterRepository.findByIdWithLock(any())).thenReturn(Optional.of(existing));
+        when(counterRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.generateRef("BOM");
+
+        ArgumentCaptor<ShipmentRefCounter> captor = ArgumentCaptor.forClass(ShipmentRefCounter.class);
+        verify(counterRepository).save(captor.capture());
+        assertThat(captor.getValue().getNextVal()).isEqualTo(11);
+    }
+
+    @Test
+    void generateRef_noExistingCounter_savesCounterWithCorrectId() {
+        // insertIfAbsent creates the row; findByIdWithLock returns it with nextVal=0.
+        when(counterRepository.findByIdWithLock(any()))
+                .thenReturn(Optional.of(counterWithNextVal("MAA", 0)));
+        when(counterRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.generateRef("MAA");
+
+        ArgumentCaptor<ShipmentRefCounter> captor = ArgumentCaptor.forClass(ShipmentRefCounter.class);
+        verify(counterRepository).save(captor.capture());
+        ShipmentRefCounter saved = captor.getValue();
+        assertThat(saved.getId().getCityCode()).isEqualTo("MAA");
+        assertThat(saved.getId().getDateKey()).isEqualTo(LocalDate.now(ZoneId.of("Asia/Kolkata")));
+        assertThat(saved.getNextVal()).isEqualTo(1);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private ShipmentRefCounter counterWithNextVal(String cityCode, int nextVal) {
+        ShipmentRefCounter c = new ShipmentRefCounter();
+        c.setId(new ShipmentRefCounterId(cityCode, LocalDate.now(ZoneId.of("Asia/Kolkata"))));
+        c.setNextVal(nextVal);
+        return c;
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/service/impl/ShipmentStateMachineTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/ShipmentStateMachineTest.java
@@ -1,0 +1,548 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.enums.DeliveryType;
+import com.oneday.common.domain.enums.DropType;
+import com.oneday.common.domain.enums.PickupType;
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.domain.ShipmentStateHistory;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.repository.ShipmentStateHistoryRepository;
+import com.oneday.orders.service.ShipmentStateMachine;
+import com.oneday.orders.service.TransitionContext;
+import com.oneday.orders.service.TransitionRegistry;
+import com.oneday.orders.service.TransitionRegistryConfigurer;
+import com.oneday.orders.service.exception.IllegalStateTransitionException;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ShipmentStateMachine")
+class ShipmentStateMachineTest {
+
+    @Mock
+    private ShipmentRepository shipmentRepo;
+    @Mock
+    private ShipmentStateHistoryRepository historyRepo;
+
+    private TransitionRegistry registry;
+    private ShipmentStateMachine stateMachine;
+
+    private final UUID shipmentId = UUID.randomUUID();
+    private final TransitionContext apiCtx = TransitionContext.fromApi("user-1", "req-1");
+
+    @BeforeEach
+    void setUp() {
+        // Real registry (no configurers) — tests the full V1 transition table
+        registry = new TransitionRegistry(Collections.emptyList());
+        registry.initialise();
+        stateMachine = new ShipmentStateMachineImpl(shipmentRepo, historyRepo, registry);
+    }
+
+    // ── Helper ────────────────────────────────────────────────────────────────
+
+    private Shipment shipmentIn(ShipmentState state) {
+        return shipmentIn(state, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY);
+    }
+
+    private Shipment shipmentIn(ShipmentState state, PickupType pickupType,
+                                 DropType dropType, DeliveryType deliveryType) {
+        Shipment s = new Shipment();
+        s.setState(state);
+        s.setPickupType(pickupType);
+        s.setDropType(dropType);
+        s.setDeliveryType(deliveryType);
+        when(shipmentRepo.findByIdWithLock(shipmentId)).thenReturn(Optional.of(s));
+        return s;
+    }
+
+    private void assertHistoryWritten(ShipmentState from, ShipmentState to) {
+        ArgumentCaptor<ShipmentStateHistory> cap = ArgumentCaptor.forClass(ShipmentStateHistory.class);
+        verify(historyRepo).save(cap.capture());
+        assertThat(cap.getValue().getFromState()).isEqualTo(from);
+        assertThat(cap.getValue().getToState()).isEqualTo(to);
+    }
+
+    // ── Entity not found ──────────────────────────────────────────────────────
+
+    @Test
+    void transition_throwsEntityNotFound_whenShipmentMissing() {
+        when(shipmentRepo.findByIdWithLock(shipmentId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> stateMachine.transition(shipmentId, ShipmentState.PICKUP_ASSIGNED, apiCtx))
+                .isInstanceOf(EntityNotFoundException.class);
+
+        verify(historyRepo, never()).save(any());
+    }
+
+    // ── DA_PICKUP path (happy paths) ──────────────────────────────────────────
+
+    @Nested
+    @DisplayName("DA_PICKUP path — normal flow")
+    class DaPickupPath {
+
+        @Test
+        void booked_to_pickupAssigned() {
+            shipmentIn(ShipmentState.BOOKED, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY);
+            stateMachine.transition(shipmentId, ShipmentState.PICKUP_ASSIGNED, apiCtx);
+            assertHistoryWritten(ShipmentState.BOOKED, ShipmentState.PICKUP_ASSIGNED);
+        }
+
+        @Test
+        void pickupAssigned_to_pickedUp() {
+            shipmentIn(ShipmentState.PICKUP_ASSIGNED);
+            stateMachine.transition(shipmentId, ShipmentState.PICKED_UP, apiCtx);
+            assertHistoryWritten(ShipmentState.PICKUP_ASSIGNED, ShipmentState.PICKED_UP);
+        }
+
+        @Test
+        void pickedUp_to_handedToPickupVan() {
+            shipmentIn(ShipmentState.PICKED_UP);
+            stateMachine.transition(shipmentId, ShipmentState.HANDED_TO_PICKUP_VAN, apiCtx);
+            assertHistoryWritten(ShipmentState.PICKED_UP, ShipmentState.HANDED_TO_PICKUP_VAN);
+        }
+
+        @Test
+        void handedToPickupVan_to_atOriginHub() {
+            shipmentIn(ShipmentState.HANDED_TO_PICKUP_VAN);
+            stateMachine.transition(shipmentId, ShipmentState.AT_ORIGIN_HUB, apiCtx);
+            assertHistoryWritten(ShipmentState.HANDED_TO_PICKUP_VAN, ShipmentState.AT_ORIGIN_HUB);
+        }
+    }
+
+    // ── SELF_DROP path ────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("SELF_DROP path")
+    class SelfDropPath {
+
+        @Test
+        void booked_to_awaitingSelfDrop() {
+            shipmentIn(ShipmentState.BOOKED, PickupType.SELF_DROP, DropType.DA_DELIVERY, DeliveryType.INTERCITY);
+            stateMachine.transition(shipmentId, ShipmentState.AWAITING_SELF_DROP, apiCtx);
+            assertHistoryWritten(ShipmentState.BOOKED, ShipmentState.AWAITING_SELF_DROP);
+        }
+
+        @Test
+        void booked_selfDrop_cannotTransitionToPickupAssigned() {
+            shipmentIn(ShipmentState.BOOKED, PickupType.SELF_DROP, DropType.DA_DELIVERY, DeliveryType.INTERCITY);
+            assertThatThrownBy(() -> stateMachine.transition(shipmentId, ShipmentState.PICKUP_ASSIGNED, apiCtx))
+                    .isInstanceOf(IllegalStateTransitionException.class);
+        }
+
+        @Test
+        void booked_daPickup_cannotTransitionToAwaitingSelfDrop() {
+            shipmentIn(ShipmentState.BOOKED, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY);
+            assertThatThrownBy(() -> stateMachine.transition(shipmentId, ShipmentState.AWAITING_SELF_DROP, apiCtx))
+                    .isInstanceOf(IllegalStateTransitionException.class);
+        }
+
+        @Test
+        void awaitingSelfDrop_to_atOriginHub() {
+            shipmentIn(ShipmentState.AWAITING_SELF_DROP, PickupType.SELF_DROP, DropType.DA_DELIVERY, DeliveryType.INTERCITY);
+            stateMachine.transition(shipmentId, ShipmentState.AT_ORIGIN_HUB, apiCtx);
+            assertHistoryWritten(ShipmentState.AWAITING_SELF_DROP, ShipmentState.AT_ORIGIN_HUB);
+        }
+    }
+
+    // ── Hub processing ────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Hub processing")
+    class HubProcessing {
+
+        @Test
+        void atOriginHub_to_originHubProcessing() {
+            shipmentIn(ShipmentState.AT_ORIGIN_HUB);
+            stateMachine.transition(shipmentId, ShipmentState.ORIGIN_HUB_PROCESSING, apiCtx);
+            assertHistoryWritten(ShipmentState.AT_ORIGIN_HUB, ShipmentState.ORIGIN_HUB_PROCESSING);
+        }
+
+        @Test
+        void originHubProcessing_to_inTakeoffBag() {
+            shipmentIn(ShipmentState.ORIGIN_HUB_PROCESSING);
+            stateMachine.transition(shipmentId, ShipmentState.IN_TAKEOFF_BAG, apiCtx);
+            assertHistoryWritten(ShipmentState.ORIGIN_HUB_PROCESSING, ShipmentState.IN_TAKEOFF_BAG);
+        }
+    }
+
+    // ── INTERCITY air leg branching ───────────────────────────────────────────
+
+    @Nested
+    @DisplayName("INTERCITY — air leg")
+    class IntercityAirLeg {
+
+        @Test
+        void inTakeoffBag_intercity_to_dispatchedToAirport() {
+            shipmentIn(ShipmentState.IN_TAKEOFF_BAG, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY);
+            stateMachine.transition(shipmentId, ShipmentState.DISPATCHED_TO_AIRPORT, apiCtx);
+            assertHistoryWritten(ShipmentState.IN_TAKEOFF_BAG, ShipmentState.DISPATCHED_TO_AIRPORT);
+        }
+
+        @Test
+        void inTakeoffBag_intercity_cannotSkipToHandedToDropVan() {
+            shipmentIn(ShipmentState.IN_TAKEOFF_BAG, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY);
+            assertThatThrownBy(() -> stateMachine.transition(shipmentId, ShipmentState.HANDED_TO_DROP_VAN, apiCtx))
+                    .isInstanceOf(IllegalStateTransitionException.class);
+        }
+
+        @Test
+        void dispatchedToAirport_to_atAirport() {
+            shipmentIn(ShipmentState.DISPATCHED_TO_AIRPORT);
+            stateMachine.transition(shipmentId, ShipmentState.AT_AIRPORT, apiCtx);
+            assertHistoryWritten(ShipmentState.DISPATCHED_TO_AIRPORT, ShipmentState.AT_AIRPORT);
+        }
+
+        @Test
+        void atAirport_to_departed() {
+            shipmentIn(ShipmentState.AT_AIRPORT);
+            stateMachine.transition(shipmentId, ShipmentState.DEPARTED, apiCtx);
+            assertHistoryWritten(ShipmentState.AT_AIRPORT, ShipmentState.DEPARTED);
+        }
+
+        @Test
+        void departed_to_landed() {
+            shipmentIn(ShipmentState.DEPARTED);
+            stateMachine.transition(shipmentId, ShipmentState.LANDED, apiCtx);
+            assertHistoryWritten(ShipmentState.DEPARTED, ShipmentState.LANDED);
+        }
+
+        @Test
+        void landed_to_dispatchedToHub() {
+            shipmentIn(ShipmentState.LANDED);
+            stateMachine.transition(shipmentId, ShipmentState.DISPATCHED_TO_HUB, apiCtx);
+            assertHistoryWritten(ShipmentState.LANDED, ShipmentState.DISPATCHED_TO_HUB);
+        }
+
+        @Test
+        void dispatchedToHub_to_atDestHub() {
+            shipmentIn(ShipmentState.DISPATCHED_TO_HUB);
+            stateMachine.transition(shipmentId, ShipmentState.AT_DEST_HUB, apiCtx);
+            assertHistoryWritten(ShipmentState.DISPATCHED_TO_HUB, ShipmentState.AT_DEST_HUB);
+        }
+
+        @Test
+        void atDestHub_to_destHubProcessing() {
+            shipmentIn(ShipmentState.AT_DEST_HUB);
+            stateMachine.transition(shipmentId, ShipmentState.DEST_HUB_PROCESSING, apiCtx);
+            assertHistoryWritten(ShipmentState.AT_DEST_HUB, ShipmentState.DEST_HUB_PROCESSING);
+        }
+    }
+
+    // ── SAME_CITY branching ───────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("SAME_CITY — skips air leg")
+    class SameCityBranching {
+
+        @Test
+        void inTakeoffBag_sameCity_to_handedToDropVan() {
+            shipmentIn(ShipmentState.IN_TAKEOFF_BAG, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.SAME_CITY);
+            stateMachine.transition(shipmentId, ShipmentState.HANDED_TO_DROP_VAN, apiCtx);
+            assertHistoryWritten(ShipmentState.IN_TAKEOFF_BAG, ShipmentState.HANDED_TO_DROP_VAN);
+        }
+
+        @Test
+        void inTakeoffBag_sameCity_cannotGoToDispatchedToAirport() {
+            shipmentIn(ShipmentState.IN_TAKEOFF_BAG, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.SAME_CITY);
+            assertThatThrownBy(() -> stateMachine.transition(shipmentId, ShipmentState.DISPATCHED_TO_AIRPORT, apiCtx))
+                    .isInstanceOf(IllegalStateTransitionException.class);
+        }
+    }
+
+    // ── DA_DELIVERY last-mile ─────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("DA_DELIVERY last-mile path")
+    class DaDeliveryPath {
+
+        @Test
+        void destHubProcessing_daDelivery_to_handedToDropVan() {
+            shipmentIn(ShipmentState.DEST_HUB_PROCESSING, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY);
+            stateMachine.transition(shipmentId, ShipmentState.HANDED_TO_DROP_VAN, apiCtx);
+            assertHistoryWritten(ShipmentState.DEST_HUB_PROCESSING, ShipmentState.HANDED_TO_DROP_VAN);
+        }
+
+        @Test
+        void destHubProcessing_daDelivery_cannotGoToAwaitingHubCollect() {
+            shipmentIn(ShipmentState.DEST_HUB_PROCESSING, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY);
+            assertThatThrownBy(() -> stateMachine.transition(shipmentId, ShipmentState.AWAITING_HUB_COLLECT, apiCtx))
+                    .isInstanceOf(IllegalStateTransitionException.class);
+        }
+
+        @Test
+        void handedToDropVan_to_dropAssigned() {
+            shipmentIn(ShipmentState.HANDED_TO_DROP_VAN);
+            stateMachine.transition(shipmentId, ShipmentState.DROP_ASSIGNED, apiCtx);
+            assertHistoryWritten(ShipmentState.HANDED_TO_DROP_VAN, ShipmentState.DROP_ASSIGNED);
+        }
+
+        @Test
+        void dropAssigned_to_dropCollected() {
+            shipmentIn(ShipmentState.DROP_ASSIGNED);
+            stateMachine.transition(shipmentId, ShipmentState.DROP_COLLECTED, apiCtx);
+            assertHistoryWritten(ShipmentState.DROP_ASSIGNED, ShipmentState.DROP_COLLECTED);
+        }
+
+        @Test
+        void dropCollected_to_dropped() {
+            shipmentIn(ShipmentState.DROP_COLLECTED);
+            stateMachine.transition(shipmentId, ShipmentState.DROPPED, apiCtx);
+            assertHistoryWritten(ShipmentState.DROP_COLLECTED, ShipmentState.DROPPED);
+        }
+    }
+
+    // ── HUB_COLLECT path ──────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("HUB_COLLECT path")
+    class HubCollectPath {
+
+        @Test
+        void destHubProcessing_hubCollect_to_awaitingHubCollect() {
+            shipmentIn(ShipmentState.DEST_HUB_PROCESSING, PickupType.DA_PICKUP, DropType.HUB_COLLECT, DeliveryType.INTERCITY);
+            stateMachine.transition(shipmentId, ShipmentState.AWAITING_HUB_COLLECT, apiCtx);
+            assertHistoryWritten(ShipmentState.DEST_HUB_PROCESSING, ShipmentState.AWAITING_HUB_COLLECT);
+        }
+
+        @Test
+        void destHubProcessing_hubCollect_cannotGoToHandedToDropVan() {
+            shipmentIn(ShipmentState.DEST_HUB_PROCESSING, PickupType.DA_PICKUP, DropType.HUB_COLLECT, DeliveryType.INTERCITY);
+            assertThatThrownBy(() -> stateMachine.transition(shipmentId, ShipmentState.HANDED_TO_DROP_VAN, apiCtx))
+                    .isInstanceOf(IllegalStateTransitionException.class);
+        }
+
+        @Test
+        void awaitingHubCollect_to_hubCollected() {
+            shipmentIn(ShipmentState.AWAITING_HUB_COLLECT);
+            stateMachine.transition(shipmentId, ShipmentState.HUB_COLLECTED, apiCtx);
+            assertHistoryWritten(ShipmentState.AWAITING_HUB_COLLECT, ShipmentState.HUB_COLLECTED);
+        }
+    }
+
+    // ── Cancellation ──────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Cancellation paths")
+    class CancellationPaths {
+
+        @Test
+        void booked_to_cancelled() {
+            shipmentIn(ShipmentState.BOOKED);
+            stateMachine.transition(shipmentId, ShipmentState.CANCELLED, apiCtx);
+            assertHistoryWritten(ShipmentState.BOOKED, ShipmentState.CANCELLED);
+        }
+
+        @Test
+        void pickupAssigned_to_cancelled() {
+            shipmentIn(ShipmentState.PICKUP_ASSIGNED);
+            stateMachine.transition(shipmentId, ShipmentState.CANCELLED, apiCtx);
+            assertHistoryWritten(ShipmentState.PICKUP_ASSIGNED, ShipmentState.CANCELLED);
+        }
+
+        @Test
+        void pickedUp_to_cancelled() {
+            shipmentIn(ShipmentState.PICKED_UP);
+            stateMachine.transition(shipmentId, ShipmentState.CANCELLED, apiCtx);
+            assertHistoryWritten(ShipmentState.PICKED_UP, ShipmentState.CANCELLED);
+        }
+
+        @Test
+        void awaitingSelfDrop_to_cancelled() {
+            shipmentIn(ShipmentState.AWAITING_SELF_DROP);
+            stateMachine.transition(shipmentId, ShipmentState.CANCELLED, apiCtx);
+            assertHistoryWritten(ShipmentState.AWAITING_SELF_DROP, ShipmentState.CANCELLED);
+        }
+
+        @Test
+        void handedToPickupVan_cannotBeCancelled() {
+            shipmentIn(ShipmentState.HANDED_TO_PICKUP_VAN);
+            assertThatThrownBy(() -> stateMachine.transition(shipmentId, ShipmentState.CANCELLED, apiCtx))
+                    .isInstanceOf(IllegalStateTransitionException.class);
+        }
+    }
+
+    // ── Exception / failure paths ─────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Failure and RTO paths")
+    class FailureAndRtoPaths {
+
+        @Test
+        void pickupAssigned_to_pickupFailed() {
+            shipmentIn(ShipmentState.PICKUP_ASSIGNED);
+            stateMachine.transition(shipmentId, ShipmentState.PICKUP_FAILED, apiCtx);
+            assertHistoryWritten(ShipmentState.PICKUP_ASSIGNED, ShipmentState.PICKUP_FAILED);
+        }
+
+        @Test
+        void pickupFailed_to_pickupAssigned_reschedule() {
+            shipmentIn(ShipmentState.PICKUP_FAILED);
+            stateMachine.transition(shipmentId, ShipmentState.PICKUP_ASSIGNED, apiCtx);
+            assertHistoryWritten(ShipmentState.PICKUP_FAILED, ShipmentState.PICKUP_ASSIGNED);
+        }
+
+        @Test
+        void dropCollected_to_deliveryFailed() {
+            shipmentIn(ShipmentState.DROP_COLLECTED);
+            stateMachine.transition(shipmentId, ShipmentState.DELIVERY_FAILED, apiCtx);
+            assertHistoryWritten(ShipmentState.DROP_COLLECTED, ShipmentState.DELIVERY_FAILED);
+        }
+
+        @Test
+        void deliveryFailed_to_rtoInitiated() {
+            shipmentIn(ShipmentState.DELIVERY_FAILED);
+            stateMachine.transition(shipmentId, ShipmentState.RTO_INITIATED, apiCtx);
+            assertHistoryWritten(ShipmentState.DELIVERY_FAILED, ShipmentState.RTO_INITIATED);
+        }
+
+        @Test
+        void deliveryFailed_to_dropAssigned_reschedule() {
+            shipmentIn(ShipmentState.DELIVERY_FAILED);
+            stateMachine.transition(shipmentId, ShipmentState.DROP_ASSIGNED, apiCtx);
+            assertHistoryWritten(ShipmentState.DELIVERY_FAILED, ShipmentState.DROP_ASSIGNED);
+        }
+
+        @Test
+        void rtoInitiated_intercity_to_rtoInTransit() {
+            shipmentIn(ShipmentState.RTO_INITIATED, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY);
+            stateMachine.transition(shipmentId, ShipmentState.RTO_IN_TRANSIT, apiCtx);
+            assertHistoryWritten(ShipmentState.RTO_INITIATED, ShipmentState.RTO_IN_TRANSIT);
+        }
+
+        @Test
+        void rtoInitiated_intercity_cannotJumpToRtoCompleted() {
+            shipmentIn(ShipmentState.RTO_INITIATED, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY);
+            assertThatThrownBy(() -> stateMachine.transition(shipmentId, ShipmentState.RTO_COMPLETED, apiCtx))
+                    .isInstanceOf(IllegalStateTransitionException.class);
+        }
+
+        @Test
+        void rtoInitiated_sameCity_to_rtoCompleted() {
+            shipmentIn(ShipmentState.RTO_INITIATED, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.SAME_CITY);
+            stateMachine.transition(shipmentId, ShipmentState.RTO_COMPLETED, apiCtx);
+            assertHistoryWritten(ShipmentState.RTO_INITIATED, ShipmentState.RTO_COMPLETED);
+        }
+
+        @Test
+        void rtoInitiated_sameCity_cannotGoToRtoInTransit() {
+            shipmentIn(ShipmentState.RTO_INITIATED, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.SAME_CITY);
+            assertThatThrownBy(() -> stateMachine.transition(shipmentId, ShipmentState.RTO_IN_TRANSIT, apiCtx))
+                    .isInstanceOf(IllegalStateTransitionException.class);
+        }
+
+        @Test
+        void rtoInTransit_to_rtoCompleted() {
+            shipmentIn(ShipmentState.RTO_IN_TRANSIT);
+            stateMachine.transition(shipmentId, ShipmentState.RTO_COMPLETED, apiCtx);
+            assertHistoryWritten(ShipmentState.RTO_IN_TRANSIT, ShipmentState.RTO_COMPLETED);
+        }
+    }
+
+    // ── Terminal states ───────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Terminal states reject all transitions")
+    class TerminalStates {
+
+        @Test
+        void dropped_isTerminal() {
+            shipmentIn(ShipmentState.DROPPED);
+            assertThatThrownBy(() -> stateMachine.transition(shipmentId, ShipmentState.DELIVERY_FAILED, apiCtx))
+                    .isInstanceOf(IllegalStateTransitionException.class);
+        }
+
+        @Test
+        void hubCollected_isTerminal() {
+            shipmentIn(ShipmentState.HUB_COLLECTED);
+            assertThatThrownBy(() -> stateMachine.transition(shipmentId, ShipmentState.DELIVERY_FAILED, apiCtx))
+                    .isInstanceOf(IllegalStateTransitionException.class);
+        }
+
+        @Test
+        void rtoCompleted_isTerminal() {
+            shipmentIn(ShipmentState.RTO_COMPLETED);
+            assertThatThrownBy(() -> stateMachine.transition(shipmentId, ShipmentState.BOOKED, apiCtx))
+                    .isInstanceOf(IllegalStateTransitionException.class);
+        }
+
+        @Test
+        void cancelled_isTerminal() {
+            shipmentIn(ShipmentState.CANCELLED);
+            assertThatThrownBy(() -> stateMachine.transition(shipmentId, ShipmentState.BOOKED, apiCtx))
+                    .isInstanceOf(IllegalStateTransitionException.class);
+        }
+    }
+
+    // ── IllegalStateTransitionException carries correct metadata ─────────────
+
+    @Test
+    void illegalTransitionException_carriesFromAndToState() {
+        shipmentIn(ShipmentState.DROPPED);
+
+        assertThatThrownBy(() -> stateMachine.transition(shipmentId, ShipmentState.BOOKED, apiCtx))
+                .isInstanceOf(IllegalStateTransitionException.class)
+                .satisfies(ex -> {
+                    IllegalStateTransitionException iste = (IllegalStateTransitionException) ex;
+                    assertThat(iste.getFromState()).isEqualTo(ShipmentState.DROPPED);
+                    assertThat(iste.getToState()).isEqualTo(ShipmentState.BOOKED);
+                    assertThat(iste.getMessage()).contains("DROPPED").contains("BOOKED");
+                });
+    }
+
+    // ── TransitionContext is written to history ───────────────────────────────
+
+    @Test
+    void transition_writesFullContextToHistory() {
+        shipmentIn(ShipmentState.PICKUP_ASSIGNED);
+        TransitionContext kafkaCtx = TransitionContext.fromKafka("m5-consumer", "kafka-msg-001")
+                .withNotes("DA arrived and customer confirmed OTP");
+
+        stateMachine.transition(shipmentId, ShipmentState.PICKED_UP, kafkaCtx);
+
+        ArgumentCaptor<ShipmentStateHistory> cap = ArgumentCaptor.forClass(ShipmentStateHistory.class);
+        verify(historyRepo).save(cap.capture());
+        ShipmentStateHistory history = cap.getValue();
+        assertThat(history.getTriggeredBy()).isEqualTo("m5-consumer");
+        assertThat(history.getEventRef()).isEqualTo("kafka-msg-001");
+        assertThat(history.getNotes()).isEqualTo("DA arrived and customer confirmed OTP");
+        assertThat(history.getOccurredAt()).isNotNull();
+    }
+
+    // ── Dynamic registration (extension point) ────────────────────────────────
+
+    @Test
+    void dynamicRegistration_newTransitionIsAccepted() {
+        // Simulates a V2 module adding a transition via TransitionRegistryConfigurer
+        TransitionRegistryConfigurer extender = reg ->
+                reg.register(ShipmentState.DROPPED, ShipmentState.RTO_INITIATED);
+
+        TransitionRegistry extendedRegistry = new TransitionRegistry(List.of(extender));
+        extendedRegistry.initialise();
+        ShipmentStateMachine extended = new ShipmentStateMachineImpl(shipmentRepo, historyRepo, extendedRegistry);
+
+        shipmentIn(ShipmentState.DROPPED);
+        // Should NOT throw — transition was registered dynamically
+        extended.transition(shipmentId, ShipmentState.RTO_INITIATED, apiCtx);
+        assertHistoryWritten(ShipmentState.DROPPED, ShipmentState.RTO_INITIATED);
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/service/impl/ShipmentStateMachineTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/ShipmentStateMachineTest.java
@@ -23,12 +23,20 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -456,6 +464,14 @@ class ShipmentStateMachineTest {
             stateMachine.transition(shipmentId, ShipmentState.RTO_COMPLETED, apiCtx);
             assertHistoryWritten(ShipmentState.RTO_IN_TRANSIT, ShipmentState.RTO_COMPLETED);
         }
+
+        @Test
+        void pickupFailed_to_cancelled_whenM11ClosesShipment() {
+            // M11 may close a shipment after exhausting all pickup reattempts
+            shipmentIn(ShipmentState.PICKUP_FAILED);
+            stateMachine.transition(shipmentId, ShipmentState.CANCELLED, apiCtx);
+            assertHistoryWritten(ShipmentState.PICKUP_FAILED, ShipmentState.CANCELLED);
+        }
     }
 
     // ── Terminal states ───────────────────────────────────────────────────────
@@ -526,6 +542,151 @@ class ShipmentStateMachineTest {
         assertThat(history.getEventRef()).isEqualTo("kafka-msg-001");
         assertThat(history.getNotes()).isEqualTo("DA arrived and customer confirmed OTP");
         assertThat(history.getOccurredAt()).isNotNull();
+    }
+
+    // ── Exhaustive 27×27 transition matrix ───────────────────────────────────
+
+    /**
+     * Parameterized test covering every (from, to) pair across all 27 states.
+     *
+     * <p>Each {@link StateConfig} entry defines one shipment configuration
+     * (pickupType / dropType / deliveryType) and the set of target states that are
+     * legally reachable from {@code from} under that configuration. Branching states
+     * appear twice — once per branch — because different field values yield different
+     * allowed target sets.</p>
+     *
+     * <p>Two parameterized tests are generated from the same data source:</p>
+     * <ul>
+     *   <li>{@code allLegalTransitions_succeed} — one case per entry in legalTargets; ~35 cases</li>
+     *   <li>{@code allIllegalTransitions_throw} — one case per target NOT in legalTargets; ~750 cases</li>
+     * </ul>
+     */
+    @Nested
+    @DisplayName("Exhaustive 27×27 transition matrix")
+    class TransitionMatrix {
+
+        private record StateConfig(
+                ShipmentState from,
+                PickupType pickupType,
+                DropType dropType,
+                DeliveryType deliveryType,
+                Set<ShipmentState> legalTargets) {
+        }
+
+        private static final List<StateConfig> CONFIGS = List.of(
+                // BOOKED — pickup_type branching
+                new StateConfig(ShipmentState.BOOKED, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.PICKUP_ASSIGNED, ShipmentState.CANCELLED)),
+                new StateConfig(ShipmentState.BOOKED, PickupType.SELF_DROP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.AWAITING_SELF_DROP, ShipmentState.CANCELLED)),
+                // AWAITING_SELF_DROP
+                new StateConfig(ShipmentState.AWAITING_SELF_DROP, PickupType.SELF_DROP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.AT_ORIGIN_HUB, ShipmentState.CANCELLED)),
+                // PICKUP_ASSIGNED
+                new StateConfig(ShipmentState.PICKUP_ASSIGNED, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.PICKED_UP, ShipmentState.PICKUP_FAILED, ShipmentState.CANCELLED)),
+                // PICKED_UP
+                new StateConfig(ShipmentState.PICKED_UP, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.HANDED_TO_PICKUP_VAN, ShipmentState.CANCELLED)),
+                // HANDED_TO_PICKUP_VAN
+                new StateConfig(ShipmentState.HANDED_TO_PICKUP_VAN, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.AT_ORIGIN_HUB)),
+                // AT_ORIGIN_HUB
+                new StateConfig(ShipmentState.AT_ORIGIN_HUB, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.ORIGIN_HUB_PROCESSING)),
+                // ORIGIN_HUB_PROCESSING
+                new StateConfig(ShipmentState.ORIGIN_HUB_PROCESSING, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.IN_TAKEOFF_BAG)),
+                // IN_TAKEOFF_BAG — delivery_type branching
+                new StateConfig(ShipmentState.IN_TAKEOFF_BAG, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.DISPATCHED_TO_AIRPORT)),
+                new StateConfig(ShipmentState.IN_TAKEOFF_BAG, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.SAME_CITY,
+                        Set.of(ShipmentState.HANDED_TO_DROP_VAN)),
+                // DISPATCHED_TO_AIRPORT
+                new StateConfig(ShipmentState.DISPATCHED_TO_AIRPORT, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.AT_AIRPORT)),
+                // AT_AIRPORT
+                new StateConfig(ShipmentState.AT_AIRPORT, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.DEPARTED)),
+                // DEPARTED
+                new StateConfig(ShipmentState.DEPARTED, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.LANDED)),
+                // LANDED
+                new StateConfig(ShipmentState.LANDED, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.DISPATCHED_TO_HUB)),
+                // DISPATCHED_TO_HUB
+                new StateConfig(ShipmentState.DISPATCHED_TO_HUB, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.AT_DEST_HUB)),
+                // AT_DEST_HUB
+                new StateConfig(ShipmentState.AT_DEST_HUB, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.DEST_HUB_PROCESSING)),
+                // DEST_HUB_PROCESSING — drop_type branching
+                new StateConfig(ShipmentState.DEST_HUB_PROCESSING, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.HANDED_TO_DROP_VAN)),
+                new StateConfig(ShipmentState.DEST_HUB_PROCESSING, PickupType.DA_PICKUP, DropType.HUB_COLLECT, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.AWAITING_HUB_COLLECT)),
+                // AWAITING_HUB_COLLECT
+                new StateConfig(ShipmentState.AWAITING_HUB_COLLECT, PickupType.DA_PICKUP, DropType.HUB_COLLECT, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.HUB_COLLECTED)),
+                // HANDED_TO_DROP_VAN
+                new StateConfig(ShipmentState.HANDED_TO_DROP_VAN, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.DROP_ASSIGNED)),
+                // DROP_ASSIGNED
+                new StateConfig(ShipmentState.DROP_ASSIGNED, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.DROP_COLLECTED)),
+                // DROP_COLLECTED
+                new StateConfig(ShipmentState.DROP_COLLECTED, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.DROPPED, ShipmentState.DELIVERY_FAILED)),
+                // PICKUP_FAILED
+                new StateConfig(ShipmentState.PICKUP_FAILED, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.PICKUP_ASSIGNED, ShipmentState.CANCELLED)),
+                // DELIVERY_FAILED
+                new StateConfig(ShipmentState.DELIVERY_FAILED, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.RTO_INITIATED, ShipmentState.DROP_ASSIGNED)),
+                // RTO_INITIATED — delivery_type branching
+                new StateConfig(ShipmentState.RTO_INITIATED, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.RTO_IN_TRANSIT)),
+                new StateConfig(ShipmentState.RTO_INITIATED, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.SAME_CITY,
+                        Set.of(ShipmentState.RTO_COMPLETED)),
+                // RTO_IN_TRANSIT
+                new StateConfig(ShipmentState.RTO_IN_TRANSIT, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                        Set.of(ShipmentState.RTO_COMPLETED)),
+                // Terminal states — no legal targets out
+                new StateConfig(ShipmentState.DROPPED,       PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY, Set.of()),
+                new StateConfig(ShipmentState.HUB_COLLECTED, PickupType.DA_PICKUP, DropType.HUB_COLLECT, DeliveryType.INTERCITY, Set.of()),
+                new StateConfig(ShipmentState.RTO_COMPLETED, PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY, Set.of()),
+                new StateConfig(ShipmentState.CANCELLED,     PickupType.DA_PICKUP, DropType.DA_DELIVERY, DeliveryType.INTERCITY, Set.of())
+        );
+
+        static Stream<Arguments> legalTransitions() {
+            return CONFIGS.stream()
+                    .flatMap(c -> c.legalTargets().stream()
+                            .map(to -> Arguments.of(c.from(), to, c.pickupType(), c.dropType(), c.deliveryType())));
+        }
+
+        static Stream<Arguments> illegalTransitions() {
+            return CONFIGS.stream()
+                    .flatMap(c -> Arrays.stream(ShipmentState.values())
+                            .filter(to -> !c.legalTargets().contains(to))
+                            .map(to -> Arguments.of(c.from(), to, c.pickupType(), c.dropType(), c.deliveryType())));
+        }
+
+        @ParameterizedTest(name = "[LEGAL]   {0} → {1}  [{2}/{3}/{4}]")
+        @MethodSource("legalTransitions")
+        void allLegalTransitions_succeed(ShipmentState from, ShipmentState to,
+                                          PickupType pt, DropType dt, DeliveryType dv) {
+            shipmentIn(from, pt, dt, dv);
+            assertThatNoException().isThrownBy(() -> stateMachine.transition(shipmentId, to, apiCtx));
+        }
+
+        @ParameterizedTest(name = "[ILLEGAL] {0} → {1}  [{2}/{3}/{4}]")
+        @MethodSource("illegalTransitions")
+        void allIllegalTransitions_throw(ShipmentState from, ShipmentState to,
+                                          PickupType pt, DropType dt, DeliveryType dv) {
+            shipmentIn(from, pt, dt, dv);
+            assertThatThrownBy(() -> stateMachine.transition(shipmentId, to, apiCtx))
+                    .isInstanceOf(IllegalStateTransitionException.class);
+        }
     }
 
     // ── Dynamic registration (extension point) ────────────────────────────────

--- a/orders/src/test/resources/application.yml
+++ b/orders/src/test/resources/application.yml
@@ -11,4 +11,3 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration/orders
-    out-of-order: true

--- a/orders/src/test/resources/application.yml
+++ b/orders/src/test/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/oneday
+    username: oneday
+    password: secret
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+  flyway:
+    enabled: true
+    locations: classpath:db/migration/orders
+    out-of-order: true


### PR DESCRIPTION
# Pull Request

## Summary
Adds shipment reference generation (`1DD-{CITY}-{YYYYMMDD}-{NNNNN}`), delivery-type classification, a Razorpay payment port, and the full pickup OTP flow (`generate → verify → resend`) with two internal REST endpoints used by the DA app at pickup time. All 8 architect findings (3 critical, 5 warning) addressed in this PR.

---

## What Changed
- `ShipmentRefService` / `ShipmentRefServiceImpl` — generates unique human-readable shipment refs using `INSERT … ON CONFLICT DO NOTHING` + `SELECT FOR UPDATE` on `shipment_ref_counters`; `Propagation.MANDATORY` so the counter increment rolls back with the caller's booking transaction if anything fails after ref generation
- `DeliveryTypeResolver` — pure `@Component`; `resolve(origin, dest)` returns `SAME_CITY` if city codes match (case-insensitive), else `INTERCITY`; zero DB calls
- `PaymentPort` — Razorpay port interface local to `orders` (not in `common`); `verifySignature / void capture / String initiateRefund`; inner unchecked exceptions `PaymentVerificationException`, `PaymentCaptureException`, `PaymentRefundException`
- `PickupOtpService` / `PickupOtpServiceImpl` — generates 4-digit OTP via `SecureRandom`, stores BCrypt(cost=4) hash in `pickup_otps`; `verify()` uses `SELECT FOR UPDATE` to prevent concurrent replay; `resend()` delete-then-insert, capped by configurable `PickupOtpProperties`
- `PickupOtpProperties` — `@ConfigurationProperties(prefix="orders.otp")`; `ttl-minutes=10`, `max-resend-count=3`
- `PickupOtp` JPA entity — append-only except `used` flag; `@OneToOne(LAZY)` to `Shipment`
- `PickupOtpRepository` — `findByShipmentId`, `findByShipmentIdWithLock` (`@Lock(PESSIMISTIC_WRITE)`), `deleteByShipmentId`
- `PickupOtpController` — `POST /internal/v1/shipments/{ref}/pickup-otp/verify` → `204`; `POST /internal/v1/shipments/{ref}/pickup-otp/resend` → `200 {"otp":"…"}`; `@Transactional` on `verifyOtp` wraps `verify()` + `stateMachine.transition()` atomically
- `OtpVerifyRequest` DTO — `@NotBlank @Pattern(regexp="\\d{4}")`
- `V4_11__create_pickup_otps.sql` — `pickup_otps` table; unique index on `shipment_id`; expiry index on `expires_at`
- `ShipmentRefCounterRepository` — `insertIfAbsent` native query (`INSERT … ON CONFLICT DO NOTHING`)
- Docs: `M4-ORDERS-DESIGN.md` v0.5, `M4-ER-DIAGRAM.md`, `M4-IMPL-PLAN.md` v1.4, `M4-INTEGRATION-CONTRACTS.md`, `CLAUDE.md` — all synced to PR #9

---

## Why This Change?
These are the foundation utilities that every booking API (PR #10+) depends on. `ShipmentRefService` assigns the ref at booking time. `DeliveryTypeResolver` picks the correct state machine path. `PaymentPort` must exist before any prepaid booking logic is wired. `PickupOtpService` + `PickupOtpController` are needed by the DA app the moment a shipment enters `PICKUP_ASSIGNED` — which happens as soon as M5 assigns a DA.

---

## Testing
- [x] Tested locally
- [x] Edge cases considered
- [x] No breaking changes introduced

### Test Evidence

```
[INFO] Tests run: 6,    Failures: 0, Errors: 0  -- PickupOtpRepositoryTest      (@DataJpaTest, real PostgreSQL)
[INFO] Tests run: 8,    Failures: 0, Errors: 0  -- PickupOtpControllerTest       (Mockito unit)
[INFO] Tests run: 11,   Failures: 0, Errors: 0  -- PickupOtpServiceTest           (Mockito unit)
[INFO] Tests run: 6,    Failures: 0, Errors: 0  -- ShipmentRefServiceTest         (Mockito unit)
[INFO] Tests run: 6,    Failures: 0, Errors: 0  -- DeliveryTypeResolverTest       (pure unit)
[INFO] Tests run: 841,  Failures: 0, Errors: 0  -- ShipmentStateMachineTest$TransitionMatrix
[INFO] Tests run: 1005, Failures: 0, Errors: 0  -- orders module total
[INFO] BUILD SUCCESS
```
<img width="222" height="159" alt="image" src="https://github.com/user-attachments/assets/acff26cc-c26a-4358-a7f0-63cd94a80714" />


`PickupOtpRepositoryTest` runs against the real local PostgreSQL DB (`@DataJpaTest` + `@AutoConfigureTestDatabase(replace=NONE)`). V4_11 was applied manually (`psql -U oneday -d oneday -f V4_11__create_pickup_otps.sql`) and registered in `flyway_schema_history` — same pattern used since PR #6.

**Architect findings addressed:**

| ID | Severity | Finding | Fix applied |
|----|----------|---------|-------------|
| C1 | Critical | `verify()` and `stateMachine.transition()` in separate transactions — OTP consumed but state stuck if transition fails | `@Transactional` on `verifyOtp`; both calls join one TX |
| C2 | Critical | `findByShipmentId` in `verify()` unguarded — concurrent calls both see `used=false` | `findByShipmentIdWithLock` (`SELECT FOR UPDATE`) in `verify()` |
| C3 | Critical | First-of-day counter: `SELECT FOR UPDATE` on non-existent row locks nothing; concurrent inserts race | `insertIfAbsent` (`INSERT … ON CONFLICT DO NOTHING`) before `findByIdWithLock` |
| W1 | Warning  | `resendOtp` missing `PICKUP_ASSIGNED` state guard | Guard added; 409 if wrong state |
| W2 | Warning  | BCrypt cost 10 adds ~100 ms per OTP op | Cost 4 (~1 ms); TTL + single-use flag are primary security controls |
| W3 | Warning  | `resend()` redundant `shipmentRepository.findById()` | Removed; uses `existing.getShipment()` |
| W4 | Warning  | `PaymentPort` comment says "Checked exceptions" | Fixed to "Unchecked exceptions" |
| W5 | Warning  | OTP TTL and resend limit hardcoded as static constants | Extracted to `PickupOtpProperties` |

Deferred nits (tracked): N1 wrong exception type in `resend()`, N2 cleartext OTP in response (see Risks), N3 inner exceptions in `PaymentPort`.

---

## Impact

### Areas Affected
- [x] Backend
- [ ] Frontend
- [ ] Routing
- [ ] Infra
- [x] Database
- [ ] NA

### Modules Affected
- [ ] M1 — Auth
- [ ] M2 — Pricing
- [ ] M3 — Grid
- [x] M4 — Orders
- [ ] M5 — Dispatch
- [ ] M6 — Routing
- [ ] M7 — Hub
- [ ] M8 — Barcode
- [ ] M9 — Airline
- [ ] M10 — SLA
- [ ] M11 — Exceptions
- [ ] NA

---

## Risks / Concerns
- **Cleartext OTP in `/resend` response (N2):** In the full flow `PickupOtpController.resendOtp()` will call `NotificationPort` (PR #10) to SMS the OTP to the sender. Until PR #10 lands, the OTP is returned in the response body so the DA app can display it as a fallback. The endpoint is on `/internal/v1/` (not public) and will require `X-Service-Token` auth in PR #18.
- **BCrypt cost 4:** Lower than the Spring Security default (10). For 4-digit OTPs with a 10-minute TTL and a single-use flag, cost 4 provides adequate protection while keeping latency acceptable. Bumping back to 10 is a one-line change if the security review disagrees.
- **Stacked on PR #8:** Base branch is `satvik/m4-pr8-idempotency`. Merge PR #8 first.

---

## Checklist
- [x] Code follows project conventions (package layout, no cross-module internal imports)
- [x] Self-review completed
- [x] Append-only audit trail preserved (no mutations to scan/manifest/role-change records)
- [x] No sensitive data or credentials exposed
- [x] Documentation updated if behaviour changed
- [x] Ready for review
