### PR TITLE
M4 IMPL - PR #14,15,16 (14c not here yet)

### DIFF
--- a/common/src/main/java/com/oneday/common/kafka/events/CronEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/CronEvent.java
@@ -1,0 +1,26 @@
+package com.oneday.common.kafka.events;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.oneday.common.kafka.DomainEvent;
+import com.oneday.common.kafka.enums.CronEventType;
+
+import java.util.UUID;
+
+/**
+ * Inbound event consumed by M4 from {@code oneday.cron.events} (produced by M6).
+ *
+ * <p>Minimal consumption contract — see {@link DaEvent} for the tolerant-reader rationale.</p>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CronEvent(UUID shipmentId, CronEventType eventType) implements DomainEvent {
+
+    @Override
+    public String partitionKey() {
+        return shipmentId != null ? shipmentId.toString() : null;
+    }
+
+    @Override
+    public String eventTypeName() {
+        return eventType != null ? eventType.name() : null;
+    }
+}

--- a/common/src/main/java/com/oneday/common/kafka/events/DaEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/DaEvent.java
@@ -1,0 +1,29 @@
+package com.oneday.common.kafka.events;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.oneday.common.kafka.DomainEvent;
+import com.oneday.common.kafka.enums.DaEventType;
+
+import java.util.UUID;
+
+/**
+ * Inbound event consumed by M4 from {@code oneday.da.events} (produced by M5).
+ *
+ * <p>Minimal consumption contract: M4 needs only the shipment and the event type to drive its
+ * state machine. The producing module (M5) owns the full payload and may ADD fields (DA id,
+ * location, timestamps, …); this reader ignores anything it does not use
+ * ({@code @JsonIgnoreProperties(ignoreUnknown = true)}), so producer additions never break it.</p>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DaEvent(UUID shipmentId, DaEventType eventType) implements DomainEvent {
+
+    @Override
+    public String partitionKey() {
+        return shipmentId != null ? shipmentId.toString() : null;
+    }
+
+    @Override
+    public String eventTypeName() {
+        return eventType != null ? eventType.name() : null;
+    }
+}

--- a/common/src/main/java/com/oneday/common/kafka/events/ExceptionsEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/ExceptionsEvent.java
@@ -1,0 +1,26 @@
+package com.oneday.common.kafka.events;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.oneday.common.kafka.DomainEvent;
+import com.oneday.common.kafka.enums.ExceptionsEventType;
+
+import java.util.UUID;
+
+/**
+ * Inbound event consumed by M4 from {@code oneday.exceptions.events} (produced by M11).
+ *
+ * <p>Minimal consumption contract — see {@link DaEvent} for the tolerant-reader rationale.</p>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ExceptionsEvent(UUID shipmentId, ExceptionsEventType eventType) implements DomainEvent {
+
+    @Override
+    public String partitionKey() {
+        return shipmentId != null ? shipmentId.toString() : null;
+    }
+
+    @Override
+    public String eventTypeName() {
+        return eventType != null ? eventType.name() : null;
+    }
+}

--- a/common/src/main/java/com/oneday/common/kafka/events/FlightEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/FlightEvent.java
@@ -1,0 +1,26 @@
+package com.oneday.common.kafka.events;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.oneday.common.kafka.DomainEvent;
+import com.oneday.common.kafka.enums.FlightEventType;
+
+import java.util.UUID;
+
+/**
+ * Inbound event consumed by M4 from {@code oneday.flight.events} (produced by M9).
+ *
+ * <p>Minimal consumption contract — see {@link DaEvent} for the tolerant-reader rationale.</p>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FlightEvent(UUID shipmentId, FlightEventType eventType) implements DomainEvent {
+
+    @Override
+    public String partitionKey() {
+        return shipmentId != null ? shipmentId.toString() : null;
+    }
+
+    @Override
+    public String eventTypeName() {
+        return eventType != null ? eventType.name() : null;
+    }
+}

--- a/common/src/main/java/com/oneday/common/kafka/events/HubEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/HubEvent.java
@@ -1,0 +1,26 @@
+package com.oneday.common.kafka.events;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.oneday.common.kafka.DomainEvent;
+import com.oneday.common.kafka.enums.HubEventType;
+
+import java.util.UUID;
+
+/**
+ * Inbound event consumed by M4 from {@code oneday.hub.events} (produced by M7).
+ *
+ * <p>Minimal consumption contract — see {@link DaEvent} for the tolerant-reader rationale.</p>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record HubEvent(UUID shipmentId, HubEventType eventType) implements DomainEvent {
+
+    @Override
+    public String partitionKey() {
+        return shipmentId != null ? shipmentId.toString() : null;
+    }
+
+    @Override
+    public String eventTypeName() {
+        return eventType != null ? eventType.name() : null;
+    }
+}

--- a/common/src/main/java/com/oneday/common/kafka/events/ScanEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/ScanEvent.java
@@ -1,0 +1,28 @@
+package com.oneday.common.kafka.events;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.oneday.common.kafka.DomainEvent;
+import com.oneday.common.kafka.enums.ScanEventType;
+
+import java.util.UUID;
+
+/**
+ * Inbound event consumed by M4 from {@code oneday.scan.events} (produced by M8).
+ *
+ * <p>Minimal consumption contract — see {@link DaEvent} for the tolerant-reader rationale.
+ * Note {@code LABEL_GENERATED} is not a state transition; it carries the generated
+ * {@code parcelId} and is handled separately (TODO) rather than via the state machine.</p>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ScanEvent(UUID shipmentId, ScanEventType eventType) implements DomainEvent {
+
+    @Override
+    public String partitionKey() {
+        return shipmentId != null ? shipmentId.toString() : null;
+    }
+
+    @Override
+    public String eventTypeName() {
+        return eventType != null ? eventType.name() : null;
+    }
+}

--- a/docs/M4/M4-EVENTS-LANE-PLAN.md
+++ b/docs/M4/M4-EVENTS-LANE-PLAN.md
@@ -1,0 +1,97 @@
+# M4 Events Lane — Implementation Plan (Person B)
+
+Owner: Person B. Scope: the M4 Kafka **producer**, **consumers**, and **B2B webhooks** —
+everything under `orders/events/` plus the minimal hooks into the write-path that fire the
+events. Companion to `M4-IMPL-PLAN.md` (PRs #14, #15, #16, #19).
+
+## Core principle
+
+The events lane must **not** guess contracts for modules that do not exist yet.
+
+- **Outbound events (producer)** are 100% M4-owned — the payloads already exist in
+  `common/kafka/events/`. Safe to build now.
+- **Inbound events (consumers)** are owned by the *producing* module (M5, M7, M8, M9, M6, M11).
+  Those modules are largely unbuilt, so their contracts are not yet real. We **defer** consumers
+  and co-design each one with its real producer when that module is built. When we do build a
+  consumer, it reads **only** what it needs to drive a transition (`shipmentId` + the event-type
+  enum, both already committed in `common`) and ignores everything else (`@JsonIgnoreProperties`).
+
+## The decoupling seam
+
+The state machine and booking flow stay ignorant of Kafka. They publish **in-process Spring
+`ApplicationEvent`s**; the producer listens with `@TransactionalEventListener(AFTER_COMMIT)` and
+emits to Kafka. `AFTER_COMMIT` guarantees no event fires for a rolled-back DB change.
+`EventPublisher` is best-effort (a broker hiccup is logged, never thrown).
+
+```
+write-path (Person A)                 events lane (Person B, orders/events/)
+─────────────────────                 ──────────────────────────────────────
+ShipmentStateMachineImpl.transition()
+   └─ publishEvent(ShipmentTransitioned) ──► ShipmentEventProducer.onShipmentTransitioned()
+                                                 └─ EventPublisher.publish(SHIPMENTS_EVENTS, STATE_CHANGED)
+BookingServiceImpl.persist()
+   └─ publishEvent(ShipmentBooked) ────────► ShipmentEventProducer.onShipmentBooked()
+                                                 └─ EventPublisher.publish(SHIPMENTS_EVENTS, CREATED)
+```
+
+There are exactly **two hooks into Person A's code**, both additive:
+1. `ShipmentStateMachineImpl` — one `publishEvent` after the history save (STATE_CHANGED).
+2. `BookingServiceImpl.persist()` — one `publishEvent` after the ETA block (CREATED).
+
+## Status & phases
+
+| # | Deliverable | Trigger / depends on | Status |
+|---|-------------|----------------------|--------|
+| 14a | `STATE_CHANGED` producer | state-machine transition (exists) | ✅ Done |
+| 14b | `CREATED` producer | shipment birth in `BookingServiceImpl` (#10/#11) | ✅ Done |
+| 14c | rich `CANCELLED` producer | cancellation flow (**PR #13 — not built**) | ⏸ Parked |
+| 15/16 | All 6 consumers (DA, Hub, Scan, Flight, Cron, Exceptions) | upstream modules (not built) | ✅ Scaffolded, **dormant** (`autoStartup=false`) |
+| 19 | B2B webhooks (HMAC) | B2B booking (**PR #12 — not built**) | ⏸ Parked |
+| 17/18 | help on read APIs (optional) | Person A's lane | ⚪ Optional |
+
+### Phase 1 — Producer (now)
+- **14a STATE_CHANGED — done.** `ShipmentTransitioned` + `ShipmentEventProducer` + hook in
+  `ShipmentStateMachineImpl`. Fires on every committed transition.
+- **14b CREATED — done.** `ShipmentBooked` + listener in `ShipmentEventProducer` + hook in
+  `BookingServiceImpl.persist()`. Lat/lon left null (not stored on `Address`); address line from
+  `Address.line1`.
+- **14c CANCELLED — parked.** A basic `→ CANCELLED` already rides STATE_CHANGED. The rich
+  `ShipmentCancelledEvent` (reason, refund fields) needs the cancellation service (PR #13). When
+  #13 lands, fire a `ShipmentCancelled` in-process event from it; add a listener here.
+
+### Phase 2 — Consumers (built, dormant)
+All six consumers exist in `orders/events/` (`DaEventsConsumer`, `HubEventsConsumer`,
+`ScanEventsConsumer`, `FlightEventsConsumer`, `CronEventsConsumer`, `ExceptionsEventsConsumer`),
+each reading a minimal `*Event` DTO from `common/kafka/events/` (`shipmentId` + the event-type
+enum, `@JsonIgnoreProperties(ignoreUnknown=true)`). Each switches on the enum and calls
+`stateMachine.transition(id, TARGET, TransitionContext.fromKafka(...))`. Mappings are taken
+verbatim from `M4-INTEGRATION-CONTRACTS.md` (§ consumer tables).
+
+`autoStartup=false` keeps them dormant until the producing module exists; flip
+`orders.kafka.consumer.auto-startup=true` to enable.
+
+**Deferred inside the consumers (TODOs), per "base flow first":**
+- `DaEventType.PICKUP_ASSIGNED` — pickup-OTP generation/send.
+- `ScanEventType.HUB_ORIGIN_IN` / `SELF_DROP_ACCEPTED` — ETA recalculation + customer notification.
+- `ScanEventType.LABEL_GENERATED` — not a transition; sets `shipment.parcel_id`. Needs `ScanEvent`
+  extended with the `parcelId` field; currently a no-op.
+- `HubEvent` HUB_COLLECT path (**OD-9 open**) — no event type exists yet; no handler.
+
+**Integration wiring to finalize when a real producer lands (the only thing not provable now):**
+JSON is snake_case on the wire (`shipment_id`); the consumer `JsonDeserializer` must map
+snake_case → DTO fields and resolve the producer's class/type-header. A 5-minute config step at
+integration, gated behind `autoStartup=false`.
+
+### Phase 3 — Webhooks (#19)
+After B2B booking (#12). Consumes the outbound shipment events; HMAC-signs and POSTs to the
+B2B account's `webhook_url`/`webhook_secret`.
+
+## Testing posture
+- No hosted broker needed. Unit tests mock `EventPublisher`; broker-level confidence comes from
+  one `@EmbeddedKafka` round-trip test (needs `spring-kafka-test` as a test dep). Deferred for now.
+- Local end-to-end (Redpanda container) only becomes useful once the app boots cleanly and a
+  consumer is wired — not yet.
+
+## Notes / coordination
+- Migration range: PR #11 took `V4_12`. If the events lane ever needs a migration, start at `V4_13`.
+- The two write-path hooks are the only coupling to Person A — keep them additive and flag them in review.

--- a/orders/src/main/java/com/oneday/orders/events/CronEventsConsumer.java
+++ b/orders/src/main/java/com/oneday/orders/events/CronEventsConsumer.java
@@ -1,0 +1,36 @@
+package com.oneday.orders.events;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.kafka.KafkaTopics;
+import com.oneday.common.kafka.events.CronEvent;
+import com.oneday.orders.service.ShipmentStateMachine;
+import com.oneday.orders.service.TransitionContext;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Consumes M6 cron (van-leg departure) events from {@code oneday.cron.events} and drives the
+ * M4 state machine. Dormant by default ({@code autoStartup=false}) until M6 produces on this topic.
+ */
+@Component
+public class CronEventsConsumer {
+
+    private static final String SOURCE = "m6-cron-consumer";
+
+    private final ShipmentStateMachine stateMachine;
+
+    CronEventsConsumer(ShipmentStateMachine stateMachine) {
+        this.stateMachine = stateMachine;
+    }
+
+    @KafkaListener(topics = KafkaTopics.CRON_EVENTS, groupId = "orders-service",
+            autoStartup = "${orders.kafka.consumer.auto-startup:false}")
+    public void onCronEvent(CronEvent event) {
+        ShipmentState target = switch (event.eventType()) {
+            case DEPARTED_HUB     -> ShipmentState.DISPATCHED_TO_AIRPORT;
+            case DEPARTED_AIRPORT -> ShipmentState.DISPATCHED_TO_HUB;
+        };
+        stateMachine.transition(event.shipmentId(), target,
+                TransitionContext.fromKafka(SOURCE, String.valueOf(event.shipmentId())));
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/events/DaEventsConsumer.java
+++ b/orders/src/main/java/com/oneday/orders/events/DaEventsConsumer.java
@@ -1,0 +1,53 @@
+package com.oneday.orders.events;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.kafka.KafkaTopics;
+import com.oneday.common.kafka.events.DaEvent;
+import com.oneday.orders.service.ShipmentStateMachine;
+import com.oneday.orders.service.TransitionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Consumes M5 DA events from {@code oneday.da.events} and drives the M4 state machine.
+ *
+ * <p>Dormant by default ({@code autoStartup=false}) until M5 produces on this topic — set
+ * {@code orders.kafka.consumer.auto-startup=true} to enable. Side-effects (pickup-OTP generation
+ * on {@code PICKUP_ASSIGNED}) are deferred until the base state flow is proven — see TODO.</p>
+ */
+@Component
+public class DaEventsConsumer {
+
+    private static final Logger log = LoggerFactory.getLogger(DaEventsConsumer.class);
+    private static final String SOURCE = "m5-da-consumer";
+
+    private final ShipmentStateMachine stateMachine;
+
+    DaEventsConsumer(ShipmentStateMachine stateMachine) {
+        this.stateMachine = stateMachine;
+    }
+
+    @KafkaListener(topics = KafkaTopics.DA_EVENTS, groupId = "orders-service",
+            autoStartup = "${orders.kafka.consumer.auto-startup:false}")
+    public void onDaEvent(DaEvent event) {
+        ShipmentState target = switch (event.eventType()) {
+            case PICKUP_ASSIGNED       -> ShipmentState.PICKUP_ASSIGNED;     // TODO: generate + send pickup OTP
+            case PICKUP_FAILED         -> ShipmentState.PICKUP_FAILED;
+            case VAN_HANDOFF_COMPLETED -> ShipmentState.HANDED_TO_PICKUP_VAN;
+            case DROP_ASSIGNED         -> ShipmentState.DROP_ASSIGNED;
+            case DROP_COLLECTED        -> ShipmentState.DROP_COLLECTED;
+            case DROP_COMPLETED        -> ShipmentState.DROPPED;
+            case DROP_FAILED           -> ShipmentState.DELIVERY_FAILED;
+            // Not consumed by M4 — PICKED_UP is driven exclusively by the OTP verify endpoint.
+            case PICKUP_COMPLETED      -> null;
+        };
+        if (target == null) {
+            log.debug("DA event {} ignored for shipment {}", event.eventType(), event.shipmentId());
+            return;
+        }
+        stateMachine.transition(event.shipmentId(), target,
+                TransitionContext.fromKafka(SOURCE, String.valueOf(event.shipmentId())));
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/events/ExceptionsEventsConsumer.java
+++ b/orders/src/main/java/com/oneday/orders/events/ExceptionsEventsConsumer.java
@@ -1,0 +1,39 @@
+package com.oneday.orders.events;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.kafka.KafkaTopics;
+import com.oneday.common.kafka.events.ExceptionsEvent;
+import com.oneday.orders.service.ShipmentStateMachine;
+import com.oneday.orders.service.TransitionContext;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Consumes M11 exception events from {@code oneday.exceptions.events} and drives the M4 state
+ * machine (RTO and reschedule flows). Dormant by default ({@code autoStartup=false}) until M11
+ * produces on this topic.
+ */
+@Component
+public class ExceptionsEventsConsumer {
+
+    private static final String SOURCE = "m11-exception-consumer";
+
+    private final ShipmentStateMachine stateMachine;
+
+    ExceptionsEventsConsumer(ShipmentStateMachine stateMachine) {
+        this.stateMachine = stateMachine;
+    }
+
+    @KafkaListener(topics = KafkaTopics.EXCEPTIONS_EVENTS, groupId = "orders-service",
+            autoStartup = "${orders.kafka.consumer.auto-startup:false}")
+    public void onExceptionsEvent(ExceptionsEvent event) {
+        ShipmentState target = switch (event.eventType()) {
+            case RTO_INITIATED        -> ShipmentState.RTO_INITIATED;
+            case PICKUP_RESCHEDULED   -> ShipmentState.PICKUP_ASSIGNED;
+            case DELIVERY_RESCHEDULED -> ShipmentState.DROP_ASSIGNED;
+            case RTO_COMPLETED        -> ShipmentState.RTO_COMPLETED;
+        };
+        stateMachine.transition(event.shipmentId(), target,
+                TransitionContext.fromKafka(SOURCE, String.valueOf(event.shipmentId())));
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/events/FlightEventsConsumer.java
+++ b/orders/src/main/java/com/oneday/orders/events/FlightEventsConsumer.java
@@ -1,0 +1,38 @@
+package com.oneday.orders.events;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.kafka.KafkaTopics;
+import com.oneday.common.kafka.events.FlightEvent;
+import com.oneday.orders.service.ShipmentStateMachine;
+import com.oneday.orders.service.TransitionContext;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Consumes M9 flight events from {@code oneday.flight.events} and drives the M4 state machine.
+ * All three are INTERCITY-only legs. Dormant by default ({@code autoStartup=false}) until M9
+ * produces on this topic.
+ */
+@Component
+public class FlightEventsConsumer {
+
+    private static final String SOURCE = "m9-flight-consumer";
+
+    private final ShipmentStateMachine stateMachine;
+
+    FlightEventsConsumer(ShipmentStateMachine stateMachine) {
+        this.stateMachine = stateMachine;
+    }
+
+    @KafkaListener(topics = KafkaTopics.FLIGHT_EVENTS, groupId = "orders-service",
+            autoStartup = "${orders.kafka.consumer.auto-startup:false}")
+    public void onFlightEvent(FlightEvent event) {
+        ShipmentState target = switch (event.eventType()) {
+            case DEPARTED       -> ShipmentState.DEPARTED;
+            case LANDED         -> ShipmentState.LANDED;
+            case RTO_IN_TRANSIT -> ShipmentState.RTO_IN_TRANSIT;
+        };
+        stateMachine.transition(event.shipmentId(), target,
+                TransitionContext.fromKafka(SOURCE, String.valueOf(event.shipmentId())));
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/events/HubEventsConsumer.java
+++ b/orders/src/main/java/com/oneday/orders/events/HubEventsConsumer.java
@@ -1,0 +1,44 @@
+package com.oneday.orders.events;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.kafka.KafkaTopics;
+import com.oneday.common.kafka.events.HubEvent;
+import com.oneday.orders.service.ShipmentStateMachine;
+import com.oneday.orders.service.TransitionContext;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Consumes M7 hub events from {@code oneday.hub.events} and drives the M4 state machine.
+ *
+ * <p>Dormant by default ({@code autoStartup=false}) until M7 produces on this topic.</p>
+ *
+ * <p>OD-9 (open): the event triggering {@code DEST_HUB_PROCESSING → AWAITING_HUB_COLLECT}
+ * (HUB_COLLECT path) is not yet decided — recommended a new {@code HUB_COLLECT_STAGED} value in
+ * {@code HubEventType}. No handler exists for it until the team confirms the event type.</p>
+ */
+@Component
+public class HubEventsConsumer {
+
+    private static final String SOURCE = "m7-hub-consumer";
+
+    private final ShipmentStateMachine stateMachine;
+
+    HubEventsConsumer(ShipmentStateMachine stateMachine) {
+        this.stateMachine = stateMachine;
+    }
+
+    @KafkaListener(topics = KafkaTopics.HUB_EVENTS, groupId = "orders-service",
+            autoStartup = "${orders.kafka.consumer.auto-startup:false}")
+    public void onHubEvent(HubEvent event) {
+        ShipmentState target = switch (event.eventType()) {
+            case STAND_ASSIGNED     -> ShipmentState.ORIGIN_HUB_PROCESSING;
+            case BAG_CREATED        -> ShipmentState.IN_TAKEOFF_BAG;
+            case SAMECITY_OUTBOUND  -> ShipmentState.HANDED_TO_DROP_VAN;   // SAME_CITY branch from IN_TAKEOFF_BAG
+            case DEST_SORT_COMPLETE -> ShipmentState.DEST_HUB_PROCESSING;
+            case DROP_VAN_HANDOFF   -> ShipmentState.HANDED_TO_DROP_VAN;   // DA_DELIVERY branch from DEST_HUB_PROCESSING
+        };
+        stateMachine.transition(event.shipmentId(), target,
+                TransitionContext.fromKafka(SOURCE, String.valueOf(event.shipmentId())));
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/events/ScanEventsConsumer.java
+++ b/orders/src/main/java/com/oneday/orders/events/ScanEventsConsumer.java
@@ -1,0 +1,52 @@
+package com.oneday.orders.events;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.kafka.KafkaTopics;
+import com.oneday.common.kafka.events.ScanEvent;
+import com.oneday.orders.service.ShipmentStateMachine;
+import com.oneday.orders.service.TransitionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Consumes M8 scan events from {@code oneday.scan.events} and drives the M4 state machine.
+ *
+ * <p>Dormant by default ({@code autoStartup=false}) until M8 produces on this topic. ETA
+ * recalculation + customer notification on {@code HUB_ORIGIN_IN}/{@code SELF_DROP_ACCEPTED}
+ * are deferred until the base state flow is proven — see TODO.</p>
+ */
+@Component
+public class ScanEventsConsumer {
+
+    private static final Logger log = LoggerFactory.getLogger(ScanEventsConsumer.class);
+    private static final String SOURCE = "m8-scan-consumer";
+
+    private final ShipmentStateMachine stateMachine;
+
+    ScanEventsConsumer(ShipmentStateMachine stateMachine) {
+        this.stateMachine = stateMachine;
+    }
+
+    @KafkaListener(topics = KafkaTopics.SCAN_EVENTS, groupId = "orders-service",
+            autoStartup = "${orders.kafka.consumer.auto-startup:false}")
+    public void onScanEvent(ScanEvent event) {
+        ShipmentState target = switch (event.eventType()) {
+            case HUB_ORIGIN_IN         -> ShipmentState.AT_ORIGIN_HUB;   // TODO: recalc ETA + notify customer
+            case SELF_DROP_ACCEPTED    -> ShipmentState.AT_ORIGIN_HUB;   // TODO: recalc ETA + notify customer
+            case GHA_ACCEPTANCE        -> ShipmentState.AT_AIRPORT;
+            case HUB_DEST_IN           -> ShipmentState.AT_DEST_HUB;
+            case HUB_COLLECT_COMPLETED -> ShipmentState.HUB_COLLECTED;
+            // Not a state transition — carries the generated parcelId (sets shipment.parcel_id).
+            // TODO: handle once ScanEvent is extended with the parcelId field.
+            case LABEL_GENERATED       -> null;
+        };
+        if (target == null) {
+            log.debug("Scan event {} ignored for shipment {}", event.eventType(), event.shipmentId());
+            return;
+        }
+        stateMachine.transition(event.shipmentId(), target,
+                TransitionContext.fromKafka(SOURCE, String.valueOf(event.shipmentId())));
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/events/ShipmentBooked.java
+++ b/orders/src/main/java/com/oneday/orders/events/ShipmentBooked.java
@@ -1,0 +1,20 @@
+package com.oneday.orders.events;
+
+import com.oneday.orders.domain.Shipment;
+
+/**
+ * In-process (NOT Kafka) Spring {@code ApplicationEvent}, published by
+ * {@code BookingServiceImpl} after a shipment is persisted in {@code BOOKED} state.
+ *
+ * <p>{@link ShipmentEventProducer} maps it to the outbound Kafka {@code ShipmentCreatedEvent}
+ * after the booking transaction commits (AFTER_COMMIT).</p>
+ *
+ * <p>Shipment creation is <em>not</em> a state-machine transition ({@code BOOKED} is a birth
+ * state, not a {@code from → to} move), so {@code CREATED} cannot ride {@link ShipmentTransitioned} —
+ * it needs this dedicated hook.</p>
+ *
+ * <p>The {@link Shipment} is detached by the time the AFTER_COMMIT listener reads it; that is
+ * safe here because all of its fields are plain columns / embeddables loaded eagerly within the
+ * booking transaction — {@code Shipment} has no lazy associations.</p>
+ */
+public record ShipmentBooked(Shipment shipment) {}

--- a/orders/src/main/java/com/oneday/orders/events/ShipmentEventProducer.java
+++ b/orders/src/main/java/com/oneday/orders/events/ShipmentEventProducer.java
@@ -1,0 +1,94 @@
+package com.oneday.orders.events;
+
+import com.oneday.common.kafka.EventPublisher;
+import com.oneday.common.kafka.KafkaTopics;
+import com.oneday.common.kafka.enums.ShipmentEventType;
+import com.oneday.common.kafka.events.ShipmentCreatedEvent;
+import com.oneday.common.kafka.events.ShipmentStateChangedEvent;
+import com.oneday.orders.domain.Shipment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * M4's outbound Kafka producer. Listens for in-process {@link ShipmentTransitioned} events
+ * (published by the state machine) and emits one Kafka STATE_CHANGED event per committed
+ * transition to {@link KafkaTopics#SHIPMENTS_EVENTS}.
+ *
+ * <p><b>AFTER_COMMIT:</b> the Kafka publish happens only once the DB transaction has
+ * committed, so a rolled-back transition never produces a phantom event. {@link EventPublisher}
+ * is best-effort — a broker hiccup is logged, not thrown, and never affects the (already
+ * committed) shipment state.</p>
+ *
+ * <p>CREATED and the rich CANCELLED events are emitted separately by the booking and
+ * cancellation flows (which know payment/refund details the state machine does not) — they
+ * are not derived from this transition hook.</p>
+ */
+@Component
+public class ShipmentEventProducer {
+
+    private static final Logger log = LoggerFactory.getLogger(ShipmentEventProducer.class);
+
+    private final EventPublisher eventPublisher;
+
+    ShipmentEventProducer(EventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onShipmentTransitioned(ShipmentTransitioned e) {
+        ShipmentStateChangedEvent event = new ShipmentStateChangedEvent();
+        event.setEventId(UUID.randomUUID());
+        event.setEventType(ShipmentEventType.STATE_CHANGED);
+        event.setOccurredAt(e.occurredAt() != null ? e.occurredAt() : Instant.now());
+        event.setShipmentId(e.shipmentId());
+        event.setShipmentRef(e.shipmentRef());
+        event.setFromState(e.fromState());
+        event.setToState(e.toState());
+        event.setTriggeredBy(e.triggeredBy());
+        event.setTriggerSource(e.triggerSource() != null ? e.triggerSource().name() : null);
+
+        log.debug("Publishing STATE_CHANGED shipmentId={} {}->{}",
+                e.shipmentId(), e.fromState(), e.toState());
+        eventPublisher.publish(KafkaTopics.SHIPMENTS_EVENTS, event);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onShipmentBooked(ShipmentBooked e) {
+        Shipment s = e.shipment();
+        ShipmentCreatedEvent event = new ShipmentCreatedEvent();
+        event.setEventId(UUID.randomUUID());
+        event.setEventType(ShipmentEventType.CREATED);
+        event.setOccurredAt(s.getCreatedAt() != null ? s.getCreatedAt() : Instant.now());
+        event.setShipmentId(s.getId());
+        event.setShipmentRef(s.getShipmentRef());
+        event.setCustomerType(s.getCustomerType());
+        event.setPaymentMode(s.getPaymentMode());
+        event.setDeliveryType(s.getDeliveryType());
+        event.setPickupType(s.getPickupType());
+        event.setDropType(s.getDropType());
+        event.setOriginCity(s.getOriginCity());
+        event.setOriginPincode(s.getOriginPincode());
+        event.setOriginTileId(s.getOriginTileId());
+        event.setDestCity(s.getDestCity());
+        event.setDestPincode(s.getDestPincode());
+        event.setChargeableWeightGrams(s.getChargeableWeightGrams());
+        event.setSlaCommitmentMinutes(s.getSlaCommitmentMinutes() != null
+                ? s.getSlaCommitmentMinutes().intValue() : null);
+        event.setEtaPromised(s.getEtaPromised());
+        event.setReceiverPhone(s.getReceiverPhone());
+        event.setReceiverName(s.getReceiverName());
+        event.setB2bAccountId(s.getB2bAccountId());
+        event.setSenderName(s.getSenderName());
+        event.setSenderAddressLine(s.getOriginAddress() != null ? s.getOriginAddress().getLine1() : null);
+        event.setReceiverAddressLine(s.getDestAddress() != null ? s.getDestAddress().getLine1() : null);
+
+        log.debug("Publishing CREATED shipmentId={} ref={}", s.getId(), s.getShipmentRef());
+        eventPublisher.publish(KafkaTopics.SHIPMENTS_EVENTS, event);
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/events/ShipmentTransitioned.java
+++ b/orders/src/main/java/com/oneday/orders/events/ShipmentTransitioned.java
@@ -1,0 +1,27 @@
+package com.oneday.orders.events;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.domain.enums.TriggerSource;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * In-process (NOT Kafka) Spring {@code ApplicationEvent}, published by
+ * {@code ShipmentStateMachineImpl} after a successful state transition.
+ *
+ * <p>{@link ShipmentEventProducer} listens for it and emits the outbound Kafka
+ * {@code ShipmentStateChangedEvent}. Keeping this internal decouples the state machine
+ * from Kafka: the machine just announces "a transition happened" — it neither knows nor
+ * cares that anything publishes it. Any future trigger of a transition (booking API, OTP
+ * verify, or an inbound Kafka consumer) produces the outbound event automatically.</p>
+ */
+public record ShipmentTransitioned(
+        UUID shipmentId,
+        String shipmentRef,
+        ShipmentState fromState,
+        ShipmentState toState,
+        String triggeredBy,
+        TriggerSource triggerSource,
+        Instant occurredAt
+) {}

--- a/orders/src/main/java/com/oneday/orders/service/impl/BookingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/BookingServiceImpl.java
@@ -18,6 +18,7 @@ import com.oneday.orders.domain.ShipmentStateHistory;
 import com.oneday.orders.domain.enums.PaymentStatus;
 import com.oneday.orders.dto.BookingRequest;
 import com.oneday.orders.dto.BookingResponse;
+import com.oneday.orders.events.ShipmentBooked;
 import com.oneday.orders.repository.PaymentTransactionRepository;
 import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.repository.ShipmentStateHistoryRepository;
@@ -33,6 +34,7 @@ import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -71,6 +73,7 @@ class BookingServiceImpl implements BookingService {
     private final TimeLimiter paymentTl;
 
     private final ScheduledExecutorService scheduler;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     BookingServiceImpl(ServiceabilityPort serviceabilityPort,
                        PricingPort pricingPort,
@@ -84,7 +87,8 @@ class BookingServiceImpl implements BookingService {
                        TransactionTemplate transactionTemplate,
                        CircuitBreakerRegistry circuitBreakerRegistry,
                        TimeLimiterRegistry timeLimiterRegistry,
-                       @Qualifier("resilienceScheduler") ScheduledExecutorService resilienceScheduler) {
+                       @Qualifier("resilienceScheduler") ScheduledExecutorService resilienceScheduler,
+                       ApplicationEventPublisher applicationEventPublisher) {
         this.serviceabilityPort = serviceabilityPort;
         this.pricingPort = pricingPort;
         this.paymentPort = paymentPort;
@@ -102,6 +106,7 @@ class BookingServiceImpl implements BookingService {
         this.pricingTl        = timeLimiterRegistry.timeLimiter("pricing");
         this.paymentTl        = timeLimiterRegistry.timeLimiter("payment");
         this.scheduler        = resilienceScheduler;
+        this.applicationEventPublisher = applicationEventPublisher;
     }
 
     @Override
@@ -260,6 +265,10 @@ class BookingServiceImpl implements BookingService {
             log.warn("ETA fetch failed for shipment {}; booking proceeds without ETA: {}",
                     shipment.getId(), e.getMessage());
         }
+
+        // ── Emit CREATED — in-process; ShipmentEventProducer publishes to Kafka AFTER_COMMIT,
+        //    so a rolled-back booking never produces a phantom CREATED event. ──────────────
+        applicationEventPublisher.publishEvent(new ShipmentBooked(shipment));
 
         // ── Build response ─────────────────────────────────────────────────────
         BookingResponse.PricingDetails pricing = new BookingResponse.PricingDetails();

--- a/orders/src/main/java/com/oneday/orders/service/impl/ShipmentStateMachineImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/ShipmentStateMachineImpl.java
@@ -11,8 +11,10 @@ import com.oneday.orders.repository.ShipmentStateHistoryRepository;
 import com.oneday.orders.service.ShipmentStateMachine;
 import com.oneday.orders.service.TransitionContext;
 import com.oneday.orders.service.TransitionRegistry;
+import com.oneday.orders.events.ShipmentTransitioned;
 import com.oneday.orders.service.exception.IllegalStateTransitionException;
 import jakarta.persistence.EntityNotFoundException;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,13 +29,16 @@ class ShipmentStateMachineImpl implements ShipmentStateMachine {
     private final ShipmentRepository shipmentRepo;
     private final ShipmentStateHistoryRepository historyRepo;
     private final TransitionRegistry registry;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     ShipmentStateMachineImpl(ShipmentRepository shipmentRepo,
                               ShipmentStateHistoryRepository historyRepo,
-                              TransitionRegistry registry) {
+                              TransitionRegistry registry,
+                              ApplicationEventPublisher applicationEventPublisher) {
         this.shipmentRepo = shipmentRepo;
         this.historyRepo = historyRepo;
         this.registry = registry;
+        this.applicationEventPublisher = applicationEventPublisher;
     }
 
     @Override
@@ -55,6 +60,13 @@ class ShipmentStateMachineImpl implements ShipmentStateMachine {
         // and flushes the UPDATE automatically when the transaction commits.
 
         historyRepo.save(ShipmentStateHistory.of(shipmentId, current, target, ctx));
+
+        // In-process announcement — ShipmentEventProducer turns this into the outbound Kafka
+        // STATE_CHANGED event after this transaction commits (AFTER_COMMIT). The state machine
+        // stays decoupled from Kafka; it just reports that a transition happened.
+        applicationEventPublisher.publishEvent(new ShipmentTransitioned(
+                shipmentId, shipment.getShipmentRef(), current, target,
+                ctx.getTriggeredBy(), ctx.getTriggerSource(), ctx.getOccurredAt()));
     }
 
     /**

--- a/orders/src/test/java/com/oneday/orders/service/impl/BookingServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/BookingServiceImplTest.java
@@ -37,6 +37,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.AbstractPlatformTransactionManager;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.support.DefaultTransactionStatus;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -67,6 +68,7 @@ class BookingServiceImplTest {
     @Mock private ShipmentRepository shipmentRepository;
     @Mock private PaymentTransactionRepository paymentTransactionRepository;
     @Mock private ShipmentStateHistoryRepository historyRepository;
+    @Mock private ApplicationEventPublisher applicationEventPublisher;
 
     // TransactionTemplate cannot be mocked on Java 25 (Mockito inline-mock restriction on
     // platform module types). Use a real TransactionTemplate backed by a no-op TX manager.
@@ -100,7 +102,7 @@ class BookingServiceImplTest {
                 historyRepository, stateMapper, new TransactionTemplate(NO_OP_TX),
                 CircuitBreakerRegistry.ofDefaults(),
                 TimeLimiterRegistry.ofDefaults(),
-                scheduler);
+                scheduler, applicationEventPublisher);
     }
 
     @AfterEach

--- a/orders/src/test/java/com/oneday/orders/service/impl/ShipmentStateMachineTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/ShipmentStateMachineTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -51,6 +52,8 @@ class ShipmentStateMachineTest {
     private ShipmentRepository shipmentRepo;
     @Mock
     private ShipmentStateHistoryRepository historyRepo;
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
 
     private TransitionRegistry registry;
     private ShipmentStateMachine stateMachine;
@@ -63,7 +66,7 @@ class ShipmentStateMachineTest {
         // Real registry (no configurers) — tests the full V1 transition table
         registry = new TransitionRegistry(Collections.emptyList());
         registry.initialise();
-        stateMachine = new ShipmentStateMachineImpl(shipmentRepo, historyRepo, registry);
+        stateMachine = new ShipmentStateMachineImpl(shipmentRepo, historyRepo, registry, applicationEventPublisher);
     }
 
     // ── Helper ────────────────────────────────────────────────────────────────
@@ -699,7 +702,7 @@ class ShipmentStateMachineTest {
 
         TransitionRegistry extendedRegistry = new TransitionRegistry(List.of(extender));
         extendedRegistry.initialise();
-        ShipmentStateMachine extended = new ShipmentStateMachineImpl(shipmentRepo, historyRepo, extendedRegistry);
+        ShipmentStateMachine extended = new ShipmentStateMachineImpl(shipmentRepo, historyRepo, extendedRegistry, applicationEventPublisher);
 
         shipmentIn(ShipmentState.DROPPED);
         // Should NOT throw — transition was registered dynamically


### PR DESCRIPTION
# Pull Request

## Summary
Adds the M4 **outbound Kafka producer** (`CREATED` + `STATE_CHANGED`) and all six **inbound event consumers** (DA, Hub, Scan, Flight, Cron, Exceptions), wired through an in-process Spring `ApplicationEvent` seam so the state machine and booking flow stay fully decoupled from Kafka. Consumers ship **dormant** (`autoStartup=false`) until their upstream producing modules exist.

---

## What Changed
- **Outbound producer:** `ShipmentEventProducer` listens (`@TransactionalEventListener(AFTER_COMMIT)`) for two in-process events — `ShipmentTransitioned` (every state-machine transition → `STATE_CHANGED`) and `ShipmentBooked` (booking persist → `CREATED`) — and publishes to `oneday.shipments.events` via the shared `EventPublisher`.
- **Two additive hooks into the write path:** `ShipmentStateMachineImpl` publishes `ShipmentTransitioned` after the history save; `BookingServiceImpl.persist()` publishes `ShipmentBooked` after the booking commit. Neither class learns about Kafka.
- **Six inbound consumers** in `orders/events/`, one per source topic, each switching on the event-type enum and calling `stateMachine.transition(...)`. Transition mappings taken verbatim from `M4-INTEGRATION-CONTRACTS.md`.
- **Six minimal inbound DTOs** in `common/kafka/events/` (`DaEvent`, `HubEvent`, `ScanEvent`, `FlightEvent`, `CronEvent`, `ExceptionsEvent`) — `shipmentId` + event-type enum, `@JsonIgnoreProperties(ignoreUnknown=true)` (tolerant readers; producing modules may extend them).
- Updated `ShipmentStateMachineTest` / `BookingServiceImplTest` for the additive constructor args (compile-green).
- Added `docs/M4/M4-EVENTS-LANE-PLAN.md` documenting the lane, the two write-path seams, and all deferred items.

---

## Why This Change?
M4 must announce shipment lifecycle changes to downstream modules (SLA, dispatch, barcode, etc.) and drive its own state machine from their events. This implements PRs #14 (minus 14c), #15, and #16 of the M4 plan. The `ApplicationEvent` indirection gives correct **after-commit** semantics (no event for a rolled-back transaction) while keeping the producer/consumer lane independent of the booking/state-machine lane.

---

## Testing
- [x] Tested locally — **compile only** (`mvn -pl orders -am test-compile` green); no functional/runtime tests run
- [x] Edge cases considered — non-transition events (`PICKUP_COMPLETED`, `LABEL_GENERATED`), OD-9 open path, duplicate/idempotency behaviour (documented, deferred)
- [x] No breaking changes introduced — constructor changes are additive and Spring-wired; existing tests updated

### Test Evidence
$ mvn -pl orders -am test-compile
[INFO] BUILD SUCCESS
[INFO] Total time:  0.785 s
No functional tests added this PR (deferred by agreement). Consumers are dormant (`autoStartup=false`), so there is no runtime behaviour to exercise without an upstream producer + broker.

---

## Impact

### Areas Affected
- [x] Backend
- [ ] Frontend
- [ ] Routing
- [ ] Infra
- [ ] Database

### Modules Affected
- [x] M4 — Orders
> Inbound DTOs live in `common` as shared contracts; the eventual producers are M5/M6/M7/M8/M9/M11, but no code in those modules changed here.

---

## Risks / Concerns
- **Consumers are dormant and not yet integration-proven.** Deserialization wiring (snake_case `shipment_id` → DTO, `JsonDeserializer` type/target-class resolution) is finalized when the first real producer (M5) lands; gated behind `autoStartup=false`.
- **No consumer idempotency yet** — Kafka is at-least-once; a duplicate/out-of-order event currently throws `IllegalStateTransitionException` → retries → DLQ. Needs a "target already current/past → no-op" rule before go-live.
- **Producer is best-effort (no transactional outbox)** — an event can be lost if the broker is down or the app dies in the commit→publish window. Tracked for resilience hardening (PR #20).
- **Two hooks touch shared write-path files** (`ShipmentStateMachineImpl`, `BookingServiceImpl`) — additive, but please review for lane coordination.
- **Deferred side-effects (TODOs in code):** pickup-OTP on `PICKUP_ASSIGNED`, ETA-recalc+notify on `HUB_ORIGIN_IN`/`SELF_DROP_ACCEPTED`, `parcel_id` on `LABEL_GENERATED`; `AWAITING_HUB_COLLECT` blocked on OD-9.

---

## Checklist
- [x] Code follows project conventions (package layout, no cross-module internal imports — consumers import only the public `ShipmentStateMachine` interface)
- [x] Self-review completed
- [x] Append-only audit trail preserved (state history still appended via the state machine; no mutations)
- [x] No sensitive data or credentials exposed
- [x] Documentation updated (`M4-EVENTS-LANE-PLAN.md`)
- [x] Ready for review
