### PR TITLE
M6 IMPL - PR #3 - Route plan service and route plan config

### DIFF
--- a/routing/src/main/java/com/oneday/routing/config/RoutingProperties.java
+++ b/routing/src/main/java/com/oneday/routing/config/RoutingProperties.java
@@ -32,6 +32,9 @@ public class RoutingProperties {
     /** Lateness past plan that escalates to VAN_RUNNING_LATE (§14.4). */
     private int lateThresholdMinutes = 10;
 
+    /** Min spacing between a DA's meeting times — must be ≥ M5's CRON_FREEZE_MINUTES (C6, §10). */
+    private int cronFreezeMinutes = 30;
+
     /** Flat per-km van cost until M2's CostFloorPort lands (M6-D-010). INR. */
     private double costPerKm = 15.0;
 

--- a/routing/src/main/java/com/oneday/routing/service/RoutePlanningService.java
+++ b/routing/src/main/java/com/oneday/routing/service/RoutePlanningService.java
@@ -1,0 +1,18 @@
+package com.oneday.routing.service;
+
+import com.oneday.routing.domain.RoutePlan;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * Orchestrates the nightly planning pipeline for one city/date (§7): demand → meeting points →
+ * travel matrix → VRP solve → periodise → persist. Produces a PROPOSED {@link RoutePlan} plus its
+ * {@code route_plan_stop} rows and per-DA {@code da_cron_schedule}, and runs the fleet-sizing pass
+ * that flags {@code UNDER_PROVISIONED} (M6-D-003/-005/-008). Approval/override/events are §10 (PR #4).
+ */
+public interface RoutePlanningService {
+
+    /** Plan the city's van loops for {@code date}; persists and returns the PROPOSED plan. */
+    RoutePlan plan(UUID cityId, LocalDate date);
+}

--- a/routing/src/main/java/com/oneday/routing/service/impl/RoutePlanAssembler.java
+++ b/routing/src/main/java/com/oneday/routing/service/impl/RoutePlanAssembler.java
@@ -1,0 +1,123 @@
+package com.oneday.routing.service.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneday.routing.domain.DaCronSchedule;
+import com.oneday.routing.domain.RoutePlanStop;
+import com.oneday.routing.domain.StopNodeKind;
+import com.oneday.routing.service.model.MeetingPlan;
+import com.oneday.routing.service.model.RouteStop;
+import com.oneday.routing.service.model.RoutingNode;
+import com.oneday.routing.service.model.SolveResult;
+import com.oneday.routing.service.model.VanRoute;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.IntFunction;
+
+/**
+ * Stage 4 (periodise) + Stage 5 (derive) of the pipeline (§7.4–7.5, M6-D-003/-008), kept pure so it
+ * is testable without a DB or the solver. Turns one solved loop into {@code n_loops} repetitions
+ * stamped to wall-clock times, then derives each DA's meeting-time list at its vertex.
+ *
+ * <p>Cadence (loop period) = {@code max(realisedCycle, cronFreezeMinutes)} so consecutive meeting
+ * times are always ≥ M5's freeze window apart (C6); {@code n_loops = floor(window / cadence)}.
+ */
+final class RoutePlanAssembler {
+
+    private static final DateTimeFormatter HHMM = DateTimeFormatter.ofPattern("HH:mm");
+
+    private RoutePlanAssembler() {}
+
+    record Assembly(int nLoops, int realisedCycleMinutes, List<RoutePlanStop> stops, List<DaCronSchedule> crons) {}
+
+    static Assembly assemble(UUID routePlanId, UUID cityId, LocalDate date,
+                             SolveResult result, List<RoutingNode> nodes, MeetingPlan plan,
+                             int windowStartHour, int windowMinutes, int dwellMinutes,
+                             int cronFreezeMinutes, ObjectMapper mapper, IntFunction<UUID> vanIdFn) {
+        if (result.routes().isEmpty()) {
+            return new Assembly(0, 0, List.of(), List.of());
+        }
+
+        long realisedCycleSeconds = result.routes().stream().mapToLong(VanRoute::spanSeconds).max().orElse(0);
+        int realisedCycleMinutes = (int) Math.ceil(realisedCycleSeconds / 60.0);
+        int cadenceMinutes = Math.max(realisedCycleMinutes, cronFreezeMinutes);
+        long cadenceSeconds = (long) cadenceMinutes * 60;
+        int nLoops = Math.max(1, windowMinutes / cadenceMinutes);
+        LocalTime windowStart = LocalTime.of(windowStartHour, 0);
+        long dwellSeconds = (long) dwellMinutes * 60;
+
+        List<RoutePlanStop> stops = new ArrayList<>();
+        // Per vertex (recorded from loop 0): its arrival offset, serving van — for cron derivation.
+        Map<UUID, Long> vertexOffset = new HashMap<>();
+        Map<UUID, UUID> vertexVan = new HashMap<>();
+
+        for (VanRoute route : result.routes()) {
+            UUID vanId = vanIdFn.apply(route.vanIndex());
+            for (int loop = 0; loop < nLoops; loop++) {
+                long loopStart = loop * cadenceSeconds;
+                int seq = 1;
+                for (RouteStop stop : route.stops()) {
+                    RoutingNode node = nodes.get(stop.nodeIndex());
+                    LocalTime arrival = windowStart.plusSeconds(loopStart + stop.arrivalOffsetSeconds());
+                    LocalTime departure = arrival.plusSeconds(dwellSeconds);
+                    stops.add(RoutePlanStop.builder()
+                            .routePlanId(routePlanId)
+                            .vanId(vanId)
+                            .loopIndex(loop)
+                            .stopSeq(seq++)
+                            .nodeKind(StopNodeKind.MEETING_VERTEX)
+                            .hexVertexId(stop.vertexId())
+                            .plannedArrival(arrival)
+                            .plannedDeparture(departure)
+                            .deliverQty(node.deliverQty())
+                            .collectQty(node.collectQty())
+                            .loadAfter(stop.loadAfter())
+                            .build());
+                    if (loop == 0) {
+                        vertexOffset.put(stop.vertexId(), stop.arrivalOffsetSeconds());
+                        vertexVan.put(stop.vertexId(), vanId);
+                    }
+                }
+            }
+        }
+
+        List<DaCronSchedule> crons = new ArrayList<>();
+        for (Map.Entry<UUID, UUID> e : plan.daToVertex().entrySet()) {
+            UUID daId = e.getKey();
+            UUID vertexId = e.getValue();
+            Long offset = vertexOffset.get(vertexId);
+            if (offset == null) continue; // DA's vertex not on any route (shouldn't happen if covered)
+
+            List<String> meetingTimes = new ArrayList<>(nLoops);
+            for (int loop = 0; loop < nLoops; loop++) {
+                meetingTimes.add(windowStart.plusSeconds(loop * cadenceSeconds + offset).format(HHMM));
+            }
+            crons.add(DaCronSchedule.builder()
+                    .routePlanId(routePlanId)
+                    .daId(daId)
+                    .hexVertexId(vertexId)
+                    .vanId(vertexVan.get(vertexId))
+                    .meetingTimes(writeJson(mapper, meetingTimes))
+                    .cityId(cityId)
+                    .validDate(date)
+                    .build());
+        }
+
+        return new Assembly(nLoops, realisedCycleMinutes, stops, crons);
+    }
+
+    private static String writeJson(ObjectMapper mapper, List<String> times) {
+        try {
+            return mapper.writeValueAsString(times);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize meeting times", e);
+        }
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/service/impl/RoutePlanningServiceImpl.java
+++ b/routing/src/main/java/com/oneday/routing/service/impl/RoutePlanningServiceImpl.java
@@ -1,0 +1,242 @@
+package com.oneday.routing.service.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneday.routing.config.RoutingProperties;
+import com.oneday.routing.domain.CityFleetConfig;
+import com.oneday.routing.domain.CityLogisticsNode;
+import com.oneday.routing.domain.LogisticsNodeKind;
+import com.oneday.routing.domain.ProvisioningFlag;
+import com.oneday.routing.domain.DaCronSchedule;
+import com.oneday.routing.domain.RoutePlan;
+import com.oneday.routing.domain.RoutePlanStatus;
+import com.oneday.routing.domain.RoutePlanSource;
+import com.oneday.routing.domain.RoutePlanStop;
+import com.oneday.routing.domain.RoutingSolverType;
+import com.oneday.routing.domain.StopNodeKind;
+import com.oneday.routing.repository.CityFleetConfigRepository;
+import com.oneday.routing.repository.CityLogisticsNodeRepository;
+import com.oneday.routing.repository.DaCronScheduleRepository;
+import com.oneday.routing.repository.RoutePlanRepository;
+import com.oneday.routing.repository.RoutePlanStopRepository;
+import com.oneday.routing.service.DemandAggregationService;
+import com.oneday.routing.service.GridDataAdapter;
+import com.oneday.routing.service.MeetingPointSelectionService;
+import com.oneday.routing.service.RoutePlanningService;
+import com.oneday.routing.service.TravelMatrixService;
+import com.oneday.routing.service.VanRouteSolver;
+import com.oneday.routing.service.model.DaTerritory;
+import com.oneday.routing.service.model.MeetingPlan;
+import com.oneday.routing.service.model.MeetingVertex;
+import com.oneday.routing.service.model.RoutingNode;
+import com.oneday.routing.service.model.SolveResult;
+import com.oneday.routing.service.model.TerritoryDemand;
+import com.oneday.routing.service.model.TravelMatrix;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Implements the §7 pipeline. Builds the OSRM matrix once, then runs a small fixed-point on
+ * {@code n_loops} (per-loop demand = daily / n_loops, M6-D-003) since the realised cycle that sets
+ * {@code n_loops} only emerges from the solve. A second fleet-sizing pass finds the minimum vans to
+ * hold the 2–3h cycle target and flags {@code UNDER_PROVISIONED} (M6-D-005). The constrained pass
+ * that ships relaxes the cycle bound to the full operating window — a loop physically cannot exceed
+ * it — so a short fleet still yields a (longer-loop, fewer-cycle) plan rather than nothing.
+ */
+@Service
+class RoutePlanningServiceImpl implements RoutePlanningService {
+
+    private static final Logger log = LoggerFactory.getLogger(RoutePlanningServiceImpl.class);
+    private static final int MAX_NLOOPS_ITERATIONS = 3;
+
+    private final GridDataAdapter gridDataAdapter;
+    private final DemandAggregationService demandAggregationService;
+    private final MeetingPointSelectionService meetingPointSelectionService;
+    private final TravelMatrixService travelMatrixService;
+    private final VanRouteSolver solver;
+    private final CityFleetConfigRepository fleetConfigRepository;
+    private final CityLogisticsNodeRepository logisticsNodeRepository;
+    private final RoutePlanRepository routePlanRepository;
+    private final RoutePlanStopRepository routePlanStopRepository;
+    private final DaCronScheduleRepository daCronScheduleRepository;
+    private final RoutingProperties properties;
+    private final ObjectMapper objectMapper;
+
+    RoutePlanningServiceImpl(GridDataAdapter gridDataAdapter,
+                             DemandAggregationService demandAggregationService,
+                             MeetingPointSelectionService meetingPointSelectionService,
+                             TravelMatrixService travelMatrixService,
+                             VanRouteSolver solver,
+                             CityFleetConfigRepository fleetConfigRepository,
+                             CityLogisticsNodeRepository logisticsNodeRepository,
+                             RoutePlanRepository routePlanRepository,
+                             RoutePlanStopRepository routePlanStopRepository,
+                             DaCronScheduleRepository daCronScheduleRepository,
+                             RoutingProperties properties,
+                             ObjectMapper objectMapper) {
+        this.gridDataAdapter = gridDataAdapter;
+        this.demandAggregationService = demandAggregationService;
+        this.meetingPointSelectionService = meetingPointSelectionService;
+        this.travelMatrixService = travelMatrixService;
+        this.solver = solver;
+        this.fleetConfigRepository = fleetConfigRepository;
+        this.logisticsNodeRepository = logisticsNodeRepository;
+        this.routePlanRepository = routePlanRepository;
+        this.routePlanStopRepository = routePlanStopRepository;
+        this.daCronScheduleRepository = daCronScheduleRepository;
+        this.properties = properties;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    @Transactional
+    public RoutePlan plan(UUID cityId, LocalDate date) {
+        CityFleetConfig fleet = fleetConfigRepository.findByCityId(cityId)
+                .orElseThrow(() -> new IllegalStateException("No city_fleet_config for cityId=" + cityId));
+        CityLogisticsNode hub = logisticsNodeRepository.findByCityIdAndKind(cityId, LogisticsNodeKind.HUB)
+                .orElseThrow(() -> new IllegalStateException("No HUB logistics node for cityId=" + cityId));
+
+        List<DaTerritory> territories = gridDataAdapter.getDaTerritories(cityId, date);
+        Map<UUID, TerritoryDemand> demandByDa = demandAggregationService.aggregate(territories).stream()
+                .collect(Collectors.toMap(TerritoryDemand::daId, d -> d));
+        MeetingPlan meetingPlan = meetingPointSelectionService.select(territories);
+
+        int windowMinutes = (properties.getWindow().getEndHour() - properties.getWindow().getStartHour()) * 60;
+
+        if (meetingPlan.vertices().isEmpty()) {
+            log.info("No meeting vertices for cityId={} date={} (no active territories) — empty plan", cityId, date);
+            return persistPlan(cityId, date, RoutingSolverType.OR_TOOLS, 0, 0, 0, 0,
+                    ProvisioningFlag.OK, "No active territories", List.of(), List.of());
+        }
+
+        // OSRM is called once: the node coordinates are fixed; only per-loop quantities change.
+        long[][] seconds = travelMatrixService.buildMatrix(buildNodes(hub, meetingPlan, demandByDa, 1)).travelSeconds();
+
+        // Fixed-point on n_loops: the realised cycle that sets n_loops only emerges from the solve.
+        int nLoops = Math.max(1, windowMinutes / fleet.getCycleTimeMaxMinutes());
+        SolveResult constrained = null;
+        List<RoutingNode> nodes = null;
+        for (int iter = 0; iter < MAX_NLOOPS_ITERATIONS; iter++) {
+            nodes = buildNodes(hub, meetingPlan, demandByDa, nLoops);
+            TravelMatrix matrix = new TravelMatrix(nodes, seconds);
+            constrained = solver.solve(matrix, fleet.getVansAvailable(), fleet.getCapacityPackets(), windowMinutes);
+            if (!constrained.feasible() || constrained.routes().isEmpty()) break;
+
+            long maxSpan = constrained.routes().stream().mapToLong(r -> r.spanSeconds()).max().orElse(0);
+            int cadence = Math.max((int) Math.ceil(maxSpan / 60.0), properties.getCronFreezeMinutes());
+            int newNLoops = Math.max(1, windowMinutes / cadence);
+            if (newNLoops == nLoops) break;
+            nLoops = newNLoops;
+        }
+
+        Integer recommended = recommendVanCount(nodes, seconds, fleet);
+        ProvisioningFlag flag = (recommended != null && fleet.getVansAvailable() < recommended)
+                ? ProvisioningFlag.UNDER_PROVISIONED : ProvisioningFlag.OK;
+        if (flag == ProvisioningFlag.UNDER_PROVISIONED) {
+            log.warn("City {} under-provisioned for {}: {} vans available, {} recommended",
+                    cityId, date, fleet.getVansAvailable(), recommended);
+        }
+
+        if (constrained == null || !constrained.feasible() || constrained.routes().isEmpty()) {
+            String note = "No feasible routing with " + fleet.getVansAvailable() + " vans"
+                    + (recommended != null ? " (recommended " + recommended + ")" : "");
+            RoutingSolverType engine = constrained != null ? constrained.solverType() : RoutingSolverType.OR_TOOLS;
+            return persistPlan(cityId, date, engine, 0, 0, 0, recommended,
+                    ProvisioningFlag.UNDER_PROVISIONED, note, List.of(), List.of());
+        }
+
+        UUID planId = UUID.randomUUID(); // assign up front so assembled children reference it
+        RoutePlanAssembler.Assembly assembly = RoutePlanAssembler.assemble(
+                planId, cityId, date, constrained, nodes, meetingPlan,
+                properties.getWindow().getStartHour(), windowMinutes, fleet.getDwellMinutes(),
+                properties.getCronFreezeMinutes(), objectMapper, idx -> vanId(cityId, idx));
+
+        int vansUsed = constrained.routes().size();
+        return persistPlanWithId(planId, cityId, date, constrained.solverType(),
+                vansUsed, assembly.nLoops(), assembly.realisedCycleMinutes(), recommended, flag, null,
+                assembly.stops(), assembly.crons());
+    }
+
+    /** Min vans to cover all vertices within capacity AND the 2–3h cycle target (M6-D-005). */
+    private Integer recommendVanCount(List<RoutingNode> nodes, long[][] seconds, CityFleetConfig fleet) {
+        if (nodes == null || nodes.size() <= 1) return 0;
+        int vertexCount = nodes.size() - 1;
+        int totalDeliver = nodes.stream().mapToInt(RoutingNode::deliverQty).sum();
+        int lowerBound = Math.max(1, (int) Math.ceil((double) totalDeliver / fleet.getCapacityPackets()));
+        TravelMatrix matrix = new TravelMatrix(nodes, seconds);
+        for (int k = lowerBound; k <= vertexCount; k++) {
+            SolveResult r = solver.solve(matrix, k, fleet.getCapacityPackets(), fleet.getCycleTimeMaxMinutes());
+            if (r.feasible() && !r.routes().isEmpty()) return k;
+        }
+        return vertexCount; // even one-van-per-vertex couldn't hold the cycle target — best effort
+    }
+
+    private List<RoutingNode> buildNodes(CityLogisticsNode hub, MeetingPlan plan,
+                                         Map<UUID, TerritoryDemand> demandByDa, int nLoops) {
+        List<RoutingNode> nodes = new ArrayList<>(plan.vertices().size() + 1);
+        nodes.add(RoutingNode.hub(hub.getId(), hub.getLat(), hub.getLon()));
+        int dwellSeconds = properties.getDwellMinutes() * 60;
+        int idx = 1;
+        for (MeetingVertex vertex : plan.vertices()) {
+            double dailyDeliver = 0, dailyCollect = 0;
+            for (UUID daId : plan.vertexToDaIds().getOrDefault(vertex.vertexId(), List.of())) {
+                TerritoryDemand d = demandByDa.get(daId);
+                if (d == null) continue;
+                dailyDeliver += d.lastMileQty();
+                dailyCollect += d.firstMileQty();
+            }
+            int perLoopDeliver = (int) Math.ceil(dailyDeliver / nLoops);
+            int perLoopCollect = (int) Math.ceil(dailyCollect / nLoops);
+            nodes.add(new RoutingNode(idx, StopNodeKind.MEETING_VERTEX, vertex.vertexId(),
+                    vertex.lat(), vertex.lon(), perLoopDeliver, perLoopCollect, dwellSeconds));
+            idx++;
+        }
+        return nodes;
+    }
+
+    /** Deterministic van id per (city, vehicle index) — no fleet registry exists yet. */
+    private static UUID vanId(UUID cityId, int vanIndex) {
+        return UUID.nameUUIDFromBytes(("van:" + cityId + ":" + vanIndex).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private RoutePlan persistPlan(UUID cityId, LocalDate date, RoutingSolverType solverType, int vansUsed, int nLoops,
+                                  int realisedCycleMinutes, Integer recommended, ProvisioningFlag flag, String notes,
+                                  List<RoutePlanStop> stops, List<DaCronSchedule> crons) {
+        return persistPlanWithId(UUID.randomUUID(), cityId, date, solverType, vansUsed, nLoops,
+                realisedCycleMinutes, recommended, flag, notes, stops, crons);
+    }
+
+    private RoutePlan persistPlanWithId(UUID planId, UUID cityId, LocalDate date, RoutingSolverType solverType,
+                                        int vansUsed, int nLoops, int realisedCycleMinutes, Integer recommended,
+                                        ProvisioningFlag flag, String notes,
+                                        List<RoutePlanStop> stops, List<DaCronSchedule> crons) {
+        RoutePlan plan = RoutePlan.builder()
+                .id(planId)
+                .cityId(cityId)
+                .validForDate(date)
+                .status(RoutePlanStatus.PROPOSED)
+                .source(RoutePlanSource.NIGHTLY)
+                .solverType(solverType)
+                .revision(1)
+                .vansUsed(vansUsed)
+                .recommendedVanCount(recommended)
+                .provisioningFlag(flag)
+                .nLoops(nLoops)
+                .realisedCycleMinutes(realisedCycleMinutes)
+                .notes(notes)
+                .build();
+        routePlanRepository.save(plan);
+        if (!stops.isEmpty()) routePlanStopRepository.saveAll(stops);
+        if (!crons.isEmpty()) daCronScheduleRepository.saveAll(crons);
+        return plan;
+    }
+}

--- a/routing/src/test/java/com/oneday/routing/service/impl/RoutePlanAssemblerTest.java
+++ b/routing/src/test/java/com/oneday/routing/service/impl/RoutePlanAssemblerTest.java
@@ -1,0 +1,132 @@
+package com.oneday.routing.service.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneday.routing.domain.DaCronSchedule;
+import com.oneday.routing.domain.RoutePlanStop;
+import com.oneday.routing.domain.RoutingSolverType;
+import com.oneday.routing.domain.StopNodeKind;
+import com.oneday.routing.service.model.MeetingPlan;
+import com.oneday.routing.service.model.MeetingVertex;
+import com.oneday.routing.service.model.RouteStop;
+import com.oneday.routing.service.model.RoutingNode;
+import com.oneday.routing.service.model.SolveResult;
+import com.oneday.routing.service.model.VanRoute;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Periodise + derive (§7.4–7.5): n_loops, wall-clock ETAs, C6 spacing, per-DA meeting times. */
+class RoutePlanAssemblerTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final int WINDOW_START_HOUR = 7;
+    private static final int WINDOW_MINUTES = 13 * 60;   // 07:00–20:00
+    private static final int DWELL_MINUTES = 5;
+    private static final int CRON_FREEZE = 30;
+
+    private final UUID cityId = UUID.randomUUID();
+    private final UUID vertexA = UUID.randomUUID();
+    private final UUID vertexB = UUID.randomUUID();
+    private final UUID daA = UUID.randomUUID();
+    private final UUID daB = UUID.randomUUID();
+
+    /** Hub + A (arr 10min) + B (arr 60min); loop span 120min. */
+    private SolveResult singleVanTwoStops() {
+        RouteStop stopA = new RouteStop(1, vertexA, 600, 2);
+        RouteStop stopB = new RouteStop(2, vertexB, 3600, 4);
+        VanRoute route = new VanRoute(0, List.of(stopA, stopB), 7200, 7200, 9);
+        return new SolveResult(List.of(route), RoutingSolverType.OR_TOOLS, true);
+    }
+
+    private List<RoutingNode> nodes() {
+        return List.of(
+                RoutingNode.hub(UUID.randomUUID(), 12.9, 77.5),
+                new RoutingNode(1, StopNodeKind.MEETING_VERTEX, vertexA, 12.95, 77.6, 5, 3, 300),
+                new RoutingNode(2, StopNodeKind.MEETING_VERTEX, vertexB, 13.0, 77.7, 4, 2, 300));
+    }
+
+    private MeetingPlan plan() {
+        return new MeetingPlan(
+                List.of(new MeetingVertex(vertexA, 12.95, 77.6), new MeetingVertex(vertexB, 13.0, 77.7)),
+                Map.of(vertexA, List.of(daA), vertexB, List.of(daB)),
+                Map.of(daA, vertexA, daB, vertexB));
+    }
+
+    private RoutePlanAssembler.Assembly assemble() {
+        UUID vanId = UUID.randomUUID();
+        return RoutePlanAssembler.assemble(UUID.randomUUID(), cityId, LocalDate.of(2026, 6, 9),
+                singleVanTwoStops(), nodes(), plan(),
+                WINDOW_START_HOUR, WINDOW_MINUTES, DWELL_MINUTES, CRON_FREEZE, MAPPER, idx -> vanId);
+    }
+
+    @Test
+    void computesNLoopsFromCadenceAndCycle() {
+        RoutePlanAssembler.Assembly a = assemble();
+        assertThat(a.realisedCycleMinutes()).isEqualTo(120);   // 7200s
+        // cadence = max(120, 30) = 120; floor(780 / 120) = 6
+        assertThat(a.nLoops()).isEqualTo(6);
+        assertThat(a.stops()).hasSize(6 * 2);                  // 6 loops × 2 stops
+    }
+
+    @Test
+    void stampsMonotonicWallClockEtas() {
+        List<RoutePlanStop> stops = assemble().stops();
+
+        // Loop 0: A at 07:10, B at 08:00.
+        RoutePlanStop loop0A = stopOf(stops, 0, vertexA);
+        RoutePlanStop loop0B = stopOf(stops, 0, vertexB);
+        assertThat(loop0A.getPlannedArrival()).isEqualTo(LocalTime.of(7, 10));
+        assertThat(loop0B.getPlannedArrival()).isEqualTo(LocalTime.of(8, 0));
+        assertThat(loop0A.getPlannedArrival()).isBefore(loop0B.getPlannedArrival());
+        assertThat(loop0A.getPlannedDeparture()).isEqualTo(LocalTime.of(7, 15)); // +dwell
+
+        // Loop 1 is one cadence (120m) later than loop 0.
+        RoutePlanStop loop1A = stopOf(stops, 1, vertexA);
+        assertThat(loop1A.getPlannedArrival()).isEqualTo(LocalTime.of(9, 10));
+
+        // Per-loop quantities carried from the node.
+        assertThat(loop0A.getDeliverQty()).isEqualTo(5);
+        assertThat(loop0A.getCollectQty()).isEqualTo(3);
+        assertThat(loop0A.getLoadAfter()).isEqualTo(2);
+    }
+
+    @Test
+    void derivesPerDaMeetingTimesSpacedByCadence() throws Exception {
+        RoutePlanAssembler.Assembly a = assemble();
+        assertThat(a.crons()).hasSize(2);
+
+        DaCronSchedule cronA = a.crons().stream().filter(c -> c.getDaId().equals(daA)).findFirst().orElseThrow();
+        assertThat(cronA.getHexVertexId()).isEqualTo(vertexA);
+
+        List<String> times = MAPPER.readValue(cronA.getMeetingTimes(), new com.fasterxml.jackson.core.type.TypeReference<>() {});
+        assertThat(times).containsExactly("07:10", "09:10", "11:10", "13:10", "15:10", "17:10");
+
+        // C6: consecutive meeting times are ≥ CRON_FREEZE minutes apart.
+        for (int i = 1; i < times.size(); i++) {
+            long gap = java.time.Duration.between(LocalTime.parse(times.get(i - 1)), LocalTime.parse(times.get(i))).toMinutes();
+            assertThat(gap).isGreaterThanOrEqualTo(CRON_FREEZE);
+        }
+    }
+
+    @Test
+    void emptySolveYieldsEmptyAssembly() {
+        RoutePlanAssembler.Assembly a = RoutePlanAssembler.assemble(UUID.randomUUID(), cityId, LocalDate.now(),
+                new SolveResult(List.of(), RoutingSolverType.OR_TOOLS, true), nodes(), plan(),
+                WINDOW_START_HOUR, WINDOW_MINUTES, DWELL_MINUTES, CRON_FREEZE, MAPPER, idx -> UUID.randomUUID());
+        assertThat(a.nLoops()).isZero();
+        assertThat(a.stops()).isEmpty();
+        assertThat(a.crons()).isEmpty();
+    }
+
+    private static RoutePlanStop stopOf(List<RoutePlanStop> stops, int loop, UUID vertexId) {
+        return stops.stream()
+                .filter(s -> s.getLoopIndex() == loop && vertexId.equals(s.getHexVertexId()))
+                .findFirst().orElseThrow();
+    }
+}


### PR DESCRIPTION
## Summary
Implements M6 Routing PR #3 — plan assembly and fleet sizing: orchestrates the nightly pipeline (demand to meeting points to matrix to VRP solve to periodise) into a persisted PROPOSED route plan with per-DA cron schedule, plus a fleet-sizing pass that flags under-provisioned cities.

## What Changed
- Added `RoutePlanningService` and its impl: orchestrates the full section 7 pipeline for one city/date and persists a PROPOSED `route_plan` with its `route_plan_stop` rows and per-DA `da_cron_schedule`.
- Built the OSRM matrix once and reused it across a bounded n_loops fixed-point, since per-loop demand is daily/n_loops but the realised cycle that sets n_loops only emerges from the solve (M6-D-003).
- Added the fleet-sizing pass: finds the minimum vans to hold the 2-3h cycle target as `recommended_van_count` and flags `UNDER_PROVISIONED` when vans_available is below it (M6-D-005).
- Added `RoutePlanAssembler`, a pure component that periodises one solved loop into n_loops wall-clock repetitions and derives each DA's meeting-time list, guaranteeing meeting times are at least the cron-freeze window apart (C6).
- Added a deterministic van-id derivation per (city, vehicle index) since no fleet registry exists yet.
- Added `cronFreezeMinutes` (default 30) to `RoutingProperties`.

## Why This Change?
PR #2 produced the optimiser core (a single solved loop). PR #3 turns that into a real, persisted nightly plan: it stamps wall-clock ETAs across repeating loops, derives the cron schedule M5 will consume, and tells ops whether the configured fleet can actually hold the cycle target. This completes the plan-time data that PR #4 (governance, approval, override, producers) acts on.

## Testing
- [x] Tested locally
- [x] Edge cases considered
- [x] No breaking changes introduced

### Test Evidence
mvn -pl routing test
  RoutingArchitectureTest .................. 1   (no grid-internal imports)
  SavingsVanRouteSolverTest ................ 3
  RoutePlanAssemblerTest ................... 4   (n_loops, monotonic ETAs, C6 spacing, cron times, empty solve)
  OrToolsVanRouteSolverTest ................ 2
  GreedyMeetingPointSelectionServiceTest ... 2
  TravelMatrixServiceTest .................. 2
Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS

mvn -pl common,grid,routing install  ->  BUILD SUCCESS

## Impact

### Areas Affected
- [x] Backend
- [x] Routing

### Modules Affected
- [x] M6 — Routing

## Risks / Concerns
- Van identity is derived deterministically per (city, vehicle index); when a real fleetthout changing the plan shape.
- Kafka events (DA_CRON_SCHEDULED, ROUTE_PLAN_PUBLISHED) and the station-manager under-provisioned notification are deferred to PR #4 by design; PR #3 persists PROPOSED and logs the warning.
- The n_loops fixed-point is capped at 3 iterations; it converges in 1-2 in practice sinpendent of per-loop quantities when capacity is not binding.
- The fleet-sizing pass iterates van count upward and solves each step; bounded by the meeting-vertex count and a capacity lower bound, fine at city scale for a nightly job.
- No Testcontainers end-to-end test in this PR (deferred to the PR #8 simulation harnessovered by the pure assembler and solver unit tests.

## Checklist
- [x] Code follows project conventions (package layout, no cross-module internal imports)
- [x] Self-review completed
- [x] Append-only audit trail preserved (no mutations to scan/manifest/role-change records)
- [x] No sensitive data or credentials exposed
- [x] Documentation updated if behaviour changed
- [x] Ready for review