### PR TITLE
Common kafka spine addition

### DIFF
--- a/app/src/main/resources/application-dev.yml
+++ b/app/src/main/resources/application-dev.yml
@@ -1,0 +1,20 @@
+# Shared TEAM-TESTING cluster (managed Redpanda Serverless / Confluent Basic).
+# Activate with:  -Dspring.profiles.active=dev   (or SPRING_PROFILES_ACTIVE=dev)
+# Secrets come from env vars — never commit real keys.
+#
+#   export KAFKA_BOOTSTRAP_SERVERS=<your-cluster-bootstrap:9092>
+#   export KAFKA_KEY=<api-key / username>
+#   export KAFKA_SECRET=<api-secret / password>
+#
+# Redpanda Cloud uses SASL_SSL + SCRAM-SHA-256 (shown below).
+# Confluent Cloud uses SASL_SSL + PLAIN — swap sasl.mechanism to PLAIN and the login
+# module to org.apache.kafka.common.security.plain.PlainLoginModule.
+spring:
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+    properties:
+      security.protocol: SASL_SSL
+      sasl.mechanism: SCRAM-SHA-256
+      sasl.jaas.config: >
+        org.apache.kafka.common.security.scram.ScramLoginModule required
+        username="${KAFKA_KEY}" password="${KAFKA_SECRET}";

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -16,3 +16,17 @@ spring:
       - classpath:db/migration/orders
   jackson:
     property-naming-strategy: SNAKE_CASE
+  kafka:
+    # Default = local. Override KAFKA_BOOTSTRAP_SERVERS (+ activate the 'dev' profile for a
+    # managed cluster's SASL creds — see application-dev.yml).
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        # In-house monolith: every producer is our own code. Tighten to explicit packages
+        # once an external/untrusted producer writes to a topic we consume.
+        spring.json.trusted.packages: "*"

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -28,5 +28,10 @@
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/common/src/main/java/com/oneday/common/kafka/DomainEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/DomainEvent.java
@@ -1,0 +1,19 @@
+package com.oneday.common.kafka;
+
+/**
+ * Contract every Kafka event payload implements so the shared infra (EventPublisher,
+ * error handling, logging) can treat any event uniformly without knowing its concrete type.
+ *
+ * Keep payloads as plain data (records, or Lombok POJOs) — no behaviour beyond these two
+ * derivations. The event TYPE (e.g. CREATED, NO_DA_ALERT) stays a per-module enum field on
+ * the payload; eventTypeName() just exposes its name for logging/DLQ headers.
+ */
+public interface DomainEvent {
+
+    /** Kafka message key — the entity this event is about (shipmentId, tileId, …).
+     *  Same key ⇒ same partition ⇒ ordered per entity. Never null. */
+    String partitionKey();
+
+    /** The event type as a string (usually {@code someEnum.name()}) — for logging and DLQ headers. */
+    String eventTypeName();
+}

--- a/common/src/main/java/com/oneday/common/kafka/EventPublisher.java
+++ b/common/src/main/java/com/oneday/common/kafka/EventPublisher.java
@@ -1,0 +1,35 @@
+package com.oneday.common.kafka;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Single shared producer. Every module injects this instead of wiring KafkaTemplate + try/catch
+ * by hand. Keys the message by the event's {@link DomainEvent#partitionKey()} so per-entity
+ * ordering is automatic, and never lets a broker hiccup break the calling business flow
+ * (a failed send is logged, not thrown — Kafka is best-effort for the producing module).
+ *
+ * Usage:  eventPublisher.publish(KafkaTopics.CRON_EVENTS, cronDepartedEvent);
+ */
+@Component
+public class EventPublisher {
+
+    private static final Logger log = LoggerFactory.getLogger(EventPublisher.class);
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    EventPublisher(KafkaTemplate<String, Object> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void publish(String topic, DomainEvent event) {
+        try {
+            kafkaTemplate.send(topic, event.partitionKey(), event);
+        } catch (Exception e) {
+            log.warn("Kafka publish failed — topic={} type={} key={}: {}",
+                    topic, event.eventTypeName(), event.partitionKey(), e.getMessage());
+        }
+    }
+}

--- a/common/src/main/java/com/oneday/common/kafka/KafkaErrorConfig.java
+++ b/common/src/main/java/com/oneday/common/kafka/KafkaErrorConfig.java
@@ -1,0 +1,46 @@
+package com.oneday.common.kafka;
+
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+/**
+ * One error handler for every @KafkaListener in the app. Spring Boot auto-wires the single
+ * {@link DefaultErrorHandler} bean into all listener containers.
+ *
+ * Behaviour: if a consumer throws while processing a record, retry 3 times (1s apart); if it
+ * still fails, publish that one record to "<original-topic>.dlq" and move on — so a single
+ * poison message can never block its partition forever. Inspect/replay the .dlq topic later.
+ */
+@Configuration
+public class KafkaErrorConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(KafkaErrorConfig.class);
+
+    private static final long RETRY_INTERVAL_MS = 1_000L;
+    private static final long MAX_RETRIES = 3L;
+
+    @Bean
+    public DefaultErrorHandler kafkaErrorHandler(KafkaTemplate<String, Object> kafkaTemplate) {
+        // Route failed records to "<topic>.dlq". Partition -1 ⇒ broker picks by key
+        // (so the DLQ topic can have a different partition count than the source).
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
+                kafkaTemplate,
+                (record, ex) -> new TopicPartition(record.topic() + ".dlq", -1));
+
+        DefaultErrorHandler handler =
+                new DefaultErrorHandler(recoverer, new FixedBackOff(RETRY_INTERVAL_MS, MAX_RETRIES));
+
+        handler.setRetryListeners((record, ex, attempt) ->
+                log.warn("Kafka consume retry {} — topic={} key={}: {}",
+                        attempt, record.topic(), record.key(), ex.getMessage()));
+
+        return handler;
+    }
+}

--- a/common/src/main/java/com/oneday/common/kafka/events/BaseShipmentEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/BaseShipmentEvent.java
@@ -2,6 +2,7 @@ package com.oneday.common.kafka.events;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.oneday.common.kafka.DomainEvent;
 import com.oneday.common.kafka.enums.ShipmentEventType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,7 +16,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public abstract class BaseShipmentEvent {
+public abstract class BaseShipmentEvent implements DomainEvent {
 
     private UUID eventId;
     private ShipmentEventType eventType;
@@ -23,4 +24,15 @@ public abstract class BaseShipmentEvent {
     private Instant occurredAt;
     private UUID shipmentId;
     private String shipmentRef;
+
+    // ── DomainEvent: shipment events are keyed by shipmentId ──
+    @Override
+    public String partitionKey() {
+        return shipmentId != null ? shipmentId.toString() : null;
+    }
+
+    @Override
+    public String eventTypeName() {
+        return eventType != null ? eventType.name() : null;
+    }
 }

--- a/common/src/test/java/com/oneday/common/kafka/EventPublisherTest.java
+++ b/common/src/test/java/com/oneday/common/kafka/EventPublisherTest.java
@@ -1,0 +1,57 @@
+package com.oneday.common.kafka;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Layer-1 test pattern (no broker, no Docker): mock KafkaTemplate, assert the publisher
+ * sends to the right topic with the event's partitionKey. This is the template every module's
+ * producer test should copy.
+ */
+@ExtendWith(MockitoExtension.class)
+class EventPublisherTest {
+
+    @Mock
+    KafkaTemplate<String, Object> kafkaTemplate;
+
+    EventPublisher publisher;
+
+    /** Minimal stand-in event so the test doesn't depend on any module's payloads. */
+    record FakeEvent(String key, String type) implements DomainEvent {
+        @Override public String partitionKey()  { return key; }
+        @Override public String eventTypeName() { return type; }
+    }
+
+    @BeforeEach
+    void setUp() {
+        publisher = new EventPublisher(kafkaTemplate);
+    }
+
+    @Test
+    void publish_sendsToTopicKeyedByPartitionKey() {
+        FakeEvent event = new FakeEvent("P-123", "CREATED");
+
+        publisher.publish("oneday.test.events", event);
+
+        verify(kafkaTemplate).send(eq("oneday.test.events"), eq("P-123"), eq(event));
+    }
+
+    @Test
+    void publish_brokerFailure_doesNotPropagate() {
+        doThrow(new RuntimeException("broker down"))
+                .when(kafkaTemplate).send(anyString(), anyString(), any());
+
+        // Must complete without throwing — Kafka is best-effort for the producer.
+        publisher.publish("oneday.test.events", new FakeEvent("P-123", "CREATED"));
+    }
+}

--- a/docs/EVENT-CONTRACTS.md
+++ b/docs/EVENT-CONTRACTS.md
@@ -1,0 +1,139 @@
+# Event Contracts (Kafka)
+
+The single source of truth for every Kafka topic, event type, producer, and consumer.
+**Append a row here whenever you add an event** — this doc *is* the cross-module contract.
+
+Transport: Kafka API (Redpanda). Engine is identical across environments — only the
+connection string + credentials change (see [Environments](#environments)).
+
+---
+
+## Conventions (read before adding anything)
+
+1. **One topic per producing module** — `oneday.<module>.events`. Not one topic per event type.
+2. **Event type is a field**, not a topic — a per-module enum (`GridEventType`, `DaEventType`, …)
+   carried in the payload. Consumers `switch` on it.
+3. **Message key = the entity the event is about** (`shipmentId`, `tileId`). Same key ⇒ same
+   partition ⇒ ordered per entity. This is `DomainEvent.partitionKey()`.
+4. **Evolve additively only.** Never rename/remove a field — add new optional ones. That's what
+   `schemaVersion` is for. Old consumers must keep working when you add a field.
+5. **One consumer group per module** (`groupId = "<module>"`). Each group reads independently and
+   tracks its own offset; adding a consumer never affects existing ones.
+6. **DLQ = `<topic>.dlq`.** A record that fails processing after 3 retries lands there
+   (see [Failure handling](#failure-handling)).
+
+### Where code lives — contract vs behaviour
+
+| Goes in `common` (shared contract) | Stays in the owning module (behaviour) |
+|---|---|
+| Event payloads (POJOs/records implementing `DomainEvent`) | The producer call / `EventPublisher` usage |
+| Event-type enums | The `@KafkaListener` consumers |
+| `KafkaTopics` constants | The state machine / business rules |
+| `DomainEvent`, `EventPublisher`, `KafkaErrorConfig` (generic infra) | Module-specific config & group ids |
+
+> A payload in `common` is correct even if only one module *produces* it, because consumers that
+> must **not** depend on the producer module (e.g. M3 grid depends only on `common`) still need the
+> class to deserialize it. Logic (a producer `@Component`, a `@KafkaListener`, `KafkaTemplate`
+> wiring) in `common` is the line being crossed — that belongs in the module.
+
+---
+
+## Topic & event registry
+
+| Topic | Producer | Event types (enum) | Consumers |
+|---|---|---|---|
+| `oneday.shipments.events` | M4 Orders | `CREATED`, `STATE_CHANGED`, `CANCELLED` | M5, M8, M10 |
+| `oneday.grid.events` | M3 Grid | `NO_DA_ALERT`, `TILE_OVERLOAD_ALERT`, `ASSIGNMENT_UPDATED`¹ | M5, M10, M11 |
+| `oneday.da.events` | M5 Dispatch | `PICKUP_ASSIGNED`, `PICKUP_COMPLETED`, `PICKUP_FAILED`, `VAN_HANDOFF_COMPLETED`, `DROP_ASSIGNED`, `DROP_COLLECTED`, `DROP_COMPLETED`, `DROP_FAILED` | M4, M8, M10, M11 |
+| `oneday.cron.events` | M6 Routing | `DEPARTED_HUB`, `DEPARTED_AIRPORT` | M4, M9, M10 |
+| `oneday.hub.events` | M7 Hub | `STAND_ASSIGNED`, `BAG_CREATED`, `SAMECITY_OUTBOUND`, `DEST_SORT_COMPLETE`, `DROP_VAN_HANDOFF` | M4, M8, M9, M10 |
+| `oneday.scan.events` | M8 Barcode | `HUB_ORIGIN_IN`, `SELF_DROP_ACCEPTED`, `GHA_ACCEPTANCE`, `HUB_DEST_IN`, `LABEL_GENERATED`, `HUB_COLLECT_COMPLETED` | M4, M7, M10 |
+| `oneday.flight.events` | M9 Airline | `DEPARTED`, `LANDED`, `RTO_IN_TRANSIT` | M4, M7, M10, M11 |
+| `oneday.exceptions.events` | M11 Exceptions | `RTO_INITIATED`, `PICKUP_RESCHEDULED`, `DELIVERY_RESCHEDULED`, `RTO_COMPLETED` | M4, M5, M6, M10 |
+| `oneday.notifications.requested` | many | command topic (single consumer) | notification service |
+| `oneday.<topic>.dlq` | infra | dead-lettered records | ops / manual replay |
+
+¹ `ASSIGNMENT_UPDATED` reserved in the enum; not emitted yet (future `ProposalServiceImpl.approve()`).
+
+**Build status:** M3 produces today; M1/M4 scaffolding exists; M5–M11 are the agreed contract to
+build against. Status: only M3 + partial M4 are wired. Consumers attach as their module is built
+(dormant `autoStartup=false` until their producer is live).
+
+---
+
+## Using the spine
+
+**Produce** — implement `DomainEvent` on the payload, inject `EventPublisher`:
+
+```java
+public record CronDepartedEvent(CronEventType eventType, UUID shipmentId, UUID vanId, Instant occurredAt)
+        implements DomainEvent {
+    public String partitionKey()  { return shipmentId.toString(); }
+    public String eventTypeName() { return eventType.name(); }
+}
+
+// in M6:
+eventPublisher.publish(KafkaTopics.CRON_EVENTS,
+        new CronDepartedEvent(DEPARTED_HUB, shipmentId, vanId, Instant.now()));
+```
+
+**Consume** — subscribe to the producer's topic, `switch` on the type:
+
+```java
+@KafkaListener(topics = KafkaTopics.DA_EVENTS, groupId = "orders")
+public void onDaEvent(DaEventEnvelope e) {
+    switch (e.eventType()) {
+        case PICKUP_ASSIGNED  -> stateMachine.toPickupAssigned(e.shipmentId());
+        case PICKUP_FAILED    -> stateMachine.toPickupFailed(e.shipmentId());
+        default               -> { /* ignore types this module doesn't care about */ }
+    }
+}
+```
+
+**Test (no broker)** — mock `KafkaTemplate` and assert the send; see `EventPublisherTest` as the
+template. For wiring/serde tests use `@EmbeddedKafka` (in-JVM, no Docker).
+
+---
+
+## Failure handling (DLQ)
+
+`KafkaErrorConfig` installs one error handler for all listeners: a throwing consumer retries
+**3× (1s apart)**, then the record is published to **`<topic>.dlq`** and the consumer moves on, so a
+poison message never blocks its partition. Inspect/replay the DLQ later.
+
+Caveats:
+- DLQ topics may need to exist first. On a managed cluster with auto-create disabled, pre-create
+  `oneday.<topic>.dlq` for each topic you consume.
+- The recoverer keys the dead-lettered record the same way, preserving per-entity order in the DLQ.
+
+---
+
+## How to hand-produce a test event
+
+To test a consumer in isolation you don't need its upstream module — drop the event yourself.
+
+**Redpanda Console** (web UI) → pick the topic → *Produce message* → set key + paste JSON.
+
+**`rpk` CLI:**
+```bash
+echo '{"eventType":"NO_DA_ALERT","cityId":"...","tileId":"...","validDate":"2026-05-30","reason":"NO_DA_AVAILABLE","alertedAt":"2026-05-30T10:00:00Z"}' \
+  | rpk topic produce oneday.grid.events --key "<tileId>"
+```
+Then watch your locally-running consumer's logs react. Two windows to debug with: your **app logs**
+("did my code run?") and the **cluster console** ("is the message on the topic / consumer lag?").
+
+---
+
+## Environments
+
+Code is identical across all three; only `bootstrap-servers` + creds differ (Spring profile).
+
+| Environment | Broker | Profile / config |
+|---|---|---|
+| Unit tests | none (mock `KafkaTemplate`) | — |
+| Integration tests | `@EmbeddedKafka` (in-JVM) | test scope |
+| Team testing | managed Redpanda Serverless | `-Dspring.profiles.active=dev` + `KAFKA_BOOTSTRAP_SERVERS`/`KAFKA_KEY`/`KAFKA_SECRET` (see `app/application-dev.yml`) |
+| Production (later) | managed or single-node Redpanda | env vars only |
+
+Topic names are code constants (`KafkaTopics`), identical in every environment — not configured
+per-env unless you later prefix them to isolate devs on a shared cluster.


### PR DESCRIPTION
# Pull Request

## Summary
Adds the shared Kafka "spine" to `common` — a uniform event contract, a single shared
producer, and global retry/DLQ error handling — so every module (starting with M4) plugs
into the event bus the same way instead of re-implementing Kafka wiring.

---

## What Changed
- **`common`**: new `DomainEvent` interface (`partitionKey()` + `eventTypeName()`), new
  `EventPublisher` (`@Component` — keys by partition key, swallows broker errors), and new
  `KafkaErrorConfig` (`@Configuration` — global `DefaultErrorHandler` + `DeadLetterPublishingRecoverer`:
  retry 3×/1s, then route to `<topic>.dlq`). `BaseShipmentEvent` now `implements DomainEvent`.
- **Tests + config**: `EventPublisherTest` (mock-`KafkaTemplate` pattern); `spring-boot-starter-test`
  added to `common/pom.xml`; `app/application.yml` gains the `spring.kafka` block (bootstrap-servers,
  JSON serdes, trusted packages); new `app/application-dev.yml` profile for a managed cluster (SASL via env vars).
- **Docs**: new `docs/EVENT-CONTRACTS.md` (living topic/event registry + conventions + DLQ + test/hand-produce guide);
  status notes in `CLAUDE.md` / `DECISIONS.md`.

---

## Why This Change?
The grid module already used Kafka with hand-rolled producer try/catch and no DLQ. Before M4
(and every later module) starts adding producers/consumers, we need one shared, consistent way to
publish, key, and fail-handle events — otherwise each module reinvents it inconsistently. This is the
foundation M4's event work builds on, kept deliberately small.

---

## Testing
- [x] Tested locally
- [x] Edge cases considered
- [x] No breaking changes introduced

### Test Evidence
`mvn test -pl common,grid -am`:
[INFO] Running com.oneday.common.kafka.EventPublisherTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0 -- in com.oneday.common.kafka.EventPublisherTest
...
[INFO] Tests run: 108, Failures: 0, Errors: 0, Skipped: 0   (grid — unchanged, still green)
[INFO] BUILD SUCCESS
App boots with **no Kafka broker** (no `@KafkaListener` auto-starts; grid's is `autoStartup=false`;
`KafkaTemplate` only connects on `send()`).

---

## Impact

### Areas Affected
- [x] Backend
- [ ] Frontend
- [ ] Routing
- [x] Infra
- [ ] Database
- [ ] NA

### Modules Affected
- [ ] M1 — Auth
- [ ] M2 — Pricing
- [ ] M3 — Grid
- [x] M4 — Orders
- [ ] M5 — Dispatch
- [ ] M6 — Routing
- [ ] M7 — Hub
- [ ] M8 — Barcode
- [ ] M9 — Airline
- [ ] M10 — SLA
- [ ] M11 — Exceptions
- [x] NA

> Note: this is **`common`-level shared infrastructure** consumed by all modules (no `common`
> checkbox exists). M4 is checked because its `BaseShipmentEvent` envelope is the one module-facing
> file touched and M4 is the first consumer of the spine. No behaviour change to other modules.

---

## Risks / Concerns
- A single global `DefaultErrorHandler` now applies to **all** `@KafkaListener` containers (retry
  3× then `<topic>.dlq`). Existing grid consumer is `autoStartup=false`, so no live impact today.
- DLQ topics (`<topic>.dlq`) must exist or broker auto-create be enabled; on a managed cluster with
  auto-create off, pre-create them. Documented in `EVENT-CONTRACTS.md`.
- `spring.json.trusted.packages: "*"` is permissive — acceptable for the in-house monolith (all
  producers are our code); tighten when an external producer writes to a consumed topic.
- No DB/schema and no API changes; additive only → no breaking changes.

---

## Checklist
- [x] Code follows project conventions (package layout, no cross-module internal imports)
- [x] Self-review completed
- [x] Append-only audit trail preserved (no mutations to scan/manifest/role-change records)
- [x] No sensitive data or credentials exposed (SASL creds are env vars in `application-dev.yml`)
- [x] Documentation updated if behaviour changed (`EVENT-CONTRACTS.md`, `CLAUDE.md`, `DECISIONS.md`)
- [x] Ready for review

One thing to double-check before you open it: the diff on this branch vs main also shows the M4 (PR8/PR9) and M5-doc files. If those are already merged into main through their own PRs, GitHub will collapse them and the PR will correctly show only the spine files. If they're not yet in main, this PR would drag them along — in that case rebase the branch onto the latest main first so the PR shows only the spine.