### PR TITLE
M6 IMPL - PR #4 - Route plan lifecycle service, ShuttleSchedule service

### DIFF
--- a/routing/src/main/java/com/oneday/routing/api/RoutePlanController.java
+++ b/routing/src/main/java/com/oneday/routing/api/RoutePlanController.java
@@ -1,0 +1,152 @@
+package com.oneday.routing.api;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneday.routing.domain.DaCronSchedule;
+import com.oneday.routing.domain.RoutePlan;
+import com.oneday.routing.dto.ApproveRequest;
+import com.oneday.routing.dto.DaCronScheduleResponse;
+import com.oneday.routing.dto.NextMeetingResponse;
+import com.oneday.routing.dto.OverrideRequest;
+import com.oneday.routing.dto.RoutePlanResponse;
+import com.oneday.routing.dto.RoutePlanStopResponse;
+import com.oneday.routing.dto.ShuttleTimetableResponse;
+import com.oneday.routing.service.RoutePlanLifecycleService;
+import com.oneday.routing.service.ShuttleScheduleService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Nightly-governance + read API for van route plans (§17.2). Approve / override / replan mutate;
+ * the GETs serve M5 (cron schedules), M9 (shuttle) and the ops console. Plan bodies are append-only,
+ * so an override returns a new revision rather than editing in place (C17).
+ */
+@RestController
+@RequestMapping("/routing")
+public class RoutePlanController {
+
+    private static final Logger log = LoggerFactory.getLogger(RoutePlanController.class);
+    private static final TypeReference<List<String>> TIME_LIST = new TypeReference<>() {};
+
+    private final RoutePlanLifecycleService lifecycleService;
+    private final ShuttleScheduleService shuttleScheduleService;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    RoutePlanController(RoutePlanLifecycleService lifecycleService,
+                        ShuttleScheduleService shuttleScheduleService,
+                        ObjectMapper objectMapper,
+                        Clock clock) {
+        this.lifecycleService = lifecycleService;
+        this.shuttleScheduleService = shuttleScheduleService;
+        this.objectMapper = objectMapper;
+        this.clock = clock;
+    }
+
+    // ── Queries ───────────────────────────────────────────────────────────────
+
+    @GetMapping("/plans/{cityId}")
+    public RoutePlanResponse getPlan(
+            @PathVariable UUID cityId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        LocalDate d = date != null ? date : LocalDate.now(clock);
+        return lifecycleService.activePlan(cityId, d)
+                .map(RoutePlanResponse::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "No active route plan for cityId=" + cityId + " date=" + d));
+    }
+
+    @GetMapping("/plans/{cityId}/vans/{vanId}/stops")
+    public List<RoutePlanStopResponse> getVanStops(
+            @PathVariable UUID cityId,
+            @PathVariable UUID vanId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        LocalDate d = date != null ? date : LocalDate.now(clock);
+        RoutePlan plan = lifecycleService.activePlan(cityId, d)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "No active route plan for cityId=" + cityId + " date=" + d));
+        return lifecycleService.stops(plan.getId(), vanId).stream()
+                .map(RoutePlanStopResponse::from)
+                .toList();
+    }
+
+    @GetMapping("/cron/da/{daId}")
+    public List<DaCronScheduleResponse> getDaCron(
+            @PathVariable UUID daId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        LocalDate d = date != null ? date : LocalDate.now(clock);
+        return lifecycleService.cronForDa(daId, d).stream()
+                .map(c -> new DaCronScheduleResponse(c.getDaId(), c.getCityId(), c.getValidDate(),
+                        c.getRoutePlanId(), c.getHexVertexId(), c.getVanId(), parseTimes(c.getMeetingTimes())))
+                .toList();
+    }
+
+    @GetMapping("/cron/da/{daId}/next")
+    public NextMeetingResponse getNextMeeting(
+            @PathVariable UUID daId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.TIME) LocalTime at) {
+        LocalDate today = LocalDate.now(clock);
+        LocalTime cutoff = at != null ? at : LocalTime.now(clock);
+        return lifecycleService.cronForDa(daId, today).stream()
+                .flatMap(c -> parseTimes(c.getMeetingTimes()).stream()
+                        .filter(t -> !t.isBefore(cutoff))
+                        .map(t -> new NextMeetingResponse(daId, c.getHexVertexId(), c.getVanId(), t)))
+                .min((a, b) -> a.nextMeeting().compareTo(b.nextMeeting()))
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "No upcoming meeting for daId=" + daId + " after " + cutoff));
+    }
+
+    @GetMapping("/shuttle/{cityId}")
+    public ShuttleTimetableResponse getShuttle(
+            @PathVariable UUID cityId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        LocalDate d = date != null ? date : LocalDate.now(clock);
+        return ShuttleTimetableResponse.from(shuttleScheduleService.timetable(cityId, d));
+    }
+
+    // ── Governance ──────────────────────────────────────────────────────────
+
+    @PostMapping("/plans/{planId}/approve")
+    public RoutePlanResponse approve(@PathVariable UUID planId, @RequestBody ApproveRequest request) {
+        return RoutePlanResponse.from(lifecycleService.approve(planId, request.actorId()));
+    }
+
+    @PostMapping("/plans/{planId}/override")
+    public RoutePlanResponse override(@PathVariable UUID planId, @RequestBody OverrideRequest request) {
+        return RoutePlanResponse.from(lifecycleService.override(planId, request));
+    }
+
+    @PostMapping("/plans/{cityId}/replan")
+    public RoutePlanResponse replan(
+            @PathVariable UUID cityId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        LocalDate d = date != null ? date : LocalDate.now(clock).plusDays(1);
+        return RoutePlanResponse.from(lifecycleService.replan(cityId, d));
+    }
+
+    private List<LocalTime> parseTimes(String json) {
+        if (json == null || json.isBlank()) return List.of();
+        try {
+            return objectMapper.readValue(json, TIME_LIST).stream().map(LocalTime::parse).toList();
+        } catch (Exception e) {
+            log.warn("Could not parse meeting_times json '{}': {}", json, e.getMessage());
+            return List.of();
+        }
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/batch/NightlyRoutePlanJob.java
+++ b/routing/src/main/java/com/oneday/routing/batch/NightlyRoutePlanJob.java
@@ -1,0 +1,164 @@
+package com.oneday.routing.batch;
+
+import com.oneday.routing.domain.CityFleetConfig;
+import com.oneday.routing.domain.DaCronSchedule;
+import com.oneday.routing.domain.RoutePlan;
+import com.oneday.routing.domain.RoutePlanSource;
+import com.oneday.routing.domain.RoutePlanStatus;
+import com.oneday.routing.domain.RoutePlanStop;
+import com.oneday.routing.repository.CityFleetConfigRepository;
+import com.oneday.routing.repository.DaCronScheduleRepository;
+import com.oneday.routing.repository.RoutePlanRepository;
+import com.oneday.routing.repository.RoutePlanStopRepository;
+import com.oneday.routing.service.RoutePlanningService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Nightly van-route governance (§10), mirroring M3's {@code NightlyReplanJob}:
+ * <ul>
+ *   <li><b>01:00</b> — solve §7 per city → a PROPOSED {@link RoutePlan} for tomorrow.</li>
+ *   <li><b>06:00</b> — escalation: no APPROVED plan for today ⇒ warn the station manager.</li>
+ *   <li><b>07:00</b> — auto-fallback: still unapproved ⇒ copy yesterday's APPROVED plan forward.</li>
+ * </ul>
+ * The set of plannable cities is exactly those with a {@code city_fleet_config} row.
+ */
+@Component
+public class NightlyRoutePlanJob {
+
+    private static final Logger log = LoggerFactory.getLogger(NightlyRoutePlanJob.class);
+
+    private final CityFleetConfigRepository fleetConfigRepository;
+    private final RoutePlanningService routePlanningService;
+    private final RoutePlanRepository routePlanRepository;
+    private final RoutePlanStopRepository routePlanStopRepository;
+    private final DaCronScheduleRepository daCronScheduleRepository;
+    private final Clock clock;
+
+    NightlyRoutePlanJob(CityFleetConfigRepository fleetConfigRepository,
+                        RoutePlanningService routePlanningService,
+                        RoutePlanRepository routePlanRepository,
+                        RoutePlanStopRepository routePlanStopRepository,
+                        DaCronScheduleRepository daCronScheduleRepository,
+                        Clock clock) {
+        this.fleetConfigRepository = fleetConfigRepository;
+        this.routePlanningService = routePlanningService;
+        this.routePlanRepository = routePlanRepository;
+        this.routePlanStopRepository = routePlanStopRepository;
+        this.daCronScheduleRepository = daCronScheduleRepository;
+        this.clock = clock;
+    }
+
+    @Scheduled(cron = "0 0 1 * * *", zone = "Asia/Kolkata")
+    public void run() {
+        LocalDate tomorrow = LocalDate.now(clock).plusDays(1);
+        log.info("NightlyRoutePlanJob starting for date={}", tomorrow);
+        for (CityFleetConfig fleet : fleetConfigRepository.findAll()) {
+            try {
+                routePlanningService.plan(fleet.getCityId(), tomorrow);
+            } catch (Exception e) {
+                log.error("NightlyRoutePlanJob failed for cityId={}", fleet.getCityId(), e);
+            }
+        }
+        log.info("NightlyRoutePlanJob complete for date={}", tomorrow);
+    }
+
+    @Scheduled(cron = "0 0 6 * * *", zone = "Asia/Kolkata")
+    public void checkEscalation() {
+        LocalDate today = LocalDate.now(clock);
+        for (CityFleetConfig fleet : fleetConfigRepository.findAll()) {
+            UUID cityId = fleet.getCityId();
+            if (!hasApproved(cityId, today)) {
+                log.warn("ESCALATION_ALERT cityId={} date={}: no approved route plan by 06:00; station manager action required",
+                        cityId, today);
+            }
+        }
+    }
+
+    @Scheduled(cron = "0 0 7 * * *", zone = "Asia/Kolkata")
+    public void applyFallbackIfNeeded() {
+        LocalDate today = LocalDate.now(clock);
+        LocalDate yesterday = today.minusDays(1);
+        for (CityFleetConfig fleet : fleetConfigRepository.findAll()) {
+            UUID cityId = fleet.getCityId();
+            if (hasApproved(cityId, today)) continue;
+
+            List<RoutePlan> yesterdayApproved = routePlanRepository
+                    .findByCityIdAndValidForDateAndStatus(cityId, yesterday, RoutePlanStatus.APPROVED);
+            if (yesterdayApproved.isEmpty()) {
+                log.warn("AUTO_FALLBACK_FAILED cityId={}: no approved plan for yesterday {} either; city has no coverage",
+                        cityId, yesterday);
+                continue;
+            }
+            applyFallback(cityId, today, yesterdayApproved.get(yesterdayApproved.size() - 1));
+        }
+    }
+
+    private boolean hasApproved(UUID cityId, LocalDate date) {
+        return !routePlanRepository.findByCityIdAndValidForDateAndStatus(cityId, date, RoutePlanStatus.APPROVED).isEmpty();
+    }
+
+    // Copy yesterday's APPROVED plan (stops + crons) forward as today's APPROVED FALLBACK plan.
+    @Transactional
+    void applyFallback(UUID cityId, LocalDate today, RoutePlan yesterdayPlan) {
+        UUID fallbackId = UUID.randomUUID();
+        RoutePlan fallback = RoutePlan.builder()
+                .id(fallbackId)
+                .cityId(cityId)
+                .validForDate(today)
+                .status(RoutePlanStatus.APPROVED)
+                .source(RoutePlanSource.FALLBACK)
+                .solverType(yesterdayPlan.getSolverType())
+                .revision(1)
+                .supersedesPlanId(yesterdayPlan.getId())
+                .vansUsed(yesterdayPlan.getVansUsed())
+                .recommendedVanCount(yesterdayPlan.getRecommendedVanCount())
+                .provisioningFlag(yesterdayPlan.getProvisioningFlag())
+                .nLoops(yesterdayPlan.getNLoops())
+                .realisedCycleMinutes(yesterdayPlan.getRealisedCycleMinutes())
+                .notes("Auto-fallback: no approved plan by 07:00; copied from " + today.minusDays(1))
+                .build();
+        routePlanRepository.save(fallback);
+
+        List<RoutePlanStop> stops = routePlanStopRepository.findByRoutePlanId(yesterdayPlan.getId()).stream()
+                .map(s -> RoutePlanStop.builder()
+                        .routePlanId(fallbackId)
+                        .vanId(s.getVanId())
+                        .loopIndex(s.getLoopIndex())
+                        .stopSeq(s.getStopSeq())
+                        .nodeKind(s.getNodeKind())
+                        .hexVertexId(s.getHexVertexId())
+                        .plannedArrival(s.getPlannedArrival())
+                        .plannedDeparture(s.getPlannedDeparture())
+                        .deliverQty(s.getDeliverQty())
+                        .collectQty(s.getCollectQty())
+                        .loadAfter(s.getLoadAfter())
+                        .build())
+                .toList();
+        if (!stops.isEmpty()) routePlanStopRepository.saveAll(stops);
+
+        List<DaCronSchedule> crons = daCronScheduleRepository.findByRoutePlanId(yesterdayPlan.getId()).stream()
+                .map(c -> DaCronSchedule.builder()
+                        .routePlanId(fallbackId)
+                        .daId(c.getDaId())
+                        .hexVertexId(c.getHexVertexId())
+                        .vanId(c.getVanId())
+                        .meetingTimes(c.getMeetingTimes())
+                        .cityId(c.getCityId())
+                        .validDate(today)
+                        .build())
+                .toList();
+        if (!crons.isEmpty()) daCronScheduleRepository.saveAll(crons);
+
+        log.info("AUTO_FALLBACK_APPLIED cityId={} date={} planId={} stops={} crons={}",
+                cityId, today, fallbackId, stops.size(), crons.size());
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/dto/ApproveRequest.java
+++ b/routing/src/main/java/com/oneday/routing/dto/ApproveRequest.java
@@ -1,0 +1,11 @@
+package com.oneday.routing.dto;
+
+import java.util.UUID;
+
+/**
+ * Body for {@code POST /routing/plans/{planId}/approve}. {@code actorId} is the approving station
+ * manager / admin (recorded as {@code route_plan.approved_by} and in the audit). Real M1 city-scope
+ * enforcement is wired the same way grid's {@code ProposalController} takes its reviewer — JWT
+ * integration lands with the cross-module auth pass.
+ */
+public record ApproveRequest(UUID actorId) {}

--- a/routing/src/main/java/com/oneday/routing/dto/DaCronScheduleResponse.java
+++ b/routing/src/main/java/com/oneday/routing/dto/DaCronScheduleResponse.java
@@ -1,0 +1,16 @@
+package com.oneday.routing.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+/** A DA's vertex + the day's meeting times ({@code GET /routing/cron/da/{daId}}) — M5's input. */
+public record DaCronScheduleResponse(
+        UUID daId,
+        UUID cityId,
+        LocalDate validDate,
+        UUID routePlanId,
+        UUID hexVertexId,
+        UUID vanId,
+        List<LocalTime> meetingTimes) {}

--- a/routing/src/main/java/com/oneday/routing/dto/NextMeetingResponse.java
+++ b/routing/src/main/java/com/oneday/routing/dto/NextMeetingResponse.java
@@ -1,0 +1,11 @@
+package com.oneday.routing.dto;
+
+import java.time.LocalTime;
+import java.util.UUID;
+
+/** The single next meeting at/after {@code at} ({@code GET /routing/cron/da/{daId}/next}) — M5 convenience. */
+public record NextMeetingResponse(
+        UUID daId,
+        UUID hexVertexId,
+        UUID vanId,
+        LocalTime nextMeeting) {}

--- a/routing/src/main/java/com/oneday/routing/dto/OverrideRequest.java
+++ b/routing/src/main/java/com/oneday/routing/dto/OverrideRequest.java
@@ -1,0 +1,17 @@
+package com.oneday.routing.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Body for {@code POST /routing/plans/{planId}/override} (§10). A station manager / admin edits a
+ * live APPROVED plan; M6 supersedes it with a new append-only revision (source MANUAL_OVERRIDE),
+ * records a {@code route_override_audit} row, and emits {@code ROUTE_CHANGED}. {@code reassignments}
+ * may be empty (e.g. a re-publish with a reason); when present each moves a stop to a new vertex.
+ */
+public record OverrideRequest(UUID actorId, String reason, List<StopReassignment> reassignments) {
+
+    public List<StopReassignment> reassignmentsOrEmpty() {
+        return reassignments != null ? reassignments : List.of();
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/dto/RoutePlanResponse.java
+++ b/routing/src/main/java/com/oneday/routing/dto/RoutePlanResponse.java
@@ -1,0 +1,40 @@
+package com.oneday.routing.dto;
+
+import com.oneday.routing.domain.RoutePlan;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+/** Plan header + fleet-sizing verdict ({@code GET /routing/plans/{cityId}}). */
+public record RoutePlanResponse(
+        UUID planId,
+        UUID cityId,
+        LocalDate validForDate,
+        String status,
+        String source,
+        String solverType,
+        int revision,
+        UUID supersedesPlanId,
+        Integer vansUsed,
+        Integer recommendedVanCount,
+        String provisioningFlag,
+        Integer nLoops,
+        Integer realisedCycleMinutes,
+        String notes,
+        UUID approvedBy,
+        Instant approvedAt,
+        Instant createdAt) {
+
+    public static RoutePlanResponse from(RoutePlan p) {
+        return new RoutePlanResponse(
+                p.getId(), p.getCityId(), p.getValidForDate(),
+                p.getStatus() != null ? p.getStatus().name() : null,
+                p.getSource() != null ? p.getSource().name() : null,
+                p.getSolverType() != null ? p.getSolverType().name() : null,
+                p.getRevision(), p.getSupersedesPlanId(), p.getVansUsed(), p.getRecommendedVanCount(),
+                p.getProvisioningFlag() != null ? p.getProvisioningFlag().name() : null,
+                p.getNLoops(), p.getRealisedCycleMinutes(), p.getNotes(),
+                p.getApprovedBy(), p.getApprovedAt(), p.getCreatedAt());
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/dto/RoutePlanStopResponse.java
+++ b/routing/src/main/java/com/oneday/routing/dto/RoutePlanStopResponse.java
@@ -1,0 +1,29 @@
+package com.oneday.routing.dto;
+
+import com.oneday.routing.domain.RoutePlanStop;
+
+import java.time.LocalTime;
+import java.util.UUID;
+
+/** One ordered stop + ETAs ({@code GET /routing/plans/{cityId}/vans/{vanId}/stops}). */
+public record RoutePlanStopResponse(
+        UUID stopId,
+        UUID vanId,
+        int loopIndex,
+        int stopSeq,
+        String nodeKind,
+        UUID hexVertexId,
+        LocalTime plannedArrival,
+        LocalTime plannedDeparture,
+        int deliverQty,
+        int collectQty,
+        int loadAfter) {
+
+    public static RoutePlanStopResponse from(RoutePlanStop s) {
+        return new RoutePlanStopResponse(
+                s.getId(), s.getVanId(), s.getLoopIndex(), s.getStopSeq(),
+                s.getNodeKind() != null ? s.getNodeKind().name() : null,
+                s.getHexVertexId(), s.getPlannedArrival(), s.getPlannedDeparture(),
+                s.getDeliverQty(), s.getCollectQty(), s.getLoadAfter());
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/dto/ShuttleTimetableResponse.java
+++ b/routing/src/main/java/com/oneday/routing/dto/ShuttleTimetableResponse.java
@@ -1,0 +1,25 @@
+package com.oneday.routing.dto;
+
+import com.oneday.routing.service.model.ShuttleTimetable;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+/** Hub↔airport shuttle timetable ({@code GET /routing/shuttle/{cityId}}) — M9's input. */
+public record ShuttleTimetableResponse(
+        UUID cityId,
+        LocalDate validDate,
+        int hubToAirportMinutes,
+        List<Departure> departures) {
+
+    public record Departure(LocalTime departure, LocalTime arrival) {}
+
+    public static ShuttleTimetableResponse from(ShuttleTimetable t) {
+        List<Departure> departures = t.departureTimes().stream()
+                .map(d -> new Departure(d, t.arrivalFor(d)))
+                .toList();
+        return new ShuttleTimetableResponse(t.cityId(), t.validDate(), t.hubToAirportMinutes(), departures);
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/dto/StopReassignment.java
+++ b/routing/src/main/java/com/oneday/routing/dto/StopReassignment.java
@@ -1,0 +1,10 @@
+package com.oneday.routing.dto;
+
+import java.util.UUID;
+
+/**
+ * One edit in a manual override (§10): move the stop identified by {@code stopId} to a different
+ * meeting vertex. The override clones the whole plan into a new append-only revision and applies
+ * each reassignment to the clone — the original {@code route_plan_stop} rows never mutate (C17).
+ */
+public record StopReassignment(UUID stopId, UUID newHexVertexId) {}

--- a/routing/src/main/java/com/oneday/routing/events/CronEventProducer.java
+++ b/routing/src/main/java/com/oneday/routing/events/CronEventProducer.java
@@ -1,0 +1,96 @@
+package com.oneday.routing.events;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneday.common.kafka.EventPublisher;
+import com.oneday.common.kafka.KafkaTopics;
+import com.oneday.common.kafka.events.cron.DaCronScheduledEvent;
+import com.oneday.common.kafka.events.cron.RouteChangedEvent;
+import com.oneday.common.kafka.events.cron.RoutePlanPublishedEvent;
+import com.oneday.common.kafka.events.cron.ShuttleScheduledEvent;
+import com.oneday.routing.domain.DaCronSchedule;
+import com.oneday.routing.domain.RoutePlan;
+import com.oneday.routing.service.model.ShuttleTimetable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalTime;
+import java.util.List;
+
+/**
+ * Publishes M6's plan-time cron events on {@code oneday.cron.events} (§17.1) via the shared
+ * {@link EventPublisher}. The typed {@code common.kafka.events.cron.*} payloads are the contract;
+ * this class is the only place that maps M6 domain rows onto them. Run-time events
+ * (VAN_ARRIVED, HANDOFF_*, …) arrive in later PRs.
+ */
+@Component
+public class CronEventProducer {
+
+    private static final Logger log = LoggerFactory.getLogger(CronEventProducer.class);
+    private static final TypeReference<List<String>> TIME_LIST = new TypeReference<>() {};
+
+    private final EventPublisher eventPublisher;
+    private final ObjectMapper objectMapper;
+
+    CronEventProducer(EventPublisher eventPublisher, ObjectMapper objectMapper) {
+        this.eventPublisher = eventPublisher;
+        this.objectMapper = objectMapper;
+    }
+
+    /** DA_CRON_SCHEDULED → M5: the DA's vertex + the day's meeting times. */
+    public void emitDaCronScheduled(DaCronSchedule cron, double meetingLat, double meetingLon) {
+        eventPublisher.publish(KafkaTopics.CRON_EVENTS, new DaCronScheduledEvent(
+                cron.getCityId(),
+                cron.getValidDate(),
+                cron.getDaId(),
+                cron.getHexVertexId(),
+                meetingLat,
+                meetingLon,
+                parseMeetingTimes(cron.getMeetingTimes()),
+                cron.getVanId(),
+                cron.getRoutePlanId()));
+    }
+
+    /** ROUTE_PLAN_PUBLISHED → M10, van app: a city's plan is approved & active. */
+    public void emitRoutePlanPublished(RoutePlan plan) {
+        eventPublisher.publish(KafkaTopics.CRON_EVENTS, new RoutePlanPublishedEvent(
+                plan.getCityId(),
+                plan.getValidForDate(),
+                plan.getId(),
+                plan.getVansUsed() != null ? plan.getVansUsed() : 0,
+                plan.getRecommendedVanCount() != null ? plan.getRecommendedVanCount() : 0,
+                plan.getProvisioningFlag() != null ? plan.getProvisioningFlag().name() : null));
+    }
+
+    /** ROUTE_CHANGED → M5, M10, station mgr: an intraday override took effect. */
+    public void emitRouteChanged(RoutePlan revision, java.util.UUID actorId, String reason) {
+        eventPublisher.publish(KafkaTopics.CRON_EVENTS, new RouteChangedEvent(
+                revision.getCityId(),
+                revision.getValidForDate(),
+                revision.getId(),
+                actorId,
+                reason));
+    }
+
+    /** SHUTTLE_SCHEDULED → M9, M10: the periodic hub↔airport timetable. */
+    public void emitShuttleScheduled(ShuttleTimetable timetable, java.util.UUID routePlanId) {
+        eventPublisher.publish(KafkaTopics.CRON_EVENTS, new ShuttleScheduledEvent(
+                timetable.cityId(),
+                timetable.validDate(),
+                routePlanId,
+                timetable.departureTimes(),
+                timetable.hubToAirportMinutes()));
+    }
+
+    // meeting_times is stored as a JSON array of "HH:mm" strings; the event carries LocalTime.
+    private List<LocalTime> parseMeetingTimes(String json) {
+        if (json == null || json.isBlank()) return List.of();
+        try {
+            return objectMapper.readValue(json, TIME_LIST).stream().map(LocalTime::parse).toList();
+        } catch (Exception e) {
+            log.warn("Could not parse meeting_times json '{}': {}", json, e.getMessage());
+            return List.of();
+        }
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/service/RoutePlanLifecycleService.java
+++ b/routing/src/main/java/com/oneday/routing/service/RoutePlanLifecycleService.java
@@ -1,0 +1,35 @@
+package com.oneday.routing.service;
+
+import com.oneday.routing.domain.DaCronSchedule;
+import com.oneday.routing.domain.RoutePlan;
+import com.oneday.routing.domain.RoutePlanStop;
+import com.oneday.routing.dto.OverrideRequest;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Nightly governance (§10): approve a PROPOSED plan, override a live one with an append-only
+ * revision, force a re-solve, and the read side that serves the §17.2 query endpoints. All state
+ * changes are append-only (C17): revisions supersede; plan bodies never mutate.
+ */
+public interface RoutePlanLifecycleService {
+
+    /** Station manager / admin approves a PROPOSED plan → APPROVED; emits DA_CRON_SCHEDULED + publish. */
+    RoutePlan approve(UUID planId, UUID actorId);
+
+    /** Append-only override of a live plan: new revision, audit row, ROUTE_CHANGED. */
+    RoutePlan override(UUID planId, OverrideRequest request);
+
+    /** Force a re-solve for {@code cityId}/{@code date}: supersede current plans, produce a new PROPOSED one. */
+    RoutePlan replan(UUID cityId, LocalDate date);
+
+    /** The live plan for a city/date — highest-revision APPROVED, else PROPOSED (ignores SUPERSEDED/REJECTED). */
+    Optional<RoutePlan> activePlan(UUID cityId, LocalDate date);
+
+    List<RoutePlanStop> stops(UUID planId, UUID vanId);
+
+    List<DaCronSchedule> cronForDa(UUID daId, LocalDate date);
+}

--- a/routing/src/main/java/com/oneday/routing/service/ShuttleScheduleService.java
+++ b/routing/src/main/java/com/oneday/routing/service/ShuttleScheduleService.java
@@ -1,0 +1,20 @@
+package com.oneday.routing.service;
+
+import com.oneday.routing.service.model.ShuttleTimetable;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * The hub↔airport shuttle (§9). A single origin–destination leg is a <i>timetable</i>, not a VRP:
+ * a configurable cadence over the operating window, with arrival ETAs from the OSRM hub↔airport
+ * time. Published as {@code SHUTTLE_SCHEDULED} for M9 (its cron-departure input) and M10.
+ */
+public interface ShuttleScheduleService {
+
+    /** Compute the timetable for {@code cityId}/{@code date} without emitting anything. */
+    ShuttleTimetable timetable(UUID cityId, LocalDate date);
+
+    /** Compute the timetable and publish {@code SHUTTLE_SCHEDULED} (called when a plan is published). */
+    ShuttleTimetable publish(UUID cityId, LocalDate date, UUID routePlanId);
+}

--- a/routing/src/main/java/com/oneday/routing/service/impl/RoutePlanLifecycleServiceImpl.java
+++ b/routing/src/main/java/com/oneday/routing/service/impl/RoutePlanLifecycleServiceImpl.java
@@ -1,0 +1,310 @@
+package com.oneday.routing.service.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneday.routing.domain.DaCronSchedule;
+import com.oneday.routing.domain.RouteOverrideAudit;
+import com.oneday.routing.domain.RoutePlan;
+import com.oneday.routing.domain.RoutePlanSource;
+import com.oneday.routing.domain.RoutePlanStatus;
+import com.oneday.routing.domain.RoutePlanStop;
+import com.oneday.routing.dto.OverrideRequest;
+import com.oneday.routing.dto.StopReassignment;
+import com.oneday.routing.events.CronEventProducer;
+import com.oneday.routing.repository.DaCronScheduleRepository;
+import com.oneday.routing.repository.RouteOverrideAuditRepository;
+import com.oneday.routing.repository.RoutePlanRepository;
+import com.oneday.routing.repository.RoutePlanStopRepository;
+import com.oneday.routing.service.GridDataAdapter;
+import com.oneday.routing.service.RoutePlanLifecycleService;
+import com.oneday.routing.service.RoutePlanningService;
+import com.oneday.routing.service.ShuttleScheduleService;
+import com.oneday.routing.service.model.DaTerritory;
+import com.oneday.routing.service.model.MeetingVertex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Nightly governance (§10). Approve flips PROPOSED→APPROVED and fans out the per-DA cron schedules
+ * (DA_CRON_SCHEDULED), the publish event (ROUTE_PLAN_PUBLISHED) and the shuttle timetable. Override
+ * never mutates a plan body: it clones the whole plan into a higher revision (source MANUAL_OVERRIDE,
+ * {@code supersedes_plan_id} set), applies the vertex reassignments to the clone, supersedes the
+ * original, records a {@code route_override_audit} row and emits ROUTE_CHANGED (C17, M6-D-008).
+ */
+@Service
+class RoutePlanLifecycleServiceImpl implements RoutePlanLifecycleService {
+
+    private static final Logger log = LoggerFactory.getLogger(RoutePlanLifecycleServiceImpl.class);
+
+    private final RoutePlanRepository routePlanRepository;
+    private final RoutePlanStopRepository routePlanStopRepository;
+    private final DaCronScheduleRepository daCronScheduleRepository;
+    private final RouteOverrideAuditRepository auditRepository;
+    private final RoutePlanningService routePlanningService;
+    private final ShuttleScheduleService shuttleScheduleService;
+    private final CronEventProducer cronEventProducer;
+    private final GridDataAdapter gridDataAdapter;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    RoutePlanLifecycleServiceImpl(RoutePlanRepository routePlanRepository,
+                                  RoutePlanStopRepository routePlanStopRepository,
+                                  DaCronScheduleRepository daCronScheduleRepository,
+                                  RouteOverrideAuditRepository auditRepository,
+                                  RoutePlanningService routePlanningService,
+                                  ShuttleScheduleService shuttleScheduleService,
+                                  CronEventProducer cronEventProducer,
+                                  GridDataAdapter gridDataAdapter,
+                                  ObjectMapper objectMapper,
+                                  Clock clock) {
+        this.routePlanRepository = routePlanRepository;
+        this.routePlanStopRepository = routePlanStopRepository;
+        this.daCronScheduleRepository = daCronScheduleRepository;
+        this.auditRepository = auditRepository;
+        this.routePlanningService = routePlanningService;
+        this.shuttleScheduleService = shuttleScheduleService;
+        this.cronEventProducer = cronEventProducer;
+        this.gridDataAdapter = gridDataAdapter;
+        this.objectMapper = objectMapper;
+        this.clock = clock;
+    }
+
+    @Override
+    @Transactional
+    public RoutePlan approve(UUID planId, UUID actorId) {
+        RoutePlan plan = routePlanRepository.findById(planId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No route_plan " + planId));
+        if (plan.getStatus() != RoutePlanStatus.PROPOSED) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Plan " + planId + " is " + plan.getStatus() + ", only PROPOSED can be approved");
+        }
+
+        // Supersede any prior APPROVED plan for the same city/date (re-approval safety).
+        for (RoutePlan other : routePlanRepository.findByCityIdAndValidForDate(plan.getCityId(), plan.getValidForDate())) {
+            if (!other.getId().equals(planId) && other.getStatus() == RoutePlanStatus.APPROVED) {
+                other.setStatus(RoutePlanStatus.SUPERSEDED);
+                routePlanRepository.save(other);
+            }
+        }
+
+        plan.setStatus(RoutePlanStatus.APPROVED);
+        plan.setApprovedBy(actorId);
+        plan.setApprovedAt(Instant.now(clock));
+        routePlanRepository.save(plan);
+
+        auditRepository.save(audit(plan.getId(), actorId, "APPROVE", null, plan, "Approved"));
+        publishCronSchedules(plan);
+        cronEventProducer.emitRoutePlanPublished(plan);
+        publishShuttleQuietly(plan);
+
+        log.info("Route plan {} approved for cityId={} date={} by {}",
+                planId, plan.getCityId(), plan.getValidForDate(), actorId);
+        return plan;
+    }
+
+    @Override
+    @Transactional
+    public RoutePlan override(UUID planId, OverrideRequest request) {
+        RoutePlan source = routePlanRepository.findById(planId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No route_plan " + planId));
+        if (source.getStatus() != RoutePlanStatus.APPROVED) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Plan " + planId + " is " + source.getStatus() + ", only an APPROVED plan can be overridden");
+        }
+
+        List<RoutePlanStop> sourceStops = routePlanStopRepository.findByRoutePlanId(planId);
+        List<DaCronSchedule> sourceCrons = daCronScheduleRepository.findByRoutePlanId(planId);
+
+        // stopId → new vertex; and old vertex → new vertex (to keep affected cron rows consistent).
+        Map<UUID, UUID> stopReassign = new HashMap<>();
+        Map<UUID, UUID> vertexReassign = new HashMap<>();
+        for (StopReassignment r : request.reassignmentsOrEmpty()) {
+            stopReassign.put(r.stopId(), r.newHexVertexId());
+            sourceStops.stream().filter(s -> s.getId().equals(r.stopId())).findFirst()
+                    .ifPresent(s -> vertexReassign.put(s.getHexVertexId(), r.newHexVertexId()));
+        }
+
+        UUID revisionId = UUID.randomUUID();
+        RoutePlan revision = RoutePlan.builder()
+                .id(revisionId)
+                .cityId(source.getCityId())
+                .validForDate(source.getValidForDate())
+                .status(RoutePlanStatus.APPROVED)
+                .source(RoutePlanSource.MANUAL_OVERRIDE)
+                .solverType(source.getSolverType())
+                .revision(source.getRevision() + 1)
+                .supersedesPlanId(source.getId())
+                .vansUsed(source.getVansUsed())
+                .recommendedVanCount(source.getRecommendedVanCount())
+                .provisioningFlag(source.getProvisioningFlag())
+                .nLoops(source.getNLoops())
+                .realisedCycleMinutes(source.getRealisedCycleMinutes())
+                .notes("Override of plan " + source.getId()
+                        + (request.reason() != null ? ": " + request.reason() : ""))
+                .approvedBy(request.actorId())
+                .approvedAt(Instant.now(clock))
+                .build();
+
+        List<RoutePlanStop> clonedStops = sourceStops.stream().map(s -> RoutePlanStop.builder()
+                .routePlanId(revisionId)
+                .vanId(s.getVanId())
+                .loopIndex(s.getLoopIndex())
+                .stopSeq(s.getStopSeq())
+                .nodeKind(s.getNodeKind())
+                .hexVertexId(stopReassign.getOrDefault(s.getId(), s.getHexVertexId()))
+                .plannedArrival(s.getPlannedArrival())
+                .plannedDeparture(s.getPlannedDeparture())
+                .deliverQty(s.getDeliverQty())
+                .collectQty(s.getCollectQty())
+                .loadAfter(s.getLoadAfter())
+                .build()).toList();
+
+        List<DaCronSchedule> clonedCrons = sourceCrons.stream().map(c -> DaCronSchedule.builder()
+                .routePlanId(revisionId)
+                .daId(c.getDaId())
+                .hexVertexId(vertexReassign.getOrDefault(c.getHexVertexId(), c.getHexVertexId()))
+                .vanId(c.getVanId())
+                .meetingTimes(c.getMeetingTimes())
+                .cityId(c.getCityId())
+                .validDate(c.getValidDate())
+                .build()).toList();
+
+        source.setStatus(RoutePlanStatus.SUPERSEDED);
+        routePlanRepository.save(source);
+        routePlanRepository.save(revision);
+        if (!clonedStops.isEmpty()) routePlanStopRepository.saveAll(clonedStops);
+        if (!clonedCrons.isEmpty()) daCronScheduleRepository.saveAll(clonedCrons);
+
+        auditRepository.save(audit(revisionId, request.actorId(), "OVERRIDE", source, revision, request.reason()));
+
+        // Affected DAs get a fresh cron schedule; M5/M10 react to the route change.
+        publishCronSchedules(revision);
+        cronEventProducer.emitRouteChanged(revision, request.actorId(), request.reason());
+
+        log.info("Route plan {} overridden → revision {} ({} reassignments) by {}",
+                planId, revisionId, stopReassign.size(), request.actorId());
+        return revision;
+    }
+
+    @Override
+    @Transactional
+    public RoutePlan replan(UUID cityId, LocalDate date) {
+        // Supersede the current live/proposed plans so the fresh PROPOSED becomes the active one.
+        for (RoutePlan p : routePlanRepository.findByCityIdAndValidForDate(cityId, date)) {
+            if (p.getStatus() == RoutePlanStatus.PROPOSED || p.getStatus() == RoutePlanStatus.APPROVED) {
+                p.setStatus(RoutePlanStatus.SUPERSEDED);
+                routePlanRepository.save(p);
+            }
+        }
+        RoutePlan fresh = routePlanningService.plan(cityId, date);
+        log.info("Forced replan for cityId={} date={} → plan {}", cityId, date, fresh.getId());
+        return fresh;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<RoutePlan> activePlan(UUID cityId, LocalDate date) {
+        return routePlanRepository.findByCityIdAndValidForDate(cityId, date).stream()
+                .filter(p -> p.getStatus() == RoutePlanStatus.APPROVED || p.getStatus() == RoutePlanStatus.PROPOSED)
+                // APPROVED beats PROPOSED; within a status the highest revision wins.
+                .max(Comparator
+                        .comparing((RoutePlan p) -> p.getStatus() == RoutePlanStatus.APPROVED)
+                        .thenComparingInt(RoutePlan::getRevision));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<RoutePlanStop> stops(UUID planId, UUID vanId) {
+        return routePlanStopRepository.findByRoutePlanId(planId).stream()
+                .filter(s -> vanId == null || vanId.equals(s.getVanId()))
+                .sorted(Comparator.comparingInt(RoutePlanStop::getLoopIndex)
+                        .thenComparingInt(RoutePlanStop::getStopSeq))
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<DaCronSchedule> cronForDa(UUID daId, LocalDate date) {
+        // Many revisions can leave cron rows for the date; M5 wants only the live (APPROVED) schedule.
+        return daCronScheduleRepository.findByDaIdAndValidDate(daId, date).stream()
+                .filter(c -> routePlanRepository.findById(c.getRoutePlanId())
+                        .map(p -> p.getStatus() == RoutePlanStatus.APPROVED)
+                        .orElse(false))
+                .toList();
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    private void publishCronSchedules(RoutePlan plan) {
+        Map<UUID, MeetingVertex> coords = vertexCoords(plan.getCityId(), plan.getValidForDate());
+        for (DaCronSchedule cron : daCronScheduleRepository.findByRoutePlanId(plan.getId())) {
+            MeetingVertex v = coords.get(cron.getHexVertexId());
+            cronEventProducer.emitDaCronScheduled(cron,
+                    v != null ? v.lat() : 0.0, v != null ? v.lon() : 0.0);
+        }
+    }
+
+    // Resolve vertexId → coords for the city/date from M3 (best-effort; the event still carries the
+    // vertex id, so a missing coord only blanks lat/lon).
+    private Map<UUID, MeetingVertex> vertexCoords(UUID cityId, LocalDate date) {
+        Map<UUID, MeetingVertex> map = new HashMap<>();
+        try {
+            for (DaTerritory t : gridDataAdapter.getDaTerritories(cityId, date)) {
+                t.hexes().forEach(h -> h.vertices().forEach(v -> map.putIfAbsent(v.vertexId(), v)));
+            }
+        } catch (Exception e) {
+            log.warn("Could not resolve vertex coords for cityId={} date={}: {}", cityId, date, e.getMessage());
+        }
+        return map;
+    }
+
+    private void publishShuttleQuietly(RoutePlan plan) {
+        try {
+            shuttleScheduleService.publish(plan.getCityId(), plan.getValidForDate(), plan.getId());
+        } catch (Exception e) {
+            log.warn("Shuttle publish failed for cityId={} date={}: {}",
+                    plan.getCityId(), plan.getValidForDate(), e.getMessage());
+        }
+    }
+
+    private RouteOverrideAudit audit(UUID planId, UUID actorId, String action,
+                                     RoutePlan before, RoutePlan after, String reason) {
+        return RouteOverrideAudit.builder()
+                .routePlanId(planId)
+                .actorId(actorId)
+                .action(action)
+                .beforeJson(summary(before))
+                .afterJson(summary(after))
+                .reason(reason)
+                .build();
+    }
+
+    private String summary(RoutePlan p) {
+        if (p == null) return null;
+        try {
+            return objectMapper.writeValueAsString(Map.of(
+                    "planId", p.getId().toString(),
+                    "revision", p.getRevision(),
+                    "status", p.getStatus().name(),
+                    "vansUsed", p.getVansUsed() != null ? p.getVansUsed() : 0,
+                    "nLoops", p.getNLoops() != null ? p.getNLoops() : 0));
+        } catch (JsonProcessingException e) {
+            return null;
+        }
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/service/impl/ShuttleScheduleServiceImpl.java
+++ b/routing/src/main/java/com/oneday/routing/service/impl/ShuttleScheduleServiceImpl.java
@@ -1,0 +1,109 @@
+package com.oneday.routing.service.impl;
+
+import com.oneday.routing.config.RoutingProperties;
+import com.oneday.routing.domain.CityFleetConfig;
+import com.oneday.routing.domain.CityLogisticsNode;
+import com.oneday.routing.domain.LogisticsNodeKind;
+import com.oneday.routing.domain.StopNodeKind;
+import com.oneday.routing.events.CronEventProducer;
+import com.oneday.routing.repository.CityFleetConfigRepository;
+import com.oneday.routing.repository.CityLogisticsNodeRepository;
+import com.oneday.routing.service.ShuttleScheduleService;
+import com.oneday.routing.service.TravelMatrixService;
+import com.oneday.routing.service.model.RoutingNode;
+import com.oneday.routing.service.model.ShuttleTimetable;
+import com.oneday.routing.service.model.TravelMatrix;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Builds the periodic hub↔airport timetable (§9). Cadence comes from {@code city_fleet_config}
+ * (falling back to {@link RoutingProperties}); the hub→airport leg time is one OSRM {@code /table}
+ * call over the 2-node set {hub, airport}. Departures run from the window start up to and including
+ * the window end at the configured cadence. v1 cadence is fixed; when M9 lands it becomes
+ * flight-cutoff-driven via {@code FlightCutoffPort} (Q1).
+ */
+@Service
+class ShuttleScheduleServiceImpl implements ShuttleScheduleService {
+
+    private static final Logger log = LoggerFactory.getLogger(ShuttleScheduleServiceImpl.class);
+
+    private final CityLogisticsNodeRepository logisticsNodeRepository;
+    private final CityFleetConfigRepository fleetConfigRepository;
+    private final TravelMatrixService travelMatrixService;
+    private final CronEventProducer cronEventProducer;
+    private final RoutingProperties properties;
+
+    ShuttleScheduleServiceImpl(CityLogisticsNodeRepository logisticsNodeRepository,
+                               CityFleetConfigRepository fleetConfigRepository,
+                               TravelMatrixService travelMatrixService,
+                               CronEventProducer cronEventProducer,
+                               RoutingProperties properties) {
+        this.logisticsNodeRepository = logisticsNodeRepository;
+        this.fleetConfigRepository = fleetConfigRepository;
+        this.travelMatrixService = travelMatrixService;
+        this.cronEventProducer = cronEventProducer;
+        this.properties = properties;
+    }
+
+    @Override
+    public ShuttleTimetable timetable(UUID cityId, LocalDate date) {
+        CityLogisticsNode hub = logisticsNodeRepository.findByCityIdAndKind(cityId, LogisticsNodeKind.HUB)
+                .orElseThrow(() -> new IllegalStateException("No HUB logistics node for cityId=" + cityId));
+        Optional<CityLogisticsNode> airport = logisticsNodeRepository.findByCityIdAndKind(cityId, LogisticsNodeKind.AIRPORT);
+        if (airport.isEmpty()) {
+            log.warn("No AIRPORT logistics node for cityId={} — empty shuttle timetable", cityId);
+            return new ShuttleTimetable(cityId, date, List.of(), 0);
+        }
+
+        int hubToAirportMinutes = hubToAirportMinutes(hub, airport.get());
+        int cadence = cadenceMinutes(cityId);
+        List<LocalTime> departures = departureTimes(cadence);
+        return new ShuttleTimetable(cityId, date, departures, hubToAirportMinutes);
+    }
+
+    @Override
+    public ShuttleTimetable publish(UUID cityId, LocalDate date, UUID routePlanId) {
+        ShuttleTimetable timetable = timetable(cityId, date);
+        if (!timetable.departureTimes().isEmpty()) {
+            cronEventProducer.emitShuttleScheduled(timetable, routePlanId);
+        }
+        return timetable;
+    }
+
+    private int hubToAirportMinutes(CityLogisticsNode hub, CityLogisticsNode airport) {
+        List<RoutingNode> nodes = List.of(
+                RoutingNode.hub(hub.getId(), hub.getLat(), hub.getLon()),
+                new RoutingNode(1, StopNodeKind.MEETING_VERTEX,
+                        airport.getId(), airport.getLat(), airport.getLon(), 0, 0, 0));
+        TravelMatrix matrix = travelMatrixService.buildMatrix(nodes);
+        long seconds = matrix.travelSeconds()[0][1];
+        return (int) Math.ceil(seconds / 60.0);
+    }
+
+    private int cadenceMinutes(UUID cityId) {
+        return fleetConfigRepository.findByCityId(cityId)
+                .map(CityFleetConfig::getShuttleCadenceMinutes)
+                .filter(c -> c > 0)
+                .orElse(properties.getShuttle().getCadenceMinutes());
+    }
+
+    // Departures from window start up to and including window end, every `cadence` minutes.
+    private List<LocalTime> departureTimes(int cadence) {
+        List<LocalTime> times = new ArrayList<>();
+        LocalTime start = LocalTime.of(properties.getWindow().getStartHour(), 0);
+        LocalTime end = LocalTime.of(properties.getWindow().getEndHour(), 0);
+        for (LocalTime t = start; !t.isAfter(end); t = t.plusMinutes(cadence)) {
+            times.add(t);
+        }
+        return times;
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/service/model/ShuttleTimetable.java
+++ b/routing/src/main/java/com/oneday/routing/service/model/ShuttleTimetable.java
@@ -1,0 +1,24 @@
+package com.oneday.routing.service.model;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * The periodic hub↔airport shuttle timetable for one city/date (§9). A single origin–destination
+ * leg expressed as a list of departure times across the operating window plus the OSRM hub→airport
+ * travel time; arrival ETAs are {@code departure + hubToAirportMinutes}. Computed on demand, not
+ * persisted (there is no shuttle table — §17.3) and published as {@code SHUTTLE_SCHEDULED}.
+ */
+public record ShuttleTimetable(
+        UUID cityId,
+        LocalDate validDate,
+        List<LocalTime> departureTimes,
+        int hubToAirportMinutes) {
+
+    /** Arrival ETA for a given departure ({@code departure + hubToAirportMinutes}). */
+    public LocalTime arrivalFor(LocalTime departure) {
+        return departure.plusMinutes(hubToAirportMinutes);
+    }
+}

--- a/routing/src/test/java/com/oneday/routing/batch/NightlyRoutePlanJobTest.java
+++ b/routing/src/test/java/com/oneday/routing/batch/NightlyRoutePlanJobTest.java
@@ -1,0 +1,128 @@
+package com.oneday.routing.batch;
+
+import com.oneday.routing.domain.CityFleetConfig;
+import com.oneday.routing.domain.DaCronSchedule;
+import com.oneday.routing.domain.RoutePlan;
+import com.oneday.routing.domain.RoutePlanSource;
+import com.oneday.routing.domain.RoutePlanStatus;
+import com.oneday.routing.domain.RoutePlanStop;
+import com.oneday.routing.domain.RoutingSolverType;
+import com.oneday.routing.domain.StopNodeKind;
+import com.oneday.routing.repository.CityFleetConfigRepository;
+import com.oneday.routing.repository.DaCronScheduleRepository;
+import com.oneday.routing.repository.RoutePlanRepository;
+import com.oneday.routing.repository.RoutePlanStopRepository;
+import com.oneday.routing.service.RoutePlanningService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NightlyRoutePlanJobTest {
+
+    @Mock CityFleetConfigRepository fleetConfigRepository;
+    @Mock RoutePlanningService routePlanningService;
+    @Mock RoutePlanRepository routePlanRepository;
+    @Mock RoutePlanStopRepository routePlanStopRepository;
+    @Mock DaCronScheduleRepository daCronScheduleRepository;
+
+    // Fixed at 2026-06-09 12:00 IST → today=2026-06-09, tomorrow=2026-06-10.
+    private final Clock clock = Clock.fixed(Instant.parse("2026-06-09T06:30:00Z"), ZoneId.of("Asia/Kolkata"));
+    private final LocalDate today = LocalDate.of(2026, 6, 9);
+    private final LocalDate tomorrow = LocalDate.of(2026, 6, 10);
+
+    NightlyRoutePlanJob job;
+
+    @BeforeEach
+    void setUp() {
+        job = new NightlyRoutePlanJob(fleetConfigRepository, routePlanningService,
+                routePlanRepository, routePlanStopRepository, daCronScheduleRepository, clock);
+    }
+
+    private CityFleetConfig fleet(UUID cityId) {
+        return CityFleetConfig.builder().cityId(cityId).build();
+    }
+
+    @Test
+    void run_solvesTomorrowForEveryConfiguredCity() {
+        UUID c1 = UUID.randomUUID(), c2 = UUID.randomUUID();
+        when(fleetConfigRepository.findAll()).thenReturn(List.of(fleet(c1), fleet(c2)));
+
+        job.run();
+
+        verify(routePlanningService).plan(c1, tomorrow);
+        verify(routePlanningService).plan(c2, tomorrow);
+        verify(routePlanningService, times(2)).plan(any(), eq(tomorrow));
+    }
+
+    @Test
+    void applyFallbackIfNeeded_unapproved_copiesYesterdaysApprovedPlanForward() {
+        UUID cityId = UUID.randomUUID();
+        UUID yId = UUID.randomUUID();
+        when(fleetConfigRepository.findAll()).thenReturn(List.of(fleet(cityId)));
+        // today: no APPROVED
+        when(routePlanRepository.findByCityIdAndValidForDateAndStatus(cityId, today, RoutePlanStatus.APPROVED))
+                .thenReturn(List.of());
+        // yesterday: APPROVED present
+        RoutePlan yesterday = RoutePlan.builder().id(yId).cityId(cityId)
+                .validForDate(today.minusDays(1)).status(RoutePlanStatus.APPROVED)
+                .source(RoutePlanSource.NIGHTLY).solverType(RoutingSolverType.OR_TOOLS)
+                .revision(1).vansUsed(2).nLoops(4).build();
+        when(routePlanRepository.findByCityIdAndValidForDateAndStatus(cityId, today.minusDays(1), RoutePlanStatus.APPROVED))
+                .thenReturn(List.of(yesterday));
+        when(routePlanStopRepository.findByRoutePlanId(yId)).thenReturn(List.of(
+                RoutePlanStop.builder().routePlanId(yId).vanId(UUID.randomUUID()).loopIndex(0).stopSeq(1)
+                        .nodeKind(StopNodeKind.MEETING_VERTEX).hexVertexId(UUID.randomUUID())
+                        .plannedArrival(LocalTime.of(7, 30)).plannedDeparture(LocalTime.of(7, 35)).build()));
+        when(daCronScheduleRepository.findByRoutePlanId(yId)).thenReturn(List.of(
+                DaCronSchedule.builder().routePlanId(yId).daId(UUID.randomUUID()).hexVertexId(UUID.randomUUID())
+                        .meetingTimes("[\"07:30\"]").cityId(cityId).validDate(today.minusDays(1)).build()));
+
+        job.applyFallbackIfNeeded();
+
+        ArgumentCaptor<RoutePlan> planCaptor = ArgumentCaptor.forClass(RoutePlan.class);
+        verify(routePlanRepository).save(planCaptor.capture());
+        RoutePlan fallback = planCaptor.getValue();
+        assertThat(fallback.getValidForDate()).isEqualTo(today);
+        assertThat(fallback.getStatus()).isEqualTo(RoutePlanStatus.APPROVED);
+        assertThat(fallback.getSource()).isEqualTo(RoutePlanSource.FALLBACK);
+        assertThat(fallback.getSupersedesPlanId()).isEqualTo(yId);
+        verify(routePlanStopRepository).saveAll(anyList());
+        verify(daCronScheduleRepository).saveAll(anyList());
+    }
+
+    @Test
+    void applyFallbackIfNeeded_alreadyApproved_doesNothing() {
+        UUID cityId = UUID.randomUUID();
+        when(fleetConfigRepository.findAll()).thenReturn(List.of(fleet(cityId)));
+        when(routePlanRepository.findByCityIdAndValidForDateAndStatus(cityId, today, RoutePlanStatus.APPROVED))
+                .thenReturn(List.of(RoutePlan.builder().id(UUID.randomUUID()).cityId(cityId)
+                        .validForDate(today).status(RoutePlanStatus.APPROVED).source(RoutePlanSource.NIGHTLY)
+                        .solverType(RoutingSolverType.OR_TOOLS).build()));
+
+        job.applyFallbackIfNeeded();
+
+        verify(routePlanRepository, never()).save(any());
+        verify(routePlanStopRepository, never()).saveAll(anyList());
+    }
+}

--- a/routing/src/test/java/com/oneday/routing/service/impl/RoutePlanLifecycleServiceImplTest.java
+++ b/routing/src/test/java/com/oneday/routing/service/impl/RoutePlanLifecycleServiceImplTest.java
@@ -1,0 +1,180 @@
+package com.oneday.routing.service.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneday.routing.domain.DaCronSchedule;
+import com.oneday.routing.domain.RouteOverrideAudit;
+import com.oneday.routing.domain.RoutePlan;
+import com.oneday.routing.domain.RoutePlanSource;
+import com.oneday.routing.domain.RoutePlanStatus;
+import com.oneday.routing.domain.RoutePlanStop;
+import com.oneday.routing.domain.RoutingSolverType;
+import com.oneday.routing.domain.StopNodeKind;
+import com.oneday.routing.dto.OverrideRequest;
+import com.oneday.routing.dto.StopReassignment;
+import com.oneday.routing.events.CronEventProducer;
+import com.oneday.routing.repository.DaCronScheduleRepository;
+import com.oneday.routing.repository.RouteOverrideAuditRepository;
+import com.oneday.routing.repository.RoutePlanRepository;
+import com.oneday.routing.repository.RoutePlanStopRepository;
+import com.oneday.routing.service.GridDataAdapter;
+import com.oneday.routing.service.RoutePlanningService;
+import com.oneday.routing.service.ShuttleScheduleService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RoutePlanLifecycleServiceImplTest {
+
+    @Mock RoutePlanRepository routePlanRepository;
+    @Mock RoutePlanStopRepository routePlanStopRepository;
+    @Mock DaCronScheduleRepository daCronScheduleRepository;
+    @Mock RouteOverrideAuditRepository auditRepository;
+    @Mock RoutePlanningService routePlanningService;
+    @Mock ShuttleScheduleService shuttleScheduleService;
+    @Mock CronEventProducer cronEventProducer;
+    @Mock GridDataAdapter gridDataAdapter;
+
+    final Clock clock = Clock.fixed(Instant.parse("2026-06-09T03:30:00Z"), ZoneId.of("Asia/Kolkata"));
+    RoutePlanLifecycleServiceImpl service;
+
+    final UUID cityId = UUID.randomUUID();
+    final LocalDate date = LocalDate.of(2026, 6, 10);
+
+    @BeforeEach
+    void setUp() {
+        service = new RoutePlanLifecycleServiceImpl(routePlanRepository, routePlanStopRepository,
+                daCronScheduleRepository, auditRepository, routePlanningService, shuttleScheduleService,
+                cronEventProducer, gridDataAdapter, new ObjectMapper(), clock);
+    }
+
+    private RoutePlan plan(UUID id, RoutePlanStatus status, RoutePlanSource source, int revision) {
+        return RoutePlan.builder().id(id).cityId(cityId).validForDate(date).status(status)
+                .source(source).solverType(RoutingSolverType.OR_TOOLS).revision(revision)
+                .vansUsed(2).nLoops(4).build();
+    }
+
+    private DaCronSchedule cron(UUID planId, UUID vertexId) {
+        return DaCronSchedule.builder().routePlanId(planId).daId(UUID.randomUUID()).hexVertexId(vertexId)
+                .vanId(UUID.randomUUID()).meetingTimes("[\"07:30\",\"09:30\"]").cityId(cityId).validDate(date).build();
+    }
+
+    @Test
+    void approve_flipsToApprovedAndEmitsCronAndPublishEvents() {
+        UUID planId = UUID.randomUUID();
+        RoutePlan proposed = plan(planId, RoutePlanStatus.PROPOSED, RoutePlanSource.NIGHTLY, 1);
+        when(routePlanRepository.findById(planId)).thenReturn(Optional.of(proposed));
+        when(routePlanRepository.findByCityIdAndValidForDate(cityId, date)).thenReturn(List.of(proposed));
+        DaCronSchedule cron = cron(planId, UUID.randomUUID());
+        when(daCronScheduleRepository.findByRoutePlanId(planId)).thenReturn(List.of(cron));
+        when(gridDataAdapter.getDaTerritories(cityId, date)).thenReturn(List.of());
+
+        UUID actor = UUID.randomUUID();
+        RoutePlan result = service.approve(planId, actor);
+
+        assertThat(result.getStatus()).isEqualTo(RoutePlanStatus.APPROVED);
+        assertThat(result.getApprovedBy()).isEqualTo(actor);
+        assertThat(result.getApprovedAt()).isNotNull();
+        verify(cronEventProducer).emitDaCronScheduled(eq(cron), anyDouble(), anyDouble());
+        verify(cronEventProducer).emitRoutePlanPublished(result);
+        verify(shuttleScheduleService).publish(cityId, date, planId);
+        verify(auditRepository).save(any(RouteOverrideAudit.class));
+    }
+
+    @Test
+    void approve_nonProposed_conflict() {
+        UUID planId = UUID.randomUUID();
+        when(routePlanRepository.findById(planId))
+                .thenReturn(Optional.of(plan(planId, RoutePlanStatus.APPROVED, RoutePlanSource.NIGHTLY, 1)));
+
+        assertThatThrownBy(() -> service.approve(planId, UUID.randomUUID()))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("409");
+    }
+
+    @Test
+    void override_clonesNewRevisionWritesAuditAndEmitsRouteChanged() {
+        UUID planId = UUID.randomUUID();
+        RoutePlan source = plan(planId, RoutePlanStatus.APPROVED, RoutePlanSource.NIGHTLY, 1);
+        when(routePlanRepository.findById(planId)).thenReturn(Optional.of(source));
+
+        UUID oldVertex = UUID.randomUUID();
+        UUID newVertex = UUID.randomUUID();
+        RoutePlanStop stop = RoutePlanStop.builder().id(UUID.randomUUID()).routePlanId(planId)
+                .vanId(UUID.randomUUID()).loopIndex(0).stopSeq(1).nodeKind(StopNodeKind.MEETING_VERTEX)
+                .hexVertexId(oldVertex).deliverQty(3).collectQty(1).loadAfter(3).build();
+        when(routePlanStopRepository.findByRoutePlanId(planId)).thenReturn(List.of(stop));
+        when(daCronScheduleRepository.findByRoutePlanId(planId)).thenReturn(List.of(cron(planId, oldVertex)));
+        when(gridDataAdapter.getDaTerritories(cityId, date)).thenReturn(List.of());
+
+        UUID actor = UUID.randomUUID();
+        OverrideRequest req = new OverrideRequest(actor, "vertex blocked",
+                List.of(new StopReassignment(stop.getId(), newVertex)));
+
+        RoutePlan revision = service.override(planId, req);
+
+        assertThat(revision.getSource()).isEqualTo(RoutePlanSource.MANUAL_OVERRIDE);
+        assertThat(revision.getRevision()).isEqualTo(2);
+        assertThat(revision.getSupersedesPlanId()).isEqualTo(planId);
+        assertThat(revision.getStatus()).isEqualTo(RoutePlanStatus.APPROVED);
+        assertThat(source.getStatus()).isEqualTo(RoutePlanStatus.SUPERSEDED);
+
+        // cloned stop carries the reassigned vertex
+        ArgumentCaptor<List<RoutePlanStop>> stopsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(routePlanStopRepository).saveAll(stopsCaptor.capture());
+        assertThat(stopsCaptor.getValue()).singleElement()
+                .satisfies(s -> assertThat(s.getHexVertexId()).isEqualTo(newVertex));
+
+        // cloned cron whose vertex matched the reassigned stop follows the new vertex
+        ArgumentCaptor<List<DaCronSchedule>> cronCaptor = ArgumentCaptor.forClass(List.class);
+        verify(daCronScheduleRepository).saveAll(cronCaptor.capture());
+        assertThat(cronCaptor.getValue()).singleElement()
+                .satisfies(c -> assertThat(c.getHexVertexId()).isEqualTo(newVertex));
+
+        verify(auditRepository).save(any(RouteOverrideAudit.class));
+        verify(cronEventProducer).emitRouteChanged(revision, actor, "vertex blocked");
+    }
+
+    @Test
+    void override_nonApproved_conflict() {
+        UUID planId = UUID.randomUUID();
+        when(routePlanRepository.findById(planId))
+                .thenReturn(Optional.of(plan(planId, RoutePlanStatus.PROPOSED, RoutePlanSource.NIGHTLY, 1)));
+
+        assertThatThrownBy(() -> service.override(planId, new OverrideRequest(UUID.randomUUID(), "x", List.of())))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("409");
+    }
+
+    @Test
+    void activePlan_prefersApprovedHighestRevision() {
+        RoutePlan proposed = plan(UUID.randomUUID(), RoutePlanStatus.PROPOSED, RoutePlanSource.NIGHTLY, 3);
+        RoutePlan approvedR1 = plan(UUID.randomUUID(), RoutePlanStatus.APPROVED, RoutePlanSource.NIGHTLY, 1);
+        RoutePlan approvedR2 = plan(UUID.randomUUID(), RoutePlanStatus.APPROVED, RoutePlanSource.MANUAL_OVERRIDE, 2);
+        RoutePlan superseded = plan(UUID.randomUUID(), RoutePlanStatus.SUPERSEDED, RoutePlanSource.NIGHTLY, 4);
+        when(routePlanRepository.findByCityIdAndValidForDate(cityId, date))
+                .thenReturn(List.of(proposed, approvedR1, approvedR2, superseded));
+
+        assertThat(service.activePlan(cityId, date)).contains(approvedR2);
+    }
+}

--- a/routing/src/test/java/com/oneday/routing/service/impl/ShuttleScheduleServiceImplTest.java
+++ b/routing/src/test/java/com/oneday/routing/service/impl/ShuttleScheduleServiceImplTest.java
@@ -1,0 +1,118 @@
+package com.oneday.routing.service.impl;
+
+import com.oneday.routing.config.RoutingProperties;
+import com.oneday.routing.domain.CityFleetConfig;
+import com.oneday.routing.domain.CityLogisticsNode;
+import com.oneday.routing.domain.LogisticsNodeKind;
+import com.oneday.routing.events.CronEventProducer;
+import com.oneday.routing.repository.CityFleetConfigRepository;
+import com.oneday.routing.repository.CityLogisticsNodeRepository;
+import com.oneday.routing.service.TravelMatrixService;
+import com.oneday.routing.service.model.ShuttleTimetable;
+import com.oneday.routing.service.model.TravelMatrix;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ShuttleScheduleServiceImplTest {
+
+    @Mock CityLogisticsNodeRepository logisticsNodeRepository;
+    @Mock CityFleetConfigRepository fleetConfigRepository;
+    @Mock TravelMatrixService travelMatrixService;
+    @Mock CronEventProducer cronEventProducer;
+
+    RoutingProperties properties;
+    ShuttleScheduleServiceImpl service;
+
+    private final UUID cityId = UUID.randomUUID();
+    private final LocalDate date = LocalDate.of(2026, 6, 10);
+
+    @BeforeEach
+    void setUp() {
+        properties = new RoutingProperties(); // window 07:00–20:00, shuttle cadence 30
+        service = new ShuttleScheduleServiceImpl(logisticsNodeRepository, fleetConfigRepository,
+                travelMatrixService, cronEventProducer, properties);
+    }
+
+    private CityLogisticsNode node(LogisticsNodeKind kind) {
+        return CityLogisticsNode.builder().id(UUID.randomUUID()).cityId(cityId)
+                .kind(kind).lat(12.97).lon(77.61).name(kind.name()).build();
+    }
+
+    private void stubNodesAndLeg(long hubToAirportSeconds) {
+        when(logisticsNodeRepository.findByCityIdAndKind(cityId, LogisticsNodeKind.HUB))
+                .thenReturn(Optional.of(node(LogisticsNodeKind.HUB)));
+        when(logisticsNodeRepository.findByCityIdAndKind(cityId, LogisticsNodeKind.AIRPORT))
+                .thenReturn(Optional.of(node(LogisticsNodeKind.AIRPORT)));
+        long[][] seconds = {{0, hubToAirportSeconds}, {hubToAirportSeconds, 0}};
+        when(travelMatrixService.buildMatrix(any())).thenReturn(new TravelMatrix(List.of(), seconds));
+    }
+
+    @Test
+    void timetable_30minCadenceOver07to20_gives27DeparturesAndArrivalEtas() {
+        stubNodesAndLeg(1800); // 30 minutes
+        when(fleetConfigRepository.findByCityId(cityId))
+                .thenReturn(Optional.of(CityFleetConfig.builder().cityId(cityId).shuttleCadenceMinutes(30).build()));
+
+        ShuttleTimetable t = service.timetable(cityId, date);
+
+        // 07:00 .. 20:00 inclusive, every 30 min = 27 departures.
+        assertThat(t.departureTimes()).hasSize(27);
+        assertThat(t.departureTimes().get(0)).isEqualTo(LocalTime.of(7, 0));
+        assertThat(t.departureTimes().get(t.departureTimes().size() - 1)).isEqualTo(LocalTime.of(20, 0));
+        assertThat(t.hubToAirportMinutes()).isEqualTo(30);
+        assertThat(t.arrivalFor(LocalTime.of(7, 0))).isEqualTo(LocalTime.of(7, 30));
+    }
+
+    @Test
+    void timetable_fallsBackToPropertiesCadenceWhenNoFleetConfig() {
+        stubNodesAndLeg(900); // 15 minutes
+        when(fleetConfigRepository.findByCityId(cityId)).thenReturn(Optional.empty());
+
+        ShuttleTimetable t = service.timetable(cityId, date);
+
+        assertThat(t.hubToAirportMinutes()).isEqualTo(15);
+        assertThat(t.departureTimes()).hasSize(27); // default cadence 30 → still 27
+    }
+
+    @Test
+    void timetable_noAirport_returnsEmptyAndDoesNotCallOsrm() {
+        when(logisticsNodeRepository.findByCityIdAndKind(cityId, LogisticsNodeKind.HUB))
+                .thenReturn(Optional.of(node(LogisticsNodeKind.HUB)));
+        when(logisticsNodeRepository.findByCityIdAndKind(cityId, LogisticsNodeKind.AIRPORT))
+                .thenReturn(Optional.empty());
+
+        ShuttleTimetable t = service.timetable(cityId, date);
+
+        assertThat(t.departureTimes()).isEmpty();
+        verify(travelMatrixService, never()).buildMatrix(anyList());
+    }
+
+    @Test
+    void publish_emitsShuttleScheduled() {
+        stubNodesAndLeg(1800);
+        when(fleetConfigRepository.findByCityId(cityId))
+                .thenReturn(Optional.of(CityFleetConfig.builder().cityId(cityId).shuttleCadenceMinutes(30).build()));
+        UUID planId = UUID.randomUUID();
+
+        service.publish(cityId, date, planId);
+
+        verify(cronEventProducer).emitShuttleScheduled(any(ShuttleTimetable.class), any());
+    }
+}


### PR DESCRIPTION
## Summary

Implements M6 **PR #4 — Nightly governance & shuttle**, completing **Part I (plan-time)** of the routing module: a nightly van-route job (01:00/06:00/07:00 cadence), the approve/override/replan plan l
ifecycle, the hub↔airport shuttle timetable, the read API, and the Kafka producer for plan-time cron events.

---

## What Changed

- **Nightly job** (`batch/NightlyRoutePlanJob`) — `@Scheduled` 01:00 IST solves tomorrow's PROPOSED plan per city (cities = `city_fleet_config` rows), 06:00 escalation warning when unapproved, 07:00 a
uto-fallback that copies yesterday's APPROVED plan + stops + crons forward as a `FALLBACK` plan. Injects `Clock` (M6-D-013), mirroring grid's `NightlyReplanJob`.
- **Plan lifecycle** (`service/RoutePlanLifecycleService` + impl) — approve (PROPOSED to APPROVED, supersede prior APPROVED, fan out cron/publish/shuttle + audit), override (append-only clone to a new
 `MANUAL_OVERRIDE` revision with `supersedesPlanId`, applies stop/vertex reassignments, supersedes source, writes `route_override_audit`, emits `ROUTE_CHANGED`), replan (supersede + re-solve), plus re
ad helpers (`activePlan`, `stops`, `cronForDa`).
- **Shuttle** (`service/ShuttleScheduleService` + impl) — hub to airport leg via one OSRM `/table` call over `{hub, airport}`; cadence from `city_fleet_config` (falls back to `RoutingProperties`); dep
artures across the operating window; `publish()` emits `SHUTTLE_SCHEDULED`.
- **Kafka producer** (`events/CronEventProducer`) — emits `DA_CRON_SCHEDULED`, `ROUTE_PLAN_PUBLISHED`, `ROUTE_CHANGED`, `SHUTTLE_SCHEDULED` on `oneday.cron.events` via the shared `EventPublisher`.
- **REST API** (`api/RoutePlanController`) — all 8 design endpoints (plan/stops/cron/cron-next/shuttle GETs + approve/override/replan POSTs) with request/response DTOs.
- **Tests** — 12 new Mockito unit tests (fixed `Clock`) across the lifecycle service, shuttle service, and nightly job.

---

## Why This Change?

M6's plan-time pipeline (PR #1 to #3) could produce a PROPOSED plan but had no way to govern it. This PR adds the operational governance the design requires: nightly scheduling, station-manager approv
al, append-only overrides with audit, an auto-fallback so a city is never left without coverage, and the cron/shuttle events that downstream modules (M5 cron schedules, M9 shuttle departures, M10) con
sume. It closes Part I of the 8-PR plan.

---

## Testing
- [x] Tested locally
- [x] Edge cases considered
- [x] No breaking changes introduced

### Test Evidence

```
$ mvn test -pl routing
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0 -- NightlyRoutePlanJobTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0 -- ShuttleScheduleServiceImplTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0 -- RoutePlanLifecycleServiceImplTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0 -- RoutingArchitectureTest
[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS

$ mvn clean install -pl routing,app -am -DskipTests
[INFO] BUILD SUCCESS   # full app assembles with the new beans wired
```

Edge cases covered by the new tests: non-PROPOSED approve returns 409, non-APPROVED override returns 409, no-airport shuttle returns an empty timetable, no-yesterday-plan fallback warns only, and acti
ve-plan revision precedence (APPROVED beats PROPOSED, highest revision wins).

---

## Impact

### Areas Affected
- [x] Backend
- [ ] Frontend
- [x] Routing
- [ ] Infra
- [ ] Database
- [ ] NA

No schema change — all `V6_*` tables already exist from PR #1.

### Modules Affected
- [ ] M1 — Auth
- [ ] M2 — Pricing
- [ ] M3 — Grid
- [ ] M4 — Orders
- [ ] M5 — Dispatch
- [x] M6 — Routing
- [ ] M7 — Hub
- [ ] M8 — Barcode
- [ ] M9 — Airline
- [ ] M10 — SLA
- [ ] M11 — Exceptions
- [ ] NA

Events on `oneday.cron.events` are produced for M5/M9/M10 to consume later, but no ote.

---

## Risks / Concerns
- **No M1 JWT / city-scope enforcement in routing.** Approve/override take `actorId` in the request body, following grid's `ProposalController` convention (routing has no `auth` dependency). The desig
n's cross-city-approve rejection is deferred to the cross-cutting M1 auth pass — same
- **`DA_CRON_SCHEDULED` lat/lon are best-effort** — resolved from `GridDataAdapter` at approve time; if a vertex coord is missing the event still carries the `vertexId` but lat/lon default to 0,0.
- **Cron/shuttle emission is best-effort** (Kafka + OSRM failures are logged, not thrnever blocks approval. Downstream consumers (M5/M9/M10) are unbuilt, so events are cur
rently dormant.

---

## Checklist
- [x] Code follows project conventions (package layout, no cross-module internal impot` green)
- [x] Self-review completed
- [x] Append-only audit trail preserved (override creates a new revision + `route_ove never mutate)
- [x] No sensitive data or credentials exposed
- [x] Documentation updated if behaviour changed (implements `docs/M6/M6-IMPLEMENTATI
- [x] Ready for review