### PR TITLE
Fix Java 25 build failures

### DIFF
--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -1,0 +1,28 @@
+spring.application.name=one-day-delivery
+
+# Database
+spring.datasource.url=jdbc:postgresql://localhost:5432/oneday
+spring.datasource.username=oneday
+spring.datasource.password=oneday
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+# JPA
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.open-in-view=false
+
+# Flyway
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+spring.flyway.baseline-on-migrate=true
+
+# Kafka — disabled for local dev; set to true and configure below when you have a broker
+kafka.enabled=false
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
+
+# JWT
+jwt.secret=change-me-in-production-must-be-at-least-32-characters-long
+jwt.expiry-hours=8
+
+# Logging
+logging.level.com.oneday=INFO

--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -20,7 +20,9 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <scope>test</scope>
+            <!-- runtime (not test) so the standalone AuthLocalApplication has the JDBC
+                 driver; the @DataJpaTest repository tests still get it transitively. -->
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.oneday</groupId>
@@ -60,4 +62,25 @@
             <scope>runtime</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Enables `mvn spring-boot:run -pl auth` for the standalone M1 runner.
+                 repackage is disabled because auth is a library consumed by app/ —
+                 a fat jar here would break that dependency. -->
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.oneday.auth.local.AuthLocalApplication</mainClass>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>repackage</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/auth/src/main/java/com/oneday/auth/local/AuthLocalApplication.java
+++ b/auth/src/main/java/com/oneday/auth/local/AuthLocalApplication.java
@@ -1,0 +1,42 @@
+package com.oneday.auth.local;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+/**
+ * Standalone launcher for M1 (auth) only — boots the identity / JWT / role-management
+ * slice on localhost without the rest of the monolith.
+ *
+ * <p>Why this exists: the only assembled artifact ({@code app/}) wires every module
+ * together, and as of the M5-Implementation branch the grid (M3) Flyway migrations are
+ * incomplete and {@code GridServiceImpl} runs an eager start-up query, so the full app
+ * cannot boot locally. M1 auth, by contrast, is self-contained — it touches no Kafka and
+ * no other module — so this runner brings it up on its own against the already-migrated
+ * local {@code oneday} database.
+ *
+ * <p>Run it with:
+ * <pre>mvn spring-boot:run -pl auth</pre>
+ * The {@code authlocal} profile is activated automatically (see
+ * {@code application-authlocal.properties}). Default admin seeded by
+ * {@code DataInitializer}: {@code admin@oneday.in} / {@code Admin1234!}.
+ *
+ * <p>Lives in {@code com.oneday.auth.local} (a sibling of the test packages, not an
+ * ancestor) so it never becomes the auto-detected {@code @SpringBootConfiguration} for
+ * the {@code @WebMvcTest}/{@code @DataJpaTest} slices, which rely on {@code TestAuthApplication}.
+ * Its component / entity / repository scans are pinned to {@code com.oneday.auth}, so the
+ * common module's unconditional Kafka {@code EventPublisher} and the grid / orders beans
+ * are never instantiated — no broker and no grid schema required.
+ */
+@SpringBootApplication(scanBasePackages = "com.oneday.auth")
+@EntityScan("com.oneday.auth")
+@EnableJpaRepositories("com.oneday.auth")
+public class AuthLocalApplication {
+
+    public static void main(String[] args) {
+        SpringApplication app = new SpringApplication(AuthLocalApplication.class);
+        app.setAdditionalProfiles("authlocal");
+        app.run(args);
+    }
+}

--- a/auth/src/main/resources/application-authlocal.properties
+++ b/auth/src/main/resources/application-authlocal.properties
@@ -1,0 +1,24 @@
+# M1 auth standalone runner — activated automatically by AuthLocalApplication.
+# Only loaded when the `authlocal` profile is active, so it never interferes with the
+# assembled app/ runtime config.
+
+spring.application.name=oneday-auth-local
+
+# Local Postgres (already migrated by the app module's Flyway V1_* + V10).
+spring.datasource.url=jdbc:postgresql://localhost:5432/oneday
+spring.datasource.username=oneday
+spring.datasource.password=oneday
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+# Auth tables already exist locally; validate the entity mappings against them
+# (acts as a schema sanity check on boot). Flyway lives in the app module, not here.
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.open-in-view=false
+spring.flyway.enabled=false
+
+# JWT — local dev secret only.
+jwt.secret=change-me-in-local-dev-must-be-at-least-32-characters-long
+jwt.expiry-hours=8
+
+logging.level.com.oneday=INFO

--- a/auth/src/test/resources/application.properties
+++ b/auth/src/test/resources/application.properties
@@ -1,0 +1,14 @@
+spring.datasource.url=jdbc:postgresql://localhost:5432/oneday
+spring.datasource.username=oneday
+spring.datasource.password=oneday
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+# Flyway migrations live in the app module — disable here so @DataJpaTest
+# uses the already-migrated real DB schema directly
+spring.flyway.enabled=false
+
+# JWT (required for existing WebMvcTest slice to boot)
+jwt.secret=test-secret-key-that-is-at-least-32-characters-long
+jwt.expiry-hours=8

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,16 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <!-- Java 25 exceeds Byte Buddy's officially supported range;
+                             experimental mode keeps mocking working until Mockito ships
+                             a bundled Byte Buddy that supports Java 25. -->
+                        <argLine>@{argLine} -Dnet.bytebuddy.experimental=true</argLine>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>0.8.11</version>
@@ -164,11 +174,9 @@
                             <goal>prepare-agent</goal>
                         </goals>
                         <configuration>
-                            <excludes>
-                                <exclude>jdk/**</exclude>
-                                <exclude>sun/**</exclude>
-                                <exclude>com/sun/**</exclude>
-                            </excludes>
+                            <includes>
+                                <include>com/oneday/**</include>
+                            </includes>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
Restores a green `mvn clean install` (1411 tests pass) on JDK 25 and adds a self-contained way to boot M1 auth on localhost, since the assembled `app/` jar cannot start on the current branch (pre-existing grid/Kafka issues, see below).

== Build fixes (root pom.xml) ==

The toolchain ran on Java 25, which two build-time agents don't yet support:

1. Mockito / Byte Buddy could not mock KafkaTemplate in common's EventPublisherTest — "Java 25 (69) is not supported by the current version of Byte Buddy". Fixed by adding `-Dnet.bytebuddy.experimental=true` to the Surefire argLine (preserving JaCoCo's @{argLine}).

2. JaCoCo 0.8.11's bundled ASM throws "Unsupported class file major version 69" while instrumenting Java 25 bytecode — including JDK classes and Hibernate's runtime-generated entity proxies — which crashed every @DataJpaTest context in auth and orders. Fixed by scoping the JaCoCo agent to `includes: com/oneday/**` instead of trying to enumerate JDK packages to exclude.

(Both are stopgaps for Java 25; they can be dropped once Mockito/JaCoCo ship releases that officially support it.)

Local DB note (no file changes): the auth V10 (onboarding_requests) and orders V4_1..V4_11 Flyway migrations were also applied to the local `oneday` database and recorded in flyway_schema_history — the repository @DataJpaTest slices run against the real schema with ddl-auto=validate, so they fail until those migrations are present.

== M1 auth standalone runner (auth module) ==

The only assembled artifact (`app/`) wires every module together and cannot boot locally right now (see "Why" below), so M1 development was blocked on a running server. Added a focused runner:

  - auth/.../local/AuthLocalApplication.java — @SpringBootApplication scoped to com.oneday.auth (component/entity/repository scans pinned there). Placed in a `.local` sub-package — a sibling of the test packages, not an ancestor — so it never becomes the auto-detected @SpringBootConfiguration for the existing @WebMvcTest/@DataJpaTest slices (which use TestAuthApplication). Activates the `authlocal` profile automatically.
  - auth/.../application-authlocal.properties — points at local Postgres, ddl-auto=validate, Flyway off. Only loads under the authlocal profile, so it never interferes with the assembled app runtime.
  - auth/pom.xml — postgresql promoted test -> runtime (driver needed by the standalone runner; @DataJpaTest still gets it transitively); added spring-boot-maven-plugin with `repackage` disabled (auth is a library consumed by app/, so it must stay a plain jar).

Run it with:  mvn spring-boot:run -pl auth
Seeded admin: admin@oneday.in / Admin1234!

Verified live on localhost:8080:
  GET  /auth/health                      -> 200 {"status":"UP"}
  POST /auth/login (admin)               -> 200 + JWT (role ADMIN)
  POST /auth/login (bad password)        -> 401
  GET  /auth/api-keys (no token)         -> 401
  GET  /auth/api-keys (admin JWT)        -> 200

== Why the full app/ cannot boot locally (pre-existing, not fixed here) ==

Diagnosed while trying to run the assembled jar. These are pre-existing issues on this branch, independent of the build fixes above, and were left for the owning teams:

1. Grid (M3) migrations are broken at the source. On a fresh database Flyway dies at V3_1 with `relation "da_tile_assignment" does not exist`. The H3 refactor removed the CREATE migrations for da_tile_assignment / assignment_proposal but left three orphaned migrations behind: V3_1 and V3_9 ALTER tables that no longer get created, and V3_8 foreign-keys to a never-created assignment_proposal (which still has a live JPA entity).
2. h3_grid schema drift: the Grid entity maps an `updated_at` column that V3_2 never creates.
3. common's EventPublisher is an unconditional @Component requiring a KafkaTemplate, but local dev excludes KafkaAutoConfiguration — so the context fails to start. It has no @ConditionalOnProperty(kafka.enabled).
4. GridServiceImpl runs an eager start-up DB query, so the broken grid schema blocks the entire monolith at boot regardless of which module you want.

app/src/main/resources/application.properties is included here as the app's runtime datasource/Flyway/JWT config used during this diagnosis.
changes introduced
     
     
<img width="1950" height="1184" alt="image" src="https://github.com/user-attachments/assets/06aab665-147c-4431-b116-77c5138b33bd" />
