### PR TITLE
M6 IMPL - PR #1 - Flyways,JPA entities , Domain, Repo layers, Kafka cron events in common

### DIFF
--- a/common/src/main/java/com/oneday/common/kafka/enums/CronEventType.java
+++ b/common/src/main/java/com/oneday/common/kafka/enums/CronEventType.java
@@ -1,6 +1,28 @@
 package com.oneday.common.kafka.enums;
 
+/**
+ * Discriminator for events M6 (routing) publishes on {@code oneday.cron.events}
+ * ({@link com.oneday.common.kafka.KafkaTopics#CRON_EVENTS}). See M6 design §17.1.
+ *
+ * <p>Custody <em>scans</em> (VAN_LOAD / VAN_TO_DA / DA_TO_VAN / VAN_UNLOAD) are NOT here —
+ * they are written to M8's append-only scan ledger, not duplicated on this topic.
+ * Raw GPS pings are not events at all (M6-D-012).</p>
+ */
 public enum CronEventType {
-    DEPARTED_HUB,      // IN_TAKEOFF_BAG → DISPATCHED_TO_AIRPORT (INTERCITY)
-    DEPARTED_AIRPORT   // LANDED → DISPATCHED_TO_HUB
+
+    // ── plan-time ────────────────────────────────────────────────────────
+    DA_CRON_SCHEDULED,     // a DA's meeting vertex + the day's meeting times      → M5
+    SHUTTLE_SCHEDULED,     // hub↔airport shuttle timetable                        → M9, M10
+    ROUTE_PLAN_PUBLISHED,  // a city's van plan is approved & active               → M10, van app
+    ROUTE_CHANGED,         // an intraday override took effect                     → M5, M10, station mgr
+
+    // ── run-time: tracking ───────────────────────────────────────────────
+    VAN_ARRIVED,           // van reached a meeting vertex                         → M10, ops
+    VAN_RUNNING_LATE,      // live ETA slipped past threshold                      → M5, M10, ops
+
+    // ── run-time: custody & failures ─────────────────────────────────────
+    HANDOFF_COMPLETED,     // a stop's per-DA handoff reconciled OK                → M4, M10
+    HANDOFF_DISCREPANCY,   // missing/extra/rejected parcel at a stop              → M11, M10
+    LOOP_OVERFLOW,         // a parcel can't fit a feasible loop before deadline   → M10, station mgr
+    VAN_BREAKDOWN          // van disabled mid-loop                                → M10, station mgr, M11
 }

--- a/common/src/main/java/com/oneday/common/kafka/events/cron/CronEventPayload.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/cron/CronEventPayload.java
@@ -1,0 +1,33 @@
+package com.oneday.common.kafka.events.cron;
+
+import com.oneday.common.kafka.DomainEvent;
+import com.oneday.common.kafka.enums.CronEventType;
+
+/**
+ * Base contract for the typed payloads M6 (routing) publishes on {@code oneday.cron.events}
+ * (M6 design §17.1). Sealed so the set of cron event shapes is closed and exhaustively handled.
+ *
+ * <p>Each payload is a plain record. {@link DomainEvent#partitionKey()} is the entity the event
+ * is about (vanId for run-time events, cityId/daId for plan-time) so per-entity ordering holds.
+ * Consumers that only need the discriminator can use the tolerant
+ * {@link com.oneday.common.kafka.events.CronEvent} reader instead.</p>
+ */
+public sealed interface CronEventPayload extends DomainEvent permits
+        DaCronScheduledEvent,
+        ShuttleScheduledEvent,
+        RoutePlanPublishedEvent,
+        RouteChangedEvent,
+        VanArrivedEvent,
+        VanRunningLateEvent,
+        HandoffCompletedEvent,
+        HandoffDiscrepancyEvent,
+        LoopOverflowEvent,
+        VanBreakdownEvent {
+
+    CronEventType eventType();
+
+    @Override
+    default String eventTypeName() {
+        return eventType().name();
+    }
+}

--- a/common/src/main/java/com/oneday/common/kafka/events/cron/DaCronScheduledEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/cron/DaCronScheduledEvent.java
@@ -1,0 +1,35 @@
+package com.oneday.common.kafka.events.cron;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.oneday.common.kafka.enums.CronEventType;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Plan-time: a DA's meeting vertex and the full day's meeting times (M6-D-008). → M5.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DaCronScheduledEvent(
+        UUID cityId,
+        LocalDate validDate,
+        UUID daId,
+        UUID cronVertexId,
+        double meetingLat,
+        double meetingLon,
+        List<LocalTime> meetingTimes,
+        UUID vanId,
+        UUID routePlanId) implements CronEventPayload {
+
+    @Override
+    public CronEventType eventType() {
+        return CronEventType.DA_CRON_SCHEDULED;
+    }
+
+    @Override
+    public String partitionKey() {
+        return daId != null ? daId.toString() : null;
+    }
+}

--- a/common/src/main/java/com/oneday/common/kafka/events/cron/HandoffCompletedEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/cron/HandoffCompletedEvent.java
@@ -1,0 +1,28 @@
+package com.oneday.common.kafka.events.cron;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.oneday.common.kafka.enums.CronEventType;
+
+import java.util.UUID;
+
+/**
+ * Run-time: a stop's per-DA handoff reconciled OK (expected == actual). → M4, M10.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record HandoffCompletedEvent(
+        UUID manifestId,
+        UUID vanId,
+        UUID cityId,
+        int stopSeq,
+        UUID daId) implements CronEventPayload {
+
+    @Override
+    public CronEventType eventType() {
+        return CronEventType.HANDOFF_COMPLETED;
+    }
+
+    @Override
+    public String partitionKey() {
+        return vanId != null ? vanId.toString() : null;
+    }
+}

--- a/common/src/main/java/com/oneday/common/kafka/events/cron/HandoffDiscrepancyEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/cron/HandoffDiscrepancyEvent.java
@@ -1,0 +1,32 @@
+package com.oneday.common.kafka.events.cron;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.oneday.common.kafka.enums.CronEventType;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Run-time: a missing / extra / rejected parcel at a stop (M6-D-018). → M11, M10.
+ * {@code discrepancyType} mirrors the routing {@code DiscrepancyType} enum (MISSING|EXTRA|REJECTED).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record HandoffDiscrepancyEvent(
+        UUID manifestId,
+        UUID vanId,
+        UUID cityId,
+        int stopSeq,
+        UUID daId,
+        String discrepancyType,
+        List<UUID> parcelIds) implements CronEventPayload {
+
+    @Override
+    public CronEventType eventType() {
+        return CronEventType.HANDOFF_DISCREPANCY;
+    }
+
+    @Override
+    public String partitionKey() {
+        return vanId != null ? vanId.toString() : null;
+    }
+}

--- a/common/src/main/java/com/oneday/common/kafka/events/cron/LoopOverflowEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/cron/LoopOverflowEvent.java
@@ -1,0 +1,29 @@
+package com.oneday.common.kafka.events.cron;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.oneday.common.kafka.enums.CronEventType;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Run-time: a parcel can't fit a feasible loop before its deadline (M6-D-017). → M10, station mgr.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record LoopOverflowEvent(
+        UUID cityId,
+        UUID vanId,
+        UUID parcelId,
+        int loopIndex,
+        Instant deadline) implements CronEventPayload {
+
+    @Override
+    public CronEventType eventType() {
+        return CronEventType.LOOP_OVERFLOW;
+    }
+
+    @Override
+    public String partitionKey() {
+        return vanId != null ? vanId.toString() : (cityId != null ? cityId.toString() : null);
+    }
+}

--- a/common/src/main/java/com/oneday/common/kafka/events/cron/RouteChangedEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/cron/RouteChangedEvent.java
@@ -1,0 +1,29 @@
+package com.oneday.common.kafka.events.cron;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.oneday.common.kafka.enums.CronEventType;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * Plan-time: an intraday override took effect (new append-only plan revision). → M5, M10, station mgr.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record RouteChangedEvent(
+        UUID cityId,
+        LocalDate validDate,
+        UUID routePlanId,
+        UUID actorId,
+        String reason) implements CronEventPayload {
+
+    @Override
+    public CronEventType eventType() {
+        return CronEventType.ROUTE_CHANGED;
+    }
+
+    @Override
+    public String partitionKey() {
+        return cityId != null ? cityId.toString() : null;
+    }
+}

--- a/common/src/main/java/com/oneday/common/kafka/events/cron/RoutePlanPublishedEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/cron/RoutePlanPublishedEvent.java
@@ -1,0 +1,30 @@
+package com.oneday.common.kafka.events.cron;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.oneday.common.kafka.enums.CronEventType;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * Plan-time: a city's van plan was approved & is now active. → M10, van app.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record RoutePlanPublishedEvent(
+        UUID cityId,
+        LocalDate validDate,
+        UUID routePlanId,
+        int vansUsed,
+        int recommendedVanCount,
+        String provisioningFlag) implements CronEventPayload {
+
+    @Override
+    public CronEventType eventType() {
+        return CronEventType.ROUTE_PLAN_PUBLISHED;
+    }
+
+    @Override
+    public String partitionKey() {
+        return cityId != null ? cityId.toString() : null;
+    }
+}

--- a/common/src/main/java/com/oneday/common/kafka/events/cron/ShuttleScheduledEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/cron/ShuttleScheduledEvent.java
@@ -1,0 +1,31 @@
+package com.oneday.common.kafka.events.cron;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.oneday.common.kafka.enums.CronEventType;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Plan-time: the periodic hub↔airport shuttle timetable (M6 §9). → M9, M10.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ShuttleScheduledEvent(
+        UUID cityId,
+        LocalDate validDate,
+        UUID routePlanId,
+        List<LocalTime> departureTimes,
+        int hubToAirportMinutes) implements CronEventPayload {
+
+    @Override
+    public CronEventType eventType() {
+        return CronEventType.SHUTTLE_SCHEDULED;
+    }
+
+    @Override
+    public String partitionKey() {
+        return cityId != null ? cityId.toString() : null;
+    }
+}

--- a/common/src/main/java/com/oneday/common/kafka/events/cron/VanArrivedEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/cron/VanArrivedEvent.java
@@ -1,0 +1,31 @@
+package com.oneday.common.kafka.events.cron;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.oneday.common.kafka.enums.CronEventType;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Run-time: a van reached a meeting vertex. → M10, ops.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record VanArrivedEvent(
+        UUID vanId,
+        UUID cityId,
+        UUID routePlanId,
+        int loopIndex,
+        int stopSeq,
+        UUID hexVertexId,
+        Instant arrivedAt) implements CronEventPayload {
+
+    @Override
+    public CronEventType eventType() {
+        return CronEventType.VAN_ARRIVED;
+    }
+
+    @Override
+    public String partitionKey() {
+        return vanId != null ? vanId.toString() : null;
+    }
+}

--- a/common/src/main/java/com/oneday/common/kafka/events/cron/VanBreakdownEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/cron/VanBreakdownEvent.java
@@ -1,0 +1,30 @@
+package com.oneday.common.kafka.events.cron;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.oneday.common.kafka.enums.CronEventType;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Run-time: a van was disabled mid-loop (M6-D-021). → M10, station mgr, M11.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record VanBreakdownEvent(
+        UUID vanId,
+        UUID cityId,
+        UUID routePlanId,
+        double lastLat,
+        double lastLon,
+        Instant reportedAt) implements CronEventPayload {
+
+    @Override
+    public CronEventType eventType() {
+        return CronEventType.VAN_BREAKDOWN;
+    }
+
+    @Override
+    public String partitionKey() {
+        return vanId != null ? vanId.toString() : null;
+    }
+}

--- a/common/src/main/java/com/oneday/common/kafka/events/cron/VanRunningLateEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/cron/VanRunningLateEvent.java
@@ -1,0 +1,29 @@
+package com.oneday.common.kafka.events.cron;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.oneday.common.kafka.enums.CronEventType;
+
+import java.util.UUID;
+
+/**
+ * Run-time: live ETA slipped past the lateness threshold. → M5, M10, ops.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record VanRunningLateEvent(
+        UUID vanId,
+        UUID cityId,
+        UUID routePlanId,
+        int loopIndex,
+        int stopSeq,
+        int minutesLate) implements CronEventPayload {
+
+    @Override
+    public CronEventType eventType() {
+        return CronEventType.VAN_RUNNING_LATE;
+    }
+
+    @Override
+    public String partitionKey() {
+        return vanId != null ? vanId.toString() : null;
+    }
+}

--- a/docs/M6/M6-IMPLEMENTATION-PLAN.md
+++ b/docs/M6/M6-IMPLEMENTATION-PLAN.md
@@ -1,0 +1,208 @@
+# M6 — Implementation Plan
+
+| Field | Value |
+|-------|-------|
+| **Module** | `routing` (`com.oneday.routing`), artifactId `routing` — depends on `common`, `grid` |
+| **Design doc** | [`docs/M6/M6-ROUTING-DESIGN.md`](./M6-ROUTING-DESIGN.md) (v0.3) — read it first; this plan implements it |
+| **Status** | Not started — `routing/` is an empty skeleton (pom only) |
+| **Shape** | **8 PRs** in 3 parts: plan-time (PR 1–4), execution + run-time (PR 5–7), simulation/E2E (PR 8) |
+
+---
+
+## How to use this plan
+
+- Work top-to-bottom. Each **PR** is independently reviewable and (from PR #1 on) leaves `mvn clean install -pl routing` green. PRs are deliberately chunky — a coherent capability each, not a micro-slice.
+- Every PR cites the design-doc section (`§n`) and decision (`M6-D-xxx`) it implements.
+- **M2, M7, M8, M9 are unbuilt.** M6 builds and tests end-to-end *now* behind stub ports (`CostFloorPort`, `FlightCutoffPort`, `HubSortPort`, `DaAccumulationPort`, `ScanLedgerPort`); real impls swap in later without touching the optimiser or manifest engine (mirrors M3's `DaRosterPort`).
+- **Package layout** (`CLAUDE.md`): `api/` · `service/` (+ `service/impl/`, `service/port/`) · `domain/` · `repository/` · `events/` (+ `events/payload/`) · `dto/` · `batch/` · `config/`. Cross-module rule: import only another module's **public service interface**, never internals.
+
+---
+
+# Part I — Plan-time
+
+## PR #1 — Foundations: contracts, schema, domain, ports, clock
+
+Implements design §17 (contracts), §6 (seams), `M6-D-007/-010/-013`. *Clubs the old "shared contracts" + "DB & domain" phases.*
+
+### Read first
+`common/kafka/KafkaTopics.java` (`CRON_EVENTS` reserved `// M6`), `common/kafka/enums/GridEventType.java` (discriminator convention), `grid/db/migration/V3_*` (Flyway style), `grid/domain/*` + `grid/config/GridProperties.java` (entity + properties style).
+
+### What to build
+1. **`common.kafka.enums.CronEventType`** — 10 values (§17.1) + record payloads (`CronEventBase` + concrete events), Jackson-serializable. *(Scans `VAN_LOAD/VAN_TO_DA/DA_TO_VAN/VAN_UNLOAD` are M8-ledger writes, not cron events.)*
+2. **Stub ports** (`routing.service.port` interfaces + No-op impls, config-toggled like `grid.batch.NoOpDaRosterPort`): `CostFloorPort`, `FlightCutoffPort`, `HubSortPort`, `DaAccumulationPort`, `ScanLedgerPort`.
+3. **`config.ClockConfig`** — `@Bean Clock` (IST); all services inject `Clock`, never `Instant.now()` (`M6-D-013`).
+4. **`config.RoutingProperties`** (`@ConfigurationProperties("routing")`) — `osrm.baseUrl`, `solver.timeLimitSeconds`, `cycle.{min,max}Minutes`, `dwellMinutes`, `maxDaToVertexMinutes`, `shuttle.cadenceMinutes`, `window.{start,end}Hour`, `lateThresholdMinutes`, `costPerKm`.
+5. **Flyway `V6_1…V6_11`** (`routing/db/migration`) — the full §17.3 DDL: `city_logistics_node`, `city_fleet_config`, `route_plan`, `route_plan_stop`, `da_cron_schedule`, `route_override_audit`, `van_manifest`, `van_manifest_item`, `handoff_reconciliation`, `van_live_status`, + `V6_11` seed (hub/airport coords + starter fleet config for all 5 cities, `ON CONFLICT DO UPDATE`, reusing `grid.cities` UUIDs). Indexes per §17.3.
+6. **JPA entities + repositories + enums** for all tables (append-only ones immutable + `@PrePersist`, copying `grid` style). Enums: `LogisticsNodeKind`, `RoutePlanStatus`, `RoutePlanSource`, `RoutingSolverType`, `ProvisioningFlag`, `StopNodeKind`, `ManifestStatus`, `ManifestItemStatus`, `HandoffDirection`, `DiscrepancyType`. Key finders: `RoutePlanRepository.findByCityIdAndValidForDateAndStatus`, `RoutePlanStopRepository.findByRoutePlanIdAndVanIdAndLoopIndex`, `DaCronScheduleRepository.findByDaIdAndValidDate`, `VanManifestItemRepository.findByManifestIdAndStopSeq`, etc.
+
+### Verify
+`mvn clean install -pl common,routing`. Boot vs local Postgres → Flyway applies V6_1…V6_11 clean; 10 `city_logistics_node` rows seeded. Each `CronEventType` payload round-trips through Jackson; one JPA round-trip test per entity.
+
+---
+
+## PR #2 — Inputs & the optimiser core
+
+Implements §6, §7.1–7.3, §3, `M6-D-001/-002/-006/-009`. *Clubs input adapters + meeting-point selection + the VRP solver.*
+
+### Read first
+`grid/service/GridService.java` (the **only** grid surface M6 may use), `grid/service/osrm/OsrmClient.java` (pattern to copy, not import), `grid/service/impl/CpSatAssignmentServiceImpl.java` (OR-Tools native-lib loading).
+
+### What to build
+1. **`service.GridDataAdapter`** — territories / vertices / per-hex demand via `GridService` **public interface only** (no `grid.domain`/`grid.repository` imports). *Blocker: may need a new `GridService` method exposing DA→hexes→vertices — see Open Blockers.*
+2. **`service.osrm.RoutingOsrmClient`** + **`service.TravelMatrixService`** — M6's own thin OSRM `/table` client over its node set `{hub} ∪ vertices (∪ airport)`; build + cache the matrix per run (`M6-D-009`).
+3. **`service.DemandAggregationService`** — per ACTIVE DA aggregate `demand_score_orders` + `service_time_min` → `TerritoryDemand` (symmetric split v1, Q3).
+4. **`service.MeetingPointSelectionService`** + impl — weighted greedy set-cover (`M6-D-001`): fewest vertices covering all territories, biased to high-degree shared vertices, bounded by `maxDaToVertexMinutes`. Output `MeetingPlan{vertices, vertexToDaIds, daToVertex}`.
+5. **`service.VanRouteSolver`** + `impl.OrToolsVanRouteSolver` — `RoutingModel`: vehicles start/end at hub; **capacity dimension with peak-load** ≤ `capacity_packets` (`M6-D-002`); **time dimension** span ≤ `cycle_max`; cost = travel time (cost-floor-weighted when M2 lands); `PATH_CHEAPEST_ARC` + `GUIDED_LOCAL_SEARCH`. Plus **`impl.SavingsVanRouteSolver`** (Clarke–Wright fallback) + **`VanRouteSolverSelector`** (OR-Tools, fall back on missing native lib / timeout — mirrors M3's BFS fallback).
+
+### Verify
+`mvn test -pl routing` (tag OR-Tools tests; CI without native lib runs the savings path, copying M3's `UnsatisfiedLinkError` handling). Tests: matrix built vs mocked OSRM; **no `import com.oneday.grid.domain`** (grep/ArchUnit check); set-cover covers all territories & prefers a shared 3-territory vertex; capacity never exceeded at any route point; span ≤ cycle_max.
+
+---
+
+## PR #3 — Plan assembly & fleet sizing
+
+Implements §7.4–7.5, §8, `M6-D-003/-005/-008`. *Clubs periodise+persist + the fleet recommendation pass.*
+
+### Read first
+`grid/service/impl/GridReplanServiceImpl.java` (orchestrate + persist pattern), design §7.4–7.5, §8.
+
+### What to build
+1. **`service.RoutePlanningService`** + impl — orchestrate Stage 1→4: demand → meeting points → matrix → solve → **periodise** (`n_loops = floor(window/cycle)`, stamp wall-clock ETAs per (van, loop, stop), `M6-D-003`). Persist `route_plan` (PROPOSED) + all `route_plan_stop` rows + derive `da_cron_schedule` `(vertex,[meetingTimes])` (`M6-D-008`). Assert **C6** (spacing ≥ M5 `CRON_FREEZE_MINUTES`).
+2. **Fleet sizing** — second solver pass with OR-Tools free to add vehicles at high fixed cost ⇒ `recommended_van_count`; set `UNDER_PROVISIONED` + station-manager notification when `vans_available < recommended` (`M6-D-005`).
+
+### Verify
+End-to-end (Testcontainers + mocked OSRM): `plan(cityId, date)` writes a coherent PROPOSED plan; one `da_cron_schedule` per active DA with ≥1 meeting time; loop ETAs monotonic, spaced ≥ 30 min. A 3-van-need / 2-van-config city → plan produced, flagged `UNDER_PROVISIONED`, recommended = 3.
+
+---
+
+## PR #4 — Nightly governance & shuttle
+
+Implements §10, §9, `M6-D-008`. *Clubs the nightly job + approval/override/audit + producers + shuttle. Completes Part I.*
+
+### Read first
+`grid/batch/NightlyReplanJob.java` (01:00/06:00/07:00 cadence + `applyFallback`), `grid/api/ProposalController.java` (approve flow), §9–§10.
+
+### What to build
+1. **`batch.NightlyRoutePlanJob`** — `@Scheduled` 01:00 IST → `RoutePlanningService.plan` per city (PROPOSED for tomorrow); 06:00 escalation; 07:00 fallback (copy yesterday's APPROVED forward — port `applyFallback`).
+2. **`api.RoutePlanController`** — `approve` (city-scoped via M1), `override` (append-only `route_plan` revision + `route_override_audit`), `replan`, and the `GET` plan/stops/cron/`cron/.../next`/shuttle endpoints (§17.2).
+3. **`events.CronEventProducer`** — `DA_CRON_SCHEDULED` on approve, `ROUTE_PLAN_PUBLISHED`, `ROUTE_CHANGED` on override.
+4. **`service.ShuttleScheduleService`** — periodic hub↔airport timetable from `shuttle.cadenceMinutes` + OSRM hub↔airport time → `SHUTTLE_SCHEDULED`; `GET /routing/shuttle/{cityId}`.
+
+### Verify
+Job test with fixed `Clock`: 01:00 → PROPOSED; unapproved by 07:00 → fallback copies prior plan. Controller: approve emits `DA_CRON_SCHEDULED`; override writes audit + emits `ROUTE_CHANGED`; cross-city approve rejected. Shuttle: cadence 30 min over 07:00–20:00 → expected departures + arrival ETAs.
+
+---
+
+# Part II — Execution & run-time
+
+## PR #5 — Manifest engine & parcel→loop binding
+
+Implements §11.2, §12, `M6-D-015/-016/-017`. *Clubs deliver + collect binding + overflow.*
+
+### Read first
+§11.2 (manifest), §12 (binding); `HubSortPort`, `DaAccumulationPort`, `FlightCutoffPort` stubs.
+
+### What to build
+1. **`service.VanManifestService`** + impl:
+   - **Deliver** — on `HubSortPort` "ready to load": destination hex → DA → vertex + van; delivery deadline (M4 SLA stub); bind to **earliest deadline-feasible loop with capacity** (`M6-D-016`); append `van_manifest_item(DELIVER, …, PLANNED)`.
+   - **Collect** — from `DaAccumulationPort`: hub-arrival deadline = cutoff − (sort+bag+shuttle) tail (`FlightCutoffPort`, §12.2) → latest feasible collect loop.
+   - Manifest lifecycle BUILDING→LOADED→IN_PROGRESS→RETURNED→RECONCILED.
+2. **Overflow** (`M6-D-017`) — loop load > capacity ⇒ bump latest-deadline items to next feasible loop; none before deadline ⇒ emit `LOOP_OVERFLOW` (station mgr + M10), recommend ad-hoc van. Never silent-drop.
+
+### Verify
+Unit: SLA-first ordering (tight parcel jumps a slack one); overflow bumps then escalates; no-feasible-loop ⇒ `LOOP_OVERFLOW`, never a drop.
+
+---
+
+## PR #6 — Custody scans, handoff & failure handling
+
+Implements §11.1, §13, §16, `M6-D-014/-018/-019/-021`. *Clubs the 4 custody scans + handoff protocol + failures/recovery.*
+
+### Read first
+§11.1 (4 scans + RACI), §13 (handoff + failures), §16 (boundaries); `ScanLedgerPort` stub.
+
+### What to build
+1. **`service.CustodyService`** — the 4 transfer points (LOAD/DELIVER/COLLECT/UNLOAD): validate vs manifest, write scan via `ScanLedgerPort` (M8), advance `van_manifest_item.status`, emit the M4 transition signal (`HANDED_TO_DROP_VAN`/`DROP_COLLECTED`/`HANDED_TO_PICKUP_VAN`/`AT_ORIGIN_HUB`). Enforce **C12** (custody continuity).
+2. **`service.HandoffService`** — per stop: open dwell window (`dwellMinutes`); per-DA reconcile expected (manifest) vs scanned; write `handoff_reconciliation`; emit `HANDOFF_COMPLETED` or `HANDOFF_DISCREPANCY` (MISSING/EXTRA/REJECTED → M11 + M10). Partial handoff legal (`M6-D-018/-019`).
+3. **Failures** (`M6-D-021`) — DA no-show (carry deliveries → rebind next loop; defer collections; escalate if deadline at risk); van breakdown (`POST /routing/vans/{vanId}/recovery` → reassign manifest to recovery van, recompute deadlines, rebind; emit `VAN_BREAKDOWN`); mis-sort (carry back to hub sort, rebind).
+
+### Verify
+Full chain on one parcel (LOAD→DELIVER, COLLECT→UNLOAD): statuses progress; unmatched scan → `HANDOFF_DISCREPANCY` → M11. Late-DA → partial handoff + rebind; breakdown → manifest reassigned + `VAN_BREAKDOWN` (recovery is the only sanctioned intraday fleet change, C18).
+
+---
+
+## PR #7 — Telemetry, live tracking & driver-app contract
+
+Implements §14, §15, `M6-D-011/-012/-020`. *Clubs ingestion + deviation + driver endpoints + Kafka wiring.*
+
+### Read first
+§14 (telemetry, in-process), §15 (driver workflow), §16 (consumers).
+
+### What to build
+1. **`api.VanTelemetryController`** — `POST /api/v1/van/{vanId}/telemetry` (GPS + DELIVER/COLLECT scans; `type` discriminates) → calls `VanTrackingService` directly (no Kafka for raw pings, `M6-D-012`).
+2. **`service.VanTrackingService`** — overwrite `van_live_status`; scans → `CustodyService`/`HandoffService`; `ARRIVED_AT_STOP` → lateness vs plan, propagate to remaining stops, emit `VAN_ARRIVED` / `VAN_RUNNING_LATE` via **`events.RouteDeviationProducer`** (`M6-D-011`).
+3. **Driver-app endpoints** (`M6-D-020`) — `GET /routing/vans/{vanId}/manifest?loop=`, load-scan, stop-confirm, return-scan, `GET /routing/vans/{cityId}/live`.
+4. Wire all producers.
+
+### Verify
+Load test ~10 req/s × 100 virtual vans — in-process path, no Kafka per ping. Slow leg → `VAN_RUNNING_LATE` + corrected ETAs. Full loop via driver endpoints → manifest BUILDING→…→RECONCILED; M4 transition signals in order; mock M5/M7/M8 consumers receive the right events / `ScanLedgerPort` writes.
+
+---
+
+# Part III — Simulation
+
+## PR #8 — Simulation harness & end-to-end
+
+Implements §21, `M6-D-013`.
+
+### Read first
+§21 (sim), `M6-D-013` (accelerated clock).
+
+### What to build
+- Test-only `simulator`: **virtual van** (drives a plan, POSTs telemetry + scans along OSRM geometry on the accelerated `Clock`), **virtual hub** (`HubSortPort` feed), **fault injector** (no-show, breakdown, mis-sort, demand spike) — public APIs/events only.
+- **Virtual-day E2E** on a seeded city: assert invariants (no cron missed unless injected, C12 custody continuity, overflow escalates not drops, van-late propagates) and calibrate `maxDaToVertexMinutes`, `cycle`, `dwellMinutes`, overflow threshold (Q4/Q5/Q9/Q10).
+
+### Verify
+`mvn test -pl routing` runs a full simulated day in seconds. Each fault-library case asserts the right module reaction.
+
+---
+
+## PR Dependency Graph
+
+```
+#1 foundations (contracts + schema + domain + ports + clock)
+      │
+#2 inputs + optimiser (adapters/matrix + set-cover + VRP/fallback)
+      │
+#3 plan assembly + fleet sizing
+      │
+#4 nightly governance + shuttle        ◄── end of Part I (plan-time)
+      │
+#5 manifest engine + binding
+      │
+#6 custody scans + handoff + failures
+      │
+#7 telemetry + live tracking + driver app
+      │
+#8 simulation + virtual-day E2E
+```
+Strictly linear — each PR builds on the last; no parallel branches to track.
+
+---
+
+## Open blockers — raise before the PR that needs them
+
+| Blocker | Needed by | Action |
+|---------|-----------|--------|
+| **M3 exposes DA→hexes→vertices via public `GridService`** | PR #2 | Raise with M3 owner now — longest-lead dependency; may need a new `GridService` method. |
+| **M5 cron-schedule format** — M5 holds one meeting time; M6 emits the day's list (`M6-D-008`) | PR #4 | Agree: M5 stores list / picks next, or uses `GET /routing/cron/da/{daId}/next`. |
+| **M7 `HubSortPort` contract** — "ready to load for delivery" shape | PR #5 | Stub now; agree real contract when M7 starts. |
+| **M9 `FlightCutoffPort` + the §12.2 end-to-end tail budget (Q2)** | PR #5 | Stub now; Q2 is cross-module (M7/M9/M10) — open early. |
+| **M8 `ScanLedgerPort`** — is the van a new scan-location type? (Q12) | PR #6 | Confirm with M8 owner; stub writes locally until M8 exists. |
+| **M4 custody state names** (`HANDED_TO_DROP_VAN` etc.) | PR #6 | Confirm with M4 owner (already in M5's design). |
+| **Driver vs van identity on scans (Q14)** | PR #6 | Confirm with M1 — put both on each scan. |
+| **OSRM in CI** | PR #2+ | Mock `/table` in tests; document a self-hosted OSRM URL for E2E. |
+
+---
+
+*Plan v0.2 — implements design doc v0.3 in **8 PRs**. Part I plan-time = PR 1–4; Part II execution + run-time = PR 5–7; simulation/E2E = PR 8. Everything builds and tests now behind stub ports; M2/M7/M8/M9 real impls swap in without touching the optimiser or manifest engine.*

--- a/docs/M6/M6-ROUTING-DESIGN.md
+++ b/docs/M6/M6-ROUTING-DESIGN.md
@@ -1,0 +1,678 @@
+# M6 — Van Routing, Scheduling & Custody: Design Doc
+
+| Field | Value |
+|-------|-------|
+| **Module** | M6 — Van Routing, Scheduling & Custody (`routing`, `com.oneday.routing`) |
+| **Status** | Draft v0.3 — full van lifecycle (planning + execution + custody + tracking) |
+| **Depends on** | `common` (Kafka contracts, BaseEntity), `grid` / M3 (DA territories, hex vertices, OSRM matrix, demand snapshots) |
+| **Consumed by** | M5 (per-DA cron schedule), M7 (van load/unload at the dock), M8 (van scan ledger), M9 (shuttle departure times), M10 (route ETAs, deviation), M4 (custody state transitions), van-driver app |
+| **Source PRD** | `docs/PRD-ONE-DAY-DELIVERY.md` §6.3, §8, §9.2 · `docs/MODULES.md` M6 |
+
+> **What M6 is, in one line.** A consolidation van is a **mobile mini-hub** (a moving cross-dock): M6 plans where it goes, schedules when, decides which parcels ride it and to whom, governs every custody handoff, tracks it live, and recovers it when things break. M6 owns *everything van*.
+
+> **How to read this doc.** The doc is in three parts.
+> **Part I — Planning (plan-time, nightly batch):** §1–§10. *Where* vans go and *when*.
+> **Part II — Execution (run-time, all day):** §11–§15. *Which parcels* ride, *to whom*, *who scans what*, and *what happens when it breaks*. This is the part the v0.1/v0.2 drafts were missing.
+> **Part III — Integration & governance:** §16–§21. Boundaries, contracts, constraints, open questions, build order, testing.
+> Design decisions are tagged `M6-D-xxx`; constraints `Cn`; open questions `Qn`.
+
+---
+
+## Table of Contents
+
+**Part I — Planning**
+1. [What M6 Does](#1-what-m6-does)
+2. [Scope & Ownership](#2-scope--ownership)
+3. [Industry Context — How This Problem Is Actually Solved](#3-industry-context--how-this-problem-is-actually-solved)
+4. [Key Design Decisions](#4-key-design-decisions)
+5. [The Routing Model](#5-the-routing-model)
+6. [Inputs](#6-inputs)
+7. [The Nightly Planning Pipeline](#7-the-nightly-planning-pipeline)
+8. [Fleet Sizing](#8-fleet-sizing)
+9. [The Hub↔Airport Shuttle](#9-the-hubairport-shuttle)
+10. [Nightly Replan, Approval, Override](#10-nightly-replan-approval-override)
+
+**Part II — Execution**
+11. [The Van as a Mobile Mini-Hub — Custody & Manifest](#11-the-van-as-a-mobile-mini-hub--custody--manifest)
+12. [Parcel ↔ Loop Binding & the Forecast-to-Actual Flow](#12-parcel--loop-binding--the-forecast-to-actual-flow)
+13. [The Handoff Protocol & Failure Handling](#13-the-handoff-protocol--failure-handling)
+14. [Live Van Tracking & Telemetry](#14-live-van-tracking--telemetry)
+15. [Van-Driver App Workflow](#15-van-driver-app-workflow)
+
+**Part III — Integration & Governance**
+16. [Cross-Module RACI & Contracts](#16-cross-module-raci--contracts)
+17. [Contracts — Events, APIs, Data Model](#17-contracts--events-apis-data-model)
+18. [Constraint Catalogue](#18-constraint-catalogue)
+19. [Open Questions](#19-open-questions)
+20. [Phase Plan](#20-phase-plan)
+21. [Testing & Simulation](#21-testing--simulation)
+
+---
+
+# Part I — Planning
+
+## 1. What M6 Does
+
+M6 governs the **consolidation vans** that move parcels between a city's central **hub** and its **delivery associates (DAs)**, who are spread across the H3 hex grid produced by M3. Three realities define the module:
+
+**1. The van is a bidirectional mini-hub.** A single van loop does *both* jobs at once, at the same stops:
+- **Deliver (last-mile):** parcels that landed at this city's hub and were sorted for outbound delivery ride *out* on the van and are handed to the DA who will deliver them.
+- **Collect (first-mile):** parcels DAs picked up from customers are handed *to* the van and brought back to the hub for sortation → bag → flight.
+
+So every van↔DA meeting is a **simultaneous, parcel-level, two-way custody transfer** — not an abstract exchange of counts.
+
+**2. The loop is periodic.** A van runs a `hub → meeting points → hub` loop with a target **2–3 h cycle time**, repeating through the ~16 h operating day (`n_loops = floor(window / cycle)`). The route *shape* is replanned nightly and locked (NFR-3); the loop *repeats* on a cadence, so a DA meets its van several times a day at the same vertex.
+
+**3. M6 has two halves.** *Plan-time* is a nightly batch (the route shape, the timetable, the fleet recommendation, the shuttle). *Run-time* is an always-on service that, through the day, binds **real parcels** to loops, builds **van manifests**, governs every **custody scan and handoff**, **tracks** the van live, and **recovers** it when a DA no-shows, a van breaks down, or a parcel is mis-sorted. A plan nobody executes and watches is half a system; Part II is the other half.
+
+M6 produces, per city, per day: meeting points covering every DA territory; an ordered, capacity- and cycle-feasible van route per van; the periodic timetable; the per-DA cron schedule (→ M5); a recommended fleet size; the hub↔airport shuttle timetable; and — at run-time — per-loop van manifests, custody events, live positions, deviation signals, and exception/recovery flows.
+
+---
+
+## 2. Scope & Ownership
+
+### 2.1 In scope — M6 owns all of this
+
+| Area | What M6 owns |
+|------|--------------|
+| **Routing** | Meeting-point selection (set-cover at territory-intersection vertices); the capacitated, time-windowed, pickup-and-delivery VRP; periodisation into loops. |
+| **Scheduling** | Per-stop ETAs; per-DA cron schedule; hub↔airport shuttle timetable. |
+| **Fleet** | Routing within the configured fleet **and** a recommended fleet size with under-provisioning flagging. |
+| **Custody** | The van manifest (which parcels ride which van/loop, to/from whom); the four custody scan points (§11); reconciliation. |
+| **Binding** | Mapping *real* parcels to loops, SLA-first then capacity-bounded; runtime overflow / back-pressure. |
+| **Handoff** | The van-side handoff protocol at each stop (multi-DA choreography, partial handoff, dwell windows). |
+| **Run-time** | Live van tracking, plan-vs-actual ETAs, deviation signalling. |
+| **Failures** | DA no-show, van breakdown, mis-sort, lost/damaged-on-van — detection, carry-back, recovery van, escalation. |
+| **Driver app contract** | The van-driver app's screens, scans, and API (parallel to M5 owning the DA app). |
+| **Config M6 introduces** | Per-city hub & airport coordinates; per-city fleet config. |
+
+### 2.2 Out of scope
+
+- **DA-internal pickup/delivery sequencing** inside a DA's territory — M5's priority queue. M6's responsibility ends at the meeting vertex.
+- **Flight assignment / cutoff computation** — M9. M6 consumes a cutoff/cadence.
+- **Hub sortation & bagging** — M7. M6 consumes M7's sort output (what's ready to load) and feeds M7 the unloaded collections.
+- **The scan ledger itself** — M8 owns the append-only `scan.event` store; M6 *originates* van scans and consumes them (§16).
+- **The shipment state machine** — M4 owns it; M6's custody events *drive* transitions but M4 owns the transitions.
+- **Building the van-driver mobile app** — a separate client project; M6 defines its contract and serves its API.
+
+### 2.3 Gaps this module closes in the codebase
+
+- **No hub/airport location exists today.** M3 stores hexes, vertices, pincodes — no logistics-node coordinate. M6 introduces `city_logistics_node` (`M6-D-007`).
+- **No van custody concept exists today.** The chain DA→van→hub had a hole "on the van." M6 makes the van a first-class custody node (`M6-D-014`).
+
+---
+
+## 3. Industry Context — How This Problem Is Actually Solved
+
+The routing core is a textbook **Vehicle Routing Problem (VRP)** with four standard extensions stacked on:
+
+| Our requirement | Standard name | What it adds |
+|-----------------|---------------|--------------|
+| Van capacity (max packets) | **CVRP** — Capacitated VRP | Load must never exceed capacity. |
+| Each stop both drops *and* collects | **VRPSPD** — Simultaneous Pickup & Delivery | Load fluctuates along the route; the binding limit is the **peak instantaneous load**, not the net. |
+| 2–3 h cycle, return-to-hub & flight cutoffs | **VRPTW** — Time Windows | Each stop / the route span has a feasible window. |
+| The loop repeats on a cadence | **PVRP** — Periodic VRP | A route is executed on a schedule, not once. |
+
+The **milk-run** term is from lean-manufacturing inbound logistics: one vehicle does a fixed, repeating, consolidated loop touching many suppliers rather than each shipping direct — exactly our model (suppliers = DA meeting points, factory = hub). The custody/manifest layer is **cross-docking**: the van is a moving cross-dock.
+
+**How the industry solves the routing:** Clarke–Wright *savings* (1964) + sweep build a warm start; 2-opt/Or-opt local search refines; **metaheuristics (ALNS, tabu, guided local search)** are what production systems actually run. Commercial routing engines (Routific, OptimoRoute, Onfleet, Wise Systems) wrap these; **UPS ORION** is a proprietary heuristic optimiser; **Amazon** layers learned sequence models on an OR core. The open-source default is **Google OR-Tools `RoutingModel`** (savings/cheapest-arc first solution → guided-local-search metaheuristic; native capacity/time *dimensions* and pickup-and-delivery pairing).
+
+**Our choice (`M6-D-006`):** OR-Tools `RoutingModel` — already a dependency (M3's CP-SAT), models everything we need, scales easily to our size (tens of stops, a handful of vans/city). Clarke–Wright savings is the documented no-solver fallback (mirrors M3's BFS-below-threshold pattern).
+
+> Meeting-point *selection* is **not** the VRP — it is a **set-cover / p-median** problem solved *before* the VRP (§7.2).
+
+---
+
+## 4. Key Design Decisions
+
+### Planning
+
+**M6-D-001 — Meeting points at DA-territory intersection vertices.** The van stops at H3 hex **vertices** (`grid.HexVertex`), preferring vertices on the boundary **shared by several DA territories** so one stop serves multiple DAs. Selection is a weighted set-cover: fewest vertices such that every active DA territory has ≥1 reachable meeting vertex, biased toward high-degree (multi-territory) vertices, bounded by `max_da_to_vertex_minutes`. *Resolves PRD §6.3 / G1 for routing.*
+
+**M6-D-002 — Bidirectional loop; capacity = peak instantaneous load (VRPSPD).** Two quantities per node (`deliver_qty`, `collect_qty`); constrain max load *anywhere* along the route ≤ capacity, not the net.
+
+**M6-D-003 — Route shape fixed nightly; loops repeat on cadence (PVRP, resolves A3).** No per-loop re-solve. Nightly fixes shape + cadence; `n_loops = floor(window / cycle)`; per-loop forecast demand = daily / `n_loops`. Demand freeze at 01:00 IST (as M3).
+
+**M6-D-004 — 70/30 demand, reusing M3's snapshot.** No recompute — aggregate `h3_hex_demand_snapshot.demand_score_orders` + `service_time_min` per territory. One demand truth across M3/M5/M6.
+
+**M6-D-005 — Fleet count is an ops input; M6 also emits a recommended count.** Route within `vans_available`; a second pass computes the minimum vans to cover all territories within cycle+capacity; `vans_available < recommended` ⇒ plan flagged `UNDER_PROVISIONED`.
+
+**M6-D-006 — Solver: OR-Tools `RoutingModel`, Clarke–Wright fallback.** §3.
+
+**M6-D-007 — M6 introduces hub & airport location config.** New `city_logistics_node` (hub + airport lat/lon/city), seeded with M3's `grid.cities`.
+
+**M6-D-008 — Per-DA cron schedule carries the full day's meeting times.** M5 today models one `scheduled_meeting_time`; M6 emits `(vertex, [meeting_times])`. Integration note in §16/§17.
+
+**M6-D-009 — M6 builds its own travel matrix.** M3's `h3_hex_travel_time` is centroid→centroid; M6 routes over *vertices + hub + airport*, so it calls `OsrmClient.getTable` on its own node set (same engine/config, different nodes).
+
+**M6-D-010 — Cost floor stubbed behind `CostFloorPort`.** M2 unbuilt ⇒ flat per-km van cost until it ships.
+
+### Run-time & tracking
+
+**M6-D-011 — Live van tracking belongs in M6, not M10.** The plan-vs-actual / live-ETA loop is a routing-scheduling concern; M10 *consumes* the deviation for SLA. Supersedes the v0.1 scoping. (DA-side equivalent is in M5; the van side is symmetric and is M6's.)
+
+**M6-D-012 — Raw GPS pings stay in-process; only meaningful events hit Kafka.** Telemetry POSTs to an M6 endpoint; the controller calls the tracking service directly (monolith). Kafka is spent only on `VAN_ARRIVED` / `VAN_RUNNING_LATE` / handoff / exception events. Keeps it effectively free (§14.5).
+
+**M6-D-013 — Injectable clock.** All time via an injected `java.time.Clock` so a 16 h day simulates in seconds; lands in P1.
+
+### Custody, manifest & execution (the new core)
+
+**M6-D-014 — The van is a custody node in M8's scan ledger.** Four custody transfer points, each an M8 `scan.event`: **LOAD** (hub→van), **DELIVER** (van→DA), **COLLECT** (DA→van), **UNLOAD** (van→hub). M6 *originates* these scans and owns the van manifest; M8 records the immutable ledger; M4 transitions shipment state. The parcel is never "nowhere": between scans it is *on van X, loop Y*.
+
+**M6-D-015 — Manifests are built from actuals at load time, not nightly.** The nightly plan routes on *forecast*. The **van manifest** (specific parcel IDs → van/loop/stop/DA) is materialised at run-time from M7's sort output (deliver side) and DA accumulation (collect side). Forecast plans capacity; actuals fill it.
+
+**M6-D-016 — Parcel→loop assignment is SLA-first, then capacity-bounded.** A parcel is bound to the **earliest loop that meets its deadline** (delivery SLA for last-mile; flight-cutoff-derived hub-arrival deadline for first-mile), subject to capacity — *not* simply "the next loop with room." Deadline beats convenience.
+
+**M6-D-017 — Runtime overflow → bump then escalate (van-level back-pressure).** If a loop's actual load exceeds capacity, the **latest-deadline** parcels bump to the next feasible loop. If no loop fits before a parcel's deadline ⇒ escalate to station manager + M10 (and optionally recommend an ad-hoc extra van, which needs approval — NFR-3). Never silently drop SLA (mirrors M7's hub-overload principle).
+
+**M6-D-018 — Every handoff is scan-reconciled; partial handoff is legal.** At each stop, expected (manifest) vs actual (scanned) is reconciled per DA. Missing/extra/rejected parcels raise a `HANDOFF_DISCREPANCY` → M11 ticket + M10. A stop can complete partially; unhandled parcels carry to the next loop or are flagged.
+
+**M6-D-019 — Multi-DA rendezvous uses a bounded dwell window; the van never waits past it.** Each stop has a dwell window; DAs assigned to that vertex meet inside it. A DA later than the window gets a partial/zero handoff this loop and catches the next loop — cycle time is hard, the van does not wait indefinitely.
+
+**M6-D-020 — The van-driver app is M6's client; M6 owns the driver-side workflow.** Symmetric to M5 owning the DA app. M6 defines the driver's load/navigate/scan/confirm/return flow and serves its API.
+
+**M6-D-021 — Explicit failure handling for no-show, breakdown, mis-sort, loss.** Each has a defined detection, carry-back/recovery, and escalation path (§13).
+
+---
+
+## 5. The Routing Model
+
+```
+                         ┌─────────────────────────────┐
+                         │           HUB (depot)        │  load deliveries ↑   unload collections ↓
+                         │  every loop starts & ends    │
+                         └───────────────┬──────────────┘
+                                         │
+        loop (target span 2–3h)          ▼
+   ●────────●────────●────────●────────●────────● ... ──► hub
+   V1       V2       V3       V4       V5       V6
+   meeting vertices (H3 hex corners on DA-territory boundaries)
+
+At each meeting vertex Vk (simultaneous, parcel-level):
+   van → DA(s):  hand the specific last-mile parcels for those DA(s)      [DELIVER scan]
+   DA(s) → van:  hand the first-mile parcels they collected               [COLLECT scan]
+   load_after = load_before − delivered + collected   (must stay ≤ capacity at every point)
+```
+
+**Nodes** — Depot = hub (`city_logistics_node`, kind=HUB). Meeting vertices = selected `HexVertex` rows, each carrying `(deliver_qty, collect_qty, service_time, served_da_ids[])` for the loop (forecast at plan-time; actual at run-time).
+
+**Edges** — OSRM driving time between node coordinates (`OsrmClient.getTable`, M6's own node set — `M6-D-009`).
+
+**Vehicles** — `vans_available` identical vans, capacity `capacity_packets`, start/end at hub.
+
+**Dimensions (OR-Tools)** — *Capacity* (peak-load constraint, `M6-D-002`); *Time* (route span ≤ `cycle_time_max`).
+
+**Coverage** — every active DA territory served by ≥1 visited vertex (enforced in set-cover, §7.2).
+
+---
+
+## 6. Inputs
+
+| Input | Source | How M6 gets it | Status |
+|-------|--------|----------------|--------|
+| DA territories (DA → hexes), for the date | M3 `da_hex_assignment` (ACTIVE) | `grid` service/repo (in-process) | ✅ |
+| Hex vertices (lat/lon, H3 index) | M3 `h3_hex_vertex` | `HexVertexRepository` | ✅ |
+| Per-hex demand (70/30) + service time | M3 `h3_hex_demand_snapshot` | repo | ✅ |
+| OSRM driving times | M3 OSRM (`OsrmClient`) | M6 node-set matrix | ✅ reuse |
+| Hub & airport coordinates | **new** `city_logistics_node` | M6 owns (`M6-D-007`) | ⚠️ M6 creates |
+| Van count + capacity per city | **new** `city_fleet_config` | M6 owns | ⚠️ M6 creates |
+| Operating window / shift hours | M3 `grid.shift` (07:00–20:00) | shared config | ✅ |
+| Sorted-for-delivery parcels ready to load | M7 sort output | event/query at run-time | ❌ M7 unbuilt — stub |
+| First-mile parcels accumulated per DA | M5 / M4 (PICKED_UP) | event at run-time | ❌ partial — stub |
+| Parcel delivery SLA / flight cutoff | M4 (SLA), M9 (cutoff) | per-parcel deadline | ❌ M9 unbuilt — stub |
+| Per-parcel cost floor | M2 | `CostFloorPort` | ❌ stub |
+| Manual override action | M1 + UI | REST (§17.2) | ✅ |
+| Live van telemetry (GPS, scans) | Van-driver app | HTTP (§14, §17.2) | run-time |
+
+**Unbuilt-dependency seams** (mirror M3's `DaRosterPort`): `CostFloorPort`, `FlightCutoffPort`, `HubSortPort` (what's ready to load), `DaAccumulationPort` (first-mile parcels per DA). Each has a stub until M2/M7/M9 land, so M6 builds and tests end-to-end now.
+
+---
+
+## 7. The Nightly Planning Pipeline
+
+Five stages, per city, in the 01:00 batch. Stages 1–2 pre-process; stage 3 is the VRP; 4–5 shape output. (All on *forecast*; actuals are bound at run-time, §12.)
+
+**7.1 Stage 1 — Demand aggregation per territory.** For each ACTIVE DA: sum `demand_score_orders` over its hexes → `territory_daily_demand`; split `first_mile_qty` / `last_mile_qty` (symmetric v1 — Q3); per-loop = daily / `n_loops`.
+
+**7.2 Stage 2 — Meeting-point selection (set cover).** Enumerate each territory's candidate vertices (its hexes' `HexVertex` rows), annotated with degree (how many territories touch them). Weighted set-cover: smallest vertex set covering every territory, maximising shared high-degree vertices, minimising DA→vertex distance, bounded by `max_da_to_vertex_minutes` (protects DA's 70% utilisation, NFR-4). Output: `M` = meeting vertices + `vertex → [da_ids]`. Greedy max-coverage (ln n guarantee) is plenty at city scale; CP-SAT exact path available.
+
+**7.3 Stage 3 — Capacitated VRP+TW over `{hub} ∪ M`.** OR-Tools `RoutingModel`: vehicles start/end at hub; capacity dimension with peak-load; time dimension span ≤ `cycle_time_max`; objective minimise travel time (→ cost-floor-weighted when M2 lands). Output: ordered stop list per van for **one loop**.
+
+**7.4 Stage 4 — Periodise.** `n_loops = floor(window / realised_cycle)`; stamp wall-clock ETAs per (van, loop, stop); per vertex, the set of ETAs across loops = the meeting times DAs use.
+
+**7.5 Stage 5 — Derive + persist.** Per DA: `(vertex, [meeting_times])` → `DA_CRON_SCHEDULED` on `oneday.cron.events` (M5). Persist `route_plan` (PROPOSED) + `route_plan_stop` + `da_cron_schedule`. Await approval (§10).
+
+---
+
+## 8. Fleet Sizing
+
+Two solver passes (`M6-D-005`): **(1) Constrained** — route within `vans_available`; this ships. **(2) Recommendation** — re-solve with OR-Tools free to add vehicles at a high fixed cost ⇒ fewest vans covering all territories within cycle+capacity ⇒ `recommended_van_count`. Surface both; if `vans_available < recommended` ⇒ `UNDER_PROVISIONED` + station-manager notification. Capacity is hard in both passes.
+
+---
+
+## 9. The Hub↔Airport Shuttle
+
+Periodic for v1. A single origin–destination leg (hub↔airport) is a *timetable*, not a VRP: configurable cadence (`shuttle_cadence_minutes`), departure times across the window, arrival ETAs from OSRM hub↔airport time. Published as `SHUTTLE_SCHEDULED` on `oneday.cron.events` for M9 (its "cron departure time" input) and M10. When M9 lands, cadence becomes flight-cutoff-driven via `FlightCutoffPort` (Q1). The shuttle carries **sealed flight bags** (from M7), not loose parcels — its custody unit is the bag, simpler than the milk-run.
+
+---
+
+## 10. Nightly Replan, Approval, Override
+
+Mirrors M3's `NightlyReplanJob` (NFR-2/3, PRD §8.3):
+
+| Time (IST) | Action |
+|------------|--------|
+| **01:00** | `NightlyRoutePlanJob` runs §7 per city → `route_plan` PROPOSED for tomorrow. |
+| **06:00** | Escalation: no APPROVED plan for today ⇒ notify station manager. |
+| **07:00** | Auto-fallback: still unapproved ⇒ copy yesterday's APPROVED plan forward (as M3). |
+
+- **Approval** — station manager (own city) / admin (any) approves PROPOSED → APPROVED; routes lock.
+- **Override** — admin / station manager edits stop order or reassigns a vertex ⇒ new append-only `route_plan` revision, `source=MANUAL_OVERRIDE`, actor + reason; emits `ROUTE_CHANGED` (M5, M10, notify).
+- **Append-only** — `route_plan` rows never mutate; revisions supersede (as M3's `assignment_proposal`).
+
+---
+
+# Part II — Execution
+
+## 11. The Van as a Mobile Mini-Hub — Custody & Manifest
+
+This is the heart of the module and what earlier drafts missed. Plan-time moves *counts*; run-time moves *identified parcels* through a chain of custody.
+
+### 11.1 The four custody points (`M6-D-014`)
+
+Each is a physical handoff, an M8 `scan.event`, and an M4 state transition. The parcel is always *somewhere*; between scans it is on a specific van/loop.
+
+```
+         (M7 dock)              (meeting vertex)            (meeting vertex)            (M7 dock)
+HUB ──LOAD──▶ VAN ──────────▶ VAN ──DELIVER──▶ DA           DA ──COLLECT──▶ VAN ──────▶ VAN ──UNLOAD──▶ HUB
+ last-mile parcel                            (last-mile)    (first-mile)                       (first-mile)
+```
+
+| # | Transfer | Physical actor(s) | Scan (M8) | M4 state result | M6 records |
+|---|----------|-------------------|-----------|-----------------|------------|
+| 1 | **LOAD** hub→van | Hub operator (M7) per M6 manifest | `VAN_LOAD` | `AT_DEST_HUB → HANDED_TO_DROP_VAN` | manifest_item PLANNED→LOADED; manifest BUILDING→LOADED |
+| 2 | **DELIVER** van→DA | Van driver (M6 app) + DA (M5 app) | `VAN_TO_DA` | `HANDED_TO_DROP_VAN → DROP_COLLECTED` | item LOADED→HANDED_OFF; reconcile |
+| 3 | **COLLECT** DA→van | DA (M5 app) + Van driver (M6 app) | `DA_TO_VAN` | `PICKED_UP → HANDED_TO_PICKUP_VAN` | item (collect) →ONBOARD; added to return manifest |
+| 4 | **UNLOAD** van→hub | Hub operator (M7) | `VAN_UNLOAD` (= hub in-scan) | `HANDED_TO_PICKUP_VAN → AT_ORIGIN_HUB` | return item ONBOARD→RECONCILED; manifest RETURNED→RECONCILED |
+
+> The M4 state names (`HANDED_TO_DROP_VAN`, `DROP_COLLECTED`, `HANDED_TO_PICKUP_VAN`, `AT_ORIGIN_HUB`) already exist in M5's design — M6 aligns to them rather than inventing parallel states. Points 2 & 3 happen **together** at every meeting stop (the simultaneous handoff).
+
+### 11.2 The van manifest
+
+The manifest *is* the van's mini-hub sort plan. Two parts per van per loop per day:
+
+- **Outbound (deliver) manifest** — the specific last-mile parcels loaded for this loop, each tagged `(parcel_id, stop_seq, meeting_vertex, destination_da_id, sla_deadline, status)`.
+- **Inbound (collect) manifest** — populated *during* the loop as DAs hand parcels to the van; each `(parcel_id, source_da_id, stop_seq, flight_cutoff_deadline, status)`.
+
+`van_manifest` lifecycle: `BUILDING → LOADED → IN_PROGRESS → RETURNED → RECONCILED`. `van_manifest_item.status`: `PLANNED → LOADED → ONBOARD → HANDED_OFF | RECONCILED | EXCEPTION`.
+
+### 11.3 In-van organisation (`M6-D-014` cont.)
+
+Deliveries are physically loaded **in reverse stop order** (last stop's parcels at the back) so each stop's parcels are reachable first. The driver app shows, at stop k, exactly the parcels for stop k's DAs (filtered by `stop_seq`). This is the cross-dock discipline that makes a many-stop loop workable.
+
+### 11.4 A parcel's journey on the van (concrete)
+
+*Last-mile:* parcel `BLR-...042` lands, M7 sorts it for delivery in hex H (DA-A's territory). M6 binds it to Van 3 / loop 2 (§12). Hub operator scans it onto Van 3 (`VAN_LOAD` → `HANDED_TO_DROP_VAN`). At stop V5 (07:50), driver + DA-A scan it (`VAN_TO_DA` → `DROP_COLLECTED`); DA-A now carries it for last-mile delivery (M5).
+*First-mile:* DA-A also hands the driver 6 parcels she picked up; each is scanned (`DA_TO_VAN` → `HANDED_TO_PICKUP_VAN`) and added to Van 3's return manifest. Back at the hub (09:30), the operator scans them in (`VAN_UNLOAD` → `AT_ORIGIN_HUB`); M7 begins sortation; M6 marks the manifest RECONCILED.
+
+---
+
+## 12. Parcel ↔ Loop Binding & the Forecast-to-Actual Flow
+
+The nightly plan is *forecast*; the day runs on *real* parcels. Binding is the bridge (`M6-D-015`, `-016`, `-017`).
+
+### 12.1 Last-mile binding (deliver)
+On `parcel.sorted_for_delivery` from M7: resolve destination hex → DA → that DA's meeting vertex + van. Compute the parcel's **delivery deadline** (M4 SLA). Bind to the **earliest loop** whose `(van ETA to vertex) + (DA delivery time)` ≤ deadline **and** that has spare capacity. Append to that loop's outbound manifest. No feasible loop ⇒ overflow (§12.4).
+
+### 12.2 First-mile binding (collect)
+A DA accumulates PICKED_UP parcels through the day. Each carries a **hub-arrival deadline** derived from its committed flight cutoff (M9) minus the end-to-end tail: `cutoff − (sort + bag + shuttle)` (the Q2 budget). M6 marks the **latest loop** on which the parcel can be collected and still reach the hub in time. M5's cron-feasibility check (it already verifies the DA can reach the vertex) is combined with M6's loop-return-time check; the parcel must be handed off on a loop ≤ that latest loop. If the DA can't make any feasible loop ⇒ exception (M5 `CRON_MISSED` path + M10).
+
+### 12.3 The combined binding rule (`M6-D-016`)
+> **SLA-first, capacity-bounded.** Order candidate parcels by deadline; assign each to the earliest feasible loop with capacity. This is *deadline-first*, not *next-loop-with-room* — a tight parcel never waits behind a slack one.
+
+### 12.4 Runtime overflow / back-pressure (`M6-D-017`)
+Capacity per loop is fixed by the locked plan. If actual demand on a loop exceeds capacity:
+1. **Bump** the latest-deadline parcels to the next feasible loop.
+2. If a bumped parcel then has **no loop before its deadline** ⇒ raise `LOOP_OVERFLOW` → station manager + M10; recommend an ad-hoc extra van (intraday van add needs approval, NFR-3) or a direct hub run.
+3. Never silently drop SLA (mirrors M7 hub overload, PRD §9.5).
+
+### 12.5 Why this can't be planned away
+Forecast (70/30) sizes loops well on average, but a demand spike, a flight pulled earlier, or DA pickups clustering late in the day all create real-time pressure the nightly plan can't see. §12.4 is the safety valve; §13 handles the physical failures.
+
+---
+
+## 13. The Handoff Protocol & Failure Handling
+
+### 13.1 The stop protocol (happy path, `M6-D-018/-019`)
+1. Van arrives at vertex Vk (`VAN_ARRIVED`); a **dwell window** opens (`dwell_minutes`, configurable; default ~5 min).
+2. For each DA assigned to Vk (within the window): driver scans **out** that DA's deliveries (`VAN_TO_DA`), DA scans them **in** (M5); DA scans **in** her collections to the van (`DA_TO_VAN`).
+3. **Reconcile per DA:** expected (manifest, filtered by `stop_seq` & `da_id`) vs scanned. Match ⇒ items HANDED_OFF/ONBOARD. Mismatch ⇒ §13.3.
+4. Driver confirms the stop; van departs (`VAN_DEPARTED` implicit). `HANDOFF_COMPLETED` event per stop.
+
+### 13.2 Multi-DA & late-DA (`M6-D-019`)
+Several DAs share Vk; they meet within the dwell window. A DA later than the window:
+- her **deliveries** are carried on the van and re-attempted on the **next loop** (re-bound, §12.1);
+- her **collections** miss this loop and are bound to the next feasible loop (§12.2);
+- if either breach a deadline ⇒ escalate. The van **does not wait** past the dwell window — cycle time is hard (C3).
+
+### 13.3 Reconciliation discrepancies (`M6-D-018`)
+At a stop, per DA: **missing** (manifest parcel not scanned), **extra** (scanned parcel not on manifest — mis-route), **rejected** (DA refuses, e.g. damaged). Each raises `HANDOFF_DISCREPANCY` → M11 ticket + M10 SLA flag; the item goes `EXCEPTION`; physical parcel handled per type (carry-back, return to sort, quarantine).
+
+### 13.4 Failure modes (`M6-D-021`)
+
+| Failure | Detection | Response | Escalation |
+|---------|-----------|----------|------------|
+| **DA no-show** at the stop | dwell window expires, no DA scan | deliveries carried back / next loop; collections deferred | if deadline at risk → M10 + M11; station manager |
+| **Van breakdown** mid-loop | telemetry stalls / driver reports | dispatch **recovery van** to transfer the manifest at the van's position; recompute affected ETAs/deadlines | `VAN_BREAKDOWN` → M10 + station manager; ad-hoc van needs approval |
+| **Mis-sort** (wrong parcel on van) | load reconciliation or stop "extra" | carry back to hub sort; rebind | `HANDOFF_DISCREPANCY` → M11 |
+| **Lost / damaged on van** | reconciliation shortfall at unload | van leg owns the gap (custody node, `M6-D-014`); investigation | M11; attributed to van/driver |
+| **Loop overflow** | binding can't fit a parcel | §12.4 bump/escalate | `LOOP_OVERFLOW` → M10 + station manager |
+
+### 13.5 Recovery van
+A recovery van is an unplanned vehicle dispatched on station-manager approval to take over a broken van's manifest. M6 transfers the manifest (custody re-assigned to the recovery van's ID, append-only), recomputes deadlines, and rebinds any now-infeasible parcels (§12.4). This is the only sanctioned intraday fleet change (NFR-3).
+
+---
+
+## 14. Live Van Tracking & Telemetry
+
+Run-time half of M6 (`M6-D-011`). Plan-time says "Van 1 *will* reach V5 at 07:50"; run-time says "Van 1 *arrived* V5 at 07:58 — 8 min late."
+
+### 14.1 Telemetry travels by HTTP, never Kafka (`M6-D-012`)
+The van-driver app is a **separate mobile client**. It POSTs to an M6 endpoint — Kafka stays private inside our infra.
+
+```
+[Van phone] every ~10s
+  POST /api/v1/van/{vanId}/telemetry  { lat, lon, type, time, [parcel_scan], [da_id] }
+      │  (ordinary HTTPS)
+      ▼
+[Monolith] routing/api/VanTelemetryController
+      │  (in-process — same app, free)
+      ▼
+  routing/service/VanTrackingService   → update live position; compare to plan; reconcile scans
+      │  ONLY on meaningful change
+      ▼
+  routing/events/*Producer ──► Kafka oneday.cron.events
+      │
+      ▼  M5 (cron feasibility) · M10 (SLA) · M4 (custody state) · M11 (exceptions) · ops map
+```
+
+- **Monolith intact:** a phone client doesn't make the backend non-monolithic; it's just a client.
+- **One API door:** `POST .../telemetry` carries GPS pings *and* scan events (`type` discriminates).
+- **Raw GPS pings stay in-process;** only `VAN_ARRIVED`, `VAN_RUNNING_LATE`, `HANDOFF_COMPLETED`, `HANDOFF_DISCREPANCY`, `VAN_BREAKDOWN`, `LOOP_OVERFLOW` reach Kafka.
+
+### 14.2 Components (`routing` module)
+
+| File | Role |
+|------|------|
+| `api/VanTelemetryController` | the HTTPS door the app POSTs to (GPS + scans) |
+| `service/VanTrackingService` | brain: position, plan-vs-actual ETA, scan reconciliation, deviation decision |
+| `service/VanManifestService` | build/seal manifests, bind parcels (§12), apply overflow |
+| `domain/VanLiveStatus` | latest position + lateness per van (overwritten; powers the map) |
+| `events/RouteDeviationProducer` / `HandoffProducer` | publish run-time events |
+
+```java
+@Service
+class VanTrackingService {
+    void handle(UUID vanId, VanTelemetryEvent e) {
+        liveByVan.get(vanId).update(e.lat(), e.lon(), e.time());        // 1. always: position
+        switch (e.type()) {
+            case GPS -> {}                                              //    nothing else
+            case ARRIVED_AT_STOP -> openDwellAndCheckLateness(vanId, e);// 2. ETA vs plan
+            case DELIVER, COLLECT -> manifest.reconcileScan(vanId, e);  // 3. custody (§11)
+            case DEPARTED_STOP -> manifest.closeStop(vanId, e);         //    reconcile stop
+        }
+    }
+}
+```
+
+### 14.3 Downstream — M5 (re-check cron feasibility on lateness), M10 (SLA), M4 (custody transitions), M11 (discrepancies), ops/M4 (live map from `VanLiveStatus`).
+
+### 14.4 Plan-vs-actual ETA
+On `ARRIVED_AT_STOP`, lateness = actual − planned; the slip propagates to this van's remaining stops; if it threatens any DA handoff or a parcel deadline ⇒ `VAN_RUNNING_LATE` with the new ETAs.
+
+### 14.5 Cost — effectively free
+~100 vans total (≈20×5). API ≈ 10 req/s (trivial); raw pings never on Kafka, only ~few-thousand meaningful events/day (cents); only latest position stored (overwrite); mobile data a few MB/van/day (driver's plan, batchable). The trap to avoid: fanning raw pings through a per-message queue.
+
+---
+
+## 15. Van-Driver App Workflow
+
+M6 owns the driver-side contract (`M6-D-020`), parallel to M5's DA app. The app is a thin client over §17.2 APIs.
+
+```
+1. LOGIN            M1 van-driver role, city-scoped JWT → today's route + loop timetable.
+2. LOAD (at hub)    App lists this loop's outbound manifest. Driver scans each parcel onto the van
+                    (VAN_LOAD). App enforces reverse-stop-order loading. Manifest sealed → LOADED.
+3. DEPART           Driver confirms; VAN_DEPARTED_HUB. Background GPS pings begin (~10s).
+4. NAVIGATE         Turn-by-turn to next vertex (OSRM/maps). ETA shown vs plan.
+5. AT STOP          App shows, per DA at this vertex:
+                      • DELIVER list (scan out, hand over)          → VAN_TO_DA
+                      • COLLECT (scan in DA's parcels)              → DA_TO_VAN
+                    Per-DA reconcile; flag missing/extra/rejected. Confirm stop.
+6. REPEAT 4–5 for all stops in the loop.
+7. RETURN (hub)     Scan collections off the van (VAN_UNLOAD). Manifest → RETURNED.
+                    Hub operator (M7) takes custody → AT_ORIGIN_HUB; manifest RECONCILED.
+8. NEXT LOOP        Repeat from 2 for the next loop, all day.
+EXCEPTIONS          Report breakdown / discrepancy from any screen → §13.
+```
+
+The app talks only to M6 over HTTPS; M6 emits the Kafka events others consume. The driver never sees Kafka.
+
+---
+
+# Part III — Integration & Governance
+
+## 16. Cross-Module RACI & Contracts
+
+The custody chain crosses M5/M6/M7/M8/M4/M9/M11. Drawing this boundary first is what unblocks everything in Part II.
+
+| Concern | M6 (van) | M5 (DA) | M7 (hub) | M8 (scan) | M4 (state) | M9 (air) |
+|---------|---------|---------|----------|-----------|-----------|----------|
+| Route plan / cron schedule | **Own** | consume | — | — | — | — |
+| What's ready to load (deliver) | consume | — | **Own** (sort output) | — | — | — |
+| Van load (hub→van) | **Own** manifest | — | physical dock | record scan | transition | — |
+| Van→DA deliver handoff | **Own** (driver side) | DA side | — | record scan | transition | — |
+| DA→van collect handoff | van side | **Own** (DA side) | — | record scan | transition | — |
+| Van→hub unload | **Own** manifest close | — | physical dock + sort | record scan | transition | — |
+| Parcel→loop binding | **Own** | feeds accumulation | feeds sort output | — | provides SLA | provides cutoff |
+| Live van position / deviation | **Own** | consume | — | — | consume | — |
+| Discrepancy / failure ticket | originate | — | — | — | — | — |
+| Flight-bag shuttle | **Own** timetable | — | provides bags | record | — | consume cutoff |
+| SLA judgement | feed | feed | feed | feed | feed | feed → **M10** |
+| Exception workflow | feed | feed | feed | — | — | feed → **M11** |
+
+**Key boundary calls:**
+- **The van manifest is M6's**, built from M7's sort output. M7 owns the physical dock; M6 owns "what should be on which van."
+- **The van is a scan node in M8.** M6 originates `VAN_LOAD / VAN_TO_DA / DA_TO_VAN / VAN_UNLOAD`; M8 stores them immutably; M4 maps them to state.
+- **Handoff is two-owner by side:** M6 owns the driver's scans, M5 owns the DA's scans; reconciliation (matching the two) is M6's at the van level.
+- **Integration note (`M6-D-008`):** M5's `da_cron_assignment` holds one meeting time; M6 emits the day's list — M5 stores the list and picks the next, or calls `GET /routing/cron/da/{daId}/next`. To confirm with M5 owner.
+
+---
+
+## 17. Contracts — Events, APIs, Data Model
+
+### 17.1 Events (Kafka)
+
+On the reserved `oneday.cron.events` (`common.kafka.KafkaTopics.CRON_EVENTS`, `// M6`), discriminated by a new `common` enum `CronEventType`:
+
+```
+CronEventType:
+  // ── plan-time ──
+  DA_CRON_SCHEDULED      DA's vertex + day's meeting times                 → M5
+  SHUTTLE_SCHEDULED      hub↔airport shuttle timetable                     → M9, M10
+  ROUTE_PLAN_PUBLISHED   a city's van plan is approved & active            → M10, van app
+  ROUTE_CHANGED          intraday override took effect                     → M5, M10, station mgr
+  // ── run-time: tracking ──
+  VAN_ARRIVED            van reached a meeting vertex                      → M10, ops
+  VAN_RUNNING_LATE       live ETA slipped past threshold                   → M5, M10, ops
+  // ── run-time: custody & failures ──
+  HANDOFF_COMPLETED      a stop's per-DA handoff reconciled OK             → M4, M10
+  HANDOFF_DISCREPANCY    missing/extra/rejected parcel at a stop           → M11, M10
+  LOOP_OVERFLOW          a parcel can't fit a feasible loop before deadline→ M10, station mgr
+  VAN_BREAKDOWN          van disabled mid-loop                             → M10, station mgr, M11
+```
+
+Custody **scans** are written to **M8's `scan.event` ledger** (`VAN_LOAD/VAN_TO_DA/DA_TO_VAN/VAN_UNLOAD`), not duplicated on `cron.events`. Raw GPS pings are **not** events (`M6-D-012`).
+
+**`DA_CRON_SCHEDULED` payload:**
+```json
+{ "cityId":"...","validDate":"2026-06-07","daId":"...","cronVertexId":"...",
+  "meetingLat":12.97,"meetingLon":77.61,
+  "meetingTimes":["07:30","10:00","12:30","15:00","17:30"],
+  "vanId":"...","routePlanId":"..." }
+```
+
+### 17.2 REST API
+
+```
+# planning / queries
+GET  /routing/plans/{cityId}?date=                 plan + recommended_van_count
+GET  /routing/plans/{cityId}/vans/{vanId}/stops    ordered stops + ETAs
+GET  /routing/cron/da/{daId}?date=                 DA vertex + meeting times (M5)
+GET  /routing/cron/da/{daId}/next?at=              single next meeting (M5 convenience)
+GET  /routing/shuttle/{cityId}?date=               shuttle timetable (M9)
+POST /routing/plans/{planId}/approve               station mgr / admin (city-scoped, M1)
+POST /routing/plans/{planId}/override              append-only revision + audit
+POST /routing/plans/{cityId}/replan                force re-solve (admin)
+# manifest / execution
+GET  /routing/vans/{vanId}/manifest?loop=          this loop's load/collect manifest (driver app)
+POST /routing/vans/{vanId}/recovery                dispatch recovery van (station mgr, §13.5)
+# run-time
+POST /api/v1/van/{vanId}/telemetry                 GPS pings + DELIVER/COLLECT scans (driver app)
+GET  /routing/vans/{cityId}/live                   live positions + lateness (ops map)
+```
+
+### 17.3 Data model (Flyway `V6_*`)
+
+```
+city_logistics_node        id, city_id, kind(HUB|AIRPORT), lat, lon, name              [M6-D-007]
+city_fleet_config          id, city_id, vans_available, capacity_packets,
+                           cycle_time_min/max_minutes, shuttle_cadence_minutes,
+                           max_da_to_vertex_minutes, dwell_minutes                      [M6-D-005/019]
+
+route_plan                 id, city_id, valid_for_date, status(PROPOSED|APPROVED|SUPERSEDED|REJECTED),
+                           source(NIGHTLY|MANUAL_OVERRIDE|FALLBACK), solver_type,
+                           vans_used, recommended_van_count, provisioning_flag,
+                           n_loops, realised_cycle_minutes, notes, approved_by/at, created_at  [append-only]
+route_plan_stop            id, route_plan_id, van_id, loop_index, stop_seq,
+                           node_kind(HUB|MEETING_VERTEX), hex_vertex_id,
+                           planned_arrival/departure, deliver_qty, collect_qty, load_after
+da_cron_schedule           id, route_plan_id, da_id, hex_vertex_id, van_id,
+                           meeting_times(jsonb), city_id, valid_date
+route_override_audit       id, route_plan_id, actor_id, action, before_json, after_json, reason, created_at [append-only]
+
+# ── execution / custody (Part II) ──
+van_manifest               id, route_plan_id, van_id, loop_index, valid_date,
+                           status(BUILDING|LOADED|IN_PROGRESS|RETURNED|RECONCILED),
+                           departed_at, returned_at                                     [M6-D-015]
+van_manifest_item          id, manifest_id, parcel_id, direction(DELIVER|COLLECT),
+                           stop_seq, meeting_vertex_id, counterparty_da_id, sla_deadline,
+                           status(PLANNED|LOADED|ONBOARD|HANDED_OFF|RECONCILED|EXCEPTION),
+                           loaded_at, handed_off_at                                     [M6-D-014]
+handoff_reconciliation     id, manifest_id, stop_seq, da_id, expected_count, actual_count,
+                           discrepancy_type(MISSING|EXTRA|REJECTED|NONE),
+                           discrepancy_parcel_ids(jsonb), reason, created_at            [append-only, M6-D-018]
+van_live_status            van_id(pk), city_id, route_plan_id, last_lat, last_lon,
+                           last_seen_at, current_stop_seq, minutes_late                 [overwritten, M6-D-012]
+```
+
+Custody scans live in **M8's ledger**, referenced by `parcel_id` + scan type — not duplicated here. `h3_hex_travel_time` is not reused (`M6-D-009`).
+
+---
+
+## 18. Constraint Catalogue
+
+| # | Constraint | Hard/Soft | Notes |
+|---|-----------|-----------|-------|
+| C1 | Coverage — every territory reachable from ≥1 visited vertex | Hard | set-cover §7.2 |
+| C2 | Capacity — peak load ≤ `capacity_packets` (VRPSPD) | Hard | M6-D-002 |
+| C3 | Cycle time — loop span ≤ `cycle_time_max` (3h), target 2h | Hard / soft | M6-D-003; van never waits past dwell (C7) |
+| C4 | Hub anchoring — every loop starts & ends at hub | Hard | depot |
+| C5 | DA reachability — DA→vertex ≤ `max_da_to_vertex_minutes` | Hard | NFR-4 |
+| C6 | Meeting-time spacing ≥ M5 `CRON_FREEZE_MINUTES` (30m) | Hard | M5 §8.3 |
+| C7 | Dwell window — bounded per stop (`dwell_minutes`) | Hard | M6-D-019 |
+| C8 | 70/30 demand weighting | — | M6-D-004 |
+| C9 | SLA-first binding — earliest deadline-feasible loop | Hard | M6-D-016 |
+| C10 | Parcel deadline — delivery SLA (last-mile) / cutoff-derived hub-arrival (first-mile) | Hard | M6-D-016; §12.2 budget = Q2 |
+| C11 | Capacity overflow → bump then escalate, never drop SLA | Hard | M6-D-017 |
+| C12 | Custody continuity — every parcel scanned at all 4 points; never "nowhere" | Hard | M6-D-014 |
+| C13 | Handoff reconciliation — expected = actual or exception | Hard | M6-D-018 |
+| C14 | Per-parcel cost floor (cost-aware routing) | Soft | M6-D-010; stub until M2 |
+| C15 | City scoping — all data carries `city_id`; overrides city-bounded | Hard | NFR-5, M1 |
+| C16 | Fleet — route within `vans_available`; also recommend | Hard / advisory | M6-D-005 |
+| C17 | Append-only — plans, overrides, reconciliations, scans never mutate | Hard | NFR-1/2 |
+| C18 | One sanctioned intraday fleet change — the recovery van, on approval | Hard | M6-D-021, NFR-3 |
+
+---
+
+## 19. Open Questions
+
+| # | Question | Why | Leaning |
+|---|----------|-----|---------|
+| Q1 | When does the shuttle become flight-cutoff-driven? | M9 coupling | fixed cadence v1; `FlightCutoffPort` |
+| Q2 | End-to-end budget: loop + sort(M7) + bag + shuttle ≤ cutoff(M9)? Who owns the split? | makes 2–3h feasible & sets first-mile deadlines (C10) | define with M7/M9/M10 |
+| Q3 | Is first-mile vs last-mile demand directional/asymmetric per territory? | peak-load maths | symmetric v1; refine on M4 history |
+| Q4 | `max_da_to_vertex_minutes` value | consolidation vs DA util | ~10–12 min; calibrate |
+| Q5 | Cycle time (2–3h hard?) & per-city operating window | sets `n_loops`, fleet | 2h target / 3h max, 07:00–20:00, configurable |
+| Q6 | One vertex per DA per day, or per-loop variation? | set-cover model | one fixed vertex/day v1 |
+| Q7 | One bidirectional fleet, or separate origin/destination vans? | fleet doubling | single bidirectional fleet |
+| Q8 | Driver shifts vs 16h window — break constraints? | VRPTW breaks | out of scope v1; flag |
+| Q9 | `dwell_minutes` value & late-DA grace | stop choreography (C7, §13.2) | ~5 min; calibrate |
+| Q10 | Overflow policy: bump-only vs auto-recommend ad-hoc van threshold | back-pressure (§12.4) | bump + recommend; ad-hoc needs approval |
+| Q11 | Recovery-van SLA — how fast must one reach a broken van? | §13.5 | ops policy; flag |
+| Q12 | Is the van a distinct M8 scan-location type, or reuse hub/DA types? | M8 schema | new VAN scan node — confirm with M8 |
+| Q13 | Mis-sort / rejected-parcel physical handling (quarantine vs immediate return) | §13.3 | with M7/M11 |
+| Q14 | Driver identity vs van identity — does custody attach to driver or vehicle? | liability (§13.4 loss) | van + driver on each scan; confirm with M1 |
+
+---
+
+## 20. Phase Plan
+
+| Phase | Deliverable |
+|-------|-------------|
+| **P1** | Skeleton; `common.CronEventType`; injectable `Clock` (M6-D-013); Flyway `V6_*` (§17.3); seed `city_logistics_node` + `city_fleet_config` for 5 cities. |
+| **P2** | Input adapters (M3 territories/vertices/demand); `OsrmClient` node-set matrix; stub ports (`CostFloorPort`, `FlightCutoffPort`, `HubSortPort`, `DaAccumulationPort`). |
+| **P3** | Stages 1–2: demand aggregation + meeting-point set-cover. |
+| **P4** | Stage 3: OR-Tools CVRP+TW+pickup/delivery; Clarke–Wright fallback. |
+| **P5** | Stages 4–5: periodise, per-DA cron, persist plan. |
+| **P6** | Fleet-sizing recommendation + `UNDER_PROVISIONED`. |
+| **P7** | `NightlyRoutePlanJob` + approval/fallback/override REST + audit. |
+| **P8** | Shuttle timetable + `SHUTTLE_SCHEDULED`. |
+| **P9** | **Manifest engine** (`VanManifestService`): parcel→loop binding (§12), SLA-first, overflow. |
+| **P10** | **Custody scans** (§11): the four scan points → M8 ledger contract + M4 transitions; reconciliation. |
+| **P11** | **Handoff protocol & failures** (§13): dwell, multi-DA, discrepancies, no-show, breakdown, recovery van. |
+| **P12** | Telemetry ingestion: `VanTelemetryController` + `VanTrackingService` + `VanLiveStatus`; in-process path; live API. |
+| **P13** | Plan-vs-actual + run-time event producers (`VAN_ARRIVED/RUNNING_LATE/HANDOFF_*/LOOP_OVERFLOW/VAN_BREAKDOWN`). |
+| **P14** | Van-driver app contract (§15) end-to-end against stubs; Kafka producers wired; integration test with mock M5/M7/M8 consumers. |
+| **P15** | End-to-end seeded-city run + calibration of Q4/Q5/Q9/Q10 constants. |
+
+---
+
+## 21. Testing & Simulation
+
+You can't put 100 real vans/DAs on the road per change, so M6 (and M5–M11) test against a **synthetic world** — fake producers talking to the *real* modules over the same Kafka/HTTP. The event-bus architecture is what makes this possible: real consumers can't tell synthetic events from real ones.
+
+**21.1 Injectable clock (`M6-D-013`).** All time via a `Clock` bean ⇒ a 16h day runs in seconds; lands in P1 (retrofitting is painful).
+
+**21.2 Fake-world producers (test-only `simulator`).** Only publish events / call public APIs — never touch internals.
+
+| Fake producer | Emulates | Feeds |
+|---|---|---|
+| Booking generator | bookings | M4 → M5, M2 |
+| Virtual DA | DA GPS + pickup/delivery + handoff scans | M5, M6, M8 |
+| **Virtual van** | van telemetry (GPS), load/deliver/collect/unload scans | **M6**, M10 |
+| Virtual hub | sort output + dock load/unload | M6, M7, M8 |
+| Flight feed stub | flight status / cutoff | M9 |
+| Failure injector | DA no-show, van breakdown, mis-sort, demand spike | M6, M11, M10 |
+
+**21.3 The virtual van (emulating the tracking + scan API).** Reads a published plan + manifest; interpolates a GPS point per simulated 10s along OSRM geometry; POSTs to the real `/api/v1/van/{vanId}/telemetry`; fires `ARRIVED_AT_STOP`, then `DELIVER`/`COLLECT` scans per the manifest. `VanTrackingService` can't tell it from a real driver. Inject a slowdown ⇒ assert `VAN_RUNNING_LATE` → M5 re-checks feasibility → M10 amber. Inject a missing scan ⇒ assert `HANDOFF_DISCREPANCY` → M11.
+
+**21.4 Test pyramid.** Unit (set-cover, peak-load capacity, binding deadline maths) → Contract (event schemas, Testcontainers Kafka+Postgres, the M3/M4 pattern) → Integration (boot monolith, synthetic events, assert DB + M4 state) → **Simulation ("virtual day")** (seed grid+plan+manifests; N virtual DAs + M virtual vans; accelerated clock; assert invariants: no cron missed unless injected, custody continuity C12 holds, overflow escalates not drops, RTO after exactly N attempts).
+
+**21.5 Fault library.** Late van → `VAN_RUNNING_LATE` → M5 defer + M10 amber · van late past dwell → handoff partial + DA next loop · DA no-show → carry-back + escalate · missing/extra scan → `HANDOFF_DISCREPANCY` → M11 · demand spike → `LOOP_OVERFLOW` → bump/escalate · breakdown → recovery van · flight delay → M9 rebind first-mile deadlines.
+
+**21.6 Rollout ladder.** **Simulation (offline)** → **shadow** (new planner on real live events, output logged not acted on, compared to live) → **canary** (one city — design is city-scoped) → **full**. The durable Kafka log also enables **replay** of a recorded real day for deterministic before/after comparison. This is the standard Uber/DoorDash dispatch-change playbook.
+
+---
+
+*Draft v0.3. M6 now owns the full van lifecycle: routing + scheduling (Part I), parcel custody + manifest + binding + handoff + failures (Part II), and integration/governance (Part III). Decisions M6-D-001…021, constraints C1…C18, open questions Q1…Q14. Sharpest items for next review: the end-to-end timing budget (Q2, gates first-mile deadlines), the M6↔M7↔M8 custody boundary (§16), and the overflow/recovery policies (Q10–Q11).*

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -14,7 +14,7 @@
 | M3 | [Serviceability & Grid Management](#m3-serviceability--grid-management) | Rectangular tile grid over urban pincodes; dynamic rebalancing |
 | M4 | [Order Booking & Shipment Lifecycle](#m4-order-booking--shipment-lifecycle) | Customer-facing booking, ETA promise, and canonical order state machine |
 | M5 | [DA Assignment & Dispatch](#m5-da-assignment--dispatch) | Real-time delivery associate queue, assignment, and cron-meeting constraint |
-| M6 | [Van Routing & Scheduling](#m6-van-routing--scheduling) | Nightly route plan for hub consolidation vans on the grid graph |
+| M6 | [Van Routing & Scheduling](#m6-van-routing--scheduling) | Nightly bidirectional milk-run plan for consolidation vans + live van tracking |
 | M7 | [Hub Operations & Sortation](#m7-hub-operations--sortation) | Inbound sort, stand assignment, bag creation, and system manifests |
 | M8 | [Barcode, Label & Scanning](#m8-barcode-label--scanning) | Unique parcel identity, label generation, and scan-event ledger |
 | M9 | [Airline & Flight Integration](#m9-airline--flight-integration) | Flight schedule, hub-level assignment, handover tracking, and GHA APIs |
@@ -198,35 +198,59 @@
 
 ## M6 — Van Routing & Scheduling
 
+> **Full design:** [`docs/M6/M6-ROUTING-DESIGN.md`](./M6/M6-ROUTING-DESIGN.md) (titled *Van Routing, Scheduling & Custody*). This summary was **expanded after design**: M6 owns the **whole van lifecycle**, not a nightly batch. Three parts — **plan-time** (nightly routing/scheduling), **execution** (parcel custody, manifests, binding, handoff, failures), and **run-time** (live tracking). The van is treated as a **mobile mini-hub** (a moving cross-dock), not a vehicle moving abstract counts.
+
 ### Business Logic / Requirements
-- Compute an **ordered sequence of stops** for each hub consolidation van covering its assigned grid area.
-- Route graph: van stops are at **grid vertices** (tile corners / defined stop points from M3).
-- **Nightly replan is the default:** routes are re-optimised once per night and locked for the following operating day. Intraday changes are strongly discouraged.
-  - If an intraday change is genuinely required, it must **notify the station manager** and (depending on severity) require **approval** before taking effect.
-- Route optimisation uses the same **70% historical / 30% current** weighting spirit as grid sizing (shared planning philosophy).
-- Key constraints for the optimiser:
-  - **Packet count** on the run (van capacity).
-  - **Time window to reach hub** (or SLA for that leg).
-  - **Per-parcel cost floor** from M2 (cost-aware routing).
-- **Admin and station manager** can manually override any route at any time with audit log entry.
+
+**Planning (plan-time)**
+- **Bidirectional consolidation milk-run:** each van loop *both* **delivers** last-mile parcels to DAs and **collects** first-mile parcels from them at the same meeting stops (simultaneous pickup-and-delivery). The binding capacity limit is the *peak* load along the loop, not the net.
+- **Meeting points at grid vertices:** van stops at H3 hex vertices (M3), chosen at vertices **shared by multiple DA territories** so one stop serves several DAs (a set-cover step in M6).
+- **Periodic loops, fixed nightly:** `hub → meeting points → hub` at a target **2–3h cycle**, repeating through the ~16h day. Route *shape* replanned nightly and locked; loop *repeats* on a cadence.
+- **70/30 weighting** (shared with grid sizing), reusing M3's demand snapshot.
+- **Fleet sizing:** count + capacity are ops inputs; M6 also computes a **recommended van count** and flags under-provisioning.
+- **Hub↔airport shuttle:** M6 owns the periodic shuttle timetable (fixed cadence v1; flight-cutoff-driven once M9 lands); the shuttle carries sealed flight bags.
+- **Hub & airport location:** M6 introduces per-city hub/airport coordinates — not stored before.
+- **Nightly replan + approval + override** (mirrors M3 governance; append-only audit).
+
+**Execution (custody — the van as mini-hub)**
+- **Four custody scans per parcel:** LOAD (hub→van), DELIVER (van→DA), COLLECT (DA→van), UNLOAD (van→hub) — each an M8 scan + an M4 state transition. The parcel is never "nowhere": between scans it is *on a specific van/loop*.
+- **Van manifest:** M6 builds the per-van, per-loop manifest (which specific parcels ride, to/from which DA, at which stop) from M7's sort output (deliver) + DA accumulation (collect). Parcels loaded in reverse stop-order.
+- **Parcel→loop binding:** SLA-first, then capacity-bounded — earliest deadline-feasible loop, not "next loop with room". Runtime **overflow → bump then escalate**, never silently drop SLA.
+- **Handoff protocol:** bounded dwell window per stop; multi-DA choreography; scan-reconciliation (expected = actual) per DA; discrepancies → M11.
+- **Failure handling:** DA no-show, van breakdown (recovery van on approval), mis-sort, lost/damaged-on-van — each with detection, carry-back/recovery, escalation.
+
+**Run-time (tracking)**
+- **Live van tracking:** M6 ingests telemetry (GPS + scans) over an HTTP API, maintains live position, compares plan-vs-actual, emits deviation ("van running late / arrived"). Raw GPS stays in-process; only meaningful events go on Kafka. M6 owns this; M10 *consumes* deviation for SLA.
+- **Van-driver app contract:** M6 owns the driver-side load/navigate/scan/confirm/return workflow (parallel to M5 owning the DA app).
 
 ### Inputs
 | Input | Source |
 |-------|--------|
-| Grid vertex list per city | M3 |
-| Historical stop + demand data (7+ days) | M4 order history |
-| Current-day order demand | M4 live feed |
-| Van capacity (max packets) | Fleet configuration |
-| Hub operating time window | Hub ops configuration |
+| DA territories (DA → hexes) + grid vertices | M3 |
+| Historical + current-day demand (70/30 blend) | M3 demand snapshot (from M4 order history) |
+| Van count + capacity per city | Fleet configuration (M6) |
+| Hub + airport coordinates per city | Ops configuration (M6) |
+| Operating window / hub time window | Hub / ops configuration |
+| Parcels sorted & ready to load (deliver) | M7 sort output |
+| First-mile parcels accumulated per DA | M5 / M4 |
+| Parcel delivery SLA / flight cutoff (parcel deadlines) | M4 (SLA), M9 (cutoff) |
 | Per-parcel cost floor | M2 |
-| Manual override action | Station manager / admin (M1) |
+| Manual override / recovery-van action | Station manager / admin (M1) |
+| Live van telemetry (GPS + custody scans) | Van-driver app (HTTP) |
 
 ### Outputs
 | Output | Consumer |
 |--------|----------|
-| Nightly route plan per van (ordered stop list, ETA per stop) | Van driver app, M5 (cron meeting point), M10 |
-| Route-change notification | Station manager notification, M10 |
-| Route override audit log entry | M1 audit log |
+| Nightly route plan per van (ordered stops, per-stop ETA) | Van driver app, M10 |
+| Per-DA cron schedule (meeting vertex + meeting times) | M5 (cron-meeting constraint) |
+| Hub↔airport shuttle timetable (cron departure times) | M9, M10 |
+| Recommended fleet size / under-provisioning flag | Station manager / ops |
+| Van manifest (per van/loop: parcels, direction, stop, DA) | Van driver app, M7 (load/unload) |
+| Custody scan events (LOAD/DELIVER/COLLECT/UNLOAD) | M8 (ledger), M4 (state) |
+| Handoff reconciliation + discrepancy events | M11 (exceptions), M10 (SLA) |
+| Loop-overflow / van-breakdown / recovery events | M10, M11, station manager |
+| Live van position + "running late / arrived" deviation events | M5 (cron feasibility), M10 (SLA), M4 / ops live map |
+| Route-change notification + override audit | Station manager, M10, M1 audit log |
 
 ---
 
@@ -490,7 +514,7 @@ How each module maps to an entity type within the codebase (assuming a **modular
 | **M3 — Grid** | Domain service + admin UI | Owns its own data (tile definitions, pincode lists). Config-heavy. Driven by nightly batch jobs (replan) and approval workflows. |
 | **M4 — Orders** | Core API service | The primary customer-facing layer. Owns the canonical state machine. Accepts HTTP requests from customers and B2B users. All other modules feed state back into it via events. |
 | **M5 — DA Assignment** | Background worker / real-time engine | Reacts to incoming `shipment.created` events; latency-sensitive (assignment must be fast). Manages the in-memory or DB-backed priority queue per DA. Always running. |
-| **M6 — Van Routing** | Scheduled batch job (cron) | Runs once per night. Pure compute on graph data. Not latency-sensitive. Can be a standalone script triggered by a scheduler (e.g. cron, Celery beat). |
+| **M6 — Van Routing & Scheduling** | Nightly batch job **+ always-on tracking service** | Two halves. *Plan-time:* a nightly batch that plans routes — pure graph compute, not latency-sensitive. *Run-time:* an always-on service that ingests live van telemetry (HTTP), tracks plan-vs-actual, and emits deviation events through the operating day. The batch fires nightly; the tracking half is always on. (The "runs once per night" framing in v0.2 of this doc was incomplete — see `docs/M6/M6-ROUTING-DESIGN.md` §11.) |
 | **M7 — Hub Ops** | Domain service + operator UI | Workflow-heavy for human operators. Owns stand and bag data. Reacts to scan events and flight status changes. Both an event consumer and a UI-backed workflow tool. |
 | **M8 — Barcode** | Utility library + append-only event store | Label generation is a pure function (shipment data in → printable label out). Scan events are an append-only ledger — never updated, only appended. |
 | **M9 — Airline** | Integration adapter / poller | Wraps external airline and GHA APIs. Translates their data model into internal events. Runs as a background poller (fetch flight status every N minutes) and publishes `flight.status_changed` events. |

--- a/orders/src/main/java/com/oneday/orders/events/CronEventsConsumer.java
+++ b/orders/src/main/java/com/oneday/orders/events/CronEventsConsumer.java
@@ -1,36 +1,33 @@
 package com.oneday.orders.events;
 
-import com.oneday.common.domain.enums.ShipmentState;
 import com.oneday.common.kafka.KafkaTopics;
 import com.oneday.common.kafka.events.CronEvent;
-import com.oneday.orders.service.ShipmentStateMachine;
-import com.oneday.orders.service.TransitionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
 /**
- * Consumes M6 cron (van-leg departure) events from {@code oneday.cron.events} and drives the
- * M4 state machine. Dormant by default ({@code autoStartup=false}) until M6 produces on this topic.
+ * Consumes M6 routing events from {@code oneday.cron.events}. Dormant by default
+ * ({@code autoStartup=false}) until M6 produces on this topic.
+ *
+ * <p>The {@link com.oneday.common.kafka.enums.CronEventType} discriminator was redefined for
+ * M6's full van lifecycle (design §17.1). Of those, only {@code HANDOFF_COMPLETED} concerns M4 —
+ * but per-shipment custody transitions ({@code HANDED_TO_DROP_VAN}, {@code DROP_COLLECTED}, …)
+ * are driven by the <strong>M8 scan ledger</strong> ({@code oneday.scan.events}), not this topic.
+ * So this consumer logs and ignores for now; the concrete cron→M4 mapping is settled with the
+ * M6 producer PRs and the M4 owner. Kept (dormant) so the wiring + topic subscription survive.</p>
  */
 @Component
 public class CronEventsConsumer {
 
-    private static final String SOURCE = "m6-cron-consumer";
-
-    private final ShipmentStateMachine stateMachine;
-
-    CronEventsConsumer(ShipmentStateMachine stateMachine) {
-        this.stateMachine = stateMachine;
-    }
+    private static final Logger log = LoggerFactory.getLogger(CronEventsConsumer.class);
 
     @KafkaListener(topics = KafkaTopics.CRON_EVENTS, groupId = "orders-service",
             autoStartup = "${orders.kafka.consumer.auto-startup:false}")
     public void onCronEvent(CronEvent event) {
-        ShipmentState target = switch (event.eventType()) {
-            case DEPARTED_HUB     -> ShipmentState.DISPATCHED_TO_AIRPORT;
-            case DEPARTED_AIRPORT -> ShipmentState.DISPATCHED_TO_HUB;
-        };
-        stateMachine.transition(event.shipmentId(), target,
-                TransitionContext.fromKafka(SOURCE, String.valueOf(event.shipmentId())));
+        // TODO(M6): map the cron events M4 acts on once the M6 producer contract is finalized.
+        log.debug("Received cron event type={} shipmentId={} — no M4 transition wired yet",
+                event.eventTypeName(), event.shipmentId());
     }
 }

--- a/routing/pom.xml
+++ b/routing/pom.xml
@@ -16,9 +16,43 @@
             <groupId>com.oneday</groupId>
             <artifactId>common</artifactId>
         </dependency>
+        <!-- M6 routes over M3's territories/vertices/demand; import only grid's public service interface. -->
         <dependency>
             <groupId>com.oneday</groupId>
             <artifactId>grid</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <!-- Test -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/routing/src/main/java/com/oneday/routing/config/ClockConfig.java
+++ b/routing/src/main/java/com/oneday/routing/config/ClockConfig.java
@@ -1,0 +1,26 @@
+package com.oneday.routing.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+import java.time.ZoneId;
+
+/**
+ * Single source of "now" for M6 (M6-D-013). Every service injects this {@link Clock} rather than
+ * calling {@code Instant.now()} so the simulation harness (§21) can drive a 16h day in seconds with
+ * a fixed/accelerated clock. {@code @ConditionalOnMissingBean} lets tests supply their own.
+ */
+@Configuration
+public class ClockConfig {
+
+    /** IST — the operating window (07:00–20:00) and all cron times are wall-clock India time. */
+    public static final ZoneId IST = ZoneId.of("Asia/Kolkata");
+
+    @Bean
+    @ConditionalOnMissingBean
+    public Clock clock() {
+        return Clock.system(IST);
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/config/RoutingProperties.java
+++ b/routing/src/main/java/com/oneday/routing/config/RoutingProperties.java
@@ -1,0 +1,70 @@
+package com.oneday.routing.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * M6 routing configuration (design §17.3 fleet/window/dwell knobs + the calibratable constants
+ * Q4/Q5/Q9). Per-city fleet rows live in {@code city_fleet_config}; these are engine-wide defaults.
+ */
+@Component
+@ConfigurationProperties(prefix = "routing")
+@Data
+public class RoutingProperties {
+
+    private Osrm osrm = new Osrm();
+    private Solver solver = new Solver();
+    private Cycle cycle = new Cycle();
+    private Shuttle shuttle = new Shuttle();
+    private Window window = new Window();
+
+    /** Dwell window per stop — the van never waits past it (C7, M6-D-019, Q9). */
+    private int dwellMinutes = 5;
+
+    /** DA→meeting-vertex reachability bound; protects the DA's 70% utilisation (C5, NFR-4, Q4). */
+    private int maxDaToVertexMinutes = 12;
+
+    /** Lateness past plan that escalates to VAN_RUNNING_LATE (§14.4). */
+    private int lateThresholdMinutes = 10;
+
+    /** Flat per-km van cost until M2's CostFloorPort lands (M6-D-010). INR. */
+    private double costPerKm = 15.0;
+
+    // Maps cityCode (e.g. "delhi") → fixed cityId UUID, shared with M3's grid.cities.
+    private Map<String, UUID> cities = new HashMap<>();
+
+    @Data
+    public static class Osrm {
+        // M6 builds its own travel matrix over {hub} ∪ vertices (∪ airport) — M6-D-009.
+        private String baseUrl = "http://localhost:5000";
+    }
+
+    @Data
+    public static class Solver {
+        private int timeLimitSeconds = 45;
+    }
+
+    @Data
+    public static class Cycle {
+        // Target 2h, hard max 3h (C3, M6-D-003, Q5).
+        private int minMinutes = 120;
+        private int maxMinutes = 180;
+    }
+
+    @Data
+    public static class Shuttle {
+        private int cadenceMinutes = 30;
+    }
+
+    @Data
+    public static class Window {
+        // Operating window, shared with M3's shift (07:00–20:00).
+        private int startHour = 7;
+        private int endHour = 20;
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/domain/CityFleetConfig.java
+++ b/routing/src/main/java/com/oneday/routing/domain/CityFleetConfig.java
@@ -1,0 +1,61 @@
+package com.oneday.routing.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.Instant;
+import java.util.UUID;
+
+// Per-city fleet + cycle/dwell knobs (M6-D-005/-019). Mutable — ops edits it.
+@Entity
+@Table(name = "city_fleet_config")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CityFleetConfig {
+
+    @Id
+    @UuidGenerator
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "city_id", nullable = false, updatable = false, unique = true)
+    private UUID cityId;
+
+    @Column(name = "vans_available", nullable = false)
+    private int vansAvailable;
+
+    @Column(name = "capacity_packets", nullable = false)
+    private int capacityPackets;
+
+    @Column(name = "cycle_time_min_minutes", nullable = false)
+    private int cycleTimeMinMinutes;
+
+    @Column(name = "cycle_time_max_minutes", nullable = false)
+    private int cycleTimeMaxMinutes;
+
+    @Column(name = "shuttle_cadence_minutes", nullable = false)
+    private int shuttleCadenceMinutes;
+
+    @Column(name = "max_da_to_vertex_minutes", nullable = false)
+    private int maxDaToVertexMinutes;
+
+    @Column(name = "dwell_minutes", nullable = false)
+    private int dwellMinutes;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    @PreUpdate
+    protected void touch() {
+        updatedAt = Instant.now();
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/domain/CityLogisticsNode.java
+++ b/routing/src/main/java/com/oneday/routing/domain/CityLogisticsNode.java
@@ -1,0 +1,54 @@
+package com.oneday.routing.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.Instant;
+import java.util.UUID;
+
+// Hub / airport coordinates per city (M6-D-007). One row per (city_id, kind).
+@Entity
+@Table(name = "city_logistics_node")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CityLogisticsNode {
+
+    @Id
+    @UuidGenerator
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "city_id", nullable = false, updatable = false)
+    private UUID cityId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "kind", nullable = false, length = 10, updatable = false)
+    private LogisticsNodeKind kind;
+
+    @Column(name = "lat", nullable = false)
+    private double lat;
+
+    @Column(name = "lon", nullable = false)
+    private double lon;
+
+    @Column(name = "name", nullable = false, length = 120)
+    private String name;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    protected void prePersist() {
+        if (createdAt == null) {
+            createdAt = Instant.now();
+        }
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/domain/DaCronSchedule.java
+++ b/routing/src/main/java/com/oneday/routing/domain/DaCronSchedule.java
@@ -1,0 +1,64 @@
+package com.oneday.routing.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.type.SqlTypes;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+// Append-only. Per DA: vertex + the day's meeting times → DA_CRON_SCHEDULED to M5 (M6-D-008).
+// meetingTimes is a JSON array of "HH:mm" strings; the service layer (de)serializes with Jackson.
+@Entity
+@Table(name = "da_cron_schedule")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DaCronSchedule {
+
+    @Id
+    @UuidGenerator
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "route_plan_id", nullable = false, updatable = false)
+    private UUID routePlanId;
+
+    @Column(name = "da_id", nullable = false, updatable = false)
+    private UUID daId;
+
+    @Column(name = "hex_vertex_id", nullable = false, updatable = false)
+    private UUID hexVertexId;
+
+    @Column(name = "van_id", updatable = false)
+    private UUID vanId;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "meeting_times", columnDefinition = "jsonb", nullable = false, updatable = false)
+    private String meetingTimes;
+
+    @Column(name = "city_id", nullable = false, updatable = false)
+    private UUID cityId;
+
+    @Column(name = "valid_date", nullable = false, updatable = false)
+    private LocalDate validDate;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    protected void prePersist() {
+        if (createdAt == null) {
+            createdAt = Instant.now();
+        }
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/domain/DiscrepancyType.java
+++ b/routing/src/main/java/com/oneday/routing/domain/DiscrepancyType.java
@@ -1,0 +1,9 @@
+package com.oneday.routing.domain;
+
+/** Reconciliation outcome at a handoff (§13.3, M6-D-018). */
+public enum DiscrepancyType {
+    NONE,
+    MISSING,    // manifest parcel not scanned
+    EXTRA,      // scanned parcel not on manifest (mis-route)
+    REJECTED    // DA refuses (e.g. damaged)
+}

--- a/routing/src/main/java/com/oneday/routing/domain/HandoffDirection.java
+++ b/routing/src/main/java/com/oneday/routing/domain/HandoffDirection.java
@@ -1,0 +1,7 @@
+package com.oneday.routing.domain;
+
+/** Direction of a manifest item at a meeting stop (§11.1). */
+public enum HandoffDirection {
+    DELIVER,   // van → DA (last-mile)
+    COLLECT    // DA → van (first-mile)
+}

--- a/routing/src/main/java/com/oneday/routing/domain/HandoffReconciliation.java
+++ b/routing/src/main/java/com/oneday/routing/domain/HandoffReconciliation.java
@@ -1,0 +1,67 @@
+package com.oneday.routing.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.type.SqlTypes;
+
+import java.time.Instant;
+import java.util.UUID;
+
+// Append-only (C17, M6-D-018). Per-stop, per-DA expected vs scanned reconciliation.
+// discrepancyParcelIds is a JSON array of parcel UUID strings (the service layer (de)serializes).
+@Entity
+@Table(name = "handoff_reconciliation")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HandoffReconciliation {
+
+    @Id
+    @UuidGenerator
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "manifest_id", nullable = false, updatable = false)
+    private UUID manifestId;
+
+    @Column(name = "stop_seq", nullable = false, updatable = false)
+    private int stopSeq;
+
+    @Column(name = "da_id", nullable = false, updatable = false)
+    private UUID daId;
+
+    @Column(name = "expected_count", nullable = false, updatable = false)
+    private int expectedCount;
+
+    @Column(name = "actual_count", nullable = false, updatable = false)
+    private int actualCount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "discrepancy_type", nullable = false, length = 20, updatable = false)
+    private DiscrepancyType discrepancyType;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "discrepancy_parcel_ids", columnDefinition = "jsonb", updatable = false)
+    private String discrepancyParcelIds;
+
+    @Column(name = "reason", columnDefinition = "text", updatable = false)
+    private String reason;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    protected void prePersist() {
+        if (createdAt == null) {
+            createdAt = Instant.now();
+        }
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/domain/LogisticsNodeKind.java
+++ b/routing/src/main/java/com/oneday/routing/domain/LogisticsNodeKind.java
@@ -1,0 +1,7 @@
+package com.oneday.routing.domain;
+
+/** Kind of fixed logistics node a city has (M6-D-007). */
+public enum LogisticsNodeKind {
+    HUB,
+    AIRPORT
+}

--- a/routing/src/main/java/com/oneday/routing/domain/ManifestItemStatus.java
+++ b/routing/src/main/java/com/oneday/routing/domain/ManifestItemStatus.java
@@ -1,0 +1,11 @@
+package com.oneday.routing.domain;
+
+/** Per-parcel manifest item status as it moves through the custody points (§11.2, M6-D-014). */
+public enum ManifestItemStatus {
+    PLANNED,
+    LOADED,
+    ONBOARD,
+    HANDED_OFF,
+    RECONCILED,
+    EXCEPTION
+}

--- a/routing/src/main/java/com/oneday/routing/domain/ManifestStatus.java
+++ b/routing/src/main/java/com/oneday/routing/domain/ManifestStatus.java
@@ -1,0 +1,10 @@
+package com.oneday.routing.domain;
+
+/** Van manifest lifecycle (§11.2, M6-D-015). */
+public enum ManifestStatus {
+    BUILDING,
+    LOADED,
+    IN_PROGRESS,
+    RETURNED,
+    RECONCILED
+}

--- a/routing/src/main/java/com/oneday/routing/domain/ProvisioningFlag.java
+++ b/routing/src/main/java/com/oneday/routing/domain/ProvisioningFlag.java
@@ -1,0 +1,7 @@
+package com.oneday.routing.domain;
+
+/** Whether the configured fleet covers the recommended count (M6-D-005). */
+public enum ProvisioningFlag {
+    OK,
+    UNDER_PROVISIONED
+}

--- a/routing/src/main/java/com/oneday/routing/domain/RouteOverrideAudit.java
+++ b/routing/src/main/java/com/oneday/routing/domain/RouteOverrideAudit.java
@@ -1,0 +1,60 @@
+package com.oneday.routing.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.type.SqlTypes;
+
+import java.time.Instant;
+import java.util.UUID;
+
+// Append-only (C17). Every approve/override/replan/fallback action with before/after snapshots.
+@Entity
+@Table(name = "route_override_audit")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RouteOverrideAudit {
+
+    @Id
+    @UuidGenerator
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "route_plan_id", nullable = false, updatable = false)
+    private UUID routePlanId;
+
+    @Column(name = "actor_id", nullable = false, updatable = false)
+    private UUID actorId;
+
+    @Column(name = "action", nullable = false, length = 40, updatable = false)
+    private String action;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "before_json", columnDefinition = "jsonb", updatable = false)
+    private String beforeJson;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "after_json", columnDefinition = "jsonb", updatable = false)
+    private String afterJson;
+
+    @Column(name = "reason", columnDefinition = "text", updatable = false)
+    private String reason;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    protected void prePersist() {
+        if (createdAt == null) {
+            createdAt = Instant.now();
+        }
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/domain/RoutePlan.java
+++ b/routing/src/main/java/com/oneday/routing/domain/RoutePlan.java
@@ -1,0 +1,90 @@
+package com.oneday.routing.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+// Append-only (C17). Overrides/fallbacks create a NEW revision that supersedes; the plan body never
+// mutates. Only the approval stamp and the status flip to SUPERSEDED change after creation.
+@Entity
+@Table(name = "route_plan")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoutePlan {
+
+    @Id
+    @UuidGenerator
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "city_id", nullable = false, updatable = false)
+    private UUID cityId;
+
+    @Column(name = "valid_for_date", nullable = false, updatable = false)
+    private LocalDate validForDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private RoutePlanStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source", nullable = false, length = 20, updatable = false)
+    private RoutePlanSource source;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "solver_type", nullable = false, length = 20, updatable = false)
+    private RoutingSolverType solverType;
+
+    @Column(name = "revision", nullable = false, updatable = false)
+    @Builder.Default
+    private int revision = 1;
+
+    @Column(name = "supersedes_plan_id", updatable = false)
+    private UUID supersedesPlanId;
+
+    @Column(name = "vans_used", updatable = false)
+    private Integer vansUsed;
+
+    @Column(name = "recommended_van_count", updatable = false)
+    private Integer recommendedVanCount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provisioning_flag", length = 20, updatable = false)
+    private ProvisioningFlag provisioningFlag;
+
+    @Column(name = "n_loops", updatable = false)
+    private Integer nLoops;
+
+    @Column(name = "realised_cycle_minutes", updatable = false)
+    private Integer realisedCycleMinutes;
+
+    @Column(name = "notes", columnDefinition = "text", updatable = false)
+    private String notes;
+
+    @Column(name = "approved_by")
+    private UUID approvedBy;
+
+    @Column(name = "approved_at")
+    private Instant approvedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    protected void prePersist() {
+        if (createdAt == null) {
+            createdAt = Instant.now();
+        }
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/domain/RoutePlanSource.java
+++ b/routing/src/main/java/com/oneday/routing/domain/RoutePlanSource.java
@@ -1,0 +1,8 @@
+package com.oneday.routing.domain;
+
+/** How a route plan was produced (§10). */
+public enum RoutePlanSource {
+    NIGHTLY,
+    MANUAL_OVERRIDE,
+    FALLBACK
+}

--- a/routing/src/main/java/com/oneday/routing/domain/RoutePlanStatus.java
+++ b/routing/src/main/java/com/oneday/routing/domain/RoutePlanStatus.java
@@ -1,0 +1,9 @@
+package com.oneday.routing.domain;
+
+/** Lifecycle of a route plan (§10). Append-only: a new revision supersedes; rows never mutate. */
+public enum RoutePlanStatus {
+    PROPOSED,
+    APPROVED,
+    SUPERSEDED,
+    REJECTED
+}

--- a/routing/src/main/java/com/oneday/routing/domain/RoutePlanStop.java
+++ b/routing/src/main/java/com/oneday/routing/domain/RoutePlanStop.java
@@ -1,0 +1,77 @@
+package com.oneday.routing.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.Instant;
+import java.time.LocalTime;
+import java.util.UUID;
+
+// Append-only — one ordered stop per (van, loop) of a plan. Immutable once written.
+// hexVertexId is M3's h3_hex_vertex.id (plain UUID, no cross-module FK).
+@Entity
+@Table(name = "route_plan_stop")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoutePlanStop {
+
+    @Id
+    @UuidGenerator
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "route_plan_id", nullable = false, updatable = false)
+    private UUID routePlanId;
+
+    @Column(name = "van_id", nullable = false, updatable = false)
+    private UUID vanId;
+
+    @Column(name = "loop_index", nullable = false, updatable = false)
+    private int loopIndex;
+
+    @Column(name = "stop_seq", nullable = false, updatable = false)
+    private int stopSeq;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "node_kind", nullable = false, length = 20, updatable = false)
+    private StopNodeKind nodeKind;
+
+    @Column(name = "hex_vertex_id", updatable = false)
+    private UUID hexVertexId;
+
+    @Column(name = "planned_arrival", updatable = false)
+    private LocalTime plannedArrival;
+
+    @Column(name = "planned_departure", updatable = false)
+    private LocalTime plannedDeparture;
+
+    @Column(name = "deliver_qty", nullable = false, updatable = false)
+    @Builder.Default
+    private int deliverQty = 0;
+
+    @Column(name = "collect_qty", nullable = false, updatable = false)
+    @Builder.Default
+    private int collectQty = 0;
+
+    @Column(name = "load_after", nullable = false, updatable = false)
+    @Builder.Default
+    private int loadAfter = 0;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    protected void prePersist() {
+        if (createdAt == null) {
+            createdAt = Instant.now();
+        }
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/domain/RoutingSolverType.java
+++ b/routing/src/main/java/com/oneday/routing/domain/RoutingSolverType.java
@@ -1,0 +1,7 @@
+package com.oneday.routing.domain;
+
+/** Which solver produced the plan (M6-D-006); SAVINGS is the no-native-lib fallback. */
+public enum RoutingSolverType {
+    OR_TOOLS,
+    SAVINGS
+}

--- a/routing/src/main/java/com/oneday/routing/domain/StopNodeKind.java
+++ b/routing/src/main/java/com/oneday/routing/domain/StopNodeKind.java
@@ -1,0 +1,7 @@
+package com.oneday.routing.domain;
+
+/** Kind of node a route stop is (§5). */
+public enum StopNodeKind {
+    HUB,
+    MEETING_VERTEX
+}

--- a/routing/src/main/java/com/oneday/routing/domain/VanLiveStatus.java
+++ b/routing/src/main/java/com/oneday/routing/domain/VanLiveStatus.java
@@ -1,0 +1,57 @@
+package com.oneday.routing.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+// Latest position + lateness per van, OVERWRITTEN in place (M6-D-012). van_id is the natural PK
+// (one live row per van); raw GPS pings never land in Kafka — only this row is kept.
+@Entity
+@Table(name = "van_live_status")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VanLiveStatus {
+
+    @Id
+    @Column(name = "van_id", updatable = false, nullable = false)
+    private UUID vanId;
+
+    @Column(name = "city_id", nullable = false)
+    private UUID cityId;
+
+    @Column(name = "route_plan_id")
+    private UUID routePlanId;
+
+    @Column(name = "last_lat")
+    private Double lastLat;
+
+    @Column(name = "last_lon")
+    private Double lastLon;
+
+    @Column(name = "last_seen_at")
+    private Instant lastSeenAt;
+
+    @Column(name = "current_stop_seq")
+    private Integer currentStopSeq;
+
+    @Column(name = "minutes_late")
+    private Integer minutesLate;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    @PreUpdate
+    protected void touch() {
+        updatedAt = Instant.now();
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/domain/VanManifest.java
+++ b/routing/src/main/java/com/oneday/routing/domain/VanManifest.java
@@ -1,0 +1,72 @@
+package com.oneday.routing.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+// The van's mini-hub sort plan, one per (van, loop, day) (M6-D-015). Mutable — status drives the
+// lifecycle BUILDING → LOADED → IN_PROGRESS → RETURNED → RECONCILED.
+@Entity
+@Table(name = "van_manifest")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VanManifest {
+
+    @Id
+    @UuidGenerator
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "route_plan_id", nullable = false, updatable = false)
+    private UUID routePlanId;
+
+    @Column(name = "van_id", nullable = false, updatable = false)
+    private UUID vanId;
+
+    @Column(name = "loop_index", nullable = false, updatable = false)
+    private int loopIndex;
+
+    @Column(name = "valid_date", nullable = false, updatable = false)
+    private LocalDate validDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private ManifestStatus status;
+
+    @Column(name = "departed_at")
+    private Instant departedAt;
+
+    @Column(name = "returned_at")
+    private Instant returnedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    protected void prePersist() {
+        Instant now = Instant.now();
+        if (createdAt == null) {
+            createdAt = now;
+        }
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void preUpdate() {
+        updatedAt = Instant.now();
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/domain/VanManifestItem.java
+++ b/routing/src/main/java/com/oneday/routing/domain/VanManifestItem.java
@@ -1,0 +1,81 @@
+package com.oneday.routing.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.Instant;
+import java.util.UUID;
+
+// A specific parcel bound to a van/loop/stop, one direction (M6-D-014). Mutable — status advances
+// PLANNED → LOADED → ONBOARD → HANDED_OFF | RECONCILED | EXCEPTION through the custody points.
+@Entity
+@Table(name = "van_manifest_item")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VanManifestItem {
+
+    @Id
+    @UuidGenerator
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "manifest_id", nullable = false, updatable = false)
+    private UUID manifestId;
+
+    @Column(name = "parcel_id", nullable = false, updatable = false)
+    private UUID parcelId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "direction", nullable = false, length = 10, updatable = false)
+    private HandoffDirection direction;
+
+    @Column(name = "stop_seq")
+    private Integer stopSeq;
+
+    @Column(name = "meeting_vertex_id")
+    private UUID meetingVertexId;
+
+    @Column(name = "counterparty_da_id")
+    private UUID counterpartyDaId;
+
+    @Column(name = "sla_deadline")
+    private Instant slaDeadline;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private ManifestItemStatus status;
+
+    @Column(name = "loaded_at")
+    private Instant loadedAt;
+
+    @Column(name = "handed_off_at")
+    private Instant handedOffAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    protected void prePersist() {
+        Instant now = Instant.now();
+        if (createdAt == null) {
+            createdAt = now;
+        }
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void preUpdate() {
+        updatedAt = Instant.now();
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/repository/CityFleetConfigRepository.java
+++ b/routing/src/main/java/com/oneday/routing/repository/CityFleetConfigRepository.java
@@ -1,0 +1,12 @@
+package com.oneday.routing.repository;
+
+import com.oneday.routing.domain.CityFleetConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CityFleetConfigRepository extends JpaRepository<CityFleetConfig, UUID> {
+
+    Optional<CityFleetConfig> findByCityId(UUID cityId);
+}

--- a/routing/src/main/java/com/oneday/routing/repository/CityLogisticsNodeRepository.java
+++ b/routing/src/main/java/com/oneday/routing/repository/CityLogisticsNodeRepository.java
@@ -1,0 +1,16 @@
+package com.oneday.routing.repository;
+
+import com.oneday.routing.domain.CityLogisticsNode;
+import com.oneday.routing.domain.LogisticsNodeKind;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CityLogisticsNodeRepository extends JpaRepository<CityLogisticsNode, UUID> {
+
+    List<CityLogisticsNode> findByCityId(UUID cityId);
+
+    Optional<CityLogisticsNode> findByCityIdAndKind(UUID cityId, LogisticsNodeKind kind);
+}

--- a/routing/src/main/java/com/oneday/routing/repository/DaCronScheduleRepository.java
+++ b/routing/src/main/java/com/oneday/routing/repository/DaCronScheduleRepository.java
@@ -1,0 +1,15 @@
+package com.oneday.routing.repository;
+
+import com.oneday.routing.domain.DaCronSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+public interface DaCronScheduleRepository extends JpaRepository<DaCronSchedule, UUID> {
+
+    List<DaCronSchedule> findByDaIdAndValidDate(UUID daId, LocalDate validDate);
+
+    List<DaCronSchedule> findByRoutePlanId(UUID routePlanId);
+}

--- a/routing/src/main/java/com/oneday/routing/repository/HandoffReconciliationRepository.java
+++ b/routing/src/main/java/com/oneday/routing/repository/HandoffReconciliationRepository.java
@@ -1,0 +1,12 @@
+package com.oneday.routing.repository;
+
+import com.oneday.routing.domain.HandoffReconciliation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface HandoffReconciliationRepository extends JpaRepository<HandoffReconciliation, UUID> {
+
+    List<HandoffReconciliation> findByManifestId(UUID manifestId);
+}

--- a/routing/src/main/java/com/oneday/routing/repository/RouteOverrideAuditRepository.java
+++ b/routing/src/main/java/com/oneday/routing/repository/RouteOverrideAuditRepository.java
@@ -1,0 +1,12 @@
+package com.oneday.routing.repository;
+
+import com.oneday.routing.domain.RouteOverrideAudit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface RouteOverrideAuditRepository extends JpaRepository<RouteOverrideAudit, UUID> {
+
+    List<RouteOverrideAudit> findByRoutePlanIdOrderByCreatedAt(UUID routePlanId);
+}

--- a/routing/src/main/java/com/oneday/routing/repository/RoutePlanRepository.java
+++ b/routing/src/main/java/com/oneday/routing/repository/RoutePlanRepository.java
@@ -1,0 +1,16 @@
+package com.oneday.routing.repository;
+
+import com.oneday.routing.domain.RoutePlan;
+import com.oneday.routing.domain.RoutePlanStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+public interface RoutePlanRepository extends JpaRepository<RoutePlan, UUID> {
+
+    List<RoutePlan> findByCityIdAndValidForDateAndStatus(UUID cityId, LocalDate validForDate, RoutePlanStatus status);
+
+    List<RoutePlan> findByCityIdAndValidForDate(UUID cityId, LocalDate validForDate);
+}

--- a/routing/src/main/java/com/oneday/routing/repository/RoutePlanStopRepository.java
+++ b/routing/src/main/java/com/oneday/routing/repository/RoutePlanStopRepository.java
@@ -1,0 +1,14 @@
+package com.oneday.routing.repository;
+
+import com.oneday.routing.domain.RoutePlanStop;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface RoutePlanStopRepository extends JpaRepository<RoutePlanStop, UUID> {
+
+    List<RoutePlanStop> findByRoutePlanIdAndVanIdAndLoopIndexOrderByStopSeq(UUID routePlanId, UUID vanId, int loopIndex);
+
+    List<RoutePlanStop> findByRoutePlanId(UUID routePlanId);
+}

--- a/routing/src/main/java/com/oneday/routing/repository/VanLiveStatusRepository.java
+++ b/routing/src/main/java/com/oneday/routing/repository/VanLiveStatusRepository.java
@@ -1,0 +1,12 @@
+package com.oneday.routing.repository;
+
+import com.oneday.routing.domain.VanLiveStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface VanLiveStatusRepository extends JpaRepository<VanLiveStatus, UUID> {
+
+    List<VanLiveStatus> findByCityId(UUID cityId);
+}

--- a/routing/src/main/java/com/oneday/routing/repository/VanManifestItemRepository.java
+++ b/routing/src/main/java/com/oneday/routing/repository/VanManifestItemRepository.java
@@ -1,0 +1,16 @@
+package com.oneday.routing.repository;
+
+import com.oneday.routing.domain.VanManifestItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface VanManifestItemRepository extends JpaRepository<VanManifestItem, UUID> {
+
+    List<VanManifestItem> findByManifestIdAndStopSeq(UUID manifestId, int stopSeq);
+
+    List<VanManifestItem> findByManifestId(UUID manifestId);
+
+    List<VanManifestItem> findByParcelId(UUID parcelId);
+}

--- a/routing/src/main/java/com/oneday/routing/repository/VanManifestRepository.java
+++ b/routing/src/main/java/com/oneday/routing/repository/VanManifestRepository.java
@@ -1,0 +1,16 @@
+package com.oneday.routing.repository;
+
+import com.oneday.routing.domain.VanManifest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface VanManifestRepository extends JpaRepository<VanManifest, UUID> {
+
+    Optional<VanManifest> findByVanIdAndLoopIndexAndValidDate(UUID vanId, int loopIndex, LocalDate validDate);
+
+    List<VanManifest> findByRoutePlanId(UUID routePlanId);
+}

--- a/routing/src/main/java/com/oneday/routing/service/port/CostFloorPort.java
+++ b/routing/src/main/java/com/oneday/routing/service/port/CostFloorPort.java
@@ -1,0 +1,16 @@
+package com.oneday.routing.service.port;
+
+import java.util.UUID;
+
+/**
+ * Seam to M2 (pricing). The optimiser weights arcs by cost, not just travel time (C14, M6-D-010).
+ * Until M2 ships, {@link NoOpCostFloorPort} returns a flat per-km van cost from config.
+ *
+ * <p>Mirrors M3's {@code DaRosterPort} seam: a real {@code @Component} impl (annotated so it wins
+ * over the no-op) drops in when M2 lands, without touching the solver.</p>
+ */
+public interface CostFloorPort {
+
+    /** Cost (INR) per km of van travel in the given city. */
+    double perKmVanCostInr(UUID cityId);
+}

--- a/routing/src/main/java/com/oneday/routing/service/port/DaAccumulationPort.java
+++ b/routing/src/main/java/com/oneday/routing/service/port/DaAccumulationPort.java
@@ -1,0 +1,24 @@
+package com.oneday.routing.service.port;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Seam to M5/M4. The collect-side manifest is filled from the first-mile parcels a DA has
+ * accumulated (PICKED_UP) through the day (§12.2). Until that feed exists,
+ * {@link NoOpDaAccumulationPort} returns nothing.
+ */
+public interface DaAccumulationPort {
+
+    /** First-mile parcels a DA has picked up and is holding for the next van collect. */
+    List<AccumulatedParcel> collectedAwaitingPickup(UUID daId, LocalDate date);
+
+    /** A first-mile parcel in a DA's custody awaiting collection by the van. */
+    record AccumulatedParcel(
+            UUID parcelId,
+            UUID daId,
+            Instant pickedUpAt) {
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/service/port/FlightCutoffPort.java
+++ b/routing/src/main/java/com/oneday/routing/service/port/FlightCutoffPort.java
@@ -1,0 +1,17 @@
+package com.oneday.routing.service.port;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Seam to M9 (airline). First-mile parcels carry a hub-arrival deadline derived from the committed
+ * flight cutoff minus the end-to-end tail {@code cutoff − (sort + bag + shuttle)} (§12.2, the Q2
+ * budget). Until M9 ships, {@link NoOpFlightCutoffPort} returns empty (no cutoff known).
+ */
+public interface FlightCutoffPort {
+
+    /** The earliest outbound flight cutoff for the city/date, or empty if unknown. */
+    Optional<Instant> outboundFlightCutoff(UUID cityId, LocalDate date);
+}

--- a/routing/src/main/java/com/oneday/routing/service/port/HubSortPort.java
+++ b/routing/src/main/java/com/oneday/routing/service/port/HubSortPort.java
@@ -1,0 +1,24 @@
+package com.oneday.routing.service.port;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Seam to M7 (hub). The deliver-side manifest is built from M7's sort output — the parcels
+ * "ready to load for delivery" (M6-D-015, §12.1). Until M7 ships, {@link NoOpHubSortPort}
+ * returns nothing. The exact shape is finalized with the M7 owner when M7 starts.
+ */
+public interface HubSortPort {
+
+    /** Parcels sorted for outbound delivery and ready to load onto a van, for this city. */
+    List<ReadyForDeliveryParcel> readyForDelivery(UUID cityId);
+
+    /** A parcel M7 has sorted for delivery; M6 resolves destinationHexId → DA → vertex/van/loop. */
+    record ReadyForDeliveryParcel(
+            UUID parcelId,
+            UUID destinationHexId,
+            Instant readyAt,
+            Instant slaDeadline) {
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/service/port/NoOpCostFloorPort.java
+++ b/routing/src/main/java/com/oneday/routing/service/port/NoOpCostFloorPort.java
@@ -1,0 +1,25 @@
+package com.oneday.routing.service.port;
+
+import com.oneday.routing.config.RoutingProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+/**
+ * Flat per-km stub until M2 (pricing) ships its cost floor (M6-D-010).
+ * When M2 lands, provide a real impl annotated {@code @Primary} to override this (as M3's pattern).
+ */
+@Component
+class NoOpCostFloorPort implements CostFloorPort {
+
+    private final RoutingProperties properties;
+
+    NoOpCostFloorPort(RoutingProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public double perKmVanCostInr(UUID cityId) {
+        return properties.getCostPerKm();
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/service/port/NoOpDaAccumulationPort.java
+++ b/routing/src/main/java/com/oneday/routing/service/port/NoOpDaAccumulationPort.java
@@ -1,0 +1,20 @@
+package com.oneday.routing.service.port;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * No accumulation feed until M5/M4 provide it. When ready, provide a real impl annotated
+ * {@code @Primary} to override this (as M3's pattern).
+ */
+@Component
+class NoOpDaAccumulationPort implements DaAccumulationPort {
+
+    @Override
+    public List<AccumulatedParcel> collectedAwaitingPickup(UUID daId, LocalDate date) {
+        return List.of();
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/service/port/NoOpFlightCutoffPort.java
+++ b/routing/src/main/java/com/oneday/routing/service/port/NoOpFlightCutoffPort.java
@@ -1,0 +1,21 @@
+package com.oneday.routing.service.port;
+
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * No cutoff known until M9 (airline) ships. When it lands, provide a real impl annotated
+ * {@code @Primary} to override this (as M3's pattern).
+ */
+@Component
+class NoOpFlightCutoffPort implements FlightCutoffPort {
+
+    @Override
+    public Optional<Instant> outboundFlightCutoff(UUID cityId, LocalDate date) {
+        return Optional.empty();
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/service/port/NoOpHubSortPort.java
+++ b/routing/src/main/java/com/oneday/routing/service/port/NoOpHubSortPort.java
@@ -1,0 +1,19 @@
+package com.oneday.routing.service.port;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Nothing ready to load until M7 (hub) ships. When it lands, provide a real impl annotated
+ * {@code @Primary} to override this (as M3's pattern).
+ */
+@Component
+class NoOpHubSortPort implements HubSortPort {
+
+    @Override
+    public List<ReadyForDeliveryParcel> readyForDelivery(UUID cityId) {
+        return List.of();
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/service/port/NoOpScanLedgerPort.java
+++ b/routing/src/main/java/com/oneday/routing/service/port/NoOpScanLedgerPort.java
@@ -1,0 +1,21 @@
+package com.oneday.routing.service.port;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Logs van scans locally until M8 (scan ledger) ships. When it lands, provide a real impl annotated
+ * {@code @Primary} to write to M8's append-only ledger (as M3's pattern).
+ */
+@Component
+class NoOpScanLedgerPort implements ScanLedgerPort {
+
+    private static final Logger log = LoggerFactory.getLogger(NoOpScanLedgerPort.class);
+
+    @Override
+    public void recordVanScan(VanCustodyScan scan) {
+        log.info("VAN_SCAN (stub, M8 not integrated) type={} parcelId={} vanId={} daId={} at={}",
+                scan.type(), scan.parcelId(), scan.vanId(), scan.counterpartyDaId(), scan.scannedAt());
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/service/port/ScanLedgerPort.java
+++ b/routing/src/main/java/com/oneday/routing/service/port/ScanLedgerPort.java
@@ -1,0 +1,32 @@
+package com.oneday.routing.service.port;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Seam to M8 (scan ledger). The van is a first-class custody node (M6-D-014): M6 originates the
+ * four van scans, M8 records them immutably. Until M8 ships, {@link NoOpScanLedgerPort} logs only.
+ * Q12 (is the van a distinct M8 scan-location type?) is confirmed with the M8 owner in PR #6.
+ */
+public interface ScanLedgerPort {
+
+    /** Record one van custody scan in M8's append-only ledger. */
+    void recordVanScan(VanCustodyScan scan);
+
+    /** The four van custody transfer points (§11.1). Both van and driver identity travel on the scan (Q14). */
+    enum VanScanType {
+        VAN_LOAD,    // hub → van
+        VAN_TO_DA,   // van → DA  (deliver)
+        DA_TO_VAN,   // DA → van  (collect)
+        VAN_UNLOAD   // van → hub
+    }
+
+    record VanCustodyScan(
+            UUID parcelId,
+            VanScanType type,
+            UUID vanId,
+            UUID driverId,
+            UUID counterpartyDaId,
+            Instant scannedAt) {
+    }
+}

--- a/routing/src/main/resources/application.yml
+++ b/routing/src/main/resources/application.yml
@@ -1,0 +1,48 @@
+spring:
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    consumer:
+      group-id: routing-service
+      auto-offset-reset: latest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: "com.oneday.common.kafka.events.cron"
+  datasource:
+    url: jdbc:postgresql://localhost:5432/oneday
+    username: oneday
+    password: secret
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+  flyway:
+    enabled: true
+    out-of-order: true
+routing:
+  osrm:
+    base-url: http://46.225.155.64:5000
+  solver:
+    time-limit-seconds: 45
+  cycle:
+    min-minutes: 120
+    max-minutes: 180
+  shuttle:
+    cadence-minutes: 30
+  window:
+    start-hour: 7
+    end-hour: 20
+  dwell-minutes: 5
+  max-da-to-vertex-minutes: 12
+  late-threshold-minutes: 10
+  cost-per-km: 15.0
+  cities:
+    delhi: f47ac10b-58cc-4372-a567-0e02b2c3d479
+    mumbai: 550e8400-e29b-41d4-a716-446655440000
+    bangalore: 6ba7b810-9dad-11d1-80b4-00c04fd430c8
+    hyderabad: 6ba7b811-9dad-11d1-80b4-00c04fd430c8
+    chennai: 6ba7b812-9dad-11d1-80b4-00c04fd430c8

--- a/routing/src/main/resources/db/migration/V6_10__create_van_live_status.sql
+++ b/routing/src/main/resources/db/migration/V6_10__create_van_live_status.sql
@@ -1,0 +1,15 @@
+-- M6-D-012: latest position + lateness per van, OVERWRITTEN in place (not append-only) — powers the
+-- ops map. Raw GPS pings never land in Kafka; only this row is kept (overwrite).
+CREATE TABLE van_live_status (
+    van_id          UUID PRIMARY KEY,
+    city_id         UUID NOT NULL,
+    route_plan_id   UUID,
+    last_lat        DOUBLE PRECISION,
+    last_lon        DOUBLE PRECISION,
+    last_seen_at    TIMESTAMPTZ,
+    current_stop_seq INT,
+    minutes_late    INT,
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_van_live_status_city ON van_live_status (city_id);

--- a/routing/src/main/resources/db/migration/V6_11__seed_logistics_nodes_and_fleet.sql
+++ b/routing/src/main/resources/db/migration/V6_11__seed_logistics_nodes_and_fleet.sql
@@ -1,0 +1,40 @@
+-- Seed hub + airport coordinates and a starter fleet config for the 5 launch cities.
+-- city_id UUIDs are the fixed ones shared with M3 (grid.cities / application.yml routing.cities).
+-- Idempotent: ON CONFLICT DO UPDATE so re-runs refresh coords/config without duplicating rows.
+
+INSERT INTO city_logistics_node (city_id, kind, lat, lon, name) VALUES
+    -- Delhi
+    ('f47ac10b-58cc-4372-a567-0e02b2c3d479', 'HUB',     28.6139, 77.2090, 'Delhi Hub'),
+    ('f47ac10b-58cc-4372-a567-0e02b2c3d479', 'AIRPORT', 28.5562, 77.1000, 'Indira Gandhi Intl (DEL)'),
+    -- Mumbai
+    ('550e8400-e29b-41d4-a716-446655440000', 'HUB',     19.0760, 72.8777, 'Mumbai Hub'),
+    ('550e8400-e29b-41d4-a716-446655440000', 'AIRPORT', 19.0896, 72.8656, 'Chhatrapati Shivaji Intl (BOM)'),
+    -- Bangalore
+    ('6ba7b810-9dad-11d1-80b4-00c04fd430c8', 'HUB',     12.9716, 77.5946, 'Bangalore Hub'),
+    ('6ba7b810-9dad-11d1-80b4-00c04fd430c8', 'AIRPORT', 13.1986, 77.7066, 'Kempegowda Intl (BLR)'),
+    -- Hyderabad
+    ('6ba7b811-9dad-11d1-80b4-00c04fd430c8', 'HUB',     17.3850, 78.4867, 'Hyderabad Hub'),
+    ('6ba7b811-9dad-11d1-80b4-00c04fd430c8', 'AIRPORT', 17.2403, 78.4294, 'Rajiv Gandhi Intl (HYD)'),
+    -- Chennai
+    ('6ba7b812-9dad-11d1-80b4-00c04fd430c8', 'HUB',     13.0827, 80.2707, 'Chennai Hub'),
+    ('6ba7b812-9dad-11d1-80b4-00c04fd430c8', 'AIRPORT', 12.9941, 80.1709, 'Chennai Intl (MAA)')
+ON CONFLICT (city_id, kind) DO UPDATE
+    SET lat = EXCLUDED.lat, lon = EXCLUDED.lon, name = EXCLUDED.name;
+
+INSERT INTO city_fleet_config
+    (city_id, vans_available, capacity_packets, cycle_time_min_minutes, cycle_time_max_minutes,
+     shuttle_cadence_minutes, max_da_to_vertex_minutes, dwell_minutes) VALUES
+    ('f47ac10b-58cc-4372-a567-0e02b2c3d479', 6, 120, 120, 180, 30, 12, 5),
+    ('550e8400-e29b-41d4-a716-446655440000', 6, 120, 120, 180, 30, 12, 5),
+    ('6ba7b810-9dad-11d1-80b4-00c04fd430c8', 6, 120, 120, 180, 30, 12, 5),
+    ('6ba7b811-9dad-11d1-80b4-00c04fd430c8', 6, 120, 120, 180, 30, 12, 5),
+    ('6ba7b812-9dad-11d1-80b4-00c04fd430c8', 6, 120, 120, 180, 30, 12, 5)
+ON CONFLICT (city_id) DO UPDATE
+    SET vans_available           = EXCLUDED.vans_available,
+        capacity_packets         = EXCLUDED.capacity_packets,
+        cycle_time_min_minutes   = EXCLUDED.cycle_time_min_minutes,
+        cycle_time_max_minutes   = EXCLUDED.cycle_time_max_minutes,
+        shuttle_cadence_minutes  = EXCLUDED.shuttle_cadence_minutes,
+        max_da_to_vertex_minutes = EXCLUDED.max_da_to_vertex_minutes,
+        dwell_minutes            = EXCLUDED.dwell_minutes,
+        updated_at               = now();

--- a/routing/src/main/resources/db/migration/V6_1__create_city_logistics_node.sql
+++ b/routing/src/main/resources/db/migration/V6_1__create_city_logistics_node.sql
@@ -1,0 +1,14 @@
+-- M6-D-007: hub & airport coordinates, which no module stored before. Plain city_id UUID
+-- (shared with M3's grid.cities config) — no cross-module FK, mirroring da_hex_assignment.city_id.
+CREATE TABLE city_logistics_node (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    city_id     UUID         NOT NULL,
+    kind        VARCHAR(10)  NOT NULL,            -- HUB | AIRPORT
+    lat         DOUBLE PRECISION NOT NULL,
+    lon         DOUBLE PRECISION NOT NULL,
+    name        VARCHAR(120) NOT NULL,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    UNIQUE (city_id, kind)
+);
+
+CREATE INDEX idx_logistics_node_city ON city_logistics_node (city_id);

--- a/routing/src/main/resources/db/migration/V6_2__create_city_fleet_config.sql
+++ b/routing/src/main/resources/db/migration/V6_2__create_city_fleet_config.sql
@@ -1,0 +1,13 @@
+-- M6-D-005/-019: per-city fleet + cycle/dwell knobs. Mutable (ops edits it) — not append-only.
+CREATE TABLE city_fleet_config (
+    id                        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    city_id                   UUID NOT NULL UNIQUE,
+    vans_available            INT  NOT NULL,
+    capacity_packets          INT  NOT NULL,
+    cycle_time_min_minutes    INT  NOT NULL,
+    cycle_time_max_minutes    INT  NOT NULL,
+    shuttle_cadence_minutes   INT  NOT NULL,
+    max_da_to_vertex_minutes  INT  NOT NULL,
+    dwell_minutes             INT  NOT NULL,
+    updated_at                TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/routing/src/main/resources/db/migration/V6_3__create_route_plan.sql
+++ b/routing/src/main/resources/db/migration/V6_3__create_route_plan.sql
@@ -1,0 +1,23 @@
+-- Append-only (C17). Overrides/fallbacks create a NEW revision that supersedes; rows never mutate
+-- except the approval stamp (approved_by/at) and status flip to SUPERSEDED. Mirrors assignment_proposal.
+CREATE TABLE route_plan (
+    id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    city_id               UUID        NOT NULL,
+    valid_for_date        DATE        NOT NULL,
+    status                VARCHAR(20) NOT NULL,            -- PROPOSED|APPROVED|SUPERSEDED|REJECTED
+    source                VARCHAR(20) NOT NULL,            -- NIGHTLY|MANUAL_OVERRIDE|FALLBACK
+    solver_type           VARCHAR(20) NOT NULL,            -- OR_TOOLS|SAVINGS
+    revision              INT         NOT NULL DEFAULT 1,
+    supersedes_plan_id    UUID        REFERENCES route_plan(id),
+    vans_used             INT,
+    recommended_van_count INT,
+    provisioning_flag     VARCHAR(20),                     -- OK|UNDER_PROVISIONED
+    n_loops               INT,
+    realised_cycle_minutes INT,
+    notes                 TEXT,
+    approved_by           UUID,
+    approved_at           TIMESTAMPTZ,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_route_plan_city_date_status ON route_plan (city_id, valid_for_date, status);

--- a/routing/src/main/resources/db/migration/V6_4__create_route_plan_stop.sql
+++ b/routing/src/main/resources/db/migration/V6_4__create_route_plan_stop.sql
@@ -1,0 +1,19 @@
+-- One ordered stop per (van, loop) of a plan. hex_vertex_id is M3's h3_hex_vertex.id (plain UUID,
+-- no cross-module FK). planned arrival/departure are wall-clock times-of-day (07:00–20:00 window).
+CREATE TABLE route_plan_stop (
+    id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    route_plan_id      UUID        NOT NULL REFERENCES route_plan(id),
+    van_id             UUID        NOT NULL,
+    loop_index         INT         NOT NULL,
+    stop_seq           INT         NOT NULL,
+    node_kind          VARCHAR(20) NOT NULL,            -- HUB | MEETING_VERTEX
+    hex_vertex_id      UUID,
+    planned_arrival    TIME,
+    planned_departure  TIME,
+    deliver_qty        INT         NOT NULL DEFAULT 0,
+    collect_qty        INT         NOT NULL DEFAULT 0,
+    load_after         INT         NOT NULL DEFAULT 0,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_route_plan_stop_plan_van_loop ON route_plan_stop (route_plan_id, van_id, loop_index);

--- a/routing/src/main/resources/db/migration/V6_5__create_da_cron_schedule.sql
+++ b/routing/src/main/resources/db/migration/V6_5__create_da_cron_schedule.sql
@@ -1,0 +1,15 @@
+-- M6-D-008: per-DA (vertex, [meeting_times]) for the day → DA_CRON_SCHEDULED to M5.
+-- meeting_times is a JSON array of "HH:mm" strings (the day's loop arrivals at the DA's vertex).
+CREATE TABLE da_cron_schedule (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    route_plan_id  UUID  NOT NULL REFERENCES route_plan(id),
+    da_id          UUID  NOT NULL,
+    hex_vertex_id  UUID  NOT NULL,
+    van_id         UUID,
+    meeting_times  JSONB NOT NULL,
+    city_id        UUID  NOT NULL,
+    valid_date     DATE  NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_da_cron_schedule_da_date ON da_cron_schedule (da_id, valid_date);

--- a/routing/src/main/resources/db/migration/V6_6__create_route_override_audit.sql
+++ b/routing/src/main/resources/db/migration/V6_6__create_route_override_audit.sql
@@ -1,0 +1,13 @@
+-- Append-only (C17). Every manual override/approval action on a plan, with before/after snapshots.
+CREATE TABLE route_override_audit (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    route_plan_id  UUID        NOT NULL REFERENCES route_plan(id),
+    actor_id       UUID        NOT NULL,
+    action         VARCHAR(40) NOT NULL,            -- APPROVE | OVERRIDE | REPLAN | FALLBACK
+    before_json    JSONB,
+    after_json     JSONB,
+    reason         TEXT,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_route_override_audit_plan ON route_override_audit (route_plan_id);

--- a/routing/src/main/resources/db/migration/V6_7__create_van_manifest.sql
+++ b/routing/src/main/resources/db/migration/V6_7__create_van_manifest.sql
@@ -1,0 +1,17 @@
+-- M6-D-015: the van's mini-hub sort plan, one per (van, loop, day). Status drives the lifecycle
+-- BUILDING → LOADED → IN_PROGRESS → RETURNED → RECONCILED, so this row is mutable.
+CREATE TABLE van_manifest (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    route_plan_id  UUID        NOT NULL REFERENCES route_plan(id),
+    van_id         UUID        NOT NULL,
+    loop_index     INT         NOT NULL,
+    valid_date     DATE        NOT NULL,
+    status         VARCHAR(20) NOT NULL,            -- BUILDING|LOADED|IN_PROGRESS|RETURNED|RECONCILED
+    departed_at    TIMESTAMPTZ,
+    returned_at    TIMESTAMPTZ,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (van_id, loop_index, valid_date)
+);
+
+CREATE INDEX idx_van_manifest_plan ON van_manifest (route_plan_id);

--- a/routing/src/main/resources/db/migration/V6_8__create_van_manifest_item.sql
+++ b/routing/src/main/resources/db/migration/V6_8__create_van_manifest_item.sql
@@ -1,0 +1,20 @@
+-- M6-D-014: a specific parcel bound to a van/loop/stop, one direction. Status advances through the
+-- custody points (PLANNED → LOADED → ONBOARD → HANDED_OFF | RECONCILED | EXCEPTION) — mutable.
+CREATE TABLE van_manifest_item (
+    id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    manifest_id        UUID        NOT NULL REFERENCES van_manifest(id),
+    parcel_id          UUID        NOT NULL,
+    direction          VARCHAR(10) NOT NULL,            -- DELIVER | COLLECT
+    stop_seq           INT,
+    meeting_vertex_id  UUID,
+    counterparty_da_id UUID,
+    sla_deadline       TIMESTAMPTZ,
+    status             VARCHAR(20) NOT NULL,            -- PLANNED|LOADED|ONBOARD|HANDED_OFF|RECONCILED|EXCEPTION
+    loaded_at          TIMESTAMPTZ,
+    handed_off_at      TIMESTAMPTZ,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_van_manifest_item_manifest_stop ON van_manifest_item (manifest_id, stop_seq);
+CREATE INDEX idx_van_manifest_item_parcel ON van_manifest_item (parcel_id);

--- a/routing/src/main/resources/db/migration/V6_9__create_handoff_reconciliation.sql
+++ b/routing/src/main/resources/db/migration/V6_9__create_handoff_reconciliation.sql
@@ -1,0 +1,15 @@
+-- Append-only (C17, M6-D-018). Per-stop, per-DA reconciliation of expected (manifest) vs scanned.
+CREATE TABLE handoff_reconciliation (
+    id                     UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    manifest_id            UUID        NOT NULL REFERENCES van_manifest(id),
+    stop_seq               INT         NOT NULL,
+    da_id                  UUID        NOT NULL,
+    expected_count         INT         NOT NULL,
+    actual_count           INT         NOT NULL,
+    discrepancy_type       VARCHAR(20) NOT NULL,        -- MISSING | EXTRA | REJECTED | NONE
+    discrepancy_parcel_ids JSONB,
+    reason                 TEXT,
+    created_at             TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_handoff_reconciliation_manifest ON handoff_reconciliation (manifest_id);


### PR DESCRIPTION
Summary

Implements M6 Phase 1 / PR #1 — foundations for the new routing module (M6): the Kafka cron-event contracts, injectable clock, configuration, unbuilt-dependency stub ports, the full V6_* schema with seed, and all JPA entities/enums/repositories. No business logic yet — this is the scaffolding every later M6 PR builds on.

---
What Changed

- common — Replaced CronEventType with the 10 M6 design values (§17.1) and added 10 sealed CronEventPayload records (common.kafka.events.cron) for the events M6 publishes on oneday.cron.events.
- orders (M4) — Rewrote the dormant CronEventsConsumer to compile against the new enum; it now log-ignores until the M6 producer contract is finalized (per-shipment custody transitions flow via the M8 scan ledger, not cron.events).
- routing config — ClockConfig (injectable IST Clock, M6-D-013) + RoutingProperties (cycle/dwell/window/cost knobs) + application.yml.
- routing ports — 5 stub ports + NoOp @Component impls (CostFloorPort, FlightCutoffPort, HubSortPort, DaAccumulationPort, ScanLedgerPort); real impls win later via @Primary, mirroring M3's NoOpDaRosterPort.
- routing schema — Flyway V6_1…V6_11: 10 tables (logistics node, fleet config, route plan/stop, cron schedule, override audit, manifest/item, reconciliation, live status) + idempotent seed of hub/airport coords + starter fleet for all 5 cities.
- routing persistence — 10 JPA entities (append-only ones immutable + @PrePersist), 10 enums, 10 Spring Data repositories with the key finders from the plan.
- Totals: 71 files changed (67 new, 4 modified), +2814 / −41.

---
Why This Change?

M6 (van routing, scheduling & custody) was an empty module skeleton. PR #1 lays the foun on — shared event contracts, the DB schema, the domain model, and the seams(CostFloorPort etc.) that let M6 build and test end-to-end now, before M2/M7/M8/M9 exist. It deliberately ships no optimiser/logic so the contract and schema can be reviewed in isolation.

---
Testing

- [x] Tested locally
- [x] Edge cases considered (seed idempotency via ON CONFLICT DO UPDATE)
- [x] No breaking changes introduced (only the dormant M4 cron consumer was touched; it

Test Evidence

Per agreement, no unit tests were added in this foundations PR (pure schema/contracts —  in PR #2+). Verified by full build + applying the migrations against the shared cloudPostgres inside a rolled-back transaction:

# Full reactor build
mvn clean install
... [9/14] M6 - Van Routing and Scheduling ... Building jar: routing-1.0.0-SNAPSHOT.jar
[INFO] BUILD SUCCESS   (all 14 modules)

# V6_1..V6_11 applied to cloud Postgres (Render), then ROLLBACK — no mutation
INSERT 0 10        -- city_logistics_node
INSERT 0 5         -- city_fleet_config
      check      | n          AIRPORT | 5
 logistics_nodes | 10         HUB     | 5
     check       | n
 fleet_configs   | 5
-- re-run seed (idempotency): counts stable
 after_reseed_nodes | 10
 after_reseed_fleet | 5
ROLLBACK

---
Impact

Areas Affected

- [x] Backend
- [ ] Frontend
- [x] Routing
- [ ] Infra
- [x] Database
- [ ] NA

Modules Affected

- [ ] M1 — Auth
- [ ] M2 — Pricing
- [ ] M3 — Grid
- [x] M4 — Orders (dormant cron consumer rewritten to compile against the new enum)
- [ ] M5 — Dispatch
- [x] M6 — Routing
- [ ] M7 — Hub
- [ ] M8 — Barcode
- [ ] M9 — Airline
- [ ] M10 — SLA
- [ ] M11 — Exceptions
- [ ] NA

---
Risks / Concerns

- Cross-module contract change: common.CronEventType was redefined (the old DEPARTED_HUBgone). The only consumer was M4's CronEventsConsumer, which is dormant(autoStartup=false) and was updated in this PR — so no runtime break. The M4 owner still needs to define which cron events drive shipment transitions when M6 producers land (flagged with a TODO).
- Schema only, no Flyway run committed to shared DB: migrations were validated against cpply for real on the next app boot. Out-of-order (V6_* after V5_*) is already enabled inapp.
- Everything else is additive (new module, new tables, plain-UUID references — no cross-is minimal.

---
Checklist

- [x] Code follows project conventions (package layout, no cross-module internal imports — only common/grid public surfaces)
- [x] Self-review completed
- [x] Append-only audit trail preserved (audit/reconciliation/plan tables are immutable @PrePersist entities; no mutations introduced)
- [x] No sensitive data or credentials exposed (.env is gitignored)
- [x] Documentation updated if behaviour changed (docs/MODULES.md)
- [x] Ready for review
