### PR TITLE
Pin build to Java 21 via enforcer guardrail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,9 +161,39 @@
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>0.8.11</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.5.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-java-21</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <!-- Compile target is Java 21. JaCoCo/Byte Buddy can't
+                                     instrument newer bytecode (e.g. Java 25 = major 69),
+                                     which silently breaks mocks + coverage. Fail loudly
+                                     if the build JVM drifts off 21 (e.g. Homebrew's
+                                     default openjdk symlink). -->
+                                <requireJavaVersion>
+                                    <version>[21,22)</version>
+                                    <message>This build must run on Java 21. Set JAVA_HOME to the JDK 21 install: export JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home</message>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>


### PR DESCRIPTION
Add maven-enforcer-plugin requireJavaVersion [21,22) so the build fails fast if run on a JDK other than 21 (e.g. Homebrew's default JDK 25 symlink). Running on Java 25 makes JaCoCo/Byte Buddy fail to instrument Mockito-generated classes ("Unsupported class file major version 69") — tests still pass but coverage is silently dropped.

Project stays on Java 21 (compile target), so no Mockito/Byte Buddy/ JaCoCo upgrades are needed.
