### PR TITLE
feat(m4): saved address book, shipment cart, and Excel bulk upload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,11 +71,22 @@ com.oneday.{module}/
 
 ## Local Dev Setup
 
-- **PostgreSQL 16** installed via Homebrew. Start: `brew services start postgresql@16`
-- **DB:** `oneday`, **user:** `oneday`, **password:** `secret`, **port:** 5432
-- **GUI:** TablePlus (`/Applications/TablePlus.app`) — connect to localhost:5432
-- `grid/src/main/resources/application.yml` already has `spring.datasource` pointing at the local DB
-- Migrations run automatically via Flyway on app startup; to run manually: `psql -U oneday -d oneday -f <migration.sql>`
+### Databases — **default to the DEVELOPMENT (Render) DB**
+
+There are two Postgres databases. **Unless told otherwise, connect to the development (Render) DB by default** — it's the shared DB that TablePlus's "DEVELOPMENT" connection and the deployed app use, so it's the source of truth for verifying real data/state.
+
+- **DEVELOPMENT (default):** Render-hosted Postgres 16, Oregon — DB `oneday_cipv`, user `oneday`, `sslmode=require`. **Credentials are not committed**; source them from `.env` (`SPRING_DATASOURCE_URL` / `SPRING_DATASOURCE_USERNAME` / `SPRING_DATASOURCE_PASSWORD`). To run psql against it:
+  ```bash
+  set -a; source .env; set +a
+  HOST=$(echo "$SPRING_DATASOURCE_URL" | sed -E 's#jdbc:postgresql://([^:/]+):.*#\1#')
+  DB=$(echo "$SPRING_DATASOURCE_URL"   | sed -E 's#.*:[0-9]+/([^?]+).*#\1#')
+  PGPASSWORD="$SPRING_DATASOURCE_PASSWORD" PGSSLMODE=require \
+    psql -h "$HOST" -p 5432 -U "$SPRING_DATASOURCE_USERNAME" -d "$DB" -c "SELECT current_database();"
+  ```
+  Caution: it's shared and remote — DML/DDL here affects everyone. Flyway DDL is best applied by booting the app against it (`SPRING_FLYWAY_TARGET=<version>` to scope) so checksums are recorded, not by raw `ALTER`.
+- **LOCAL (offline/throwaway):** PostgreSQL 16 via Homebrew (`brew services start postgresql@16`) — DB `oneday`, user `oneday`, password `secret`, port 5432. `grid/src/main/resources/application.yml` points the app here by default; a locally-run app (`mvn spring-boot:run` without sourcing `.env`) writes here. Use for isolated/offline work.
+- **GUI:** TablePlus (`/Applications/TablePlus.app`) — "DEVELOPMENT" → Render `oneday_cipv`; add a separate connection to localhost:5432 for the local DB.
+- Migrations run automatically via Flyway on app startup; to run manually against local: `psql -U oneday -d oneday -f <migration.sql>`.
 - **Run the M1+M4 demo:** build/run **must** use JDK 21 (`export JAVA_HOME=/opt/homebrew/opt/openjdk@21`; system default JDK 25 is rejected by the enforcer), then `mvn spring-boot:run -pl app` → `http://localhost:8080/`. The 5 city H3 grids seed on startup so serviceability is live. Demo UI is `app/src/main/resources/static/index.html`; `spring-boot:run` serves static files from `app/target/classes/static/`, so hot-update via `cp app/src/main/resources/static/index.html app/target/classes/static/index.html` + hard-refresh (backend changes still need `mvn clean install -pl orders,app -am -DskipTests` + restart). PREPAID uses the mock gateway by default; real Razorpay with `RAZORPAY_LIVE=true RAZORPAY_KEY_ID=… RAZORPAY_KEY_SECRET=…`.
 
 ## Open Questions (block implementation of specific modules)

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/oneday}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/oneday?reWriteBatchedInserts=true}
     username: ${SPRING_DATASOURCE_USERNAME:oneday}
     password: ${SPRING_DATASOURCE_PASSWORD:secret}
     driver-class-name: org.postgresql.Driver
@@ -8,6 +8,14 @@ spring:
     hibernate:
       ddl-auto: validate
     show-sql: false
+    properties:
+      hibernate:
+        jdbc:
+          # Batch multi-row inserts/updates (e.g. bulk cart upload) into single round trips.
+          # IDs are app-side GenerationType.UUID, so batching is not disabled by IDENTITY.
+          batch_size: 100
+        order_inserts: true
+        order_updates: true
   flyway:
     enabled: true
     # Single recursive location catches auth/ and orders/ subfolders AND grid's V3_x +

--- a/app/src/main/resources/db/migration/V11__add_phone_to_onboarding_requests.sql
+++ b/app/src/main/resources/db/migration/V11__add_phone_to_onboarding_requests.sql
@@ -1,0 +1,4 @@
+-- Capture the applicant's phone during B2C/B2B onboarding so the approved user has an account
+-- phone (the locked sender contact on retail bookings, same as C2C). Nullable for rows created
+-- before this column existed.
+ALTER TABLE onboarding_requests ADD COLUMN phone VARCHAR(15);

--- a/app/src/main/resources/db/migration/auth/V1_10__add_phone_to_users.sql
+++ b/app/src/main/resources/db/migration/auth/V1_10__add_phone_to_users.sql
@@ -1,0 +1,3 @@
+-- C2C customers register with a phone number, fixed as the sender contact on their bookings.
+-- Nullable: pre-existing users (admin, staff onboarded before this) and non-C2C accounts may lack one.
+ALTER TABLE users ADD COLUMN phone VARCHAR(15);

--- a/app/src/main/resources/static/index.html
+++ b/app/src/main/resources/static/index.html
@@ -68,6 +68,10 @@
         <input type="text" id="reg-name" placeholder="Ravi Kumar" />
       </div>
       <div class="field" style="margin-bottom:.75rem">
+        <label>Phone (+91XXXXXXXXXX)</label>
+        <input type="tel" id="reg-phone" placeholder="+919000000001" />
+      </div>
+      <div class="field" style="margin-bottom:.75rem">
         <label>Email</label>
         <input type="email" id="reg-email" placeholder="ravi@example.com" />
       </div>
@@ -86,6 +90,7 @@
 <div id="dashboard-view">
   <div class="tab-bar">
     <button class="tab-btn active" onclick="switchTab('orders')">📦 Book Shipment</button>
+    <button class="tab-btn" id="cart-tab-btn" style="display:none" onclick="switchTab('cart')">🛒 Cart</button>
     <button class="tab-btn" onclick="switchTab('auth')">Auth</button>
     <button class="tab-btn" onclick="switchTab('users')">Users</button>
     <button class="tab-btn" onclick="switchTab('roles')">Roles</button>
@@ -119,14 +124,20 @@
           <div class="loc-card">
             <div class="loc-card-head">
               <span class="loc-kind">📦 Pickup location</span>
-              <button type="button" class="btn btn-sm btn-primary" onclick="openMapPicker('b2c','origin')">📍 Set on map</button>
+              <div style="display:flex;gap:.4rem">
+                <button type="button" class="btn btn-sm btn-ghost" onclick="openSavedPicker('b2c','origin')">📒 Saved</button>
+                <button type="button" class="btn btn-sm btn-primary" onclick="setOnMap('b2c','origin')">📍 Set on map</button>
+              </div>
             </div>
             <div class="loc-card-body" id="o-b2c-origin-loc"><div class="loc-empty">No pickup point yet — tap “Set on map”.</div></div>
           </div>
           <div class="loc-card">
             <div class="loc-card-head">
               <span class="loc-kind">🎯 Drop location</span>
-              <button type="button" class="btn btn-sm btn-primary" onclick="openMapPicker('b2c','dest')">📍 Set on map</button>
+              <div style="display:flex;gap:.4rem">
+                <button type="button" class="btn btn-sm btn-ghost" onclick="openSavedPicker('b2c','dest')">📒 Saved</button>
+                <button type="button" class="btn btn-sm btn-primary" onclick="setOnMap('b2c','dest')">📍 Set on map</button>
+              </div>
             </div>
             <div class="loc-card-body" id="o-b2c-dest-loc"><div class="loc-empty">No drop point yet — tap “Set on map”.</div></div>
           </div>
@@ -149,13 +160,25 @@
             <label>Payment</label>
             <div class="seg" id="b2c-pay-seg">
               <button type="button" class="active" data-mode="PREPAID" onclick="selectPay(this)">Prepaid</button>
-              <button type="button" data-mode="COD" onclick="selectPay(this)">COD</button>
             </div>
           </div>
+          <button class="btn btn-ghost" style="align-self:flex-end" onclick="addCurrentToCart('b2c')">🛒 Add to Cart</button>
           <button class="btn btn-primary" style="align-self:flex-end" onclick="bookB2c()">Book Shipment</button>
         </div>
         <div id="b2c-booking-summary"></div>
         <div id="b2c-booking-response" class="response"></div>
+
+        <!-- Bulk: one pickup → many destinations (B2C/B2B only) -->
+        <div id="b2c-bulk" style="display:none;margin-top:1rem;border-top:1px dashed #cbd5e1;padding-top:.85rem">
+          <div class="section-label">📑 Bulk destinations from this pickup <span class="tag tag-post">POST /api/v1/bulk/upload</span></div>
+          <p class="muted" style="margin:.25rem 0 .5rem">Set the <strong>Pickup location</strong> above, then upload a sheet of destinations — each becomes a cart item sharing this pickup.</p>
+          <div class="form-row" style="align-items:center">
+            <button class="btn btn-ghost" onclick="downloadTemplate()">⬇️ Destinations Template</button>
+            <input type="file" id="b2c-bulk-file" accept=".xlsx" style="display:none" onchange="uploadBulk(this,'b2c')" />
+            <button class="btn btn-primary" id="b2c-bulk-btn" onclick="document.getElementById('b2c-bulk-file').click()">⬆️ Upload Destinations</button>
+          </div>
+          <div id="b2c-bulk-response" class="response"></div>
+        </div>
       </div>
 
       <!-- B2B Booking -->
@@ -170,14 +193,20 @@
           <div class="loc-card">
             <div class="loc-card-head">
               <span class="loc-kind">📦 Pickup location</span>
-              <button type="button" class="btn btn-sm btn-primary" onclick="openMapPicker('b2b','origin')">📍 Set on map</button>
+              <div style="display:flex;gap:.4rem">
+                <button type="button" class="btn btn-sm btn-ghost" onclick="openSavedPicker('b2b','origin')">📒 Saved</button>
+                <button type="button" class="btn btn-sm btn-primary" onclick="setOnMap('b2b','origin')">📍 Set on map</button>
+              </div>
             </div>
             <div class="loc-card-body" id="o-b2b-origin-loc"><div class="loc-empty">No pickup point yet — tap “Set on map”.</div></div>
           </div>
           <div class="loc-card">
             <div class="loc-card-head">
               <span class="loc-kind">🎯 Drop location</span>
-              <button type="button" class="btn btn-sm btn-primary" onclick="openMapPicker('b2b','dest')">📍 Set on map</button>
+              <div style="display:flex;gap:.4rem">
+                <button type="button" class="btn btn-sm btn-ghost" onclick="openSavedPicker('b2b','dest')">📒 Saved</button>
+                <button type="button" class="btn btn-sm btn-primary" onclick="setOnMap('b2b','dest')">📍 Set on map</button>
+              </div>
             </div>
             <div class="loc-card-body" id="o-b2b-dest-loc"><div class="loc-empty">No drop point yet — tap “Set on map”.</div></div>
           </div>
@@ -197,10 +226,23 @@
         </div>
         <div class="form-row">
           <button class="btn btn-primary" onclick="bookB2b()">Book on Credit</button>
+          <button class="btn btn-ghost" onclick="addCurrentToCart('b2b')">🛒 Add to Cart</button>
           <button class="btn btn-ghost" onclick="bookB2b(true)" title="Books against the near-limit QuickShip demo account → 402">Demo: Over Credit Limit</button>
         </div>
         <div id="b2b-booking-summary"></div>
         <div id="b2b-booking-response" class="response"></div>
+
+        <!-- Bulk: one pickup → many destinations -->
+        <div id="b2b-bulk" style="display:none;margin-top:1rem;border-top:1px dashed #cbd5e1;padding-top:.85rem">
+          <div class="section-label">📑 Bulk destinations from this pickup <span class="tag tag-post">POST /api/v1/bulk/upload</span></div>
+          <p class="muted" style="margin:.25rem 0 .5rem">Set the <strong>Pickup location</strong> above, then upload a sheet of destinations — each becomes a cart item sharing this pickup.</p>
+          <div class="form-row" style="align-items:center">
+            <button class="btn btn-ghost" onclick="downloadTemplate()">⬇️ Destinations Template</button>
+            <input type="file" id="b2b-bulk-file" accept=".xlsx" style="display:none" onchange="uploadBulk(this,'b2b')" />
+            <button class="btn btn-primary" id="b2b-bulk-btn" onclick="document.getElementById('b2b-bulk-file').click()">⬆️ Upload Destinations</button>
+          </div>
+          <div id="b2b-bulk-response" class="response"></div>
+        </div>
       </div>
 
       <!-- Recent bookings -->
@@ -219,6 +261,30 @@
           <button class="btn btn-sm btn-ghost" id="admin-orders-clear" style="display:none" onclick="clearAdminFilters()">Clear filters</button>
         </div>
         <div id="admin-orders-container" style="overflow-x:auto"><div class="empty-state">Click Refresh to load orders</div></div>
+      </div>
+    </div>
+
+    <!-- ══════════ CART & BULK TAB (M4) ══════════ -->
+    <div class="tab-panel" id="tab-cart">
+
+      <!-- Cart (saved addresses are managed inline from the Book Shipment flow: "📒 Saved" /
+           "Save this address") so the dedicated address card lives there, not here. -->
+      <div class="card" id="card-cart">
+        <h2><span class="icon">🛒</span> Your Cart <span class="tag tag-get">GET /api/v1/cart</span></h2>
+        <p class="muted" style="margin-bottom:.5rem">Each line is an independent shipment. Add items from the Book Shipment tab or via Excel, then check out together.</p>
+        <div class="form-row" style="align-items:center">
+          <button class="btn btn-sm btn-ghost" onclick="loadCart()">Refresh</button>
+          <span class="muted" id="cart-summary">—</span>
+        </div>
+        <div id="cart-list" style="margin-top:.5rem"><div class="empty-state">Cart is empty</div></div>
+        <div class="form-row" id="cart-checkout-row" style="display:none;align-items:center;margin-top:.75rem">
+          <div class="field" id="cart-b2b-acct-field" style="display:none;max-width:340px">
+            <label>B2B Account ID</label>
+            <input id="cart-b2b-acct" value="a1b2c3d4-e5f6-7890-abcd-ef1234567890" />
+          </div>
+          <button class="btn btn-primary" style="align-self:flex-end" onclick="checkoutCart()">Checkout</button>
+        </div>
+        <div id="cart-response" class="response"></div>
       </div>
     </div>
 
@@ -603,10 +669,98 @@
   </div>
 </div>
 
+<!-- ══════════ ADDRESS FORM MODAL ══════════ -->
+<div id="addr-modal" class="map-modal" style="display:none">
+  <div class="map-dialog" style="max-width:520px">
+    <div class="map-head">
+      <strong id="addr-modal-title">Add address</strong>
+      <button class="btn btn-ghost btn-sm" onclick="closeAddressForm()">✕ Close</button>
+    </div>
+    <div style="padding:1rem;max-height:70vh;overflow-y:auto">
+      <div class="loc-card" id="addr-loc-card" style="margin-bottom:.75rem">
+        <div class="loc-card-head">
+          <span class="loc-kind">📍 Location</span>
+          <button type="button" class="btn btn-sm btn-primary" onclick="pickAddressOnMap()">Set on map</button>
+        </div>
+        <div class="loc-card-body" id="addr-loc-body"><div class="loc-empty">No location yet — tap “Set on map”.</div></div>
+      </div>
+      <div class="form-row">
+        <div class="field"><label>House / Flat / Floor</label><input id="addr-house" placeholder="Flat G06" /></div>
+        <div class="field"><label>Building / Street</label><input id="addr-building" placeholder="Vajra Jasmine County" /></div>
+      </div>
+      <div class="form-row">
+        <div class="field"><label>Contact Name</label><input id="addr-cname" placeholder="Ravi Kumar" /></div>
+        <div class="field"><label>Contact Phone</label><input id="addr-cphone" placeholder="+919000000001" /></div>
+      </div>
+      <div class="form-row">
+        <div class="field" style="width:100%"><label>Delivery Instructions (optional)</label><input id="addr-instr" placeholder="Ring the bell" /></div>
+      </div>
+      <!-- Save toggle: shown only when capturing a location during booking (the Add Address tab always saves). -->
+      <div class="form-row" id="addr-save-toggle-row" style="display:none;margin-top:.25rem">
+        <label style="display:flex;align-items:center;gap:.5rem;cursor:pointer;font-weight:600">
+          <input type="checkbox" id="addr-save-toggle" onchange="toggleSaveFields()" /> 💾 Save this address to my address book
+        </label>
+      </div>
+      <div id="addr-save-fields">
+        <div class="field" style="margin:.5rem 0 .6rem">
+          <label>Label</label>
+          <div class="seg" id="addr-label-seg">
+            <button type="button" class="active" data-label="HOME" onclick="selectAddrLabel(this)">🏠 Home</button>
+            <button type="button" data-label="OFFICE" onclick="selectAddrLabel(this)">💼 Office</button>
+            <button type="button" data-label="OTHER" onclick="selectAddrLabel(this)">📍 Other</button>
+          </div>
+        </div>
+        <div class="form-row">
+          <div class="field"><label>Save as (optional)</label><input id="addr-saveas" placeholder="Mom's place" /></div>
+        </div>
+      </div>
+    </div>
+    <div class="map-foot">
+      <div id="addr-form-status" class="map-status">Pick a serviceable location, choose a label, then save.</div>
+      <div class="map-foot-actions">
+        <button class="btn btn-ghost" onclick="closeAddressForm()">Cancel</button>
+        <button id="addr-save-btn" class="btn btn-primary" onclick="confirmAddress()" disabled>Save Address</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════ SAVED ADDRESS PICKER MODAL ══════════ -->
+<div id="saved-pick-modal" class="map-modal" style="display:none">
+  <div class="map-dialog" style="max-width:520px">
+    <div class="map-head">
+      <strong>📒 Choose a saved address</strong>
+      <button class="btn btn-ghost btn-sm" onclick="closeSavedPicker()">✕ Close</button>
+    </div>
+    <div style="padding:1rem;max-height:65vh;overflow-y:auto" id="saved-pick-list"></div>
+  </div>
+</div>
+
+<!-- ══════════ BULK UPLOAD FAILURE MODAL ══════════ -->
+<div id="bulk-modal" class="map-modal" style="display:none">
+  <div class="map-dialog" style="max-width:560px">
+    <div class="map-head">
+      <strong id="bulk-modal-title">Upload result</strong>
+      <button class="btn btn-ghost btn-sm" onclick="closeBulkModal()">✕ Close</button>
+    </div>
+    <div style="padding:1rem;max-height:65vh;overflow-y:auto">
+      <div id="bulk-modal-summary" class="order-banner" style="margin-bottom:.75rem"></div>
+      <div id="bulk-modal-failures"></div>
+    </div>
+    <div class="map-foot">
+      <div class="map-status">Valid rows have been added to your cart. Fix the rows below and re-upload.</div>
+      <div class="map-foot-actions">
+        <button class="btn btn-primary" onclick="closeBulkModal()">✕ Got it</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <script src="js/core.js"></script>
 <script src="js/auth.js"></script>
 <script src="js/users.js"></script>
 <script src="js/orders.js"></script>
+<script src="js/cart.js"></script>
 <script src="js/admin.js"></script>
 <script src="js/init.js"></script>
 </body>

--- a/app/src/main/resources/static/js/auth.js
+++ b/app/src/main/resources/static/js/auth.js
@@ -31,6 +31,7 @@
   async function register() {
     const btn = document.querySelector('#register-fields .btn-accent');
     const name = document.getElementById('reg-name').value.trim();
+    const phone = document.getElementById('reg-phone').value.trim();
     const email = document.getElementById('reg-email').value.trim();
     const password = document.getElementById('reg-password').value;
     const accountType = document.querySelector('#reg-type-group .type-btn.selected')?.dataset.type || 'C2C_CUSTOMER';
@@ -40,12 +41,25 @@
     setLoading(btn, true);
     try {
       if (accountType === 'C2C_CUSTOMER') {
-        const data = await api('POST', '/auth/register', { name, email, password });
+        // C2C captures a phone too — it becomes the locked sender contact on every booking.
+        if (!/^\+91[0-9]{10}$/.test(phone)) {
+          errEl.className = 'response error visible';
+          errEl.textContent = 'Enter a valid phone in +91XXXXXXXXXX format.';
+          setLoading(btn, false); return;
+        }
+        const data = await api('POST', '/auth/register', { name, phone, email, password });
         token = data.token;
         currentUser = { email, role: data.role, cityId: data.cityId, expiresAt: data.expiresAt };
         await showDashboard(data);
       } else {
-        await api('POST', '/auth/request-onboarding', { name, email, password, requestedRole: accountType });
+        // B2C/B2B also capture a phone (locked as the sender contact once approved).
+        if (!/^\+91[0-9]{10}$/.test(phone)) {
+          errEl.className = 'response error visible';
+          errEl.textContent = 'Enter a valid phone in +91XXXXXXXXXX format.';
+          setLoading(btn, false); return;
+        }
+        // Backend JSON is snake_case → send requested_role + phone.
+        await api('POST', '/auth/request-onboarding', { name, email, password, phone, requested_role: accountType });
         errEl.className = 'response success visible';
         errEl.textContent = 'Request submitted! An admin will review your account. You can log in once approved.';
       }
@@ -64,6 +78,7 @@
     data.mustChangePassword = data.mustChangePassword ?? data.must_change_password;
     currentUser.cityId = data.cityId;
     currentUser.name = data.name;   // stored account name — used to auto-fill the sender
+    currentUser.phone = data.phone; // stored account phone — locked as the C2C sender contact
 
     document.getElementById('login-view').style.display = 'none';
     document.getElementById('dashboard-view').style.display = 'flex';
@@ -111,6 +126,8 @@
 
     // Bring the M4 order experience online for this identity
     setupOrderExperience(data.role);
+    // Saved addresses + cart + bulk upload (customer roles only)
+    if (typeof setupCartExperience === 'function') setupCartExperience(data.role);
   }
 
   function logout() {

--- a/app/src/main/resources/static/js/cart.js
+++ b/app/src/main/resources/static/js/cart.js
@@ -1,0 +1,464 @@
+// cart.js — M4 saved address book, shipment cart (add/checkout), and Excel bulk upload.
+// Reuses globals from core.js (orderApi, val, esc, inr, currentUser, token, showResponse,
+// setLoading) and orders.js (picked, legAddress, ensureLocations, ORDER_CITIES, openMapPicker).
+
+  const CUSTOMER_ROLES = ['C2C_CUSTOMER', 'B2C_CUSTOMER', 'B2B_USER'];
+
+  // Called from auth.js on login to wire the Cart tab + bulk sections for customer roles.
+  function setupCartExperience(role) {
+    const isCustomer = CUSTOMER_ROLES.includes(role);
+    document.getElementById('cart-tab-btn').style.display = isCustomer ? '' : 'none';
+    document.getElementById('cart-b2b-acct-field').style.display = role === 'B2B_USER' ? '' : 'none';
+    document.getElementById('cart-response').className = 'response';
+    // Bulk (one pickup → many destinations) is for business senders only — never C2C.
+    const b2cBulk = document.getElementById('b2c-bulk');
+    if (b2cBulk) b2cBulk.style.display = role === 'B2C_CUSTOMER' ? '' : 'none';
+    const b2bBulk = document.getElementById('b2b-bulk');
+    if (b2bBulk) b2bBulk.style.display = role === 'B2B_USER' ? '' : 'none';
+    if (isCustomer) { loadCart(); }
+  }
+
+  // ════════════════════ SAVED ADDRESS BOOK ════════════════════
+  let _addrPick = null;     // confirmed map pin for the address form
+  let _addrLabel = 'HOME';
+  let _addrMode = 'save';   // 'save' (Add Address tab) | 'booking' (Set on map → details, optional save)
+  let _bookingTarget = null;// { form, leg } when _addrMode === 'booking'
+
+  async function loadAddresses() {
+    const c = document.getElementById('addresses-list');
+    if (!c) return;   // the dedicated address card was removed; saving still works via booking
+    try {
+      const { status, data } = await orderApi('GET', '/api/v1/addresses');
+      if (status >= 200 && status < 300 && Array.isArray(data)) renderAddresses(data);
+      else c.innerHTML = '<div class="empty-state">Could not load addresses</div>';
+    } catch { c.innerHTML = '<div class="empty-state">Could not load addresses</div>'; }
+  }
+
+  const LABEL_ICON = { HOME: '🏠', OFFICE: '💼', OTHER: '📍' };
+
+  function renderAddresses(list) {
+    const c = document.getElementById('addresses-list');
+    if (!list.length) { c.innerHTML = '<div class="empty-state">No saved addresses yet</div>'; return; }
+    c.innerHTML = list.map(a => {
+      const title = (a.save_as && a.save_as.trim()) ? a.save_as : (LABEL_ICON[a.label] || '') + ' ' + a.label;
+      const line = [a.house_floor, a.building_street, a.area_locality || a.line1].filter(Boolean).join(', ');
+      return `<div class="loc-card set" style="margin-bottom:.5rem">
+        <div class="loc-card-head">
+          <span class="loc-kind">${LABEL_ICON[a.label] || '📍'} ${esc(title)} <span class="badge badge-blue">${esc(a.label)}</span></span>
+          <button class="btn btn-sm btn-danger" onclick="deleteAddress('${a.id}')">Delete</button>
+        </div>
+        <div class="loc-card-body">
+          <div class="loc-addr">${esc(line)}</div>
+          <div class="loc-city">${esc(a.city)} · ${esc(a.pincode)}</div>
+          ${a.contact_name ? `<div class="loc-coords">${esc(a.contact_name)} · ${esc(a.contact_phone || '')}</div>` : ''}
+        </div>
+      </div>`;
+    }).join('');
+  }
+
+  function resetAddrFields() {
+    ['addr-house', 'addr-building', 'addr-saveas', 'addr-cname', 'addr-cphone', 'addr-instr'].forEach(id => document.getElementById(id).value = '');
+    document.querySelectorAll('#addr-label-seg button').forEach((b, i) => b.classList.toggle('active', i === 0));
+    _addrLabel = 'HOME';
+    document.getElementById('addr-loc-body').innerHTML = '<div class="loc-empty">No location yet — tap “Set on map”.</div>';
+    document.getElementById('addr-loc-card').classList.remove('set');
+    document.getElementById('addr-save-btn').disabled = true;
+    document.getElementById('addr-form-status').className = 'map-status';
+  }
+
+  // "Add Address" tab → pure save mode (always saves to the book).
+  function openAddressForm() {
+    _addrMode = 'save'; _bookingTarget = null; _addrPick = null;
+    resetAddrFields();
+    document.getElementById('addr-modal-title').textContent = 'Add address';
+    document.getElementById('addr-save-toggle-row').style.display = 'none';
+    document.getElementById('addr-save-fields').style.display = '';
+    document.getElementById('addr-save-btn').textContent = 'Save Address';
+    document.getElementById('addr-form-status').textContent = 'Pick a serviceable location, choose a label, then save.';
+    document.getElementById('addr-modal').style.display = 'flex';
+  }
+  function closeAddressForm() { document.getElementById('addr-modal').style.display = 'none'; }
+
+  function selectAddrLabel(btn) {
+    document.querySelectorAll('#addr-label-seg button').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+    _addrLabel = btn.dataset.label;
+  }
+
+  // Booking mode: label + save-as only matter if the user ticks "save this address".
+  function toggleSaveFields() {
+    document.getElementById('addr-save-fields').style.display =
+      document.getElementById('addr-save-toggle').checked ? '' : 'none';
+  }
+
+  // Booking "Set on map": pick on the map, THEN capture flat/building details (with optional save).
+  function setOnMap(form, leg) {
+    openMapPicker(form, leg, {
+      title: (leg === 'origin' ? '📦 Pickup' : '🎯 Drop') + ' location',
+      onConfirm: (pick) => openBookingDetails(form, leg, pick),
+    });
+  }
+
+  function openBookingDetails(form, leg, pick) {
+    _addrMode = 'booking'; _bookingTarget = { form, leg };
+    resetAddrFields();
+    fillAddrLocCard(pick);
+    if (pick.line1) document.getElementById('addr-building').value = pick.line1;
+    document.getElementById('addr-modal-title').textContent = (leg === 'origin' ? 'Pickup' : 'Drop') + ' address details';
+    document.getElementById('addr-save-toggle').checked = false;
+    document.getElementById('addr-save-toggle-row').style.display = '';
+    document.getElementById('addr-save-fields').style.display = 'none';
+    document.getElementById('addr-save-btn').textContent = 'Use this location';
+    document.getElementById('addr-save-btn').disabled = false;     // location already chosen on the map
+    document.getElementById('addr-form-status').textContent = 'Add flat / building details (optional), then use this location.';
+    document.getElementById('addr-modal').style.display = 'flex';
+  }
+
+  function fillAddrLocCard(pick) {
+    _addrPick = pick;
+    const c = ORDER_CITIES[pick.city];
+    document.getElementById('addr-loc-card').classList.add('set');
+    document.getElementById('addr-loc-body').innerHTML =
+      `<div class="loc-city">${c.name} · ${pick.pincode}</div>` +
+      `<div class="loc-coords">${pick.lat}, ${pick.lon}</div>` +
+      (pick.label ? `<div class="loc-addr">${esc(pick.label)}</div>` : '');
+    document.getElementById('addr-save-btn').disabled = false;
+  }
+
+  // The Location card's "Set on map" inside the modal (re-pick) — used in both modes.
+  function pickAddressOnMap() {
+    window._reopenAddrForm = true;     // hide the form while the full-screen map is open
+    document.getElementById('addr-modal').style.display = 'none';
+    openMapPicker(null, null, { title: '📍 Address location', onConfirm: (pick) => fillAddrLocCard(pick) });
+  }
+
+  function addressBodyFromForm() {
+    const c = ORDER_CITIES[_addrPick.city];
+    return {
+      label: _addrLabel,
+      save_as: val('addr-saveas') || null,
+      contact_name: val('addr-cname') || null,
+      contact_phone: val('addr-cphone') || null,
+      house_floor: val('addr-house') || null,
+      building_street: val('addr-building') || null,
+      area_locality: _addrPick.label || null,
+      line1: _addrPick.line1 || val('addr-building') || c.addr,
+      city: c.name, pincode: _addrPick.pincode, state: c.state,
+      latitude: _addrPick.lat, longitude: _addrPick.lon,
+      delivery_instructions: val('addr-instr') || null,
+    };
+  }
+
+  // Primary modal action — saves (Add Address tab) or applies the location to the booking leg
+  // (Set on map), optionally saving it to the book along the way.
+  async function confirmAddress() {
+    if (!_addrPick) return;
+    const btn = document.getElementById('addr-save-btn');
+
+    if (_addrMode === 'save') {
+      setLoading(btn, true);
+      try {
+        const { status, data } = await orderApi('POST', '/api/v1/addresses', addressBodyFromForm());
+        if (status >= 200 && status < 300) { closeAddressForm(); loadAddresses(); }
+        else addrFormError((data && (data.detail || data.title)) || ('HTTP ' + status));
+      } finally { setLoading(btn, false); }
+      return;
+    }
+
+    // Booking mode: fold the flat/building details into the pin, optionally save, then apply.
+    const { form, leg } = _bookingTarget;
+    const pick = Object.assign({}, _addrPick, {
+      houseFloor: val('addr-house') || null,
+      buildingStreet: val('addr-building') || _addrPick.line1 || null,
+      areaLocality: _addrPick.label || null,
+    });
+    const detail = [pick.houseFloor, pick.buildingStreet].filter(Boolean).join(', ');
+    if (detail) pick.label = detail + (pick.label ? ' · ' + pick.label : '');
+
+    if (document.getElementById('addr-save-toggle').checked) {
+      try { await orderApi('POST', '/api/v1/addresses', addressBodyFromForm()); loadAddresses(); }
+      catch { /* saving is best-effort — never block the booking on it */ }
+    }
+    picked[form][leg] = pick;
+    renderLocCard(form, leg, pick);
+    closeAddressForm();
+  }
+
+  function addrFormError(msg) {
+    const s = document.getElementById('addr-form-status');
+    s.className = 'map-status err';
+    s.textContent = msg;
+  }
+
+  async function deleteAddress(id) {
+    if (!confirm('Delete this saved address?')) return;
+    await orderApi('DELETE', '/api/v1/addresses/' + encodeURIComponent(id));
+    loadAddresses();
+  }
+
+  // ── Use a saved address as a booking pickup/drop ────────────────────────────
+  let _savedAddresses = [];
+  let _savedPickTarget = null;     // { form, leg } on the booking form awaiting a saved address
+
+  async function openSavedPicker(form, leg) {
+    _savedPickTarget = { form, leg };
+    const c = document.getElementById('saved-pick-list');
+    c.innerHTML = '<div class="empty-state">Loading…</div>';
+    document.getElementById('saved-pick-modal').style.display = 'flex';
+    let list = [];
+    try {
+      const { status, data } = await orderApi('GET', '/api/v1/addresses');
+      if (status >= 200 && status < 300 && Array.isArray(data)) list = data;
+    } catch { /* show empty below */ }
+    _savedAddresses = list;
+    if (!list.length) {
+      c.innerHTML = '<div class="empty-state">No saved addresses yet — save one from the Book Shipment flow (“Set on map” → tick “Save this address”).</div>';
+      return;
+    }
+    c.innerHTML = list.map((a, i) => {
+      const title = (a.save_as && a.save_as.trim()) ? a.save_as : (LABEL_ICON[a.label] || '') + ' ' + a.label;
+      const line = [a.house_floor, a.building_street, a.area_locality || a.line1].filter(Boolean).join(', ');
+      return `<div class="loc-card" style="margin-bottom:.5rem;cursor:pointer" onclick="applySavedAddress(${i})">
+        <div class="loc-card-head">
+          <span class="loc-kind">${LABEL_ICON[a.label] || '📍'} ${esc(title)} <span class="badge badge-blue">${esc(a.label)}</span></span>
+          <button class="btn btn-sm btn-danger" onclick="deleteSavedFromPicker('${a.id}', event)">Delete</button>
+        </div>
+        <div class="loc-card-body"><div class="loc-addr">${esc(line)}</div><div class="loc-city">${esc(a.city)} · ${esc(a.pincode)}</div></div>
+      </div>`;
+    }).join('');
+  }
+  function closeSavedPicker() { document.getElementById('saved-pick-modal').style.display = 'none'; }
+
+  // Delete from inside the picker without selecting the row (stopPropagation), then refresh the list.
+  async function deleteSavedFromPicker(id, ev) {
+    if (ev) ev.stopPropagation();
+    if (!confirm('Delete this saved address?')) return;
+    await orderApi('DELETE', '/api/v1/addresses/' + encodeURIComponent(id));
+    if (_savedPickTarget) openSavedPicker(_savedPickTarget.form, _savedPickTarget.leg);
+  }
+
+  // Re-validate the saved address against M3 (it may have gone out of grid) and, if serviceable,
+  // fold it into the booking form's picked[form][leg] exactly like a fresh map pin.
+  async function applySavedAddress(i) {
+    const a = _savedAddresses[i];
+    if (!a || !_savedPickTarget) return;
+    const { form, leg } = _savedPickTarget;
+    closeSavedPicker();
+    if (a.latitude == null || a.longitude == null) {
+      showResponse(form + '-booking-response', { body: { detail: 'That saved address has no map location — edit it to set one.' } }, true);
+      return;
+    }
+    const m3 = await m3ServiceableAt(a.latitude, a.longitude);
+    const serviceable = !!(m3 && m3.serviceable);
+    const demo = serviceable ? GRID_TO_DEMO[m3.city_code] : null;
+    if (!serviceable || !demo) {
+      showResponse(form + '-booking-response',
+        { body: { detail: `Saved address “${a.save_as || a.label}” is outside the serviceable grid.` } }, true);
+      return;
+    }
+    const pincode = (a.pincode && /^\d{6}$/.test(a.pincode)) ? a.pincode : ORDER_CITIES[demo].pin;
+    const pick = {
+      lat: +(+a.latitude).toFixed(6), lon: +(+a.longitude).toFixed(6),
+      pincode, city: demo,
+      line1: a.building_street || a.line1 || '',
+      label: [a.house_floor, a.building_street, a.area_locality].filter(Boolean).join(', '),
+      hex: m3.h3_index,
+    };
+    picked[form][leg] = pick;
+    renderLocCard(form, leg, pick);
+  }
+
+  // ════════════════════ CART ════════════════════
+  function buildCartItemBody(form) {
+    const o = picked[form].origin, d = picked[form].dest;
+    const p = 'o-' + form;
+    return {
+      sender_name: val(p + '-sname'), sender_phone: val(p + '-sphone'),
+      origin_address: legAddress(o), origin_city: o.city, origin_pincode: o.pincode,
+      receiver_name: val(p + '-rname'), receiver_phone: val(p + '-rphone'),
+      dest_address: legAddress(d), dest_city: d.city, dest_pincode: d.pincode,
+      weight_grams: +val(p + '-weight') || 1000,
+      length_cm: +val(p + '-len') || 20, width_cm: +val(p + '-wid') || 15, height_cm: +val(p + '-hei') || 10,
+      declared_value_paise: (+val(p + '-dval') || 0) * 100 || null,
+      pickup_type: 'DA_PICKUP', drop_type: 'DA_DELIVERY',
+    };
+  }
+
+  async function addCurrentToCart(form) {
+    if (!ensureLocations(form)) return;
+    const respId = form + '-booking-response';
+    try {
+      const { status, data } = await orderApi('POST', '/api/v1/cart/items', buildCartItemBody(form));
+      if (status >= 200 && status < 300) {
+        showResponse(respId, '🛒 Added to cart — open the “Cart & Bulk” tab to review and check out.', false);
+        loadCart();
+      } else {
+        showResponse(respId, { body: data }, true);
+      }
+    } catch {
+      showResponse(respId, { body: { detail: 'Network error adding to cart.' } }, true);
+    }
+  }
+
+  async function loadCart() {
+    const c = document.getElementById('cart-list');
+    try {
+      const { status, data } = await orderApi('GET', '/api/v1/cart');
+      if (status >= 200 && status < 300) renderCart(data);
+      else c.innerHTML = '<div class="empty-state">Could not load cart</div>';
+    } catch { c.innerHTML = '<div class="empty-state">Could not load cart</div>'; }
+  }
+
+  function renderCart(cart) {
+    const c = document.getElementById('cart-list');
+    const items = (cart && cart.items) || [];
+    document.getElementById('cart-summary').textContent =
+      items.length ? `${items.length} item(s) · total ${inr(cart.cart_total_paise)}` : '—';
+    document.getElementById('cart-checkout-row').style.display = items.length ? 'flex' : 'none';
+    if (!items.length) { c.innerHTML = '<div class="empty-state">Cart is empty</div>'; return; }
+    c.innerHTML = `<table class="data-table">
+      <thead><tr><th>Route</th><th>Receiver</th><th>Weight</th><th>Price</th><th></th></tr></thead>
+      <tbody>${items.map(i => `<tr>
+        <td><strong>${esc(i.origin_city)}</strong> → <strong>${esc(i.dest_city)}</strong>
+            <div class="muted" style="font-size:.75rem">${esc(i.origin_pincode)} → ${esc(i.dest_pincode)}${i.source === 'EXCEL' ? ' · 📑 excel' : ''}</div></td>
+        <td>${esc(i.receiver_name)}<div class="muted" style="font-size:.75rem">${esc(i.receiver_phone)}</div></td>
+        <td>${i.weight_grams} g</td>
+        <td>${inr(i.quoted_total_paise)}</td>
+        <td><button class="btn btn-sm btn-danger" onclick="removeCartItem('${i.id}')">Remove</button></td>
+      </tr>`).join('')}</tbody></table>`;
+  }
+
+  async function removeCartItem(id) {
+    await orderApi('DELETE', '/api/v1/cart/items/' + encodeURIComponent(id));
+    loadCart();
+  }
+
+  async function checkoutCart() {
+    const btn = document.querySelector('[onclick="checkoutCart()"]');
+    setLoading(btn, true);
+    try {
+      if (currentUser.role === 'B2B_USER') {
+        const { status, data } = await orderApi('POST', '/api/v1/cart/checkout', { b2b_account_id: val('cart-b2b-acct') });
+        handleCheckoutResult(status, data);
+      } else {
+        const { status, data } = await orderApi('POST', '/api/v1/cart/payment-order', {});
+        if (status >= 400) { showResponse('cart-response', { body: data }, true); return; }
+        await payCartThenCheckout(data);   // { order_id, amount_paise, key_id, mock }
+      }
+    } catch {
+      showResponse('cart-response', { body: { detail: 'Network error during checkout.' } }, true);
+    } finally { setLoading(btn, false); }
+  }
+
+  async function payCartThenCheckout(order) {
+    const refsThenCheckout = async (refs) => {
+      const { status, data } = await orderApi('POST', '/api/v1/cart/checkout', refs);
+      handleCheckoutResult(status, data);
+    };
+    // Live/test-API mode → Razorpay hosted checkout.
+    if (!order.mock && window.Razorpay) {
+      const rzp = new Razorpay({
+        key: order.key_id, amount: order.amount_paise, currency: order.currency || 'INR',
+        order_id: order.order_id, name: '1DD Logistics', description: 'Cart checkout',
+        theme: { color: '#1a1a2e' },
+        handler: (res) => refsThenCheckout({
+          razorpay_order_id: res.razorpay_order_id,
+          razorpay_payment_id: res.razorpay_payment_id,
+          razorpay_signature: res.razorpay_signature,
+        }),
+        modal: { ondismiss: () => showResponse('cart-response', { body: { detail: 'Payment cancelled — cart not checked out.' } }, true) },
+      });
+      rzp.open();
+      return;
+    }
+    // Mock gateway → sign locally, then check out.
+    const { status, data } = await orderApi('POST', '/api/v1/payments/mock/pay', { order_id: order.order_id });
+    if (status >= 400) { showResponse('cart-response', { body: data }, true); return; }
+    await refsThenCheckout({
+      razorpay_order_id: data.razorpay_order_id,
+      razorpay_payment_id: data.razorpay_payment_id,
+      razorpay_signature: data.razorpay_signature,
+    });
+  }
+
+  function handleCheckoutResult(status, data) {
+    if (status >= 200 && status < 300 && data) {
+      const msg = `✅ Checkout: ${data.booked} booked, ${data.failed} failed · charged ${inr(data.charged_total_paise)} · cart ${data.cart_status}`;
+      showResponse('cart-response', data.failed ? { body: { title: 'Partial checkout', detail: msg } } : msg, data.failed > 0);
+      loadCart();
+      if (typeof loadMyBookings === 'function') loadMyBookings();
+    } else {
+      showResponse('cart-response', { body: data }, true);
+    }
+  }
+
+  // ════════════════════ BULK UPLOAD (one pickup → many destinations) ════════════════════
+  async function downloadTemplate() {
+    try {
+      const r = await fetch('/api/v1/bulk/template', { headers: { 'Authorization': 'Bearer ' + token } });
+      if (!r.ok) { alert('Could not download template (HTTP ' + r.status + ')'); return; }
+      const blob = await r.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url; a.download = 'oneday-destinations-template.xlsx';
+      document.body.appendChild(a); a.click(); a.remove();
+      URL.revokeObjectURL(url);
+    } catch { alert('Network error downloading template.'); }
+  }
+
+  // form = 'b2c' | 'b2b'. The single shared pickup comes from that form's pickup pin + sender.
+  async function uploadBulk(input, form) {
+    const file = input.files && input.files[0];
+    if (!file) return;
+    const respId = form + '-bulk-response';
+    const o = picked[form] && picked[form].origin;
+    if (!o) {
+      input.value = '';
+      showResponse(respId, { body: { detail: 'Set the Pickup location on the map first — it applies to every destination.' } }, true);
+      return;
+    }
+    const p = 'o-' + form;
+    const pickup = {
+      sender_name: val(p + '-sname'), sender_phone: val(p + '-sphone'),
+      origin_address: legAddress(o), origin_city: o.city, origin_pincode: o.pincode,
+    };
+    const fd = new FormData();
+    fd.append('file', file);
+    fd.append('pickup', JSON.stringify(pickup));
+    const btn = document.getElementById(form + '-bulk-btn');
+    if (btn) setLoading(btn, true);
+    showResponse(respId, `⏳ Uploading “${file.name}” — validating destinations and pricing each route…`, false);
+    const t0 = performance.now();
+    try {
+      const r = await fetch('/api/v1/bulk/upload', { method: 'POST', headers: { 'Authorization': 'Bearer ' + token }, body: fd });
+      const data = await r.json().catch(() => null);
+      input.value = '';
+      if (!r.ok) { showResponse(respId, { body: data }, true); return; }
+      showBulkResult(data, respId, performance.now() - t0);
+    } catch {
+      input.value = '';
+      showResponse(respId, { body: { detail: 'Network error uploading file.' } }, true);
+    } finally {
+      if (btn) setLoading(btn, false);
+    }
+  }
+
+  function showBulkResult(data, respId, elapsedMs) {
+    const secs = elapsedMs != null ? ` in ${(elapsedMs / 1000).toFixed(1)}s` : '';
+    showResponse(respId,
+      `📑 ${data.added} destination(s) added to cart, ${data.failed} failed${secs}. Open the 🛒 Cart tab to review and check out.`,
+      data.failed > 0);
+    loadCart();
+    if (data.failed > 0) {
+      document.getElementById('bulk-modal-summary').innerHTML =
+        `<strong>${data.added}</strong> added · <strong style="color:#dc2626">${data.failed}</strong> failed validation`;
+      document.getElementById('bulk-modal-failures').innerHTML = (data.failures || []).map(f =>
+        `<div class="loc-card" style="margin-bottom:.5rem">
+          <div class="loc-card-head"><span class="loc-kind">Row ${f.row}</span></div>
+          <div class="loc-card-body">${(f.errors || []).map(e =>
+            `<div class="loc-addr"><code>${esc(e.field)}</code> — ${esc(e.reason)}</div>`).join('')}</div>
+        </div>`).join('');
+      document.getElementById('bulk-modal').style.display = 'flex';
+    }
+  }
+  function closeBulkModal() { document.getElementById('bulk-modal').style.display = 'none'; }

--- a/app/src/main/resources/static/js/orders.js
+++ b/app/src/main/resources/static/js/orders.js
@@ -45,8 +45,11 @@
     document.getElementById('order-no-booking').style.display = (canBook || isOrdersViewer) ? 'none' : '';
 
     // For a retail (B2C/C2C) booking the sender IS the logged-in account, so auto-fill the sender
-    // name from the stored account and lock it. (B2B's sender is the warehouse → stays editable.)
-    if (showB2c) applyAccountSender('o-b2c-sname');
+    // name and phone from the stored account and lock them. (B2B's sender is the warehouse → editable.)
+    if (showB2c) {
+      applyAccountSender('o-b2c-sname', currentUser && currentUser.name);
+      applyAccountSender('o-b2c-sphone', currentUser && currentUser.phone);
+    }
 
     recentBookings = [];
     renderRecent();
@@ -58,13 +61,13 @@
     switchTab('orders');
   }
 
-  // Fills the given sender-name input from the logged-in account and locks it (read-only),
-  // since the booker is the sender. No-op if the account name is unknown (older token).
-  function applyAccountSender(inputId) {
+  // Fills the given sender input from the logged-in account and locks it (read-only),
+  // since the booker is the sender. No-op if the value is unknown (older token without it).
+  function applyAccountSender(inputId, value) {
     const el = document.getElementById(inputId);
     if (!el) return;
-    if (currentUser && currentUser.name) {
-      el.value = currentUser.name;
+    if (value) {
+      el.value = value;
       el.readOnly = true;
       el.classList.add('locked-field');
       el.title = 'Auto-filled from your account';
@@ -84,7 +87,10 @@
   function legAddress(p) {
     const c = ORDER_CITIES[p.city];
     return {
-      line1: p.line1 || c.addr,
+      house_floor: p.houseFloor || null,
+      building_street: p.buildingStreet || null,
+      area_locality: p.areaLocality || null,
+      line1: p.line1 || p.buildingStreet || c.addr,
       city: c.name, pincode: p.pincode, state: c.state,
       latitude: p.lat, longitude: p.lon,
     };
@@ -287,15 +293,19 @@
       (p.label ? `<div class="loc-addr">${esc(p.label)}</div>` : '');
   }
 
-  function openMapPicker(form, leg) {
-    _mapState = { form, leg };
+  // opts (optional) lets other modules reuse the picker: { title, onConfirm(pick) }. When given,
+  // confirm fires onConfirm instead of writing to the booking form's picked[form][leg].
+  function openMapPicker(form, leg, opts) {
+    _mapState = opts || { form, leg };
     _mapPick = null;
+    const isLeg = _mapState.leg === 'origin' || _mapState.leg === 'dest';
     document.getElementById('map-title').textContent =
-      (leg === 'origin' ? '📦 Pickup' : '🎯 Drop') + ' location';
+      (_mapState.title) ? _mapState.title
+      : (_mapState.leg === 'origin' ? '📦 Pickup' : '🎯 Drop') + ' location';
     document.getElementById('map-search').value = '';
     document.getElementById('map-search-results').style.display = 'none';
     document.getElementById('map-confirm').disabled = true;
-    setMapStatus('Search for an area, then click or drag the pin to the exact ' + (leg === 'origin' ? 'pickup' : 'drop') + ' point.');
+    setMapStatus('Search for an area, then click or drag the pin to the exact point.');
     document.getElementById('map-modal').style.display = 'flex';
 
     // Init after the container is visible so Leaflet measures it correctly.
@@ -306,14 +316,22 @@
           { maxZoom: 19, attribution: '© OpenStreetMap contributors' }).addTo(_map);
         _map.on('click', e => placeMarker(e.latlng.lat, e.latlng.lng));
       }
-      const prev = picked[form][leg];
+      const prev = isLeg && _mapState.form ? picked[_mapState.form][_mapState.leg] : null;
       if (prev) { _map.setView([prev.lat, prev.lon], 15); placeMarker(prev.lat, prev.lon); }
       else      { _map.setView(INDIA_VIEW.center, INDIA_VIEW.zoom); if (_marker) { _map.removeLayer(_marker); _marker = null; } }
       _map.invalidateSize();
     }, 60);
   }
 
-  function closeMapPicker() { document.getElementById('map-modal').style.display = 'none'; }
+  function closeMapPicker() {
+    document.getElementById('map-modal').style.display = 'none';
+    // If the picker was opened from the address form, bring that form back (confirm or cancel).
+    if (window._reopenAddrForm) {
+      window._reopenAddrForm = false;
+      const m = document.getElementById('addr-modal');
+      if (m) m.style.display = 'flex';
+    }
+  }
 
   function setMapStatus(html, cls) {
     const el = document.getElementById('map-status');
@@ -376,6 +394,11 @@
 
   function confirmMapPicker() {
     if (!_mapPick || !_mapPick.city) return;
+    if (_mapState && typeof _mapState.onConfirm === 'function') {
+      _mapState.onConfirm(_mapPick);    // reused by the address book (cart.js)
+      closeMapPicker();
+      return;
+    }
     const { form, leg } = _mapState;
     picked[form][leg] = _mapPick;       // the pin is now the source of truth for city + pincode
     renderLocCard(form, leg, _mapPick);

--- a/auth/src/main/java/com/oneday/auth/domain/OnboardingRequest.java
+++ b/auth/src/main/java/com/oneday/auth/domain/OnboardingRequest.java
@@ -25,6 +25,9 @@ public class OnboardingRequest extends BaseEntity {
     @Column(name = "requested_role", nullable = false)
     private String requestedRole;
 
+    @Column(name = "phone")
+    private String phone;
+
     @Column(name = "password_hash", nullable = false)
     private String passwordHash;
 

--- a/auth/src/main/java/com/oneday/auth/domain/User.java
+++ b/auth/src/main/java/com/oneday/auth/domain/User.java
@@ -20,6 +20,9 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
+    @Column(length = 15)
+    private String phone;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "role_id", nullable = false)
     private Role role;

--- a/auth/src/main/java/com/oneday/auth/dto/request/OnboardingSubmitRequest.java
+++ b/auth/src/main/java/com/oneday/auth/dto/request/OnboardingSubmitRequest.java
@@ -9,6 +9,8 @@ public record OnboardingSubmitRequest(
         @NotBlank @Email String email,
         @NotBlank String name,
         @NotBlank @Size(min = 8) String password,
+        @NotBlank @Pattern(regexp = "\\+91[0-9]{10}",
+                message = "must be E.164 format (+91XXXXXXXXXX)") String phone,
         @NotBlank @Pattern(regexp = "B2B_USER|B2C_CUSTOMER",
                 message = "must be B2B_USER or B2C_CUSTOMER") String requestedRole
 ) {}

--- a/auth/src/main/java/com/oneday/auth/dto/request/RegisterRequest.java
+++ b/auth/src/main/java/com/oneday/auth/dto/request/RegisterRequest.java
@@ -2,10 +2,15 @@ package com.oneday.auth.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record RegisterRequest(
         @NotBlank @Email String email,
         @NotBlank @Size(min = 8) String password,
-        @NotBlank String name
+        @NotBlank String name,
+        // E.164 (+91XXXXXXXXXX) — same format M4 requires for sender_phone, since this
+        // number is pre-filled and locked as the sender contact on C2C bookings.
+        @NotBlank @Size(max = 15) @Pattern(regexp = "\\+91[0-9]{10}",
+                message = "must be E.164 format (+91XXXXXXXXXX)") String phone
 ) {}

--- a/auth/src/main/java/com/oneday/auth/dto/response/LoginResponse.java
+++ b/auth/src/main/java/com/oneday/auth/dto/response/LoginResponse.java
@@ -8,5 +8,6 @@ public record LoginResponse(
         String role,
         String cityId,
         String name,
+        String phone,
         boolean mustChangePassword
 ) {}

--- a/auth/src/main/java/com/oneday/auth/service/impl/AuthServiceImpl.java
+++ b/auth/src/main/java/com/oneday/auth/service/impl/AuthServiceImpl.java
@@ -91,6 +91,7 @@ class AuthServiceImpl implements AuthService {
         user.setEmail(request.email());
         user.setPasswordHash(passwordEncoder.encode(request.password()));
         user.setName(request.name());
+        user.setPhone(request.phone());
         user.setRole(c2cRole);
         user.setActive(true);
         user.setMustChangePassword(false);
@@ -195,7 +196,7 @@ class AuthServiceImpl implements AuthService {
         String token = jwtService.createToken(user);
         Instant expiresAt = jwtService.expiryFor(user);
         return new LoginResponse(token, expiresAt, user.getRole().getName(),
-                user.getCityId(), user.getName(), user.isMustChangePassword());
+                user.getCityId(), user.getName(), user.getPhone(), user.isMustChangePassword());
     }
 
     private void writeAuditLog(UUID actorId, UUID targetUserId, String action,

--- a/auth/src/main/java/com/oneday/auth/service/impl/OnboardingServiceImpl.java
+++ b/auth/src/main/java/com/oneday/auth/service/impl/OnboardingServiceImpl.java
@@ -56,6 +56,7 @@ class OnboardingServiceImpl implements OnboardingService {
         var onboardingRequest = new OnboardingRequest();
         onboardingRequest.setEmail(request.email());
         onboardingRequest.setName(request.name());
+        onboardingRequest.setPhone(request.phone());
         onboardingRequest.setRequestedRole(request.requestedRole());
         onboardingRequest.setPasswordHash(passwordEncoder.encode(request.password()));
         onboardingRequest.setStatus("PENDING");
@@ -93,6 +94,7 @@ class OnboardingServiceImpl implements OnboardingService {
         var user = new User();
         user.setEmail(onboardingRequest.getEmail());
         user.setName(onboardingRequest.getName());
+        user.setPhone(onboardingRequest.getPhone());
         user.setPasswordHash(onboardingRequest.getPasswordHash());
         user.setRole(role);
         user.setActive(true);

--- a/auth/src/test/java/com/oneday/auth/e2e/AuthE2eTest.java
+++ b/auth/src/test/java/com/oneday/auth/e2e/AuthE2eTest.java
@@ -41,9 +41,10 @@ class AuthE2eTest extends AuthE2eSupport {
     @Test
     void register_thenLogin_succeedsAsC2cCustomer() throws Exception {
         String email = uniqueEmail();
-        mvc.perform(asJson(post("/auth/register"), new RegisterRequest(email, PW, "New Customer")))
+        mvc.perform(asJson(post("/auth/register"), new RegisterRequest(email, PW, "New Customer", "+919000000001")))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.role").value("C2C_CUSTOMER"))
+                .andExpect(jsonPath("$.phone").value("+919000000001"))
                 .andExpect(jsonPath("$.token").isNotEmpty());
 
         mvc.perform(asJson(post("/auth/login"), new LoginRequest(email, PW)))
@@ -54,9 +55,9 @@ class AuthE2eTest extends AuthE2eSupport {
     @Test
     void register_duplicateEmail_returns409() throws Exception {
         String email = uniqueEmail();
-        mvc.perform(asJson(post("/auth/register"), new RegisterRequest(email, PW, "First")))
+        mvc.perform(asJson(post("/auth/register"), new RegisterRequest(email, PW, "First", "+919000000001")))
                 .andExpect(status().isOk());
-        mvc.perform(asJson(post("/auth/register"), new RegisterRequest(email, PW, "Second")))
+        mvc.perform(asJson(post("/auth/register"), new RegisterRequest(email, PW, "Second", "+919000000002")))
                 .andExpect(status().isConflict());
     }
 

--- a/auth/src/test/java/com/oneday/auth/e2e/OnboardingE2eTest.java
+++ b/auth/src/test/java/com/oneday/auth/e2e/OnboardingE2eTest.java
@@ -18,7 +18,7 @@ class OnboardingE2eTest extends AuthE2eSupport {
     @Test
     void submitOnboarding_isPublicAndPending() throws Exception {
         mvc.perform(asJson(post("/auth/request-onboarding"),
-                        new OnboardingSubmitRequest(uniqueEmail(), "Acme Corp", "Signup123!", "B2B_USER")))
+                        new OnboardingSubmitRequest(uniqueEmail(), "Acme Corp", "Signup123!", "+919000000001", "B2B_USER")))
                 .andExpect(status().isAccepted())
                 .andExpect(jsonPath("$.status").value("PENDING"))
                 .andExpect(jsonPath("$.requestedRole").value("B2B_USER"));
@@ -30,7 +30,7 @@ class OnboardingE2eTest extends AuthE2eSupport {
     void adminApproves_userCanThenLogin() throws Exception {
         String email = uniqueEmail();
         mvc.perform(asJson(post("/auth/request-onboarding"),
-                        new OnboardingSubmitRequest(email, "Acme Corp", "Signup123!", "B2B_USER")))
+                        new OnboardingSubmitRequest(email, "Acme Corp", "Signup123!", "+919000000001", "B2B_USER")))
                 .andExpect(status().isAccepted());
 
         String admin = adminToken();
@@ -52,7 +52,7 @@ class OnboardingE2eTest extends AuthE2eSupport {
     void adminRejects_noUserCreated() throws Exception {
         String email = uniqueEmail();
         mvc.perform(asJson(post("/auth/request-onboarding"),
-                        new OnboardingSubmitRequest(email, "Reject Me", "Signup123!", "B2C_CUSTOMER")))
+                        new OnboardingSubmitRequest(email, "Reject Me", "Signup123!", "+919000000001", "B2C_CUSTOMER")))
                 .andExpect(status().isAccepted());
 
         String admin = adminToken();

--- a/docs/M4/ADDRESS-CART-BULK-PLAN.md
+++ b/docs/M4/ADDRESS-CART-BULK-PLAN.md
@@ -1,0 +1,225 @@
+# Address Book + Shipment Cart + Excel Bulk Booking — Implementation Plan
+
+Status: **approved, not yet implemented** · Owner: M4 (orders) · Created 2026-06-08
+
+Adds a Swiggy-style address-capture flow, a per-user saved-address book, a shipment
+**cart** (each line is an independent shipment), and **Excel bulk upload** that validates
+rows, adds valid ones to the cart, and reports invalid ones with reasons.
+
+All new code lands in the **orders (M4)** module — it already owns `Address`, `Shipment`,
+the booking flow (`BookingService`), and depends on `auth` for the user FK.
+
+---
+
+## 1. Confirmed decisions
+
+| # | Decision |
+|---|----------|
+| Lanes | Both **B2C** and **B2B**. Address book + map capture for everyone; cart + Excel for both (Excel is the B2B headline). |
+| Cart item | **Independent shipment** — each line carries its own pickup + drop + parcel. Checkout books them all. |
+| Build | Backend APIs **+** the existing static demo UI (Leaflet), end-to-end testable. |
+| **Payment / COD** | **COD removed from the UI entirely.** B2C cart → one **Razorpay prepaid** order for the cart total. B2B cart → **debit against the credit account** (`B2bAccount.credit_limit` / `outstanding_balance_paise`, `SELECT FOR UPDATE`) — the industry-standard B2B model (Shiprocket / Delhivery One / DTDC business accounts). No gateway for B2B. |
+| Excel failures | Valid rows are added to the cart; invalid rows surface as a **dismissable error modal** (closes only on the ✕) listing each failed row + field + reason. |
+| Partial checkout | Book every valid item; failures stay in the cart with their reason (not all-or-nothing). |
+| Stale prices | Cart caches a quote per item; re-validated at checkout (nightly grid replan can move prices) — mismatches surface **before** payment. |
+| `save_as` name | **Optional** (nullable) — a user may save an address without naming it. |
+| Door/building photos | **Out of scope for v1** (no file-upload/storage work). |
+
+---
+
+## 2. Data model & migrations (orders, next free versions `V4_18`–`V4_20`)
+
+`Address` (the embeddable in `orders/domain/Address.java`) gains three **optional** fields,
+persisted inside the existing JSONB blob (no column migration for the shipment use):
+`house_floor`, `building_street`, `area_locality`.
+
+### `V4_18__create_saved_address.sql`
+```sql
+CREATE TABLE saved_address (
+    id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id               UUID NOT NULL REFERENCES users(id),
+    label                 VARCHAR(10) NOT NULL,          -- HOME | OFFICE | OTHER
+    save_as               VARCHAR(100),                  -- optional free text ("Mom's place")
+    contact_name          VARCHAR(100),
+    contact_phone         VARCHAR(15),                   -- +91XXXXXXXXXX
+    -- address (mirrors the embedded Address)
+    house_floor           VARCHAR(200),
+    building_street       VARCHAR(200),
+    area_locality         VARCHAR(300),
+    line1                 VARCHAR(200) NOT NULL,
+    line2                 VARCHAR(200),
+    city                  VARCHAR(100) NOT NULL,
+    pincode               VARCHAR(10)  NOT NULL,
+    state                 VARCHAR(100) NOT NULL,
+    landmark              VARCHAR(200),
+    latitude              DOUBLE PRECISION,
+    longitude             DOUBLE PRECISION,
+    delivery_instructions VARCHAR(500),
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_saved_address_user ON saved_address(user_id);
+```
+
+### `V4_19__create_cart.sql`
+```sql
+CREATE TABLE cart (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id    UUID NOT NULL REFERENCES users(id),
+    status     VARCHAR(16) NOT NULL DEFAULT 'OPEN',      -- OPEN | CHECKED_OUT | ABANDONED
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+-- at most one OPEN cart per user
+CREATE UNIQUE INDEX uq_cart_open_per_user ON cart(user_id) WHERE status = 'OPEN';
+```
+
+### `V4_20__create_cart_item.sql`
+```sql
+CREATE TABLE cart_item (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    cart_id             UUID NOT NULL REFERENCES cart(id) ON DELETE CASCADE,
+    source              VARCHAR(8) NOT NULL DEFAULT 'MANUAL',  -- MANUAL | EXCEL
+    excel_row_num       INT,
+    -- pickup
+    sender_name         VARCHAR(100) NOT NULL,
+    sender_phone        VARCHAR(15)  NOT NULL,
+    sender_email        VARCHAR(254),
+    origin_address      JSONB NOT NULL,                        -- embedded Address
+    origin_city         VARCHAR(100) NOT NULL,
+    origin_pincode      VARCHAR(10)  NOT NULL,
+    -- drop
+    receiver_name       VARCHAR(100) NOT NULL,
+    receiver_phone      VARCHAR(15)  NOT NULL,
+    receiver_email      VARCHAR(254),
+    dest_address        JSONB NOT NULL,
+    dest_city           VARCHAR(100) NOT NULL,
+    dest_pincode        VARCHAR(10)  NOT NULL,
+    -- parcel
+    weight_grams        INT NOT NULL,
+    length_cm           SMALLINT NOT NULL,
+    width_cm            SMALLINT NOT NULL,
+    height_cm           SMALLINT NOT NULL,
+    declared_value_paise BIGINT,
+    pickup_type         VARCHAR(16) NOT NULL,
+    drop_type           VARCHAR(16) NOT NULL,
+    -- cached compute (so the cart shows price without re-pricing)
+    origin_tile_id      UUID,
+    dest_tile_id        UUID,
+    delivery_type       VARCHAR(16),
+    quoted_total_paise  BIGINT,
+    validation_status   VARCHAR(8) NOT NULL DEFAULT 'VALID',   -- VALID | STALE
+    booked_shipment_ref VARCHAR(64),                           -- set at checkout
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_cart_item_cart ON cart_item(cart_id);
+```
+
+> No `payment_mode` column on `cart_item` — payment is decided once per cart at checkout
+> (B2C prepaid vs B2B credit), not per line, now that COD is gone.
+
+---
+
+## 3. Backend APIs
+
+### Address book — `AddressBookController` (`/api/v1/addresses`)
+- `GET /` — list current user's saved addresses
+- `POST /` — create (label required; `save_as`, contact, instructions optional)
+- `PUT /{id}` · `DELETE /{id}` — user-scoped via `Authz.requireUserId`
+
+### Cart — `CartController` (`/api/v1/cart`)
+- `GET /` — active cart: items + per-item price + total + counts
+- `POST /items` — add one shipment draft; runs serviceability + pricing, caches tile/quote
+- `PUT /items/{id}` · `DELETE /items/{id}`
+- `POST /checkout` — books every item via `BookingService.book(...)`; B2C mints one Razorpay
+  order for the total, B2B debits the credit account. Returns per-item result
+  (`shipment_ref` or failure). **Idempotent** (reuses the `Idempotency-Key` filter).
+
+### Excel — `BulkUploadController` (`/api/v1/bulk`)
+- `GET /template` — streams the fixed-header `.xlsx` with one example row
+- `POST /upload` (multipart) — parse → validate each row → add VALID rows to cart →
+  return `{ added, failed, failures: [{row, errors:[{field, reason}]}] }`
+
+---
+
+## 4. Excel design
+
+- **Library:** add `com.dhatim:fastexcel` + `fastexcel-reader` (lightweight streaming
+  `.xlsx`; smaller than full Apache POI).
+- **Fixed headers** (derived from `BookingRequest`; `?` = optional):
+  ```
+  sender_name, sender_phone, sender_email?,
+  origin_line1, origin_line2?, origin_city, origin_pincode, origin_state, origin_lat?, origin_lon?,
+  receiver_name, receiver_phone, receiver_email?,
+  dest_line1, dest_line2?, dest_city, dest_pincode, dest_state, dest_lat?, dest_lon?,
+  weight_grams, length_cm, width_cm, height_cm, declared_value_inr,
+  pickup_type, drop_type
+  ```
+  (No `payment_mode` column — COD is gone and the cart decides payment at checkout.)
+  Rows without lat/lon fall back to the adapter's **pincode-prefix serviceability**.
+- **Per-row validation (reuses existing rules, no duplication):**
+  1. Header check (exact set/order) — else reject the whole file.
+  2. Map row → `BookingRequest`; run **Jakarta Bean Validation** (the `@NotBlank` /
+     `@Pattern` / `@Max` annotations already on `BookingRequest`).
+  3. **Serviceability** (both legs) + **pricing** via existing ports → cache tile + quote.
+  4. Valid → `cart_item(source=EXCEL, excel_row_num=n)`. Invalid → collected.
+- **Response report** drives the dismissable error modal:
+  ```json
+  { "added": 42, "failed": 3,
+    "failures": [
+      {"row": 5, "errors": [{"field": "dest_pincode", "reason": "not serviceable in any covered city"}]},
+      {"row": 9, "errors": [{"field": "sender_phone", "reason": "must be +91XXXXXXXXXX"}]}
+    ] }
+  ```
+- **Synchronous, capped at ~500 rows** (inline report). Larger files → async job (future).
+
+---
+
+## 5. Demo UI (static `index.html`, Leaflet)
+
+- **Two-step capture:** map pin → reverse-geocode (Nominatim, already wired) auto-fills
+  Area/Locality → details form (House/Flat/Floor, Building/Street, HOME/OFFICE/OTHER,
+  contact, instructions) → **Save**.
+- **Saved-address picker** in the booking form for pickup & drop ("choose saved / add new").
+- **Cart view:** staged shipments, per-item price, edit/remove, total, **Checkout**.
+- **Excel panel:** download template, upload, render the added/failed report as the
+  **dismissable error modal** (closes on ✕).
+
+---
+
+## 6. Phasing (4 reviewable PRs)
+
+- **PR A — Address book — ✅ DONE (backend + tests):** `Address` extra fields, `V4_18`,
+  `SavedAddress` entity/repo/DTOs, `AddressBookController` + service, 404 handler,
+  idempotency exempt-paths fix, Flyway test `out-of-order` fix. `AddressBookE2eTest` (5 green).
+- **PR B — Cart core — ✅ DONE (backend + tests):** `V4_19/20`, `Cart`/`CartItem` +
+  repos/DTOs, add/list/edit/remove, checkout (B2C aggregate Razorpay via new
+  `BookingService.bookSettled`; B2B per-item credit via `b2bBookingService`), partial-failure
+  handling. `CartE2eTest` (5 green).
+- **PR C — Excel — ✅ DONE (backend + tests):** `fastexcel` dep, `GET /bulk/template`,
+  `POST /bulk/upload` (parse + per-row validation + add-to-cart + failure report, 500-row cap).
+  `BulkUploadE2eTest` (3 green).
+- **PR D — UI — ✅ DONE:** new "🛒 Cart & Bulk" tab (customer roles) with Saved Addresses
+  (map-pin → details form → save/list/delete), Cart (add-from-booking-form, list/remove,
+  checkout), and Bulk Excel (download template, upload, **dismissable failure modal**). COD
+  removed from the booking form. New `js/cart.js`; booking map picker extended with an
+  `onConfirm` hook so the address form reuses it. Added backend `POST /api/v1/cart/payment-order`
+  to mint a single Razorpay order for the cart total (completes the B2C checkout contract).
+
+### Implementation notes / deviations
+- `saved_address.user_id` / `cart.user_id` are **plain UUIDs (no FK to `users`)** — matches the
+  repo convention (`shipments.booked_by_user_id`); orders does not couple to auth's schema.
+- The orders **test** Flyway config needed `out-of-order: true` (top-level `V10` sorts as 10 > 4.x,
+  else new `V4_NN` migrations are silently skipped). Fixed in `orders/src/test/resources/application.yml`.
+- B2C cart shipments are persisted via `bookSettled` (no per-shipment `PaymentTransaction`); the
+  aggregate Razorpay refs + total live on the `cart` row. Per-shipment payment attribution is a
+  deferred refinement.
+
+---
+
+## 7. Open / deferred
+
+- Async Excel for very large files (>500 rows).
+- Door/building photos (deferred from v1).
+- Wallet/top-up model for B2B (currently credit-line only, which already exists).

--- a/grid/src/main/java/com/oneday/grid/repository/HexRepository.java
+++ b/grid/src/main/java/com/oneday/grid/repository/HexRepository.java
@@ -14,4 +14,9 @@ public interface HexRepository extends JpaRepository<Hex, UUID> {
     List<Hex> findByH3GridIdAndActiveTrue(UUID h3GridId);
 
     Optional<Hex> findByH3GridIdAndH3Index(UUID h3GridId, long h3Index);
+
+    // All city grids share one H3 resolution and H3 cells are globally unique, so an h3Index
+    // identifies at most one hex across every grid — lets serviceableAt resolve a point in a
+    // single query instead of scanning every city's grid.
+    Optional<Hex> findByH3Index(long h3Index);
 }

--- a/grid/src/main/java/com/oneday/grid/service/impl/GridServiceImpl.java
+++ b/grid/src/main/java/com/oneday/grid/service/impl/GridServiceImpl.java
@@ -116,25 +116,47 @@ public class GridServiceImpl implements GridService {
 
     @Override
     public ServiceableAtResponse serviceableAt(double lat, double lon) {
-        // A WGS84 point belongs to at most one city's polyfill, so scan the configured
-        // cities and return the first whose grid contains the point's H3 cell.
-        for (Map.Entry<String, UUID> entry : gridProperties.getCities().entrySet()) {
-            UUID cityId = entry.getValue();
-            Optional<Grid> gridOpt = gridRepository.findByCityId(cityId);
-            if (gridOpt.isEmpty()) {
-                continue;
-            }
-            Grid grid = gridOpt.get();
-            long h3Index = h3Core.latLngToCell(lat, lon, grid.getH3Resolution());
-            Optional<Hex> hexOpt = hexRepository.findByH3GridIdAndH3Index(grid.getId(), h3Index);
-            if (hexOpt.isPresent()) {
-                Hex hex = hexOpt.get();
-                return new ServiceableAtResponse(
-                        hex.isActive(), entry.getKey(), cityId, hex.getId(),
-                        Long.toHexString(hex.getH3Index()));
+        // Every city grid shares one H3 resolution and H3 cells are globally unique, so a WGS84
+        // point maps to exactly one hex across all grids. Resolve it in a single indexed lookup
+        // instead of scanning each city (the old loop did up to one findByCityId + one hex query
+        // per configured city, on every call). Grids are cached at startup and immutable intraday.
+        long h3Index = h3Core.latLngToCell(lat, lon, gridProperties.getH3().getResolution());
+        Optional<Hex> hexOpt = hexRepository.findByH3Index(h3Index);
+        if (hexOpt.isEmpty()) {
+            return new ServiceableAtResponse(false, null, null, null, null);
+        }
+        Hex hex = hexOpt.get();
+        UUID cityId = cityIdForGrid(hex.getH3GridId());
+        String cityCode = cityCodeForCity(cityId);
+        if (cityId == null || cityCode == null) {
+            // Hex exists but its grid is not a configured serviceable city — treat as not serviceable.
+            return new ServiceableAtResponse(false, null, null, null, null);
+        }
+        return new ServiceableAtResponse(
+                hex.isActive(), cityCode, cityId, hex.getId(), Long.toHexString(hex.getH3Index()));
+    }
+
+    /** Resolves a grid's own id to its cityId via the in-memory grid cache (no DB hit). */
+    private UUID cityIdForGrid(UUID gridId) {
+        for (Grid g : gridCache.values()) {
+            if (g.getId().equals(gridId)) {
+                return g.getCityId();
             }
         }
-        return new ServiceableAtResponse(false, null, null, null, null);
+        return null;
+    }
+
+    /** Reverse of the configured cityCode→cityId map. */
+    private String cityCodeForCity(UUID cityId) {
+        if (cityId == null) {
+            return null;
+        }
+        for (Map.Entry<String, UUID> e : gridProperties.getCities().entrySet()) {
+            if (cityId.equals(e.getValue())) {
+                return e.getKey();
+            }
+        }
+        return null;
     }
 
     @Override

--- a/orders/pom.xml
+++ b/orders/pom.xml
@@ -69,5 +69,16 @@
             <artifactId>razorpay-java</artifactId>
             <version>1.4.8</version>
         </dependency>
+        <!-- Excel bulk upload: lightweight streaming .xlsx reader + writer (no full Apache POI) -->
+        <dependency>
+            <groupId>org.dhatim</groupId>
+            <artifactId>fastexcel</artifactId>
+            <version>0.18.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.dhatim</groupId>
+            <artifactId>fastexcel-reader</artifactId>
+            <version>0.18.4</version>
+        </dependency>
     </dependencies>
 </project>

--- a/orders/src/main/java/com/oneday/orders/api/AddressBookController.java
+++ b/orders/src/main/java/com/oneday/orders/api/AddressBookController.java
@@ -1,0 +1,69 @@
+package com.oneday.orders.api;
+
+import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.orders.dto.SavedAddressRequest;
+import com.oneday.orders.dto.SavedAddressResponse;
+import com.oneday.orders.service.AddressBookService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Per-user saved address book. Scoped to customer roles (ADMIN manages these directly in
+ * the DB); every operation is filtered by the authenticated user id, so addresses are never
+ * visible or mutable across users.
+ */
+@RestController
+@RequestMapping("/api/v1/addresses")
+class AddressBookController {
+
+    private static final String[] CUSTOMER_ROLES = {"C2C_CUSTOMER", "B2C_CUSTOMER", "B2B_USER"};
+
+    private final AddressBookService addressBookService;
+
+    AddressBookController(AddressBookService addressBookService) {
+        this.addressBookService = addressBookService;
+    }
+
+    @GetMapping
+    public List<SavedAddressResponse> list(@AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireCustomerRole(principal, CUSTOMER_ROLES);
+        return addressBookService.list(UUID.fromString(Authz.requireUserId(principal)));
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public SavedAddressResponse create(@AuthenticationPrincipal AuthUserDetails principal,
+                                       @Valid @RequestBody SavedAddressRequest request) {
+        Authz.requireCustomerRole(principal, CUSTOMER_ROLES);
+        return addressBookService.create(UUID.fromString(Authz.requireUserId(principal)), request);
+    }
+
+    @PutMapping("/{id}")
+    public SavedAddressResponse update(@AuthenticationPrincipal AuthUserDetails principal,
+                                       @PathVariable("id") UUID id,
+                                       @Valid @RequestBody SavedAddressRequest request) {
+        Authz.requireCustomerRole(principal, CUSTOMER_ROLES);
+        return addressBookService.update(UUID.fromString(Authz.requireUserId(principal)), id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@AuthenticationPrincipal AuthUserDetails principal,
+                       @PathVariable("id") UUID id) {
+        Authz.requireCustomerRole(principal, CUSTOMER_ROLES);
+        addressBookService.delete(UUID.fromString(Authz.requireUserId(principal)), id);
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/api/BulkUploadController.java
+++ b/orders/src/main/java/com/oneday/orders/api/BulkUploadController.java
@@ -1,0 +1,69 @@
+package com.oneday.orders.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.orders.dto.BulkPickup;
+import com.oneday.orders.dto.BulkUploadResponse;
+import com.oneday.orders.service.BulkUploadService;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Excel bulk upload for the cart: one shared pickup → many destination rows. B2B + B2C only
+ * (C2C is excluded — they book one-off). Download the destinations template, fill rows, and
+ * upload along with the pickup chosen on the booking map; valid rows are added to the cart.
+ */
+@RestController
+@RequestMapping("/api/v1/bulk")
+class BulkUploadController {
+
+    // Bulk is for business-style senders (B2C/B2B); C2C and ADMIN are not permitted.
+    private static final String[] BULK_ROLES = {"B2C_CUSTOMER", "B2B_USER"};
+    private static final String XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+    private final BulkUploadService bulkUploadService;
+    private final ObjectMapper objectMapper;
+
+    BulkUploadController(BulkUploadService bulkUploadService, ObjectMapper objectMapper) {
+        this.bulkUploadService = bulkUploadService;
+        this.objectMapper = objectMapper;
+    }
+
+    @GetMapping("/template")
+    public ResponseEntity<Resource> template(@AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireCustomerRole(principal, BULK_ROLES);
+        byte[] bytes = bulkUploadService.generateTemplate();
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"oneday-destinations-template.xlsx\"")
+                .contentType(MediaType.parseMediaType(XLSX))
+                .body(new ByteArrayResource(bytes));
+    }
+
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public BulkUploadResponse upload(@AuthenticationPrincipal AuthUserDetails principal,
+                                     @RequestParam("file") MultipartFile file,
+                                     @RequestParam("pickup") String pickupJson) throws IOException {
+        Authz.requireCustomerRole(principal, BULK_ROLES);
+        UUID userId = UUID.fromString(Authz.requireUserId(principal));
+        BulkPickup pickup;
+        try {
+            pickup = objectMapper.readValue(pickupJson, BulkPickup.class);
+        } catch (Exception e) {
+            throw new BulkUploadService.BadTemplateException("Invalid pickup data: " + e.getMessage());
+        }
+        return bulkUploadService.process(userId, pickup, file.getInputStream());
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/api/CartController.java
+++ b/orders/src/main/java/com/oneday/orders/api/CartController.java
@@ -1,0 +1,116 @@
+package com.oneday.orders.api;
+
+import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.common.domain.enums.CustomerType;
+import com.oneday.orders.config.RazorpayProperties;
+import com.oneday.orders.dto.AddCartItemRequest;
+import com.oneday.orders.dto.CartCheckoutRequest;
+import com.oneday.orders.dto.CartCheckoutResponse;
+import com.oneday.orders.dto.CartItemResponse;
+import com.oneday.orders.dto.CartResponse;
+import com.oneday.orders.dto.PaymentOrderResponse;
+import com.oneday.orders.service.CartService;
+import com.oneday.orders.service.PaymentPort;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+/**
+ * Shipment cart for customer roles. Each line is an independent shipment; checkout books them
+ * all (B2C → one Razorpay payment for the total, B2B → credit-account debit per item). ADMIN is
+ * barred from booking (same rule as the shipment controllers); it reads the DB directly.
+ */
+@RestController
+@RequestMapping("/api/v1/cart")
+class CartController {
+
+    private static final String[] CUSTOMER_ROLES = {"C2C_CUSTOMER", "B2C_CUSTOMER", "B2B_USER"};
+
+    private final CartService cartService;
+    private final PaymentPort paymentPort;
+    private final RazorpayProperties razorpayProps;
+
+    CartController(CartService cartService, PaymentPort paymentPort, RazorpayProperties razorpayProps) {
+        this.cartService = cartService;
+        this.paymentPort = paymentPort;
+        this.razorpayProps = razorpayProps;
+    }
+
+    @GetMapping
+    public CartResponse getCart(@AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireCustomerRole(principal, CUSTOMER_ROLES);
+        return cartService.getCart(userId(principal));
+    }
+
+    @PostMapping("/items")
+    @ResponseStatus(HttpStatus.CREATED)
+    public CartItemResponse addItem(@AuthenticationPrincipal AuthUserDetails principal,
+                                    @Valid @RequestBody AddCartItemRequest request) {
+        Authz.requireCustomerRole(principal, CUSTOMER_ROLES);
+        return cartService.addItem(userId(principal), request);
+    }
+
+    @PutMapping("/items/{id}")
+    public CartItemResponse updateItem(@AuthenticationPrincipal AuthUserDetails principal,
+                                       @PathVariable("id") UUID id,
+                                       @Valid @RequestBody AddCartItemRequest request) {
+        Authz.requireCustomerRole(principal, CUSTOMER_ROLES);
+        return cartService.updateItem(userId(principal), id, request);
+    }
+
+    @DeleteMapping("/items/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void removeItem(@AuthenticationPrincipal AuthUserDetails principal,
+                           @PathVariable("id") UUID id) {
+        Authz.requireCustomerRole(principal, CUSTOMER_ROLES);
+        cartService.removeItem(userId(principal), id);
+    }
+
+    /**
+     * Mints a single Razorpay order for the whole-cart total (B2C/C2C prepaid checkout). The client
+     * pays this once, then posts the resulting refs to {@code /checkout}. B2B uses credit, not this.
+     */
+    @PostMapping("/payment-order")
+    public PaymentOrderResponse paymentOrder(@AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireCustomerRole(principal, CUSTOMER_ROLES);
+        long total = cartService.getCart(userId(principal)).cartTotalPaise();
+        if (total <= 0) {
+            throw new CartService.EmptyCartException("Cart is empty — nothing to pay for");
+        }
+        PaymentPort.PaymentOrder order = paymentPort.createOrder(total, "cart-checkout");
+        return new PaymentOrderResponse(order.orderId(), order.amountPaise(), order.currency(),
+                order.keyId(), !razorpayProps.isLive());
+    }
+
+    @PostMapping("/checkout")
+    public CartCheckoutResponse checkout(@AuthenticationPrincipal AuthUserDetails principal,
+                                         @Valid @RequestBody CartCheckoutRequest request) {
+        Authz.requireCustomerRole(principal, CUSTOMER_ROLES);
+        return cartService.checkout(userId(principal), customerType(principal), request);
+    }
+
+    private static UUID userId(AuthUserDetails principal) {
+        return UUID.fromString(Authz.requireUserId(principal));
+    }
+
+    /** Lane from the caller's role: B2B_USER → B2B (credit), C2C → C2C, otherwise B2C. */
+    private static CustomerType customerType(AuthUserDetails principal) {
+        String role = principal.getUser().getRole().getName();
+        return switch (role) {
+            case "B2B_USER" -> CustomerType.B2B;
+            case "C2C_CUSTOMER" -> CustomerType.C2C;
+            default -> CustomerType.B2C;
+        };
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/api/OrdersGlobalExceptionHandler.java
+++ b/orders/src/main/java/com/oneday/orders/api/OrdersGlobalExceptionHandler.java
@@ -1,8 +1,11 @@
 package com.oneday.orders.api;
 
+import com.oneday.orders.service.AddressBookService;
 import com.oneday.orders.service.B2bBookingService;
 import com.oneday.orders.service.BookingService;
+import com.oneday.orders.service.BulkUploadService;
 import com.oneday.orders.service.CancellationService;
+import com.oneday.orders.service.CartService;
 import com.oneday.orders.service.PaymentPort;
 import com.oneday.orders.service.exception.IllegalStateTransitionException;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
@@ -35,6 +38,38 @@ class OrdersGlobalExceptionHandler {
     ProblemDetail handleServiceability(BookingService.ServiceabilityException ex) {
         ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.UNPROCESSABLE_ENTITY);
         pd.setTitle("Route not serviceable");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    @ExceptionHandler(AddressBookService.AddressNotFoundException.class)
+    ProblemDetail handleAddressNotFound(AddressBookService.AddressNotFoundException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
+        pd.setTitle("Address not found");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    @ExceptionHandler(CartService.CartItemNotFoundException.class)
+    ProblemDetail handleCartItemNotFound(CartService.CartItemNotFoundException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
+        pd.setTitle("Cart item not found");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    @ExceptionHandler({CartService.EmptyCartException.class, CartService.CheckoutValidationException.class})
+    ProblemDetail handleCartCheckout(RuntimeException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.UNPROCESSABLE_ENTITY);
+        pd.setTitle("Cart checkout not possible");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    @ExceptionHandler(BulkUploadService.BadTemplateException.class)
+    ProblemDetail handleBadTemplate(BulkUploadService.BadTemplateException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.UNPROCESSABLE_ENTITY);
+        pd.setTitle("Invalid upload");
         pd.setDetail(ex.getMessage());
         return pd;
     }

--- a/orders/src/main/java/com/oneday/orders/api/filter/IdempotencyFilter.java
+++ b/orders/src/main/java/com/oneday/orders/api/filter/IdempotencyFilter.java
@@ -121,6 +121,8 @@ public class IdempotencyFilter extends OncePerRequestFilter {
      * <ul>
      *   <li>Non-POST methods (GET, PUT, DELETE are naturally idempotent or handled differently)</li>
      *   <li>Paths that do not match {@link IdempotencyProperties#getApplyToPathPattern()}</li>
+     *   <li>Paths explicitly exempted via {@link IdempotencyProperties#getExemptPathPatterns()}
+     *       (simple resource CRUD that needs no replay protection)</li>
      * </ul>
      */
     @Override
@@ -128,7 +130,16 @@ public class IdempotencyFilter extends OncePerRequestFilter {
         if (!HttpMethod.POST.matches(request.getMethod())) {
             return true;
         }
-        return !pathMatcher.match(properties.getApplyToPathPattern(), request.getRequestURI());
+        String uri = request.getRequestURI();
+        if (!pathMatcher.match(properties.getApplyToPathPattern(), uri)) {
+            return true;
+        }
+        for (String exempt : properties.getExemptPathPatterns()) {
+            if (pathMatcher.match(exempt, uri)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/orders/src/main/java/com/oneday/orders/config/IdempotencyProperties.java
+++ b/orders/src/main/java/com/oneday/orders/config/IdempotencyProperties.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
 import java.time.Duration;
+import java.util.List;
 
 /**
  * Configuration properties for the idempotency infrastructure.
@@ -44,6 +45,21 @@ public class IdempotencyProperties {
     @NotBlank
     private String applyToPathPattern = "/api/v1/**";
 
+    /**
+     * Ant-style URL patterns that are exempt from idempotency enforcement even though they
+     * match {@link #applyToPathPattern}. Use for simple resource CRUD that doesn't need
+     * replay protection (e.g. saved-address and cart-item management); booking, payment,
+     * and cart checkout deliberately stay enforced.
+     */
+    @NotNull
+    private List<String> exemptPathPatterns = List.of(
+            "/api/v1/addresses/**",
+            "/api/v1/addresses",
+            "/api/v1/cart/items/**",
+            "/api/v1/cart/items",
+            "/api/v1/bulk/**"
+    );
+
     public Duration getTtl() {
         return ttl;
     }
@@ -58,5 +74,13 @@ public class IdempotencyProperties {
 
     public void setApplyToPathPattern(String applyToPathPattern) {
         this.applyToPathPattern = applyToPathPattern;
+    }
+
+    public List<String> getExemptPathPatterns() {
+        return exemptPathPatterns;
+    }
+
+    public void setExemptPathPatterns(List<String> exemptPathPatterns) {
+        this.exemptPathPatterns = exemptPathPatterns;
     }
 }

--- a/orders/src/main/java/com/oneday/orders/config/ResilienceConfig.java
+++ b/orders/src/main/java/com/oneday/orders/config/ResilienceConfig.java
@@ -10,10 +10,12 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 @Configuration
 public class ResilienceConfig {
@@ -30,22 +32,42 @@ public class ResilienceConfig {
 
     @Bean
     public TimeLimiterRegistry timeLimiterRegistry(ResilienceProperties props) {
-        Map<String, TimeLimiterConfig> configs = new HashMap<>();
-        configs.put("serviceability", TimeLimiterConfig.custom()
+        // NOTE: registry.timeLimiter("name") uses the registry's DEFAULT config, NOT the
+        // same-named entry from a config map. So we must pre-create each instance WITH its
+        // config; otherwise every limiter silently falls back to resilience4j's 1s default
+        // (which the booking service then hits against the remote dev DB).
+        TimeLimiterRegistry registry = TimeLimiterRegistry.ofDefaults();
+        registry.timeLimiter("serviceability", TimeLimiterConfig.custom()
                 .timeoutDuration(Duration.ofMillis(props.getServiceabilityTimeoutMs()))
                 .build());
-        configs.put("pricing", TimeLimiterConfig.custom()
+        registry.timeLimiter("pricing", TimeLimiterConfig.custom()
                 .timeoutDuration(Duration.ofMillis(props.getPricingTimeoutMs()))
                 .build());
-        configs.put("payment", TimeLimiterConfig.custom()
+        registry.timeLimiter("payment", TimeLimiterConfig.custom()
                 .timeoutDuration(Duration.ofMillis(props.getPaymentTimeoutMs()))
                 .build());
-        return TimeLimiterRegistry.of(configs);
+        return registry;
     }
 
     @Bean(name = "resilienceScheduler", destroyMethod = "shutdown")
     public ScheduledExecutorService resilienceScheduler() {
-        return Executors.newScheduledThreadPool(4);
+        // TimeLimiter-wrapped serviceability/pricing/payment calls run on this pool. Bulk upload
+        // prices rows in parallel, so each concurrent quote needs a slot here — 8 gives room for
+        // parallel bulk pricing without starving interactive bookings.
+        return Executors.newScheduledThreadPool(8);
+    }
+
+    /**
+     * Bounded pool for pricing bulk-upload rows concurrently (each row does a read-only
+     * serviceability + quote). Capped so a large sheet can't exhaust the DB connection pool or
+     * monopolise the resilience scheduler; overflow runs on the calling thread (back-pressure).
+     */
+    @Bean(name = "bulkPricingExecutor", destroyMethod = "shutdown")
+    public ExecutorService bulkPricingExecutor() {
+        int threads = 8;
+        return new ThreadPoolExecutor(threads, threads, 0L, TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>(256),
+                new ThreadPoolExecutor.CallerRunsPolicy());
     }
 
     @Bean

--- a/orders/src/main/java/com/oneday/orders/domain/Address.java
+++ b/orders/src/main/java/com/oneday/orders/domain/Address.java
@@ -14,6 +14,12 @@ import lombok.Setter;
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Address {
+    // Granular components from the two-step map capture (Swiggy-style). All optional —
+    // persisted inside the address JSONB blob, no schema column needed.
+    @Size(max = 200) private String houseFloor;
+    @Size(max = 200) private String buildingStreet;
+    @Size(max = 300) private String areaLocality;
+
     @NotBlank @Size(max = 200) private String line1;
     @Size(max = 200) private String line2;
     @NotBlank @Size(max = 100) private String city;

--- a/orders/src/main/java/com/oneday/orders/domain/Cart.java
+++ b/orders/src/main/java/com/oneday/orders/domain/Cart.java
@@ -1,0 +1,42 @@
+package com.oneday.orders.domain;
+
+import com.oneday.common.domain.MutableBaseEntity;
+import com.oneday.orders.domain.enums.CartStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+/**
+ * A user's shipment cart. At most one {@link CartStatus#OPEN} cart exists per user (enforced by
+ * a partial unique index). Aggregate B2C payment refs are recorded at checkout for audit.
+ */
+@Entity
+@Table(name = "cart")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Cart extends MutableBaseEntity {
+
+    @Column(name = "user_id", nullable = false, updatable = false)
+    private UUID userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 16, nullable = false)
+    private CartStatus status = CartStatus.OPEN;
+
+    @Column(name = "checkout_razorpay_order_id", length = 100)
+    private String checkoutRazorpayOrderId;
+
+    @Column(name = "checkout_razorpay_payment_id", length = 100)
+    private String checkoutRazorpayPaymentId;
+
+    @Column(name = "checkout_total_paise")
+    private Long checkoutTotalPaise;
+}

--- a/orders/src/main/java/com/oneday/orders/domain/CartItem.java
+++ b/orders/src/main/java/com/oneday/orders/domain/CartItem.java
@@ -1,0 +1,104 @@
+package com.oneday.orders.domain;
+
+import com.oneday.common.domain.MutableBaseEntity;
+import com.oneday.common.domain.enums.DeliveryType;
+import com.oneday.common.domain.enums.DropType;
+import com.oneday.common.domain.enums.PickupType;
+import com.oneday.orders.domain.enums.CartItemSource;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.UUID;
+
+/**
+ * One complete, independent shipment draft inside a {@link Cart}. Mirrors the fields of a
+ * booking request; serviceability/pricing are cached for display and re-validated at checkout.
+ */
+@Entity
+@Table(name = "cart_item")
+@Getter
+@Setter
+@NoArgsConstructor
+public class CartItem extends MutableBaseEntity {
+
+    @Column(name = "cart_id", nullable = false, updatable = false)
+    private UUID cartId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source", length = 8, nullable = false)
+    private CartItemSource source = CartItemSource.MANUAL;
+
+    @Column(name = "excel_row_num")
+    private Integer excelRowNum;
+
+    // ── Pickup ──────────────────────────────────────────────────────────────
+    @Column(name = "sender_name", length = 100, nullable = false)
+    private String senderName;
+    @Column(name = "sender_phone", length = 15, nullable = false)
+    private String senderPhone;
+    @Column(name = "sender_email", length = 254)
+    private String senderEmail;
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "origin_address", nullable = false, columnDefinition = "jsonb")
+    private Address originAddress;
+    @Column(name = "origin_city", length = 100, nullable = false)
+    private String originCity;
+    @Column(name = "origin_pincode", length = 10, nullable = false)
+    private String originPincode;
+
+    // ── Drop ────────────────────────────────────────────────────────────────
+    @Column(name = "receiver_name", length = 100, nullable = false)
+    private String receiverName;
+    @Column(name = "receiver_phone", length = 15, nullable = false)
+    private String receiverPhone;
+    @Column(name = "receiver_email", length = 254)
+    private String receiverEmail;
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "dest_address", nullable = false, columnDefinition = "jsonb")
+    private Address destAddress;
+    @Column(name = "dest_city", length = 100, nullable = false)
+    private String destCity;
+    @Column(name = "dest_pincode", length = 10, nullable = false)
+    private String destPincode;
+
+    // ── Parcel ──────────────────────────────────────────────────────────────
+    @Column(name = "weight_grams", nullable = false)
+    private int weightGrams;
+    @Column(name = "length_cm", nullable = false)
+    private short lengthCm;
+    @Column(name = "width_cm", nullable = false)
+    private short widthCm;
+    @Column(name = "height_cm", nullable = false)
+    private short heightCm;
+    @Column(name = "declared_value_paise")
+    private Long declaredValuePaise;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "pickup_type", length = 16, nullable = false)
+    private PickupType pickupType;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "drop_type", length = 16, nullable = false)
+    private DropType dropType;
+
+    // ── Cached compute ──────────────────────────────────────────────────────
+    @Column(name = "origin_tile_id")
+    private UUID originTileId;
+    @Column(name = "dest_tile_id")
+    private UUID destTileId;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "delivery_type", length = 16)
+    private DeliveryType deliveryType;
+    @Column(name = "quoted_total_paise")
+    private Long quotedTotalPaise;
+    @Column(name = "validation_status", length = 8, nullable = false)
+    private String validationStatus = "VALID";
+    @Column(name = "booked_shipment_ref", length = 64)
+    private String bookedShipmentRef;
+}

--- a/orders/src/main/java/com/oneday/orders/domain/SavedAddress.java
+++ b/orders/src/main/java/com/oneday/orders/domain/SavedAddress.java
@@ -1,0 +1,96 @@
+package com.oneday.orders.domain;
+
+import com.oneday.common.domain.MutableBaseEntity;
+import com.oneday.orders.domain.enums.AddressLabel;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+/**
+ * A user's saved delivery/pickup address. Reused as either leg when booking or adding a
+ * cart item. User-scoped: the API only ever reads/writes rows for the authenticated user.
+ */
+@Entity
+@Table(name = "saved_address")
+@Getter
+@Setter
+@NoArgsConstructor
+public class SavedAddress extends MutableBaseEntity {
+
+    @Column(name = "user_id", nullable = false, updatable = false)
+    private UUID userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "label", length = 10, nullable = false)
+    private AddressLabel label;
+
+    /** Optional friendly name ("Mom's place"); a user may save without naming it. */
+    @Column(name = "save_as", length = 100)
+    private String saveAs;
+
+    @Column(name = "contact_name", length = 100)
+    private String contactName;
+
+    @Column(name = "contact_phone", length = 15)
+    private String contactPhone;
+
+    @Column(name = "house_floor", length = 200)
+    private String houseFloor;
+
+    @Column(name = "building_street", length = 200)
+    private String buildingStreet;
+
+    @Column(name = "area_locality", length = 300)
+    private String areaLocality;
+
+    @Column(name = "line1", length = 200, nullable = false)
+    private String line1;
+
+    @Column(name = "line2", length = 200)
+    private String line2;
+
+    @Column(name = "city", length = 100, nullable = false)
+    private String city;
+
+    @Column(name = "pincode", length = 10, nullable = false)
+    private String pincode;
+
+    @Column(name = "state", length = 100, nullable = false)
+    private String state;
+
+    @Column(name = "landmark", length = 200)
+    private String landmark;
+
+    @Column(name = "latitude")
+    private Double latitude;
+
+    @Column(name = "longitude")
+    private Double longitude;
+
+    @Column(name = "delivery_instructions", length = 500)
+    private String deliveryInstructions;
+
+    /** Projects this saved row into the embeddable {@link Address} used by booking/cart. */
+    public Address toAddress() {
+        Address a = new Address();
+        a.setHouseFloor(houseFloor);
+        a.setBuildingStreet(buildingStreet);
+        a.setAreaLocality(areaLocality);
+        a.setLine1(line1);
+        a.setLine2(line2);
+        a.setCity(city);
+        a.setPincode(pincode);
+        a.setState(state);
+        a.setLandmark(landmark);
+        a.setLatitude(latitude);
+        a.setLongitude(longitude);
+        return a;
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/domain/enums/AddressLabel.java
+++ b/orders/src/main/java/com/oneday/orders/domain/enums/AddressLabel.java
@@ -1,0 +1,11 @@
+package com.oneday.orders.domain.enums;
+
+/**
+ * Category for a user's saved address, mirroring the consumer-app convention
+ * (House / Office / Other). Purely a display/grouping label.
+ */
+public enum AddressLabel {
+    HOME,
+    OFFICE,
+    OTHER
+}

--- a/orders/src/main/java/com/oneday/orders/domain/enums/CartItemSource.java
+++ b/orders/src/main/java/com/oneday/orders/domain/enums/CartItemSource.java
@@ -1,0 +1,9 @@
+package com.oneday.orders.domain.enums;
+
+/** How a cart item was added. */
+public enum CartItemSource {
+    /** Added one-by-one via the booking form. */
+    MANUAL,
+    /** Added by an Excel bulk upload. */
+    EXCEL
+}

--- a/orders/src/main/java/com/oneday/orders/domain/enums/CartStatus.java
+++ b/orders/src/main/java/com/oneday/orders/domain/enums/CartStatus.java
@@ -1,0 +1,11 @@
+package com.oneday.orders.domain.enums;
+
+/** Lifecycle of a shipment cart. */
+public enum CartStatus {
+    /** Accepting items; the user's single active cart. */
+    OPEN,
+    /** All items booked; the cart is closed. */
+    CHECKED_OUT,
+    /** Discarded without booking. */
+    ABANDONED
+}

--- a/orders/src/main/java/com/oneday/orders/dto/AddCartItemRequest.java
+++ b/orders/src/main/java/com/oneday/orders/dto/AddCartItemRequest.java
@@ -1,0 +1,89 @@
+package com.oneday.orders.dto;
+
+import com.oneday.common.domain.enums.DropType;
+import com.oneday.common.domain.enums.PickupType;
+import com.oneday.orders.domain.Address;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Adds one independent shipment draft to the cart. Mirrors {@link BookingRequest} but carries
+ * <b>no payment fields</b> — payment is settled once per cart at checkout.
+ */
+public class AddCartItemRequest {
+
+    @NotBlank @Size(max = 100) private String senderName;
+    @NotBlank @Size(max = 15) @Pattern(regexp = "\\+91[0-9]{10}", message = "must be E.164 format (+91XXXXXXXXXX)")
+    private String senderPhone;
+    @Size(max = 254) @Email private String senderEmail;
+
+    @NotNull @Valid private Address originAddress;
+    @NotBlank @Size(max = 10) private String originCity;
+    @NotBlank @Size(max = 10) @Pattern(regexp = "\\d{6}", message = "must be a 6-digit pincode")
+    private String originPincode;
+
+    @NotBlank @Size(max = 100) private String receiverName;
+    @NotBlank @Size(max = 15) @Pattern(regexp = "\\+91[0-9]{10}", message = "must be E.164 format (+91XXXXXXXXXX)")
+    private String receiverPhone;
+    @Size(max = 254) @Email private String receiverEmail;
+
+    @NotNull @Valid private Address destAddress;
+    @NotBlank @Size(max = 10) private String destCity;
+    @NotBlank @Size(max = 10) @Pattern(regexp = "\\d{6}", message = "must be a 6-digit pincode")
+    private String destPincode;
+
+    @Positive @Max(70_000) private int weightGrams;
+    @Positive @Max(150) private short lengthCm;
+    @Positive @Max(150) private short widthCm;
+    @Positive @Max(150) private short heightCm;
+    @PositiveOrZero private Long declaredValuePaise;
+
+    @NotNull private PickupType pickupType;
+    @NotNull private DropType dropType;
+
+    public String getSenderName() { return senderName; }
+    public void setSenderName(String v) { this.senderName = v; }
+    public String getSenderPhone() { return senderPhone; }
+    public void setSenderPhone(String v) { this.senderPhone = v; }
+    public String getSenderEmail() { return senderEmail; }
+    public void setSenderEmail(String v) { this.senderEmail = v; }
+    public Address getOriginAddress() { return originAddress; }
+    public void setOriginAddress(Address v) { this.originAddress = v; }
+    public String getOriginCity() { return originCity; }
+    public void setOriginCity(String v) { this.originCity = v; }
+    public String getOriginPincode() { return originPincode; }
+    public void setOriginPincode(String v) { this.originPincode = v; }
+    public String getReceiverName() { return receiverName; }
+    public void setReceiverName(String v) { this.receiverName = v; }
+    public String getReceiverPhone() { return receiverPhone; }
+    public void setReceiverPhone(String v) { this.receiverPhone = v; }
+    public String getReceiverEmail() { return receiverEmail; }
+    public void setReceiverEmail(String v) { this.receiverEmail = v; }
+    public Address getDestAddress() { return destAddress; }
+    public void setDestAddress(Address v) { this.destAddress = v; }
+    public String getDestCity() { return destCity; }
+    public void setDestCity(String v) { this.destCity = v; }
+    public String getDestPincode() { return destPincode; }
+    public void setDestPincode(String v) { this.destPincode = v; }
+    public int getWeightGrams() { return weightGrams; }
+    public void setWeightGrams(int v) { this.weightGrams = v; }
+    public short getLengthCm() { return lengthCm; }
+    public void setLengthCm(short v) { this.lengthCm = v; }
+    public short getWidthCm() { return widthCm; }
+    public void setWidthCm(short v) { this.widthCm = v; }
+    public short getHeightCm() { return heightCm; }
+    public void setHeightCm(short v) { this.heightCm = v; }
+    public Long getDeclaredValuePaise() { return declaredValuePaise; }
+    public void setDeclaredValuePaise(Long v) { this.declaredValuePaise = v; }
+    public PickupType getPickupType() { return pickupType; }
+    public void setPickupType(PickupType v) { this.pickupType = v; }
+    public DropType getDropType() { return dropType; }
+    public void setDropType(DropType v) { this.dropType = v; }
+}

--- a/orders/src/main/java/com/oneday/orders/dto/BulkPickup.java
+++ b/orders/src/main/java/com/oneday/orders/dto/BulkPickup.java
@@ -1,0 +1,17 @@
+package com.oneday.orders.dto;
+
+import com.oneday.orders.domain.Address;
+
+/**
+ * The single shared pickup for a bulk upload (one pickup → many destinations). Sent alongside
+ * the destinations spreadsheet; applied to every row so the user sets the pickup just once on
+ * the booking map. Sender name/phone come from the booking form (their account).
+ */
+public record BulkPickup(
+        String senderName,
+        String senderPhone,
+        String senderEmail,
+        Address originAddress,
+        String originCity,
+        String originPincode
+) {}

--- a/orders/src/main/java/com/oneday/orders/dto/BulkUploadResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/BulkUploadResponse.java
@@ -1,0 +1,18 @@
+package com.oneday.orders.dto;
+
+import java.util.List;
+
+/**
+ * Outcome of an Excel bulk upload. Valid rows are added to the cart ({@code added}); invalid
+ * rows are reported with their 1-based spreadsheet row number and the per-field reasons so the
+ * UI can show a dismissable error list.
+ */
+public record BulkUploadResponse(
+        int added,
+        int failed,
+        List<RowFailure> failures
+) {
+    public record RowFailure(int row, List<FieldError> errors) {}
+
+    public record FieldError(String field, String reason) {}
+}

--- a/orders/src/main/java/com/oneday/orders/dto/CartCheckoutRequest.java
+++ b/orders/src/main/java/com/oneday/orders/dto/CartCheckoutRequest.java
@@ -1,0 +1,33 @@
+package com.oneday.orders.dto;
+
+import jakarta.validation.constraints.Size;
+
+import java.util.UUID;
+
+/**
+ * Checkout payload.
+ * <ul>
+ *   <li><b>B2C / C2C:</b> one Razorpay order/payment covering the whole-cart total — the three
+ *       razorpay* fields are required and verified once before the items are booked.</li>
+ *   <li><b>B2B:</b> {@code b2bAccountId} is required; items are booked against the account's
+ *       credit line (no gateway). The razorpay* fields are ignored.</li>
+ * </ul>
+ * The lane is derived from the caller's role, not from this payload.
+ */
+public class CartCheckoutRequest {
+
+    @Size(max = 100) private String razorpayOrderId;
+    @Size(max = 100) private String razorpayPaymentId;
+    @Size(max = 500) private String razorpaySignature;
+
+    private UUID b2bAccountId;
+
+    public String getRazorpayOrderId() { return razorpayOrderId; }
+    public void setRazorpayOrderId(String v) { this.razorpayOrderId = v; }
+    public String getRazorpayPaymentId() { return razorpayPaymentId; }
+    public void setRazorpayPaymentId(String v) { this.razorpayPaymentId = v; }
+    public String getRazorpaySignature() { return razorpaySignature; }
+    public void setRazorpaySignature(String v) { this.razorpaySignature = v; }
+    public UUID getB2bAccountId() { return b2bAccountId; }
+    public void setB2bAccountId(UUID v) { this.b2bAccountId = v; }
+}

--- a/orders/src/main/java/com/oneday/orders/dto/CartCheckoutResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/CartCheckoutResponse.java
@@ -1,0 +1,21 @@
+package com.oneday.orders.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Per-item outcome of a checkout. Successfully booked items carry a {@code shipmentRef};
+ * failed items carry a reason and remain in the (still OPEN) cart for the user to fix.
+ */
+public record CartCheckoutResponse(
+        int booked,
+        int failed,
+        long chargedTotalPaise,
+        String cartStatus,
+        List<Result> results
+) {
+    public record Result(UUID cartItemId, boolean success, String shipmentRef, String reason) {
+        public static Result ok(UUID id, String ref) { return new Result(id, true, ref, null); }
+        public static Result fail(UUID id, String reason) { return new Result(id, false, null, reason); }
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/dto/CartItemResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/CartItemResponse.java
@@ -1,0 +1,35 @@
+package com.oneday.orders.dto;
+
+import com.oneday.orders.domain.CartItem;
+
+import java.util.UUID;
+
+/** Read model for one cart line. */
+public record CartItemResponse(
+        UUID id,
+        String source,
+        Integer excelRowNum,
+        String senderName,
+        String senderPhone,
+        String originCity,
+        String originPincode,
+        String receiverName,
+        String receiverPhone,
+        String destCity,
+        String destPincode,
+        int weightGrams,
+        String deliveryType,
+        Long quotedTotalPaise,
+        String validationStatus,
+        String bookedShipmentRef
+) {
+    public static CartItemResponse from(CartItem i) {
+        return new CartItemResponse(
+                i.getId(), i.getSource().name(), i.getExcelRowNum(),
+                i.getSenderName(), i.getSenderPhone(), i.getOriginCity(), i.getOriginPincode(),
+                i.getReceiverName(), i.getReceiverPhone(), i.getDestCity(), i.getDestPincode(),
+                i.getWeightGrams(),
+                i.getDeliveryType() == null ? null : i.getDeliveryType().name(),
+                i.getQuotedTotalPaise(), i.getValidationStatus(), i.getBookedShipmentRef());
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/dto/CartResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/CartResponse.java
@@ -1,0 +1,13 @@
+package com.oneday.orders.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+/** The user's active cart with its items and a rolled-up total of the cached quotes. */
+public record CartResponse(
+        UUID cartId,
+        String status,
+        int itemCount,
+        long cartTotalPaise,
+        List<CartItemResponse> items
+) {}

--- a/orders/src/main/java/com/oneday/orders/dto/SavedAddressRequest.java
+++ b/orders/src/main/java/com/oneday/orders/dto/SavedAddressRequest.java
@@ -1,0 +1,75 @@
+package com.oneday.orders.dto;
+
+import com.oneday.orders.domain.enums.AddressLabel;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Create/update payload for a saved address. Label is required; the friendly name
+ * ({@code saveAs}) and contact/instruction fields are optional. Mirrors the embedded
+ * {@link com.oneday.orders.domain.Address} constraints for the address portion.
+ */
+public class SavedAddressRequest {
+
+    @NotNull private AddressLabel label;
+
+    @Size(max = 100) private String saveAs;
+
+    @Size(max = 100) private String contactName;
+    @Size(max = 15) @Pattern(regexp = "\\+91[0-9]{10}", message = "must be E.164 format (+91XXXXXXXXXX)")
+    private String contactPhone;
+
+    @Size(max = 200) private String houseFloor;
+    @Size(max = 200) private String buildingStreet;
+    @Size(max = 300) private String areaLocality;
+
+    @NotBlank @Size(max = 200) private String line1;
+    @Size(max = 200) private String line2;
+    @NotBlank @Size(max = 100) private String city;
+    @NotBlank @Size(max = 10) @Pattern(regexp = "\\d{6}", message = "must be a 6-digit pincode")
+    private String pincode;
+    @NotBlank @Size(max = 100) private String state;
+    @Size(max = 200) private String landmark;
+
+    @DecimalMin("6.0") @DecimalMax("38.0")  private Double latitude;
+    @DecimalMin("68.0") @DecimalMax("98.0") private Double longitude;
+
+    @Size(max = 500) private String deliveryInstructions;
+
+    public AddressLabel getLabel() { return label; }
+    public void setLabel(AddressLabel v) { this.label = v; }
+    public String getSaveAs() { return saveAs; }
+    public void setSaveAs(String v) { this.saveAs = v; }
+    public String getContactName() { return contactName; }
+    public void setContactName(String v) { this.contactName = v; }
+    public String getContactPhone() { return contactPhone; }
+    public void setContactPhone(String v) { this.contactPhone = v; }
+    public String getHouseFloor() { return houseFloor; }
+    public void setHouseFloor(String v) { this.houseFloor = v; }
+    public String getBuildingStreet() { return buildingStreet; }
+    public void setBuildingStreet(String v) { this.buildingStreet = v; }
+    public String getAreaLocality() { return areaLocality; }
+    public void setAreaLocality(String v) { this.areaLocality = v; }
+    public String getLine1() { return line1; }
+    public void setLine1(String v) { this.line1 = v; }
+    public String getLine2() { return line2; }
+    public void setLine2(String v) { this.line2 = v; }
+    public String getCity() { return city; }
+    public void setCity(String v) { this.city = v; }
+    public String getPincode() { return pincode; }
+    public void setPincode(String v) { this.pincode = v; }
+    public String getState() { return state; }
+    public void setState(String v) { this.state = v; }
+    public String getLandmark() { return landmark; }
+    public void setLandmark(String v) { this.landmark = v; }
+    public Double getLatitude() { return latitude; }
+    public void setLatitude(Double v) { this.latitude = v; }
+    public Double getLongitude() { return longitude; }
+    public void setLongitude(Double v) { this.longitude = v; }
+    public String getDeliveryInstructions() { return deliveryInstructions; }
+    public void setDeliveryInstructions(String v) { this.deliveryInstructions = v; }
+}

--- a/orders/src/main/java/com/oneday/orders/dto/SavedAddressResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/SavedAddressResponse.java
@@ -1,0 +1,37 @@
+package com.oneday.orders.dto;
+
+import com.oneday.orders.domain.SavedAddress;
+import com.oneday.orders.domain.enums.AddressLabel;
+
+import java.util.UUID;
+
+/**
+ * Read model for a saved address. Snake_case on the wire (project-wide Jackson strategy).
+ */
+public record SavedAddressResponse(
+        UUID id,
+        AddressLabel label,
+        String saveAs,
+        String contactName,
+        String contactPhone,
+        String houseFloor,
+        String buildingStreet,
+        String areaLocality,
+        String line1,
+        String line2,
+        String city,
+        String pincode,
+        String state,
+        String landmark,
+        Double latitude,
+        Double longitude,
+        String deliveryInstructions
+) {
+    public static SavedAddressResponse from(SavedAddress a) {
+        return new SavedAddressResponse(
+                a.getId(), a.getLabel(), a.getSaveAs(), a.getContactName(), a.getContactPhone(),
+                a.getHouseFloor(), a.getBuildingStreet(), a.getAreaLocality(),
+                a.getLine1(), a.getLine2(), a.getCity(), a.getPincode(), a.getState(), a.getLandmark(),
+                a.getLatitude(), a.getLongitude(), a.getDeliveryInstructions());
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/repository/CartItemRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/CartItemRepository.java
@@ -1,0 +1,17 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.CartItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CartItemRepository extends JpaRepository<CartItem, UUID> {
+
+    List<CartItem> findByCartIdOrderByCreatedAtAsc(UUID cartId);
+
+    Optional<CartItem> findByIdAndCartId(UUID id, UUID cartId);
+
+    long countByCartId(UUID cartId);
+}

--- a/orders/src/main/java/com/oneday/orders/repository/CartRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/CartRepository.java
@@ -1,0 +1,13 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.Cart;
+import com.oneday.orders.domain.enums.CartStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CartRepository extends JpaRepository<Cart, UUID> {
+
+    Optional<Cart> findByUserIdAndStatus(UUID userId, CartStatus status);
+}

--- a/orders/src/main/java/com/oneday/orders/repository/SavedAddressRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/SavedAddressRepository.java
@@ -1,0 +1,16 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.SavedAddress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SavedAddressRepository extends JpaRepository<SavedAddress, UUID> {
+
+    List<SavedAddress> findByUserIdOrderByCreatedAtDesc(UUID userId);
+
+    /** User-scoped fetch so one user can never read/edit another's address by id. */
+    Optional<SavedAddress> findByIdAndUserId(UUID id, UUID userId);
+}

--- a/orders/src/main/java/com/oneday/orders/service/AddressBookService.java
+++ b/orders/src/main/java/com/oneday/orders/service/AddressBookService.java
@@ -1,0 +1,27 @@
+package com.oneday.orders.service;
+
+import com.oneday.orders.dto.SavedAddressRequest;
+import com.oneday.orders.dto.SavedAddressResponse;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Per-user saved address book. All operations are scoped to the authenticated user id
+ * supplied by the controller — one user can never see or mutate another's addresses.
+ */
+public interface AddressBookService {
+
+    List<SavedAddressResponse> list(UUID userId);
+
+    SavedAddressResponse create(UUID userId, SavedAddressRequest request);
+
+    SavedAddressResponse update(UUID userId, UUID addressId, SavedAddressRequest request);
+
+    void delete(UUID userId, UUID addressId);
+
+    /** Thrown when an address id does not exist for this user → mapped to 404. */
+    class AddressNotFoundException extends RuntimeException {
+        public AddressNotFoundException(String message) { super(message); }
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/BookingService.java
+++ b/orders/src/main/java/com/oneday/orders/service/BookingService.java
@@ -39,6 +39,16 @@ public interface BookingService {
     BookingResponse book(BookingRequest request, String idempotencyKey, String userId, CustomerType customerType);
 
     /**
+     * Books a retail shipment whose payment has already been settled once at the cart level
+     * (the B2C aggregate Razorpay capture). Runs serviceability → pricing → persist, marks the
+     * shipment PREPAID, but writes <b>no</b> per-shipment {@code PaymentTransaction} and performs
+     * no gateway call. Used by cart checkout; re-prices the request so cart staleness is caught.
+     *
+     * @throws ServiceabilityException if the route is no longer serviceable at checkout time
+     */
+    BookingResponse bookSettled(BookingRequest request, String idempotencyKey, String userId, CustomerType customerType);
+
+    /**
      * Prices a request without booking or taking payment (serviceability → pricing).
      * Used by the payment flow to mint a gateway order for the exact amount before checkout.
      *

--- a/orders/src/main/java/com/oneday/orders/service/BulkUploadService.java
+++ b/orders/src/main/java/com/oneday/orders/service/BulkUploadService.java
@@ -1,0 +1,31 @@
+package com.oneday.orders.service;
+
+import com.oneday.orders.dto.BulkPickup;
+import com.oneday.orders.dto.BulkUploadResponse;
+
+import java.io.InputStream;
+import java.util.UUID;
+
+/**
+ * Excel bulk upload for the cart, modelled as <b>one shared pickup → many destinations</b>: the
+ * user sets a single pickup on the booking map and uploads a sheet of destination rows. Each row
+ * is validated (field constraints + serviceability/pricing), and valid rows are added to the cart
+ * with the shared pickup applied; invalid rows are reported with reasons. Destinations are
+ * pincode-based (no coordinates in the sheet) — the city is derived from the pincode prefix.
+ */
+public interface BulkUploadService {
+
+    /** The fixed destination column headers, in order. The uploaded sheet must match exactly. */
+    java.util.List<String> headers();
+
+    /** Generates the template workbook (headers + one example row) as xlsx bytes. */
+    byte[] generateTemplate();
+
+    /** Parses + validates the destinations, applying {@code pickup} to each and adding valid rows to the cart. */
+    BulkUploadResponse process(UUID userId, BulkPickup pickup, InputStream xlsx);
+
+    /** The sheet's header row does not match the template, or it exceeds the row cap → 422. */
+    class BadTemplateException extends RuntimeException {
+        public BadTemplateException(String message) { super(message); }
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/CartService.java
+++ b/orders/src/main/java/com/oneday/orders/service/CartService.java
@@ -1,0 +1,63 @@
+package com.oneday.orders.service;
+
+import com.oneday.common.domain.enums.CustomerType;
+import com.oneday.orders.dto.AddCartItemRequest;
+import com.oneday.orders.dto.CartCheckoutRequest;
+import com.oneday.orders.dto.CartCheckoutResponse;
+import com.oneday.orders.dto.CartItemResponse;
+import com.oneday.orders.dto.CartResponse;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Per-user shipment cart: add/list/edit/remove independent shipment drafts, then checkout to
+ * book them all. B2C checkout settles one aggregate Razorpay payment for the cart total; B2B
+ * checkout debits the account credit line per item. Items that fail validation stay in the cart.
+ */
+public interface CartService {
+
+    CartResponse getCart(UUID userId);
+
+    CartItemResponse addItem(UUID userId, AddCartItemRequest request);
+
+    /**
+     * Adds many items in a single transaction: the open cart is fetched/created once and all
+     * priced, serviceable items are inserted as one batch (bulk upload uses this instead of
+     * calling {@link #addItem} per row, which opened a transaction and re-looked-up the cart
+     * for every row). Each result aligns positionally with {@code requests}; a row that fails
+     * pricing/serviceability is reported as a failure and simply omitted from the insert — it
+     * does not roll back the others (pricing performs no writes).
+     */
+    List<BulkItemResult> addItems(UUID userId, List<AddCartItemRequest> requests);
+
+    /** Outcome of one row in {@link #addItems}: {@code added} true, or a {@code failureReason}. */
+    record BulkItemResult(boolean added, String failureReason) {
+        public static BulkItemResult ok() { return new BulkItemResult(true, null); }
+        public static BulkItemResult fail(String reason) { return new BulkItemResult(false, reason); }
+    }
+
+    CartItemResponse updateItem(UUID userId, UUID itemId, AddCartItemRequest request);
+
+    void removeItem(UUID userId, UUID itemId);
+
+    /**
+     * @param customerType lane derived from the caller's role (C2C/B2C → gateway, B2B → credit)
+     */
+    CartCheckoutResponse checkout(UUID userId, CustomerType customerType, CartCheckoutRequest request);
+
+    /** Cart has no items to check out → 422. */
+    class EmptyCartException extends RuntimeException {
+        public EmptyCartException(String message) { super(message); }
+    }
+
+    /** Required checkout fields missing for the lane (razorpay for B2C, account for B2B) → 422. */
+    class CheckoutValidationException extends RuntimeException {
+        public CheckoutValidationException(String message) { super(message); }
+    }
+
+    /** Cart item id not found in the user's open cart → 404. */
+    class CartItemNotFoundException extends RuntimeException {
+        public CartItemNotFoundException(String message) { super(message); }
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/AddressBookServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/AddressBookServiceImpl.java
@@ -1,0 +1,75 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.domain.SavedAddress;
+import com.oneday.orders.dto.SavedAddressRequest;
+import com.oneday.orders.dto.SavedAddressResponse;
+import com.oneday.orders.repository.SavedAddressRepository;
+import com.oneday.orders.service.AddressBookService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+class AddressBookServiceImpl implements AddressBookService {
+
+    private final SavedAddressRepository repository;
+
+    AddressBookServiceImpl(SavedAddressRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<SavedAddressResponse> list(UUID userId) {
+        return repository.findByUserIdOrderByCreatedAtDesc(userId).stream()
+                .map(SavedAddressResponse::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public SavedAddressResponse create(UUID userId, SavedAddressRequest request) {
+        SavedAddress entity = new SavedAddress();
+        entity.setUserId(userId);
+        apply(entity, request);
+        return SavedAddressResponse.from(repository.save(entity));
+    }
+
+    @Override
+    @Transactional
+    public SavedAddressResponse update(UUID userId, UUID addressId, SavedAddressRequest request) {
+        SavedAddress entity = repository.findByIdAndUserId(addressId, userId)
+                .orElseThrow(() -> new AddressNotFoundException("Address not found: " + addressId));
+        apply(entity, request);
+        return SavedAddressResponse.from(repository.save(entity));
+    }
+
+    @Override
+    @Transactional
+    public void delete(UUID userId, UUID addressId) {
+        SavedAddress entity = repository.findByIdAndUserId(addressId, userId)
+                .orElseThrow(() -> new AddressNotFoundException("Address not found: " + addressId));
+        repository.delete(entity);
+    }
+
+    private static void apply(SavedAddress e, SavedAddressRequest r) {
+        e.setLabel(r.getLabel());
+        e.setSaveAs(r.getSaveAs());
+        e.setContactName(r.getContactName());
+        e.setContactPhone(r.getContactPhone());
+        e.setHouseFloor(r.getHouseFloor());
+        e.setBuildingStreet(r.getBuildingStreet());
+        e.setAreaLocality(r.getAreaLocality());
+        e.setLine1(r.getLine1());
+        e.setLine2(r.getLine2());
+        e.setCity(r.getCity());
+        e.setPincode(r.getPincode());
+        e.setState(r.getState());
+        e.setLandmark(r.getLandmark());
+        e.setLatitude(r.getLatitude());
+        e.setLongitude(r.getLongitude());
+        e.setDeliveryInstructions(r.getDeliveryInstructions());
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/BookingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/BookingServiceImpl.java
@@ -117,6 +117,18 @@ class BookingServiceImpl implements BookingService {
         return priceRequest(req, CustomerType.B2C).quote();
     }
 
+    @Override
+    public BookingResponse bookSettled(BookingRequest req, String idempotencyKey, String userId,
+                                       CustomerType customerType) {
+        // Cart checkout already settled payment once for the whole cart, so we re-price (to catch
+        // staleness) and persist — but write NO per-shipment PaymentTransaction and take no payment.
+        Priced priced = priceRequest(req, customerType);
+        return tx.execute(status ->
+                persist(req, idempotencyKey, userId, customerType, priced.serviceability(),
+                        priced.volumetricWeightGrams(), priced.chargeableWeightGrams(), priced.quote(),
+                        /* recordPayment */ false));
+    }
+
     // Steps 1-3 of booking, with no payment or DB write — reused by book() and quote()
     // (the payment create-order flow prices the shipment via quote() before checkout).
     private Priced priceRequest(BookingRequest req, CustomerType customerType) {
@@ -192,7 +204,7 @@ class BookingServiceImpl implements BookingService {
         try {
             return tx.execute(status ->
                     persist(req, idempotencyKey, userId, customerType, serviceability,
-                            finalVolumetricWeight, finalChargeableWeight, quote));
+                            finalVolumetricWeight, finalChargeableWeight, quote, /* recordPayment */ true));
         } catch (RuntimeException dbEx) {
             if (isPrepaid) {
                 try {
@@ -214,7 +226,7 @@ class BookingServiceImpl implements BookingService {
     private BookingResponse persist(BookingRequest req, String idempotencyKey, String userId,
                                     CustomerType customerType, ServiceabilityResult serviceability,
                                     int volumetricWeightGrams, int chargeableWeightGrams,
-                                    QuoteResult quote) {
+                                    QuoteResult quote, boolean recordPayment) {
         Instant bookedAt = Instant.now();
         String shipmentRef = shipmentRefService.generateRef(req.getOriginCity());
 
@@ -257,7 +269,7 @@ class BookingServiceImpl implements BookingService {
 
         shipment = shipmentRepository.save(shipment);
 
-        if (PaymentMode.PREPAID == req.getPaymentMode()) {
+        if (recordPayment && PaymentMode.PREPAID == req.getPaymentMode()) {
             PaymentTransaction payment = new PaymentTransaction();
             payment.setShipmentId(shipment.getId());
             payment.setRazorpayOrderId(req.getRazorpayOrderId());

--- a/orders/src/main/java/com/oneday/orders/service/impl/BulkUploadServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/BulkUploadServiceImpl.java
@@ -1,0 +1,264 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.enums.DropType;
+import com.oneday.common.domain.enums.PickupType;
+import com.oneday.orders.domain.Address;
+import com.oneday.orders.dto.AddCartItemRequest;
+import com.oneday.orders.dto.BulkPickup;
+import com.oneday.orders.dto.BulkUploadResponse;
+import com.oneday.orders.dto.BulkUploadResponse.FieldError;
+import com.oneday.orders.dto.BulkUploadResponse.RowFailure;
+import com.oneday.orders.service.BulkUploadService;
+import com.oneday.orders.service.CartService;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import org.dhatim.fastexcel.Workbook;
+import org.dhatim.fastexcel.Worksheet;
+import org.dhatim.fastexcel.reader.ReadableWorkbook;
+import org.dhatim.fastexcel.reader.Row;
+import org.dhatim.fastexcel.reader.Sheet;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+class BulkUploadServiceImpl implements BulkUploadService {
+
+    /**
+     * Destination columns only — the pickup + sender come from the booking form, and
+     * pickup/drop type are set internally. Coordinates are derived from the pincode.
+     */
+    private static final List<String> HEADERS = List.of(
+            "receiver_name", "receiver_phone", "receiver_email",
+            "dest_line1", "dest_line2", "dest_city", "dest_pincode", "dest_state",
+            "weight_grams", "length_cm", "width_cm", "height_cm", "declared_value_inr");
+
+    private static final String[] EXAMPLE = {
+            "Priya Sharma", "+919000000002", "priya@example.com",
+            "1 MG Road", "", "Bengaluru", "560001", "Karnataka",
+            "1000", "20", "15", "10", "500"};
+
+    private static final int MAX_ROWS = 500;
+
+    // Pincode prefix → demo city code + that city's grid centroid (lat, lon). A destination's
+    // serviceability resolves through the real grid at the centroid, so the sheet needs no coords.
+    private static final Map<String, String> DEMO_BY_PREFIX =
+            Map.of("110", "DEL", "560", "BLR", "400", "BOM", "600", "MAA", "500", "HYD");
+    private static final Map<String, double[]> CENTROID = Map.of(
+            "DEL", new double[]{28.6139, 77.2090},
+            "BLR", new double[]{12.9716, 77.5946},
+            "BOM", new double[]{19.0760, 72.8777},
+            "MAA", new double[]{13.0827, 80.2707},
+            "HYD", new double[]{17.3850, 78.4867});
+
+    private final CartService cartService;
+    private final Validator validator;
+
+    BulkUploadServiceImpl(CartService cartService, Validator validator) {
+        this.cartService = cartService;
+        this.validator = validator;
+    }
+
+    @Override
+    public List<String> headers() {
+        return HEADERS;
+    }
+
+    @Override
+    public byte[] generateTemplate() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (Workbook wb = new Workbook(out, "OneDayDelivery", "1.0")) {
+            Worksheet ws = wb.newWorksheet("Destinations");
+            for (int c = 0; c < HEADERS.size(); c++) {
+                ws.value(0, c, HEADERS.get(c));
+                ws.style(0, c).bold().set();
+                ws.value(1, c, EXAMPLE[c]);
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to generate template", e);
+        }
+        return out.toByteArray();
+    }
+
+    @Override
+    public BulkUploadResponse process(UUID userId, BulkPickup pickup, InputStream xlsx) {
+        if (pickup == null || pickup.originAddress() == null
+                || isBlank(pickup.originCity()) || isBlank(pickup.originPincode())) {
+            throw new BadTemplateException("Set the pickup location on the map before uploading destinations.");
+        }
+
+        List<Row> rows;
+        try (ReadableWorkbook wb = new ReadableWorkbook(xlsx)) {
+            Sheet sheet = wb.getFirstSheet();
+            if (sheet == null) throw new BadTemplateException("Workbook has no sheet");
+            rows = sheet.read();
+        } catch (BadTemplateException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BadTemplateException("Could not read the .xlsx file: " + e.getMessage());
+        }
+
+        if (rows.isEmpty()) throw new BadTemplateException("The sheet is empty");
+        validateHeader(rows.get(0));
+
+        List<Row> dataRows = rows.subList(1, rows.size());
+        if (dataRows.size() > MAX_ROWS) {
+            throw new BadTemplateException("Too many rows: " + dataRows.size() + " (max " + MAX_ROWS + ")");
+        }
+
+        // ── Pass 1: parse + validate every row in memory (no DB) ───────────────────
+        List<RowFailure> failures = new java.util.ArrayList<>();
+        List<Integer> validRowNums = new java.util.ArrayList<>();
+        List<AddCartItemRequest> validReqs = new java.util.ArrayList<>();
+        for (Row row : dataRows) {
+            if (isBlankRow(row)) continue;
+            int rowNum = row.getRowNum();
+            List<FieldError> errors = new java.util.ArrayList<>();
+            AddCartItemRequest req = mapRow(pickup, row, errors);
+
+            if (errors.isEmpty()) {
+                for (ConstraintViolation<AddCartItemRequest> v : validator.validate(req)) {
+                    errors.add(new FieldError(v.getPropertyPath().toString(), v.getMessage()));
+                }
+            }
+            if (errors.isEmpty()) {
+                validRowNums.add(rowNum);
+                validReqs.add(req);
+            } else {
+                failures.add(new RowFailure(rowNum, errors));
+            }
+        }
+
+        // ── Pass 2: price + insert all valid rows in one transaction/batch ─────────
+        int added = 0;
+        List<CartService.BulkItemResult> results = cartService.addItems(userId, validReqs);
+        for (int i = 0; i < results.size(); i++) {
+            CartService.BulkItemResult r = results.get(i);
+            if (r.added()) {
+                added++;
+            } else {
+                failures.add(new RowFailure(validRowNums.get(i),
+                        List.of(new FieldError("route", r.failureReason()))));
+            }
+        }
+        failures.sort(java.util.Comparator.comparingInt(RowFailure::row));
+        return new BulkUploadResponse(added, failures.size(), failures);
+    }
+
+    // ── Parsing / mapping ─────────────────────────────────────────────────────
+
+    private void validateHeader(Row header) {
+        for (int c = 0; c < HEADERS.size(); c++) {
+            String actual = cell(header, c).toLowerCase();
+            if (!HEADERS.get(c).equals(actual)) {
+                throw new BadTemplateException(
+                        "Header mismatch at column " + (c + 1) + ": expected '" + HEADERS.get(c)
+                                + "' but found '" + actual + "'. Download the template for the correct format.");
+            }
+        }
+    }
+
+    private AddCartItemRequest mapRow(BulkPickup pickup, Row row, List<FieldError> errors) {
+        AddCartItemRequest r = new AddCartItemRequest();
+
+        // Shared pickup (same for every destination row).
+        r.setSenderName(pickup.senderName());
+        r.setSenderPhone(pickup.senderPhone());
+        r.setSenderEmail(pickup.senderEmail());
+        r.setOriginAddress(pickup.originAddress());
+        r.setOriginCity(pickup.originCity());
+        r.setOriginPincode(pickup.originPincode());
+
+        // Destination from the row.
+        r.setReceiverName(cellOrNull(row, 0));
+        r.setReceiverPhone(cellOrNull(row, 1));
+        r.setReceiverEmail(cellOrNull(row, 2));
+
+        String destPincode = cellOrNull(row, 6);
+        Address dest = new Address();
+        dest.setLine1(cellOrNull(row, 3));
+        dest.setLine2(cellOrNull(row, 4));
+        dest.setCity(cellOrNull(row, 5));
+        dest.setPincode(destPincode);
+        dest.setState(cellOrNull(row, 7));
+
+        // Derive the city (code + centroid) from the pincode prefix so serviceability resolves
+        // through the real grid without coordinates in the sheet.
+        String demoCity = null;
+        if (destPincode != null && destPincode.length() >= 3) {
+            demoCity = DEMO_BY_PREFIX.get(destPincode.substring(0, 3));
+        }
+        if (demoCity == null) {
+            errors.add(new FieldError("dest_pincode", "not in a serviceable city (Delhi/Mumbai/Bengaluru/Chennai/Hyderabad)"));
+        } else {
+            double[] c = CENTROID.get(demoCity);
+            dest.setLatitude(c[0]);
+            dest.setLongitude(c[1]);
+        }
+        r.setDestAddress(dest);
+        r.setDestCity(demoCity);            // city code for pricing
+        r.setDestPincode(destPincode);
+
+        r.setWeightGrams(intCell(row, 8, "weight_grams", errors));
+        r.setLengthCm((short) intCell(row, 9, "length_cm", errors));
+        r.setWidthCm((short) intCell(row, 10, "width_cm", errors));
+        r.setHeightCm((short) intCell(row, 11, "height_cm", errors));
+        Long rupees = longCell(row, 12, "declared_value_inr", errors);
+        r.setDeclaredValuePaise(rupees == null ? null : rupees * 100);
+
+        // Set internally — not part of the sheet.
+        r.setPickupType(PickupType.DA_PICKUP);
+        r.setDropType(DropType.DA_DELIVERY);
+        return r;
+    }
+
+    // ── Cell helpers ──────────────────────────────────────────────────────────
+
+    private static String cell(Row row, int idx) {
+        if (idx >= row.getCellCount()) return "";
+        // getCellAsString() throws on numeric cells, so read the raw value instead — this handles
+        // strings, numbers (BigDecimal), booleans, etc. uniformly for both typed and text cells.
+        org.dhatim.fastexcel.reader.Cell c = row.getCell(idx);
+        if (c == null) return "";
+        Object v = c.getValue();
+        if (v == null) return "";
+        if (v instanceof java.math.BigDecimal bd) {
+            return bd.stripTrailingZeros().toPlainString();   // 1000.0 → "1000"
+        }
+        return v.toString().trim();
+    }
+
+    private static String cellOrNull(Row row, int idx) {
+        String v = cell(row, idx);
+        return v.isEmpty() ? null : v;
+    }
+
+    private static int intCell(Row row, int idx, String field, List<FieldError> errors) {
+        String v = cell(row, idx);
+        if (v.isEmpty()) { errors.add(new FieldError(field, "is required")); return 0; }
+        try { return (int) Math.round(Double.parseDouble(v)); }
+        catch (NumberFormatException e) { errors.add(new FieldError(field, "must be a number")); return 0; }
+    }
+
+    private static Long longCell(Row row, int idx, String field, List<FieldError> errors) {
+        String v = cell(row, idx);
+        if (v.isEmpty()) return null;
+        try { return (long) Math.round(Double.parseDouble(v)); }
+        catch (NumberFormatException e) { errors.add(new FieldError(field, "must be a number")); return null; }
+    }
+
+    private static boolean isBlankRow(Row row) {
+        for (int c = 0; c < HEADERS.size() && c < row.getCellCount(); c++) {
+            if (!cell(row, c).isEmpty()) return false;
+        }
+        return true;
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.isBlank();
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/CartServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/CartServiceImpl.java
@@ -1,0 +1,359 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.enums.CustomerType;
+import com.oneday.common.domain.enums.PaymentMode;
+import com.oneday.orders.domain.Cart;
+import com.oneday.orders.domain.CartItem;
+import com.oneday.orders.domain.enums.CartItemSource;
+import com.oneday.orders.domain.enums.CartStatus;
+import com.oneday.orders.dto.AddCartItemRequest;
+import com.oneday.orders.dto.B2bBookingRequest;
+import com.oneday.orders.dto.BookingRequest;
+import com.oneday.orders.dto.BookingResponse;
+import com.oneday.orders.dto.CartCheckoutRequest;
+import com.oneday.orders.dto.CartCheckoutResponse;
+import com.oneday.orders.dto.CartItemResponse;
+import com.oneday.orders.dto.CartResponse;
+import com.oneday.orders.repository.CartItemRepository;
+import com.oneday.orders.repository.CartRepository;
+import com.oneday.orders.service.B2bBookingService;
+import com.oneday.orders.service.BookingService;
+import com.oneday.orders.service.CartService;
+import com.oneday.orders.service.PaymentPort;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+
+@Service
+class CartServiceImpl implements CartService {
+
+    private static final Logger log = LoggerFactory.getLogger(CartServiceImpl.class);
+
+    private final CartRepository cartRepository;
+    private final CartItemRepository cartItemRepository;
+    private final BookingService bookingService;
+    private final B2bBookingService b2bBookingService;
+    private final PaymentPort paymentPort;
+    private final TransactionTemplate txTemplate;
+    private final ExecutorService bulkPricingExecutor;
+
+    CartServiceImpl(CartRepository cartRepository, CartItemRepository cartItemRepository,
+                    BookingService bookingService, B2bBookingService b2bBookingService,
+                    PaymentPort paymentPort, TransactionTemplate txTemplate,
+                    @Qualifier("bulkPricingExecutor") ExecutorService bulkPricingExecutor) {
+        this.cartRepository = cartRepository;
+        this.cartItemRepository = cartItemRepository;
+        this.bookingService = bookingService;
+        this.b2bBookingService = b2bBookingService;
+        this.paymentPort = paymentPort;
+        this.txTemplate = txTemplate;
+        this.bulkPricingExecutor = bulkPricingExecutor;
+    }
+
+    // ── Reads ───────────────────────────────────────────────────────────────
+
+    @Override
+    @Transactional(readOnly = true)
+    public CartResponse getCart(UUID userId) {
+        Cart cart = cartRepository.findByUserIdAndStatus(userId, CartStatus.OPEN).orElse(null);
+        if (cart == null) {
+            return new CartResponse(null, CartStatus.OPEN.name(), 0, 0L, List.of());
+        }
+        return toCartResponse(cart);
+    }
+
+    // ── Mutations ─────────────────────────────────────────────────────────────
+
+    @Override
+    @Transactional
+    public CartItemResponse addItem(UUID userId, AddCartItemRequest req) {
+        Cart cart = getOrCreateOpenCart(userId);
+        CartItem item = new CartItem();
+        item.setCartId(cart.getId());
+        item.setSource(CartItemSource.MANUAL);
+        applyToItem(item, req);
+        priceItem(item);                       // serviceability + quote (throws if not serviceable)
+        return CartItemResponse.from(cartItemRepository.save(item));
+    }
+
+    @Override
+    public List<BulkItemResult> addItems(UUID userId, List<AddCartItemRequest> requests) {
+        if (requests.isEmpty()) {
+            return List.of();
+        }
+
+        // 1. Price every row CONCURRENTLY. Pricing (serviceability + quote) is read-only and
+        //    stateless — each task builds its own CartItem, so there's no shared mutable state.
+        //    Done outside any transaction so no DB connection is held during the quote calls.
+        List<CompletableFuture<Priced>> futures = requests.stream()
+                .map(req -> CompletableFuture.supplyAsync(() -> priceOne(req), bulkPricingExecutor))
+                .toList();
+
+        // 2. Collect in input order (each future carries either a priced item or a failure reason).
+        List<BulkItemResult> results = new ArrayList<>(requests.size());
+        List<CartItem> toSave = new ArrayList<>(requests.size());
+        for (CompletableFuture<Priced> f : futures) {
+            Priced p = f.join();                           // tasks never throw — failures are captured
+            results.add(p.result());
+            if (p.item() != null) {
+                toSave.add(p.item());
+            }
+        }
+
+        // 3. Persist the serviceable rows in ONE short transaction: cart fetch/create + batch insert.
+        if (!toSave.isEmpty()) {
+            txTemplate.executeWithoutResult(status -> {
+                Cart cart = getOrCreateOpenCart(userId);
+                toSave.forEach(item -> item.setCartId(cart.getId()));
+                cartItemRepository.saveAll(toSave);
+            });
+        }
+        return results;
+    }
+
+    /** Builds + prices one cart item off the booking thread; captures any pricing failure per row. */
+    private Priced priceOne(AddCartItemRequest req) {
+        CartItem item = new CartItem();
+        item.setSource(CartItemSource.MANUAL);
+        applyToItem(item, req);
+        try {
+            priceItem(item);                               // serviceability + quote (no DB writes)
+            return new Priced(item, BulkItemResult.ok());
+        } catch (RuntimeException e) {
+            return new Priced(null, BulkItemResult.fail(reasonOf(e)));
+        }
+    }
+
+    private record Priced(CartItem item, BulkItemResult result) {}
+
+    @Override
+    @Transactional
+    public CartItemResponse updateItem(UUID userId, UUID itemId, AddCartItemRequest req) {
+        CartItem item = requireItem(userId, itemId);
+        applyToItem(item, req);
+        priceItem(item);
+        return CartItemResponse.from(cartItemRepository.save(item));
+    }
+
+    @Override
+    @Transactional
+    public void removeItem(UUID userId, UUID itemId) {
+        cartItemRepository.delete(requireItem(userId, itemId));
+    }
+
+    // ── Checkout ──────────────────────────────────────────────────────────────
+
+    @Override
+    public CartCheckoutResponse checkout(UUID userId, CustomerType customerType, CartCheckoutRequest req) {
+        Cart cart = cartRepository.findByUserIdAndStatus(userId, CartStatus.OPEN)
+                .orElseThrow(() -> new EmptyCartException("No open cart to check out"));
+        List<CartItem> items = cartItemRepository.findByCartIdOrderByCreatedAtAsc(cart.getId());
+        if (items.isEmpty()) {
+            throw new EmptyCartException("Cart is empty");
+        }
+        return customerType == CustomerType.B2B
+                ? checkoutB2b(cart, items, req)
+                : checkoutB2c(cart, items, customerType, req);
+    }
+
+    private CartCheckoutResponse checkoutB2c(Cart cart, List<CartItem> items,
+                                             CustomerType customerType, CartCheckoutRequest req) {
+        if (isBlank(req.getRazorpayOrderId()) || isBlank(req.getRazorpayPaymentId())
+                || isBlank(req.getRazorpaySignature())) {
+            throw new CheckoutValidationException(
+                    "razorpayOrderId, razorpayPaymentId and razorpaySignature are required for a B2C checkout");
+        }
+
+        // 1. Re-price each item; non-serviceable ones become failures (stay in cart).
+        List<CartItem> payable = new ArrayList<>();
+        List<CartCheckoutResponse.Result> results = new ArrayList<>();
+        long captureTotal = 0L;
+        for (CartItem item : items) {
+            try {
+                captureTotal += bookingService.quote(toBookingRequest(item, customerType)).totalPricePaise();
+                payable.add(item);
+            } catch (RuntimeException e) {
+                results.add(CartCheckoutResponse.Result.fail(item.getId(), reasonOf(e)));
+            }
+        }
+        if (payable.isEmpty()) {
+            return finish(cart, items.size(), null, null, 0L, results); // nothing to capture
+        }
+
+        // 2. Settle the single aggregate payment for the whole serviceable cart.
+        final long total = captureTotal;
+        paymentPort.verifySignature(req.getRazorpayOrderId(), req.getRazorpayPaymentId(), req.getRazorpaySignature());
+        paymentPort.capture(req.getRazorpayPaymentId(), total);
+
+        // 3. Persist each shipment without re-capturing.
+        for (CartItem item : payable) {
+            try {
+                BookingResponse r = bookingService.bookSettled(
+                        toBookingRequest(item, customerType), "cart-" + item.getId(), cart.getUserId().toString(), customerType);
+                results.add(CartCheckoutResponse.Result.ok(item.getId(), r.getShipmentRef()));
+                cartItemRepository.delete(item);
+            } catch (RuntimeException e) {
+                log.error("cart {} item {} captured but booking failed: {}", cart.getId(), item.getId(), e.toString());
+                results.add(CartCheckoutResponse.Result.fail(item.getId(), reasonOf(e)));
+            }
+        }
+        cart.setCheckoutRazorpayOrderId(req.getRazorpayOrderId());
+        cart.setCheckoutRazorpayPaymentId(req.getRazorpayPaymentId());
+        return finish(cart, items.size(), req.getRazorpayOrderId(), req.getRazorpayPaymentId(), total, results);
+    }
+
+    private CartCheckoutResponse checkoutB2b(Cart cart, List<CartItem> items, CartCheckoutRequest req) {
+        if (req.getB2bAccountId() == null) {
+            throw new CheckoutValidationException("b2bAccountId is required for a B2B checkout");
+        }
+        List<CartCheckoutResponse.Result> results = new ArrayList<>();
+        long charged = 0L;
+        for (CartItem item : items) {
+            try {
+                BookingResponse r = b2bBookingService.book(
+                        toB2bRequest(item, req.getB2bAccountId()), "cart-" + item.getId(), cart.getUserId().toString());
+                charged += r.getPricing().getTotalPricePaise();
+                results.add(CartCheckoutResponse.Result.ok(item.getId(), r.getShipmentRef()));
+                cartItemRepository.delete(item);
+            } catch (RuntimeException e) {
+                results.add(CartCheckoutResponse.Result.fail(item.getId(), reasonOf(e)));
+            }
+        }
+        return finish(cart, items.size(), null, null, charged, results);
+    }
+
+    /** Marks the cart CHECKED_OUT only if every item booked; otherwise it stays OPEN with the failures. */
+    private CartCheckoutResponse finish(Cart cart, int originalCount, String orderId, String paymentId,
+                                        long charged, List<CartCheckoutResponse.Result> results) {
+        int booked = (int) results.stream().filter(CartCheckoutResponse.Result::success).count();
+        int failed = results.size() - booked;
+        cart.setCheckoutTotalPaise(charged);
+        cart.setCheckoutRazorpayOrderId(orderId);
+        cart.setCheckoutRazorpayPaymentId(paymentId);
+        boolean allBooked = booked == originalCount && failed == 0;
+        cart.setStatus(allBooked ? CartStatus.CHECKED_OUT : CartStatus.OPEN);
+        cartRepository.save(cart);
+        return new CartCheckoutResponse(booked, failed, charged, cart.getStatus().name(), results);
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    private Cart getOrCreateOpenCart(UUID userId) {
+        return cartRepository.findByUserIdAndStatus(userId, CartStatus.OPEN).orElseGet(() -> {
+            Cart c = new Cart();
+            c.setUserId(userId);
+            c.setStatus(CartStatus.OPEN);
+            return cartRepository.save(c);
+        });
+    }
+
+    private CartItem requireItem(UUID userId, UUID itemId) {
+        Cart cart = cartRepository.findByUserIdAndStatus(userId, CartStatus.OPEN)
+                .orElseThrow(() -> new CartItemNotFoundException("Cart item not found: " + itemId));
+        return cartItemRepository.findByIdAndCartId(itemId, cart.getId())
+                .orElseThrow(() -> new CartItemNotFoundException("Cart item not found: " + itemId));
+    }
+
+    /** Validates serviceability and caches the display quote; throws if the route is not serviceable. */
+    private void priceItem(CartItem item) {
+        long total = bookingService.quote(toBookingRequest(item, CustomerType.B2C)).totalPricePaise();
+        item.setQuotedTotalPaise(total);
+        item.setValidationStatus("VALID");
+    }
+
+    private CartResponse toCartResponse(Cart cart) {
+        List<CartItem> items = cartItemRepository.findByCartIdOrderByCreatedAtAsc(cart.getId());
+        long total = items.stream().mapToLong(i -> i.getQuotedTotalPaise() == null ? 0 : i.getQuotedTotalPaise()).sum();
+        return new CartResponse(cart.getId(), cart.getStatus().name(), items.size(), total,
+                items.stream().map(CartItemResponse::from).toList());
+    }
+
+    private static void applyToItem(CartItem item, AddCartItemRequest r) {
+        item.setSenderName(r.getSenderName());
+        item.setSenderPhone(r.getSenderPhone());
+        item.setSenderEmail(r.getSenderEmail());
+        item.setOriginAddress(r.getOriginAddress());
+        item.setOriginCity(r.getOriginCity());
+        item.setOriginPincode(r.getOriginPincode());
+        item.setReceiverName(r.getReceiverName());
+        item.setReceiverPhone(r.getReceiverPhone());
+        item.setReceiverEmail(r.getReceiverEmail());
+        item.setDestAddress(r.getDestAddress());
+        item.setDestCity(r.getDestCity());
+        item.setDestPincode(r.getDestPincode());
+        item.setWeightGrams(r.getWeightGrams());
+        item.setLengthCm(r.getLengthCm());
+        item.setWidthCm(r.getWidthCm());
+        item.setHeightCm(r.getHeightCm());
+        item.setDeclaredValuePaise(r.getDeclaredValuePaise());
+        item.setPickupType(r.getPickupType());
+        item.setDropType(r.getDropType());
+    }
+
+    private static BookingRequest toBookingRequest(CartItem i, CustomerType type) {
+        BookingRequest b = new BookingRequest();
+        b.setSenderName(i.getSenderName());
+        b.setSenderPhone(i.getSenderPhone());
+        b.setSenderEmail(i.getSenderEmail());
+        b.setOriginAddress(i.getOriginAddress());
+        b.setOriginCity(i.getOriginCity());
+        b.setOriginPincode(i.getOriginPincode());
+        b.setReceiverName(i.getReceiverName());
+        b.setReceiverPhone(i.getReceiverPhone());
+        b.setReceiverEmail(i.getReceiverEmail());
+        b.setDestAddress(i.getDestAddress());
+        b.setDestCity(i.getDestCity());
+        b.setDestPincode(i.getDestPincode());
+        b.setWeightGrams(i.getWeightGrams());
+        b.setLengthCm(i.getLengthCm());
+        b.setWidthCm(i.getWidthCm());
+        b.setHeightCm(i.getHeightCm());
+        b.setDeclaredValuePaise(i.getDeclaredValuePaise());
+        b.setPickupType(i.getPickupType());
+        b.setDropType(i.getDropType());
+        // Cart items are paid once at the cart level → mark PREPAID; bookSettled writes no txn.
+        b.setPaymentMode(PaymentMode.PREPAID);
+        return b;
+    }
+
+    private static B2bBookingRequest toB2bRequest(CartItem i, UUID accountId) {
+        B2bBookingRequest b = new B2bBookingRequest();
+        b.setB2bAccountId(accountId);
+        b.setSenderName(i.getSenderName());
+        b.setSenderPhone(i.getSenderPhone());
+        b.setOriginAddress(i.getOriginAddress());
+        b.setOriginCity(i.getOriginCity());
+        b.setOriginPincode(i.getOriginPincode());
+        b.setReceiverName(i.getReceiverName());
+        b.setReceiverPhone(i.getReceiverPhone());
+        b.setDestAddress(i.getDestAddress());
+        b.setDestCity(i.getDestCity());
+        b.setDestPincode(i.getDestPincode());
+        b.setWeightGrams(i.getWeightGrams());
+        b.setLengthCm(i.getLengthCm());
+        b.setWidthCm(i.getWidthCm());
+        b.setHeightCm(i.getHeightCm());
+        b.setDeclaredValuePaise(i.getDeclaredValuePaise());
+        b.setPickupType(i.getPickupType());
+        b.setDropType(i.getDropType());
+        return b;
+    }
+
+    private static String reasonOf(RuntimeException e) {
+        String m = e.getMessage();
+        return m == null || m.isBlank() ? e.getClass().getSimpleName() : m;
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.isBlank();
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/CartServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/CartServiceImpl.java
@@ -179,7 +179,7 @@ class CartServiceImpl implements CartService {
         long captureTotal = 0L;
         for (CartItem item : items) {
             try {
-                captureTotal += bookingService.quote(toBookingRequest(item, customerType)).totalPricePaise();
+                captureTotal += bookingService.quote(toBookingRequest(item)).totalPricePaise();
                 payable.add(item);
             } catch (RuntimeException e) {
                 results.add(CartCheckoutResponse.Result.fail(item.getId(), reasonOf(e)));
@@ -198,7 +198,7 @@ class CartServiceImpl implements CartService {
         for (CartItem item : payable) {
             try {
                 BookingResponse r = bookingService.bookSettled(
-                        toBookingRequest(item, customerType), "cart-" + item.getId(), cart.getUserId().toString(), customerType);
+                        toBookingRequest(item), "cart-" + item.getId(), cart.getUserId().toString(), customerType);
                 results.add(CartCheckoutResponse.Result.ok(item.getId(), r.getShipmentRef()));
                 cartItemRepository.delete(item);
             } catch (RuntimeException e) {
@@ -265,7 +265,7 @@ class CartServiceImpl implements CartService {
 
     /** Validates serviceability and caches the display quote; throws if the route is not serviceable. */
     private void priceItem(CartItem item) {
-        long total = bookingService.quote(toBookingRequest(item, CustomerType.B2C)).totalPricePaise();
+        long total = bookingService.quote(toBookingRequest(item)).totalPricePaise();
         item.setQuotedTotalPaise(total);
         item.setValidationStatus("VALID");
     }
@@ -299,7 +299,9 @@ class CartServiceImpl implements CartService {
         item.setDropType(r.getDropType());
     }
 
-    private static BookingRequest toBookingRequest(CartItem i, CustomerType type) {
+    // No CustomerType param: cart items always price on the retail rate card (B2C and C2C share it),
+    // and the real customer type is applied later by bookSettled when the shipment is persisted.
+    private static BookingRequest toBookingRequest(CartItem i) {
         BookingRequest b = new BookingRequest();
         b.setSenderName(i.getSenderName());
         b.setSenderPhone(i.getSenderPhone());

--- a/orders/src/main/resources/db/migration/orders/V4_18__create_saved_address.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_18__create_saved_address.sql
@@ -1,0 +1,34 @@
+-- M4: per-user saved address book (HOME/OFFICE/OTHER), reused for pickup & drop in
+-- the booking + cart flows. ADMIN manages these via direct DB access; the API is
+-- scoped to customer roles (C2C/B2C/B2B).
+CREATE TABLE saved_address (
+  id                    UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- Plain UUID, no FK to users: orders is a separate module from auth and intentionally
+  -- does not couple its schema to the users table (matches shipments.booked_by_user_id).
+  user_id               UUID         NOT NULL,
+  label                 VARCHAR(10)  NOT NULL,            -- HOME | OFFICE | OTHER
+  save_as               VARCHAR(100),                     -- optional free text ("Mom's place")
+  contact_name          VARCHAR(100),
+  contact_phone         VARCHAR(15),                      -- +91XXXXXXXXXX
+  -- address (mirrors the embedded Address; flattened so it is queryable)
+  house_floor           VARCHAR(200),
+  building_street       VARCHAR(200),
+  area_locality         VARCHAR(300),
+  line1                 VARCHAR(200) NOT NULL,
+  line2                 VARCHAR(200),
+  city                  VARCHAR(100) NOT NULL,
+  pincode               VARCHAR(10)  NOT NULL,
+  state                 VARCHAR(100) NOT NULL,
+  landmark              VARCHAR(200),
+  latitude              DOUBLE PRECISION,
+  longitude             DOUBLE PRECISION,
+  delivery_instructions VARCHAR(500),
+  created_at            TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at            TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_saved_address_user ON saved_address(user_id);
+
+CREATE TRIGGER trg_saved_address_updated_at
+  BEFORE UPDATE ON saved_address
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/orders/src/main/resources/db/migration/orders/V4_19__create_cart.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_19__create_cart.sql
@@ -1,0 +1,21 @@
+-- M4: a per-user shipment cart. Each user has at most one OPEN cart at a time; checkout
+-- books every (valid) item, then the cart is marked CHECKED_OUT (or stays OPEN holding the
+-- items that failed validation). Payment for a B2C checkout is settled once for the whole
+-- cart, so the aggregate Razorpay refs + total are recorded here for audit.
+CREATE TABLE cart (
+  id                          UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                     UUID         NOT NULL,         -- plain UUID, no FK (see saved_address)
+  status                      VARCHAR(16)  NOT NULL DEFAULT 'OPEN',  -- OPEN | CHECKED_OUT | ABANDONED
+  checkout_razorpay_order_id  VARCHAR(100),
+  checkout_razorpay_payment_id VARCHAR(100),
+  checkout_total_paise        BIGINT,
+  created_at                  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at                  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+-- At most one OPEN cart per user.
+CREATE UNIQUE INDEX uq_cart_open_per_user ON cart (user_id) WHERE status = 'OPEN';
+
+CREATE TRIGGER trg_cart_updated_at
+  BEFORE UPDATE ON cart
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/orders/src/main/resources/db/migration/orders/V4_20__create_cart_item.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_20__create_cart_item.sql
@@ -1,0 +1,45 @@
+-- M4: one line in a cart = one complete, independent shipment draft (its own pickup + drop +
+-- parcel). serviceability/pricing are cached for display; checkout re-validates and books.
+CREATE TABLE cart_item (
+  id                   UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  cart_id              UUID         NOT NULL REFERENCES cart(id) ON DELETE CASCADE,
+  source               VARCHAR(8)   NOT NULL DEFAULT 'MANUAL',  -- MANUAL | EXCEL
+  excel_row_num        INT,
+  -- pickup
+  sender_name          VARCHAR(100) NOT NULL,
+  sender_phone         VARCHAR(15)  NOT NULL,
+  sender_email         VARCHAR(254),
+  origin_address       JSONB        NOT NULL,
+  origin_city          VARCHAR(100) NOT NULL,
+  origin_pincode       VARCHAR(10)  NOT NULL,
+  -- drop
+  receiver_name        VARCHAR(100) NOT NULL,
+  receiver_phone       VARCHAR(15)  NOT NULL,
+  receiver_email       VARCHAR(254),
+  dest_address         JSONB        NOT NULL,
+  dest_city            VARCHAR(100) NOT NULL,
+  dest_pincode         VARCHAR(10)  NOT NULL,
+  -- parcel
+  weight_grams         INT          NOT NULL,
+  length_cm            SMALLINT     NOT NULL,
+  width_cm             SMALLINT     NOT NULL,
+  height_cm            SMALLINT     NOT NULL,
+  declared_value_paise BIGINT,
+  pickup_type          VARCHAR(16)  NOT NULL,
+  drop_type            VARCHAR(16)  NOT NULL,
+  -- cached compute (for cart display; re-validated at checkout)
+  origin_tile_id       UUID,
+  dest_tile_id         UUID,
+  delivery_type        VARCHAR(16),
+  quoted_total_paise   BIGINT,
+  validation_status    VARCHAR(8)   NOT NULL DEFAULT 'VALID',  -- VALID | STALE
+  booked_shipment_ref  VARCHAR(64),
+  created_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_cart_item_cart ON cart_item (cart_id);
+
+CREATE TRIGGER trg_cart_item_updated_at
+  BEFORE UPDATE ON cart_item
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/orders/src/test/java/com/oneday/orders/e2e/AddressBookE2eTest.java
+++ b/orders/src/test/java/com/oneday/orders/e2e/AddressBookE2eTest.java
@@ -1,0 +1,138 @@
+package com.oneday.orders.e2e;
+
+import com.oneday.orders.domain.enums.AddressLabel;
+import com.oneday.orders.dto.SavedAddressRequest;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end coverage for the saved-address book: real HTTP → controller → service →
+ * Postgres (rolled back). Verifies CRUD, optional save-as, validation, 404, role gating,
+ * and cross-user isolation.
+ */
+class AddressBookE2eTest extends OrdersE2eSupport {
+
+    private SavedAddressRequest homeAddress() {
+        SavedAddressRequest r = new SavedAddressRequest();
+        r.setLabel(AddressLabel.HOME);
+        r.setContactName("Addr User");
+        r.setContactPhone("+919811000000");
+        r.setHouseFloor("Flat G06");
+        r.setBuildingStreet("Vajra Jasmine County");
+        r.setAreaLocality("Nanakramguda");
+        r.setLine1("Block C, Vajra Jasmine County");
+        r.setCity("Hyderabad");
+        r.setPincode("500032");
+        r.setState("Telangana");
+        r.setLatitude(17.4156);
+        r.setLongitude(78.3414);
+        r.setDeliveryInstructions("Ring the bell");
+        return r;
+    }
+
+    private String createReturningId(String token, SavedAddressRequest req) throws Exception {
+        String body = mvc.perform(post("/api/v1/addresses")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType("application/json")
+                        .content(json.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return json.readTree(body).get("id").asText();
+    }
+
+    @Test
+    void createListUpdateDelete_happyPath() throws Exception {
+        String token = tokenFor("C2C_CUSTOMER", randomUserId());
+
+        // CREATE — no save_as supplied (it is optional)
+        String createBody = mvc.perform(post("/api/v1/addresses")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType("application/json")
+                        .content(json.writeValueAsString(homeAddress())))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.label", is("HOME")))
+                .andExpect(jsonPath("$.save_as", nullValue()))
+                .andExpect(jsonPath("$.house_floor", is("Flat G06")))
+                .andExpect(jsonPath("$.area_locality", is("Nanakramguda")))
+                .andExpect(jsonPath("$.latitude", is(17.4156)))
+                .andReturn().getResponse().getContentAsString();
+        String id = json.readTree(createBody).get("id").asText();
+
+        // LIST
+        mvc.perform(get("/api/v1/addresses").header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].id", is(id)));
+
+        // UPDATE → OFFICE + save_as
+        SavedAddressRequest upd = homeAddress();
+        upd.setLabel(AddressLabel.OFFICE);
+        upd.setSaveAs("HQ");
+        mvc.perform(put("/api/v1/addresses/" + id)
+                        .header("Authorization", "Bearer " + token)
+                        .contentType("application/json")
+                        .content(json.writeValueAsString(upd)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.label", is("OFFICE")))
+                .andExpect(jsonPath("$.save_as", is("HQ")));
+
+        // DELETE
+        mvc.perform(delete("/api/v1/addresses/" + id).header("Authorization", "Bearer " + token))
+                .andExpect(status().isNoContent());
+
+        // LIST empty again
+        mvc.perform(get("/api/v1/addresses").header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+    @Test
+    void create_invalidPincode_returns422() throws Exception {
+        String token = tokenFor("B2C_CUSTOMER", randomUserId());
+        SavedAddressRequest bad = homeAddress();
+        bad.setPincode("ABC");
+        mvc.perform(post("/api/v1/addresses")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType("application/json")
+                        .content(json.writeValueAsString(bad)))
+                .andExpect(status().isUnprocessableEntity());
+    }
+
+    @Test
+    void update_unknownId_returns404() throws Exception {
+        String token = tokenFor("B2B_USER", randomUserId());
+        mvc.perform(put("/api/v1/addresses/" + java.util.UUID.randomUUID())
+                        .header("Authorization", "Bearer " + token)
+                        .contentType("application/json")
+                        .content(json.writeValueAsString(homeAddress())))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void addresses_areIsolatedPerUser() throws Exception {
+        String userA = tokenFor("C2C_CUSTOMER", randomUserId());
+        String userB = tokenFor("C2C_CUSTOMER", randomUserId());
+        createReturningId(userA, homeAddress());
+
+        // user B sees none of A's addresses
+        mvc.perform(get("/api/v1/addresses").header("Authorization", "Bearer " + userB))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+    @Test
+    void admin_isForbidden_fromAddressBook() throws Exception {
+        String admin = tokenFor("ADMIN", randomUserId());
+        mvc.perform(get("/api/v1/addresses").header("Authorization", "Bearer " + admin))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/e2e/BulkUploadE2eTest.java
+++ b/orders/src/test/java/com/oneday/orders/e2e/BulkUploadE2eTest.java
@@ -1,0 +1,126 @@
+package com.oneday.orders.e2e;
+
+import com.oneday.orders.domain.Address;
+import com.oneday.orders.dto.BulkPickup;
+import com.oneday.orders.service.BulkUploadService;
+import org.dhatim.fastexcel.Workbook;
+import org.dhatim.fastexcel.Worksheet;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end coverage for the bulk upload (one pickup → many destinations): valid destination
+ * rows are added to the cart with the shared pickup applied, invalid rows are reported, the header
+ * is validated, the template downloads, and C2C is forbidden.
+ */
+class BulkUploadE2eTest extends OrdersE2eSupport {
+
+    private static final String XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+    @Autowired BulkUploadService bulkUploadService;
+
+    // A destination row: receiver_name, receiver_phone, receiver_email, dest_line1, dest_line2,
+    // dest_city, dest_pincode, dest_state, weight_grams, length_cm, width_cm, height_cm, declared_value_inr
+    private String[] destRow(String receiver, String pincode) {
+        return new String[]{
+                receiver, "+919000000002", "",
+                "1 MG Road", "", "Bengaluru", pincode, "Karnataka",
+                "1000", "20", "15", "10", "500"};
+    }
+
+    private byte[] xlsx(List<String[]> rows) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (Workbook wb = new Workbook(out, "test", "1.0")) {
+            Worksheet ws = wb.newWorksheet("Sheet1");
+            for (int r = 0; r < rows.size(); r++) {
+                String[] cells = rows.get(r);
+                for (int c = 0; c < cells.length; c++) ws.value(r, c, cells[c]);
+            }
+        }
+        return out.toByteArray();
+    }
+
+    private MockMultipartFile file(byte[] bytes) {
+        return new MockMultipartFile("file", "dest.xlsx", XLSX, bytes);
+    }
+
+    private String pickupJson() throws Exception {
+        Address origin = addr("1 Connaught Place", "Delhi", "110001", "DL");
+        origin.setLatitude(28.6139); origin.setLongitude(77.2090);
+        return json.writeValueAsString(new BulkPickup("Acme Warehouse", "+919000000010", null, origin, "DEL", "110001"));
+    }
+
+    @Test
+    void upload_addsValidDestinations_reportsInvalidRows() throws Exception {
+        String token = tokenFor("B2C_CUSTOMER", randomUserId());
+
+        List<String[]> rows = new ArrayList<>();
+        rows.add(bulkUploadService.headers().toArray(new String[0]));
+        rows.add(destRow("Priya Sharma", "560001"));    // valid (Bengaluru prefix)
+        String[] badPincode = destRow("Amit Verma", "999001");
+        rows.add(badPincode);                            // pincode not in a serviceable city
+        String[] missingReceiver = destRow("", "560002");
+        rows.add(missingReceiver);                       // receiver_name blank → validation failure
+
+        mvc.perform(multipart("/api/v1/bulk/upload")
+                        .file(file(xlsx(rows)))
+                        .param("pickup", pickupJson())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.added", is(1)))
+                .andExpect(jsonPath("$.failed", is(2)));
+
+        // the one valid destination is now in the cart
+        mvc.perform(get("/api/v1/cart").header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.item_count", is(1)));
+    }
+
+    @Test
+    void upload_headerMismatch_returns422() throws Exception {
+        String token = tokenFor("B2B_USER", randomUserId());
+        List<String[]> rows = new ArrayList<>();
+        String[] wrong = bulkUploadService.headers().toArray(new String[0]);
+        wrong[0] = "name";
+        rows.add(wrong);
+        rows.add(destRow("Priya", "560001"));
+        mvc.perform(multipart("/api/v1/bulk/upload")
+                        .file(file(xlsx(rows)))
+                        .param("pickup", pickupJson())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isUnprocessableEntity());
+    }
+
+    @Test
+    void upload_c2c_isForbidden() throws Exception {
+        String token = tokenFor("C2C_CUSTOMER", randomUserId());
+        List<String[]> rows = new ArrayList<>();
+        rows.add(bulkUploadService.headers().toArray(new String[0]));
+        rows.add(destRow("Priya", "560001"));
+        mvc.perform(multipart("/api/v1/bulk/upload")
+                        .file(file(xlsx(rows)))
+                        .param("pickup", pickupJson())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void template_downloads_asXlsx() throws Exception {
+        String token = tokenFor("B2B_USER", randomUserId());
+        mvc.perform(get("/api/v1/bulk/template").header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Disposition", org.hamcrest.Matchers.containsString("oneday-destinations-template.xlsx")));
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/e2e/CartE2eTest.java
+++ b/orders/src/test/java/com/oneday/orders/e2e/CartE2eTest.java
@@ -1,0 +1,160 @@
+package com.oneday.orders.e2e;
+
+import com.oneday.common.domain.enums.DropType;
+import com.oneday.common.domain.enums.PickupType;
+import com.oneday.common.port.dto.ServiceabilityResult;
+import com.oneday.orders.dto.AddCartItemRequest;
+import com.oneday.orders.dto.CartCheckoutRequest;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.lenient;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end coverage for the shipment cart: add → list → checkout for both lanes, B2B credit
+ * debit, partial-failure handling (non-serviceable item stays in the cart), and empty-cart guard.
+ */
+class CartE2eTest extends OrdersE2eSupport {
+
+    private AddCartItemRequest cartItem(String originPincode, String destPincode) {
+        AddCartItemRequest r = new AddCartItemRequest();
+        r.setSenderName("Ravi Sender");
+        r.setSenderPhone("+919000000001");
+        r.setOriginAddress(addr("1 Connaught Place", "Delhi", originPincode, "DL"));
+        r.setOriginCity("DEL");
+        r.setOriginPincode(originPincode);
+        r.setReceiverName("Priya Receiver");
+        r.setReceiverPhone("+919000000002");
+        r.setDestAddress(addr("1 MG Road", "Bengaluru", destPincode, "KA"));
+        r.setDestCity("BLR");
+        r.setDestPincode(destPincode);
+        r.setWeightGrams(1000);
+        r.setLengthCm((short) 20);
+        r.setWidthCm((short) 15);
+        r.setHeightCm((short) 10);
+        r.setDeclaredValuePaise(500000L);
+        r.setPickupType(PickupType.DA_PICKUP);
+        r.setDropType(DropType.DA_DELIVERY);
+        return r;
+    }
+
+    private void addItem(String token, AddCartItemRequest item) throws Exception {
+        mvc.perform(post("/api/v1/cart/items")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType("application/json")
+                        .content(json.writeValueAsString(item)))
+                .andExpect(status().isCreated());
+    }
+
+    private CartCheckoutRequest b2cCheckout() {
+        CartCheckoutRequest c = new CartCheckoutRequest();
+        c.setRazorpayOrderId("order_test_1");
+        c.setRazorpayPaymentId("pay_test_1");
+        c.setRazorpaySignature("sig_test_1");
+        return c;
+    }
+
+    @Test
+    void b2c_add_list_checkout_booksAllItems() throws Exception {
+        String token = tokenFor("B2C_CUSTOMER", randomUserId());
+        addItem(token, cartItem("110001", "560001"));
+        addItem(token, cartItem("110002", "560002"));
+
+        // cart shows 2 items and the rolled-up total (2 × 4720)
+        mvc.perform(get("/api/v1/cart").header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.item_count", is(2)))
+                .andExpect(jsonPath("$.cart_total_paise", is(9440)));
+
+        // checkout: one aggregate payment, both booked, cart closed
+        mvc.perform(post("/api/v1/cart/checkout")
+                        .header("Authorization", "Bearer " + token)
+                        .header("Idempotency-Key", idemKey())
+                        .contentType("application/json")
+                        .content(json.writeValueAsString(b2cCheckout())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.booked", is(2)))
+                .andExpect(jsonPath("$.failed", is(0)))
+                .andExpect(jsonPath("$.charged_total_paise", is(9440)))
+                .andExpect(jsonPath("$.cart_status", is("CHECKED_OUT")));
+    }
+
+    @Test
+    void b2c_partialFailure_keepsBadItemInOpenCart() throws Exception {
+        String token = tokenFor("B2C_CUSTOMER", randomUserId());
+        // Both items are serviceable when added to the cart (base stub).
+        addItem(token, cartItem("110001", "560001"));   // stays good
+        addItem(token, cartItem("110002", "560002"));   // will go stale below
+
+        // Simulate a nightly grid replan: the second route is no longer serviceable at checkout.
+        lenient().when(serviceabilityPort.check(argThat(q -> q != null && "560002".equals(q.destPincode()))))
+                .thenReturn(new ServiceabilityResult(false, null, null, null));
+
+        mvc.perform(post("/api/v1/cart/checkout")
+                        .header("Authorization", "Bearer " + token)
+                        .header("Idempotency-Key", idemKey())
+                        .contentType("application/json")
+                        .content(json.writeValueAsString(b2cCheckout())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.booked", is(1)))
+                .andExpect(jsonPath("$.failed", is(1)))
+                .andExpect(jsonPath("$.charged_total_paise", is(4720)))   // only the good item charged
+                .andExpect(jsonPath("$.cart_status", is("OPEN")));        // bad item remains
+
+        // the failed item is still in the open cart
+        mvc.perform(get("/api/v1/cart").header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.item_count", is(1)));
+    }
+
+    @Test
+    void b2b_checkout_booksAgainstCreditAccount() throws Exception {
+        // The owner of the demo B2B account (₹50k limit, ₹12k outstanding) checks out via credit.
+        String token = tokenFor("B2B_USER", B2B_OWNER_USER_ID);
+        addItem(token, cartItem("110001", "560001"));
+
+        CartCheckoutRequest c = new CartCheckoutRequest();
+        c.setB2bAccountId(UUID.fromString(B2B_ACCOUNT_ID));
+
+        mvc.perform(post("/api/v1/cart/checkout")
+                        .header("Authorization", "Bearer " + token)
+                        .header("Idempotency-Key", idemKey())
+                        .contentType("application/json")
+                        .content(json.writeValueAsString(c)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.booked", is(1)))
+                .andExpect(jsonPath("$.failed", is(0)))
+                .andExpect(jsonPath("$.cart_status", is("CHECKED_OUT")));
+    }
+
+    @Test
+    void checkout_emptyCart_returns422() throws Exception {
+        String token = tokenFor("B2C_CUSTOMER", randomUserId());
+        mvc.perform(post("/api/v1/cart/checkout")
+                        .header("Authorization", "Bearer " + token)
+                        .header("Idempotency-Key", idemKey())
+                        .contentType("application/json")
+                        .content(json.writeValueAsString(b2cCheckout())))
+                .andExpect(status().isUnprocessableEntity());
+    }
+
+    @Test
+    void b2c_checkout_missingPaymentRefs_returns422() throws Exception {
+        String token = tokenFor("B2C_CUSTOMER", randomUserId());
+        addItem(token, cartItem("110001", "560001"));
+        mvc.perform(post("/api/v1/cart/checkout")
+                        .header("Authorization", "Bearer " + token)
+                        .header("Idempotency-Key", idemKey())
+                        .contentType("application/json")
+                        .content(json.writeValueAsString(new CartCheckoutRequest())))
+                .andExpect(status().isUnprocessableEntity());
+    }
+}

--- a/orders/src/test/resources/application.yml
+++ b/orders/src/test/resources/application.yml
@@ -15,6 +15,9 @@ spring:
     # which this orders-only location can't resolve. Skip cross-module checksum validation here;
     # Hibernate ddl-auto=validate still enforces that the entities match the live schema.
     validate-on-migrate: false
+    # The top-level V10 migration sorts numerically as 10 > 4.x, so without out-of-order Flyway
+    # treats the schema as "ahead" of every new V4_NN and skips it. Matches app/application.yml.
+    out-of-order: true
   # Match the production API JSON contract (app/application.yml) so the E2E tests assert the
   # same snake_case payloads the frontend actually consumes.
   jackson:


### PR DESCRIPTION
   - Saved addresses: AddressBook CRUD (V4_18) with Swiggy-style two-step map capture (house/building/locality folded into the address JSONB); usable as booking pickup/drop with re-validation against the M3 grid.
   - Cart: per-user OPEN cart (V4_19/V4_20); add/edit/remove priced items; B2C checkout settles ONE aggregate Razorpay payment then books each item via bookSettled (no per-shipment capture); B2B checkout debits the credit line per item. Partial failures stay in the cart.
   - Bulk upload: xlsx of destinations sharing one map-picked pickup (POST /api/v1/bulk/upload, fastexcel); per-row validation with row-level failure reasons; valid rows priced concurrently and inserted as one batch.
   - Auth: users gain phone (V1_10, V11) — E.164-validated at register/onboard, returned in LoginResponse, prefilled as sender contact.
   - Idempotency: exempt simple resource CRUD (addresses, cart items, bulk) from Idempotency-Key enforcement; booking/checkout stay enforced.
   - UI: cart & bulk tabs, address picker modals, upload spinner + elapsed-time readout, per-row failure modal.
