### PR TITLE
M6 IMPL - PR #6 : Custody service (all 4 states of ledger),find bound state a…

### DIFF
--- a/routing/src/main/java/com/oneday/routing/api/RecoveryController.java
+++ b/routing/src/main/java/com/oneday/routing/api/RecoveryController.java
@@ -1,0 +1,45 @@
+package com.oneday.routing.api;
+
+import com.oneday.routing.dto.RecoveryRequest;
+import com.oneday.routing.service.RecoveryService;
+import com.oneday.routing.service.model.RecoverySummary;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * Intraday recovery endpoint (§13.5, §17.2). A station manager reports a broken van and dispatches a
+ * recovery van; M6 moves the broken van's open manifest items to the recovery van and emits
+ * VAN_BREAKDOWN. This is the only sanctioned intraday fleet change (C18, NFR-3) — real M1
+ * station-manager scoping is wired the same way RoutePlanController takes its actor.
+ */
+@RestController
+@RequestMapping("/routing")
+public class RecoveryController {
+
+    private static final Logger log = LoggerFactory.getLogger(RecoveryController.class);
+
+    private final RecoveryService recoveryService;
+    private final Clock clock;
+
+    RecoveryController(RecoveryService recoveryService, Clock clock) {
+        this.recoveryService = recoveryService;
+        this.clock = clock;
+    }
+
+    @PostMapping("/vans/{vanId}/recovery")
+    public RecoverySummary recover(@PathVariable UUID vanId, @RequestBody RecoveryRequest request) {
+        LocalDate date = request.dateOrToday(LocalDate.now(clock));
+        log.info("Recovery requested for van {} → recovery van {} ({})", vanId, request.recoveryVanId(), date);
+        return recoveryService.recoverVan(vanId, request.recoveryVanId(), request.cityId(), date,
+                request.lastLat(), request.lastLon());
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/dto/RecoveryRequest.java
+++ b/routing/src/main/java/com/oneday/routing/dto/RecoveryRequest.java
@@ -1,0 +1,17 @@
+package com.oneday.routing.dto;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * Body for {@code POST /routing/vans/{vanId}/recovery} (§13.5). A station manager dispatches a
+ * recovery van to a broken one: the recovery van inherits the broken van's open manifest items and a
+ * {@code VAN_BREAKDOWN} is emitted. {@code lastLat}/{@code lastLon} = the broken van's last known
+ * position (from telemetry / the driver report), carried on the event. Intraday van add (NFR-3, C18).
+ */
+public record RecoveryRequest(UUID recoveryVanId, UUID cityId, LocalDate date, double lastLat, double lastLon) {
+
+    public LocalDate dateOrToday(LocalDate today) {
+        return date != null ? date : today;
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/events/CronEventProducer.java
+++ b/routing/src/main/java/com/oneday/routing/events/CronEventProducer.java
@@ -5,11 +5,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.oneday.common.kafka.EventPublisher;
 import com.oneday.common.kafka.EventStreams;
 import com.oneday.common.kafka.events.cron.DaCronScheduledEvent;
+import com.oneday.common.kafka.events.cron.HandoffCompletedEvent;
+import com.oneday.common.kafka.events.cron.HandoffDiscrepancyEvent;
 import com.oneday.common.kafka.events.cron.LoopOverflowEvent;
 import com.oneday.common.kafka.events.cron.RouteChangedEvent;
 import com.oneday.common.kafka.events.cron.RoutePlanPublishedEvent;
 import com.oneday.common.kafka.events.cron.ShuttleScheduledEvent;
+import com.oneday.common.kafka.events.cron.VanBreakdownEvent;
 import com.oneday.routing.domain.DaCronSchedule;
+import com.oneday.routing.domain.DiscrepancyType;
 import com.oneday.routing.domain.RoutePlan;
 import com.oneday.routing.service.model.ShuttleTimetable;
 import org.slf4j.Logger;
@@ -80,6 +84,25 @@ public class CronEventProducer {
     public void emitLoopOverflow(UUID cityId, UUID vanId, UUID parcelId, int loopIndex, Instant deadline) {
         eventPublisher.publish(EventStreams.CRON_EVENTS,
                 new LoopOverflowEvent(cityId, vanId, parcelId, loopIndex, deadline));
+    }
+
+    // HANDOFF_COMPLETED → M4, M10: a stop's per-DA exchange reconciled cleanly.
+    public void emitHandoffCompleted(UUID manifestId, UUID vanId, UUID cityId, int stopSeq, UUID daId) {
+        eventPublisher.publish(EventStreams.CRON_EVENTS,
+                new HandoffCompletedEvent(manifestId, vanId, cityId, stopSeq, daId));
+    }
+
+    // HANDOFF_DISCREPANCY → M11, M10: a missing/extra/rejected parcel at a stop.
+    public void emitHandoffDiscrepancy(UUID manifestId, UUID vanId, UUID cityId, int stopSeq, UUID daId,
+                                       DiscrepancyType type, List<UUID> parcelIds) {
+        eventPublisher.publish(EventStreams.CRON_EVENTS,
+                new HandoffDiscrepancyEvent(manifestId, vanId, cityId, stopSeq, daId, type.name(), parcelIds));
+    }
+
+    // VAN_BREAKDOWN → M10, station mgr, M11: a van was disabled mid-loop; a recovery van took over.
+    public void emitVanBreakdown(UUID vanId, UUID cityId, UUID routePlanId, double lat, double lon, Instant reportedAt) {
+        eventPublisher.publish(EventStreams.CRON_EVENTS,
+                new VanBreakdownEvent(vanId, cityId, routePlanId, lat, lon, reportedAt));
     }
 
     /** SHUTTLE_SCHEDULED → M9, M10: the periodic hub↔airport timetable. */

--- a/routing/src/main/java/com/oneday/routing/repository/VanManifestRepository.java
+++ b/routing/src/main/java/com/oneday/routing/repository/VanManifestRepository.java
@@ -16,6 +16,9 @@ public interface VanManifestRepository extends JpaRepository<VanManifest, UUID> 
 
     Optional<VanManifest> findByVanIdAndLoopIndexAndValidDate(UUID vanId, int loopIndex, LocalDate validDate);
 
+    // All of a van's manifests for a day — recovery reassigns these to the recovery van (§13.5).
+    List<VanManifest> findByVanIdAndValidDate(UUID vanId, LocalDate validDate);
+
     // SELECT FOR UPDATE: lock the loop's manifest row before counting capacity so binds can't race.
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select m from VanManifest m where m.vanId = :van and m.loopIndex = :loop and m.validDate = :date")

--- a/routing/src/main/java/com/oneday/routing/service/CustodyService.java
+++ b/routing/src/main/java/com/oneday/routing/service/CustodyService.java
@@ -1,0 +1,14 @@
+package com.oneday.routing.service;
+
+import com.oneday.routing.service.model.CustodyResult;
+import com.oneday.routing.service.model.VanCustodyCommand;
+
+// The four custody transfer points (§11.1, M6-D-014): LOAD (hub→van), DELIVER (van→DA),
+// COLLECT (DA→van), UNLOAD (van→hub). Each scan is written to M8's append-only ledger and
+// advances the bound manifest item's status; the scan itself is the signal M4 maps to a state
+// transition (HANDED_TO_DROP_VAN / DROP_COLLECTED / HANDED_TO_PICKUP_VAN / AT_ORIGIN_HUB).
+// Enforces custody continuity (C12): a scan only advances an item from its legal predecessor state.
+public interface CustodyService {
+
+    CustodyResult record(VanCustodyCommand command);
+}

--- a/routing/src/main/java/com/oneday/routing/service/HandoffService.java
+++ b/routing/src/main/java/com/oneday/routing/service/HandoffService.java
@@ -1,0 +1,17 @@
+package com.oneday.routing.service;
+
+import com.oneday.routing.service.model.StopReconciliation;
+
+import java.time.LocalDate;
+import java.util.Set;
+import java.util.UUID;
+
+// Per-stop, per-DA reconciliation (§13.1/§13.3, M6-D-018). After the dwell window closes the driver
+// app reports what was actually scanned each way; this compares it to the manifest, writes an
+// append-only handoff_reconciliation row, marks any missing/rejected items EXCEPTION, and emits
+// HANDOFF_COMPLETED (clean) or HANDOFF_DISCREPANCY (missing/extra/rejected). Partial handoff is legal.
+public interface HandoffService {
+
+    StopReconciliation reconcileStop(UUID vanId, int loopIndex, LocalDate date, int stopSeq, UUID daId,
+                                     Set<UUID> deliverScanned, Set<UUID> collectScanned, Set<UUID> rejected);
+}

--- a/routing/src/main/java/com/oneday/routing/service/RecoveryService.java
+++ b/routing/src/main/java/com/oneday/routing/service/RecoveryService.java
@@ -1,0 +1,20 @@
+package com.oneday.routing.service;
+
+import com.oneday.routing.service.model.RecoverySummary;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+// Intraday failure recovery (§13.4/§13.5, M6-D-021). The only sanctioned intraday fleet change (C18):
+// when a van breaks down, a recovery van takes over its open manifest items; a DA no-show carries
+// that DA's undelivered parcels onto their next feasible loop.
+public interface RecoveryService {
+
+    // Van breakdown: emit VAN_BREAKDOWN and move the broken van's in-flight items to the recovery van.
+    RecoverySummary recoverVan(UUID brokenVanId, UUID recoveryVanId, UUID cityId, LocalDate date,
+                               double lastLat, double lastLon);
+
+    // DA no-show at a stop: carry that DA's still-undelivered parcels to their next loop; collections
+    // are deferred (the next pickup event re-binds them).
+    int carryNoShow(UUID vanId, int loopIndex, LocalDate date, int stopSeq, UUID daId);
+}

--- a/routing/src/main/java/com/oneday/routing/service/VanManifestService.java
+++ b/routing/src/main/java/com/oneday/routing/service/VanManifestService.java
@@ -22,4 +22,8 @@ public interface VanManifestService {
     BindingResult reconcileDeliveries(UUID cityId, LocalDate date);
 
     BindingResult reconcileCollections(UUID cityId, LocalDate date);
+
+    // Carry a delivery the DA didn't take (no-show / late, §13.2) onto its next feasible loop: the
+    // current item is marked EXCEPTION and the parcel re-bound to a later loop, else overflow.
+    BindOutcome rebindDelivery(UUID parcelId);
 }

--- a/routing/src/main/java/com/oneday/routing/service/impl/CustodyServiceImpl.java
+++ b/routing/src/main/java/com/oneday/routing/service/impl/CustodyServiceImpl.java
@@ -1,0 +1,136 @@
+package com.oneday.routing.service.impl;
+
+import com.oneday.routing.domain.HandoffDirection;
+import com.oneday.routing.domain.ManifestItemStatus;
+import com.oneday.routing.domain.ManifestStatus;
+import com.oneday.routing.domain.VanManifest;
+import com.oneday.routing.domain.VanManifestItem;
+import com.oneday.routing.repository.VanManifestItemRepository;
+import com.oneday.routing.repository.VanManifestRepository;
+import com.oneday.routing.service.CustodyService;
+import com.oneday.routing.service.model.CustodyResult;
+import com.oneday.routing.service.model.VanCustodyCommand;
+import com.oneday.routing.service.port.ScanLedgerPort;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Records the four van custody scans (§11.1). The physical scan is written to M8's ledger
+ * unconditionally (append-only truth, {@link ScanLedgerPort}); the manifest item then advances
+ * only from its legal predecessor state (C12). Replays are idempotent; an out-of-order or
+ * off-manifest scan is reported, never silently applied.
+ */
+@Service
+class CustodyServiceImpl implements CustodyService {
+
+    private static final Logger log = LoggerFactory.getLogger(CustodyServiceImpl.class);
+
+    private static final List<ManifestItemStatus> TERMINAL =
+            List.of(ManifestItemStatus.RECONCILED, ManifestItemStatus.HANDED_OFF, ManifestItemStatus.EXCEPTION);
+
+    private final VanManifestItemRepository itemRepository;
+    private final VanManifestRepository manifestRepository;
+    private final ScanLedgerPort scanLedgerPort;
+
+    CustodyServiceImpl(VanManifestItemRepository itemRepository, VanManifestRepository manifestRepository,
+                       ScanLedgerPort scanLedgerPort) {
+        this.itemRepository = itemRepository;
+        this.manifestRepository = manifestRepository;
+        this.scanLedgerPort = scanLedgerPort;
+    }
+
+    @Override
+    @Transactional
+    public CustodyResult record(VanCustodyCommand cmd) {
+        // 1. The scan physically happened — record it in M8's immutable ledger before anything else.
+        scanLedgerPort.recordVanScan(new ScanLedgerPort.VanCustodyScan(
+                cmd.parcelId(), cmd.type(), cmd.vanId(), cmd.driverId(), cmd.counterpartyDaId(), cmd.scannedAt()));
+
+        HandoffDirection direction = directionOf(cmd.type());
+        VanManifestItem item = itemRepository.findByParcelId(cmd.parcelId()).stream()
+                .filter(i -> i.getDirection() == direction && i.getStatus() != ManifestItemStatus.EXCEPTION)
+                .findFirst()
+                .orElse(null);
+        if (item == null) {
+            // Scanned a parcel this van wasn't carrying for this direction — mis-route; the stop
+            // reconcile (HandoffService) will surface it as an EXTRA. Custody just records the scan.
+            log.warn("Custody {} parcel {} not on any active manifest item — mis-route/extra", cmd.type(), cmd.parcelId());
+            return CustodyResult.unknownParcel(cmd.parcelId(), cmd.type());
+        }
+
+        ManifestItemStatus next = nextStatus(cmd.type());
+        if (item.getStatus() == next) {
+            return CustodyResult.idempotent(cmd.parcelId(), cmd.type(), next); // replayed scan
+        }
+        ManifestItemStatus expectedPrev = prevStatus(cmd.type());
+        if (item.getStatus() != expectedPrev) {
+            log.warn("Custody {} parcel {} illegal: status {} (expected {}) — C12", cmd.type(), cmd.parcelId(),
+                    item.getStatus(), expectedPrev);
+            return CustodyResult.illegal(cmd.parcelId(), cmd.type(), item.getStatus());
+        }
+
+        applyTransition(item, cmd);
+        itemRepository.save(item);
+        advanceManifestLifecycle(item, cmd.type());
+        return CustodyResult.recorded(cmd.parcelId(), cmd.type(), next);
+    }
+
+    // ── transition tables (§11.1) ──────────────────────────────────────────
+
+    private void applyTransition(VanManifestItem item, VanCustodyCommand cmd) {
+        switch (cmd.type()) {
+            case VAN_LOAD -> { item.setStatus(ManifestItemStatus.LOADED); item.setLoadedAt(cmd.scannedAt()); }
+            case VAN_TO_DA -> { item.setStatus(ManifestItemStatus.HANDED_OFF); item.setHandedOffAt(cmd.scannedAt()); }
+            case DA_TO_VAN -> item.setStatus(ManifestItemStatus.ONBOARD);
+            case VAN_UNLOAD -> item.setStatus(ManifestItemStatus.RECONCILED);
+        }
+    }
+
+    private static HandoffDirection directionOf(ScanLedgerPort.VanScanType type) {
+        return switch (type) {
+            case VAN_LOAD, VAN_TO_DA -> HandoffDirection.DELIVER;
+            case DA_TO_VAN, VAN_UNLOAD -> HandoffDirection.COLLECT;
+        };
+    }
+
+    private static ManifestItemStatus prevStatus(ScanLedgerPort.VanScanType type) {
+        return switch (type) {
+            case VAN_LOAD -> ManifestItemStatus.PLANNED;
+            case VAN_TO_DA -> ManifestItemStatus.LOADED;
+            case DA_TO_VAN -> ManifestItemStatus.PLANNED;
+            case VAN_UNLOAD -> ManifestItemStatus.ONBOARD;
+        };
+    }
+
+    private static ManifestItemStatus nextStatus(ScanLedgerPort.VanScanType type) {
+        return switch (type) {
+            case VAN_LOAD -> ManifestItemStatus.LOADED;
+            case VAN_TO_DA -> ManifestItemStatus.HANDED_OFF;
+            case DA_TO_VAN -> ManifestItemStatus.ONBOARD;
+            case VAN_UNLOAD -> ManifestItemStatus.RECONCILED;
+        };
+    }
+
+    // First load seals the manifest (BUILDING → LOADED); the final unload reconciles it. The
+    // in-loop IN_PROGRESS / RETURNED transitions are driven by van telemetry (PR7).
+    private void advanceManifestLifecycle(VanManifestItem item, ScanLedgerPort.VanScanType type) {
+        VanManifest manifest = manifestRepository.findById(item.getManifestId()).orElse(null);
+        if (manifest == null) return;
+        if (type == ScanLedgerPort.VanScanType.VAN_LOAD && manifest.getStatus() == ManifestStatus.BUILDING) {
+            manifest.setStatus(ManifestStatus.LOADED);
+            manifestRepository.save(manifest);
+        } else if (type == ScanLedgerPort.VanScanType.VAN_UNLOAD && allItemsTerminal(manifest.getId())) {
+            manifest.setStatus(ManifestStatus.RECONCILED);
+            manifestRepository.save(manifest);
+        }
+    }
+
+    private boolean allItemsTerminal(java.util.UUID manifestId) {
+        return itemRepository.findByManifestId(manifestId).stream()
+                .allMatch(i -> TERMINAL.contains(i.getStatus()));
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/service/impl/HandoffServiceImpl.java
+++ b/routing/src/main/java/com/oneday/routing/service/impl/HandoffServiceImpl.java
@@ -1,0 +1,172 @@
+package com.oneday.routing.service.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneday.routing.domain.DiscrepancyType;
+import com.oneday.routing.domain.HandoffDirection;
+import com.oneday.routing.domain.HandoffReconciliation;
+import com.oneday.routing.domain.ManifestItemStatus;
+import com.oneday.routing.domain.RoutePlan;
+import com.oneday.routing.domain.VanManifest;
+import com.oneday.routing.domain.VanManifestItem;
+import com.oneday.routing.events.CronEventProducer;
+import com.oneday.routing.repository.HandoffReconciliationRepository;
+import com.oneday.routing.repository.RoutePlanRepository;
+import com.oneday.routing.repository.VanManifestItemRepository;
+import com.oneday.routing.repository.VanManifestRepository;
+import com.oneday.routing.service.HandoffService;
+import com.oneday.routing.service.model.StopReconciliation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Reconciles one DA's exchange at a stop. Expected = manifest items filtered by stop_seq + da_id +
+ * direction; actual = the scanned sets the driver reports. The set math yields MISSING (expected,
+ * not scanned), EXTRA (scanned, not expected — mis-route), REJECTED (expected, refused). Each bucket
+ * is persisted append-only and emitted as HANDOFF_DISCREPANCY; a fully clean DA emits HANDOFF_COMPLETED.
+ */
+@Service
+class HandoffServiceImpl implements HandoffService {
+
+    private static final Logger log = LoggerFactory.getLogger(HandoffServiceImpl.class);
+
+    private final VanManifestRepository manifestRepository;
+    private final VanManifestItemRepository itemRepository;
+    private final HandoffReconciliationRepository reconciliationRepository;
+    private final RoutePlanRepository planRepository;
+    private final CronEventProducer cronEventProducer;
+    private final ObjectMapper objectMapper;
+
+    HandoffServiceImpl(VanManifestRepository manifestRepository, VanManifestItemRepository itemRepository,
+                       HandoffReconciliationRepository reconciliationRepository, RoutePlanRepository planRepository,
+                       CronEventProducer cronEventProducer, ObjectMapper objectMapper) {
+        this.manifestRepository = manifestRepository;
+        this.itemRepository = itemRepository;
+        this.reconciliationRepository = reconciliationRepository;
+        this.planRepository = planRepository;
+        this.cronEventProducer = cronEventProducer;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    @Transactional
+    public StopReconciliation reconcileStop(UUID vanId, int loopIndex, LocalDate date, int stopSeq, UUID daId,
+                                            Set<UUID> deliverScanned, Set<UUID> collectScanned, Set<UUID> rejected) {
+        VanManifest manifest = manifestRepository.findByVanIdAndLoopIndexAndValidDate(vanId, loopIndex, date)
+                .orElse(null);
+        if (manifest == null) {
+            log.warn("Reconcile stop: no manifest for van {} loop {} date {}", vanId, loopIndex, date);
+            return StopReconciliation.noManifest(stopSeq, daId);
+        }
+        UUID cityId = cityOf(manifest);
+
+        List<VanManifestItem> atStop = itemRepository.findByManifestIdAndStopSeq(manifest.getId(), stopSeq).stream()
+                .filter(i -> daId.equals(i.getCounterpartyDaId()) && i.getStatus() != ManifestItemStatus.EXCEPTION)
+                .toList();
+
+        List<StopReconciliation.Discrepancy> discrepancies = new ArrayList<>();
+        discrepancies.addAll(reconcileDirection(manifest, cityId, stopSeq, daId, HandoffDirection.DELIVER,
+                atStop, deliverScanned, rejected));
+        discrepancies.addAll(reconcileDirection(manifest, cityId, stopSeq, daId, HandoffDirection.COLLECT,
+                atStop, collectScanned, Set.of()));
+
+        boolean clean = discrepancies.isEmpty();
+        if (clean) {
+            cronEventProducer.emitHandoffCompleted(manifest.getId(), vanId, cityId, stopSeq, daId);
+        }
+        return new StopReconciliation(manifest.getId(), stopSeq, daId, clean, discrepancies);
+    }
+
+    // Reconcile one direction's expected items against what was scanned. Writes one reconciliation
+    // row per discrepancy bucket (or a single NONE row when clean) and emits per-bucket discrepancy events.
+    private List<StopReconciliation.Discrepancy> reconcileDirection(
+            VanManifest manifest, UUID cityId, int stopSeq, UUID daId, HandoffDirection direction,
+            List<VanManifestItem> atStop, Set<UUID> scanned, Set<UUID> rejected) {
+
+        List<VanManifestItem> expected = atStop.stream().filter(i -> i.getDirection() == direction).toList();
+        Set<UUID> expectedIds = expected.stream().map(VanManifestItem::getParcelId)
+                .collect(java.util.stream.Collectors.toSet());
+
+        List<UUID> missing = expected.stream()
+                .filter(i -> !scanned.contains(i.getParcelId()) && !rejected.contains(i.getParcelId()))
+                .map(VanManifestItem::getParcelId).toList();
+        List<UUID> rejectedHere = expected.stream()
+                .filter(i -> rejected.contains(i.getParcelId()))
+                .map(VanManifestItem::getParcelId).toList();
+        List<UUID> extra = scanned.stream().filter(id -> !expectedIds.contains(id)).toList();
+        int matched = expected.size() - missing.size() - rejectedHere.size();
+
+        if (missing.isEmpty() && rejectedHere.isEmpty() && extra.isEmpty()) {
+            if (!expected.isEmpty()) {
+                writeRow(manifest.getId(), stopSeq, daId, expected.size(), matched, DiscrepancyType.NONE, List.of(),
+                        direction + " clean");
+            }
+            return List.of();
+        }
+
+        // Missing & rejected parcels fall out of this loop's custody — flag the items EXCEPTION.
+        markException(expected, missing);
+        markException(expected, rejectedHere);
+
+        List<StopReconciliation.Discrepancy> out = new ArrayList<>();
+        out.addAll(emitBucket(manifest, cityId, stopSeq, daId, direction, expected.size(), matched,
+                DiscrepancyType.MISSING, missing));
+        out.addAll(emitBucket(manifest, cityId, stopSeq, daId, direction, expected.size(), matched,
+                DiscrepancyType.REJECTED, rejectedHere));
+        out.addAll(emitBucket(manifest, cityId, stopSeq, daId, direction, expected.size(), matched,
+                DiscrepancyType.EXTRA, extra));
+        return out;
+    }
+
+    private List<StopReconciliation.Discrepancy> emitBucket(
+            VanManifest manifest, UUID cityId, int stopSeq, UUID daId, HandoffDirection direction,
+            int expectedCount, int actualCount, DiscrepancyType type, List<UUID> parcelIds) {
+        if (parcelIds.isEmpty()) return List.of();
+        writeRow(manifest.getId(), stopSeq, daId, expectedCount, actualCount, type, parcelIds,
+                direction + " " + type);
+        cronEventProducer.emitHandoffDiscrepancy(manifest.getId(), manifest.getVanId(), cityId, stopSeq, daId,
+                type, parcelIds);
+        return List.of(new StopReconciliation.Discrepancy(direction, type, parcelIds));
+    }
+
+    private void markException(List<VanManifestItem> expected, List<UUID> parcelIds) {
+        expected.stream().filter(i -> parcelIds.contains(i.getParcelId())).forEach(i -> {
+            i.setStatus(ManifestItemStatus.EXCEPTION);
+            itemRepository.save(i);
+        });
+    }
+
+    private void writeRow(UUID manifestId, int stopSeq, UUID daId, int expected, int actual,
+                          DiscrepancyType type, List<UUID> parcelIds, String reason) {
+        reconciliationRepository.save(HandoffReconciliation.builder()
+                .manifestId(manifestId)
+                .stopSeq(stopSeq)
+                .daId(daId)
+                .expectedCount(expected)
+                .actualCount(actual)
+                .discrepancyType(type)
+                .discrepancyParcelIds(toJson(parcelIds))
+                .reason(reason)
+                .build());
+    }
+
+    private UUID cityOf(VanManifest manifest) {
+        return planRepository.findById(manifest.getRoutePlanId()).map(RoutePlan::getCityId).orElse(null);
+    }
+
+    private String toJson(List<UUID> ids) {
+        try {
+            return objectMapper.writeValueAsString(ids.stream().map(UUID::toString).toList());
+        } catch (Exception e) {
+            log.warn("Could not serialize discrepancy parcel ids {}: {}", ids, e.getMessage());
+            return "[]";
+        }
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/service/impl/RecoveryServiceImpl.java
+++ b/routing/src/main/java/com/oneday/routing/service/impl/RecoveryServiceImpl.java
@@ -1,0 +1,120 @@
+package com.oneday.routing.service.impl;
+
+import com.oneday.routing.domain.HandoffDirection;
+import com.oneday.routing.domain.ManifestItemStatus;
+import com.oneday.routing.domain.ManifestStatus;
+import com.oneday.routing.domain.VanManifest;
+import com.oneday.routing.domain.VanManifestItem;
+import com.oneday.routing.events.CronEventProducer;
+import com.oneday.routing.repository.VanManifestItemRepository;
+import com.oneday.routing.repository.VanManifestRepository;
+import com.oneday.routing.service.RecoveryService;
+import com.oneday.routing.service.VanManifestService;
+import com.oneday.routing.service.model.RecoverySummary;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Failure recovery (§13.4/§13.5). Breakdown: the recovery van inherits the broken van's open items
+ * (custody re-pointed to fresh recovery-van manifests, append-only — the broken van's rows are left
+ * as the historical record). No-show: undelivered deliveries are carried to the DA's next loop via
+ * {@link VanManifestService#rebindDelivery}; collections are deferred to the next pickup-driven bind.
+ */
+@Service
+class RecoveryServiceImpl implements RecoveryService {
+
+    private static final Logger log = LoggerFactory.getLogger(RecoveryServiceImpl.class);
+
+    private static final List<ManifestItemStatus> TERMINAL =
+            List.of(ManifestItemStatus.RECONCILED, ManifestItemStatus.HANDED_OFF, ManifestItemStatus.EXCEPTION);
+
+    private final VanManifestRepository manifestRepository;
+    private final VanManifestItemRepository itemRepository;
+    private final VanManifestService manifestService;
+    private final CronEventProducer cronEventProducer;
+    private final Clock clock;
+
+    RecoveryServiceImpl(VanManifestRepository manifestRepository, VanManifestItemRepository itemRepository,
+                        VanManifestService manifestService, CronEventProducer cronEventProducer, Clock clock) {
+        this.manifestRepository = manifestRepository;
+        this.itemRepository = itemRepository;
+        this.manifestService = manifestService;
+        this.cronEventProducer = cronEventProducer;
+        this.clock = clock;
+    }
+
+    @Override
+    @Transactional
+    public RecoverySummary recoverVan(UUID brokenVanId, UUID recoveryVanId, UUID cityId, LocalDate date,
+                                      double lastLat, double lastLon) {
+        List<VanManifest> manifests = manifestRepository.findByVanIdAndValidDate(brokenVanId, date);
+        UUID routePlanId = manifests.isEmpty() ? null : manifests.get(0).getRoutePlanId();
+        cronEventProducer.emitVanBreakdown(brokenVanId, cityId, routePlanId, lastLat, lastLon, Instant.now(clock));
+
+        int reassigned = 0;
+        for (VanManifest broken : manifests) {
+            List<VanManifestItem> open = itemRepository.findByManifestId(broken.getId()).stream()
+                    .filter(i -> !TERMINAL.contains(i.getStatus()))
+                    .toList();
+            if (open.isEmpty()) continue;
+            VanManifest recovery = recoveryManifestFor(broken, recoveryVanId, date);
+            for (VanManifestItem item : open) {
+                item.setManifestId(recovery.getId());
+                itemRepository.save(item);
+                reassigned++;
+            }
+        }
+        log.info("Recovery van {} took over {} open items from broken van {} ({})",
+                recoveryVanId, reassigned, brokenVanId, date);
+        return new RecoverySummary(brokenVanId, recoveryVanId, reassigned, 0);
+    }
+
+    @Override
+    @Transactional
+    public int carryNoShow(UUID vanId, int loopIndex, LocalDate date, int stopSeq, UUID daId) {
+        VanManifest manifest = manifestRepository.findByVanIdAndLoopIndexAndValidDate(vanId, loopIndex, date)
+                .orElse(null);
+        if (manifest == null) return 0;
+        // Deliveries still on the van (PLANNED/LOADED) for this DA & stop — carry to the next loop.
+        List<VanManifestItem> undelivered = itemRepository.findByManifestIdAndStopSeq(manifest.getId(), stopSeq).stream()
+                .filter(i -> i.getDirection() == HandoffDirection.DELIVER && daId.equals(i.getCounterpartyDaId()))
+                .filter(i -> i.getStatus() == ManifestItemStatus.PLANNED || i.getStatus() == ManifestItemStatus.LOADED)
+                .toList();
+        int carried = 0;
+        for (VanManifestItem item : undelivered) {
+            manifestService.rebindDelivery(item.getParcelId());
+            carried++;
+        }
+        log.info("DA {} no-show at van {} loop {} stop {}: carried {} deliveries to next loop",
+                daId, vanId, loopIndex, stopSeq, carried);
+        return carried;
+    }
+
+    // Find or create the recovery van's manifest for the same loop/day (race-safe via UNIQUE constraint).
+    private VanManifest recoveryManifestFor(VanManifest broken, UUID recoveryVanId, LocalDate date) {
+        return manifestRepository.findByVanIdAndLoopIndexAndValidDate(recoveryVanId, broken.getLoopIndex(), date)
+                .orElseGet(() -> {
+                    try {
+                        return manifestRepository.saveAndFlush(VanManifest.builder()
+                                .routePlanId(broken.getRoutePlanId())
+                                .vanId(recoveryVanId)
+                                .loopIndex(broken.getLoopIndex())
+                                .validDate(date)
+                                .status(ManifestStatus.IN_PROGRESS)
+                                .build());
+                    } catch (DataIntegrityViolationException raced) {
+                        return manifestRepository.findByVanIdAndLoopIndexAndValidDate(recoveryVanId, broken.getLoopIndex(), date)
+                                .orElseThrow(() -> new IllegalStateException("recovery manifest vanished for van=" + recoveryVanId));
+                    }
+                });
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/service/impl/VanManifestServiceImpl.java
+++ b/routing/src/main/java/com/oneday/routing/service/impl/VanManifestServiceImpl.java
@@ -98,15 +98,19 @@ class VanManifestServiceImpl implements VanManifestService {
             log.warn("Deliver parcel {} unresolved: hex {} not in any DA territory / no cron", parcelId, destinationHexId);
             return BindOutcome.unresolved(parcelId);
         }
+        return bindDeliverToCron(ctx, cityId, date, parcelId, cron, slaDeadline, -1);
+    }
+
+    // Greedy earliest-feasible deliver loop with live capacity (FCFS, §12.3); loops ≤ afterLoopExclusive
+    // are skipped so a carried/no-show parcel lands strictly after its failed loop (§13.2).
+    private BindOutcome bindDeliverToCron(PlanCtx ctx, UUID cityId, LocalDate date, UUID parcelId,
+                                          DaCronSchedule cron, Instant slaDeadline, int afterLoopExclusive) {
         UUID van = cron.getVanId();
         Duration daDelivery = Duration.ofMinutes(properties.getBinding().getDaDeliveryMinutes());
         List<LoopSlot> feasible = LoopBinder.feasibleDeliverLoopsAsc(
                 ctx.deliverSlots(van, cron.getHexVertexId()), slaDeadline, daDelivery);
-
-        // v1: greedy earliest-feasible loop with live capacity, else overflow (FCFS). The SLA-first
-        // reactive bump (§12.3/§12.4) is deferred post-v1 — capacity is configured high in v1 so loops
-        // don't fill; symmetric with bindCollect. See docs/M6/M6-ROUTING-DESIGN.md §12.
         for (LoopSlot slot : feasible) {
+            if (slot.loopIndex() <= afterLoopExclusive) continue;
             VanManifest manifest = lockOrCreate(ctx, van, slot.loopIndex(), date);
             if (itemRepository.countByManifestIdAndDirection(manifest.getId(), HandoffDirection.DELIVER) < ctx.capacity) {
                 VanManifestItem item = appendItem(manifest, HandoffDirection.DELIVER, parcelId, slot, cron.getDaId(), slaDeadline);
@@ -114,6 +118,30 @@ class VanManifestServiceImpl implements VanManifestService {
             }
         }
         return overflow(cityId, van, parcelId, slaDeadline);
+    }
+
+    @Override
+    @Transactional
+    public BindOutcome rebindDelivery(UUID parcelId) {
+        VanManifestItem old = itemRepository.findByParcelId(parcelId).stream()
+                .filter(i -> i.getDirection() == HandoffDirection.DELIVER && i.getStatus() != ManifestItemStatus.EXCEPTION)
+                .findFirst()
+                .orElse(null);
+        if (old == null) return BindOutcome.unresolved(parcelId);
+
+        VanManifest oldManifest = manifestRepository.findById(old.getManifestId())
+                .orElseThrow(() -> new IllegalStateException("manifest missing for item " + old.getId()));
+        int failedLoop = oldManifest.getLoopIndex();
+        old.setStatus(ManifestItemStatus.EXCEPTION); // carried off this loop; the rebind below re-places it
+        itemRepository.save(old);
+
+        RoutePlan plan = planRepository.findById(oldManifest.getRoutePlanId())
+                .orElseThrow(() -> new IllegalStateException("plan missing for manifest " + oldManifest.getId()));
+        PlanCtx ctx = context(plan.getCityId(), oldManifest.getValidDate());
+        DaCronSchedule cron = ctx.daToCron.get(old.getCounterpartyDaId());
+        if (cron == null) return BindOutcome.unresolved(parcelId);
+        return bindDeliverToCron(ctx, plan.getCityId(), oldManifest.getValidDate(), parcelId, cron,
+                old.getSlaDeadline(), failedLoop);
     }
 
     @Override
@@ -177,10 +205,11 @@ class VanManifestServiceImpl implements VanManifestService {
         return BindOutcome.overflow(parcelId, van);
     }
 
-    // Returns a BOUND outcome if the parcel already has an item for the direction (replay-safe), else null.
+    // Returns a BOUND outcome if the parcel already has a live item for the direction (replay-safe),
+    // else null. EXCEPTION items (carried/no-show) are ignored so the parcel can be re-bound.
     private BindOutcome alreadyBound(UUID parcelId, HandoffDirection direction) {
         return itemRepository.findByParcelId(parcelId).stream()
-                .filter(i -> i.getDirection() == direction)
+                .filter(i -> i.getDirection() == direction && i.getStatus() != ManifestItemStatus.EXCEPTION)
                 .findFirst()
                 .map(i -> BindOutcome.bound(parcelId, null, null, i.getId(), List.of()))
                 .orElse(null);

--- a/routing/src/main/java/com/oneday/routing/service/model/CustodyResult.java
+++ b/routing/src/main/java/com/oneday/routing/service/model/CustodyResult.java
@@ -1,0 +1,35 @@
+package com.oneday.routing.service.model;
+
+import com.oneday.routing.domain.ManifestItemStatus;
+import com.oneday.routing.service.port.ScanLedgerPort;
+
+import java.util.UUID;
+
+// Outcome of one custody scan. The scan is always written to the ledger (M8) regardless; this
+// records what it did to the manifest item. UNKNOWN_PARCEL = scanned a parcel not on this van's
+// manifest (mis-route → an EXTRA at stop reconcile); ILLEGAL_TRANSITION = out-of-order scan (C12).
+public record CustodyResult(UUID parcelId, ScanLedgerPort.VanScanType type, Status status,
+                            ManifestItemStatus itemStatus) {
+
+    public enum Status { RECORDED, IDEMPOTENT, UNKNOWN_PARCEL, ILLEGAL_TRANSITION }
+
+    public static CustodyResult recorded(UUID parcelId, ScanLedgerPort.VanScanType type, ManifestItemStatus to) {
+        return new CustodyResult(parcelId, type, Status.RECORDED, to);
+    }
+
+    public static CustodyResult idempotent(UUID parcelId, ScanLedgerPort.VanScanType type, ManifestItemStatus at) {
+        return new CustodyResult(parcelId, type, Status.IDEMPOTENT, at);
+    }
+
+    public static CustodyResult unknownParcel(UUID parcelId, ScanLedgerPort.VanScanType type) {
+        return new CustodyResult(parcelId, type, Status.UNKNOWN_PARCEL, null);
+    }
+
+    public static CustodyResult illegal(UUID parcelId, ScanLedgerPort.VanScanType type, ManifestItemStatus at) {
+        return new CustodyResult(parcelId, type, Status.ILLEGAL_TRANSITION, at);
+    }
+
+    public boolean accepted() {
+        return status == Status.RECORDED || status == Status.IDEMPOTENT;
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/service/model/RecoverySummary.java
+++ b/routing/src/main/java/com/oneday/routing/service/model/RecoverySummary.java
@@ -1,0 +1,8 @@
+package com.oneday.routing.service.model;
+
+import java.util.UUID;
+
+// Outcome of dispatching a recovery van for a broken one (§13.5): how many in-flight manifest items
+// were moved to the recovery van's custody, and how many carried deliveries were re-bound.
+public record RecoverySummary(UUID brokenVanId, UUID recoveryVanId, int itemsReassigned, int deliveriesRebound) {
+}

--- a/routing/src/main/java/com/oneday/routing/service/model/StopReconciliation.java
+++ b/routing/src/main/java/com/oneday/routing/service/model/StopReconciliation.java
@@ -1,0 +1,20 @@
+package com.oneday.routing.service.model;
+
+import com.oneday.routing.domain.DiscrepancyType;
+import com.oneday.routing.domain.HandoffDirection;
+
+import java.util.List;
+import java.util.UUID;
+
+// Result of reconciling one DA's exchange at a stop (§13.1). clean == no discrepancies (a clean
+// stop emits HANDOFF_COMPLETED; otherwise one HANDOFF_DISCREPANCY per discrepancy bucket).
+public record StopReconciliation(UUID manifestId, int stopSeq, UUID daId, boolean clean,
+                                 List<Discrepancy> discrepancies) {
+
+    public record Discrepancy(HandoffDirection direction, DiscrepancyType type, List<UUID> parcelIds) {
+    }
+
+    public static StopReconciliation noManifest(int stopSeq, UUID daId) {
+        return new StopReconciliation(null, stopSeq, daId, true, List.of());
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/service/model/VanCustodyCommand.java
+++ b/routing/src/main/java/com/oneday/routing/service/model/VanCustodyCommand.java
@@ -1,0 +1,17 @@
+package com.oneday.routing.service.model;
+
+import com.oneday.routing.service.port.ScanLedgerPort;
+
+import java.time.Instant;
+import java.util.UUID;
+
+// One physical scan at a custody transfer point (§11.1). Both van and driver identity travel on it
+// (Q14). counterpartyDaId is the DA at a meeting stop (deliver/collect); null at the hub (load/unload).
+public record VanCustodyCommand(
+        UUID parcelId,
+        ScanLedgerPort.VanScanType type,
+        UUID vanId,
+        UUID driverId,
+        UUID counterpartyDaId,
+        Instant scannedAt) {
+}

--- a/routing/src/test/java/com/oneday/routing/service/impl/CustodyServiceImplTest.java
+++ b/routing/src/test/java/com/oneday/routing/service/impl/CustodyServiceImplTest.java
@@ -1,0 +1,144 @@
+package com.oneday.routing.service.impl;
+
+import com.oneday.routing.domain.HandoffDirection;
+import com.oneday.routing.domain.ManifestItemStatus;
+import com.oneday.routing.domain.ManifestStatus;
+import com.oneday.routing.domain.VanManifest;
+import com.oneday.routing.domain.VanManifestItem;
+import com.oneday.routing.repository.VanManifestItemRepository;
+import com.oneday.routing.repository.VanManifestRepository;
+import com.oneday.routing.service.model.CustodyResult;
+import com.oneday.routing.service.model.VanCustodyCommand;
+import com.oneday.routing.service.port.ScanLedgerPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class CustodyServiceImplTest {
+
+    @Mock VanManifestItemRepository itemRepository;
+    @Mock VanManifestRepository manifestRepository;
+    @Mock ScanLedgerPort scanLedgerPort;
+
+    private static final UUID VAN = UUID.randomUUID();
+    private static final UUID DRIVER = UUID.randomUUID();
+    private static final UUID DA = UUID.randomUUID();
+
+    private final List<VanManifestItem> itemStore = new ArrayList<>();
+    private final Map<UUID, VanManifest> manifestStore = new HashMap<>();
+
+    private CustodyServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CustodyServiceImpl(itemRepository, manifestRepository, scanLedgerPort);
+        when(itemRepository.findByParcelId(any())).thenAnswer(inv -> itemStore.stream()
+                .filter(i -> i.getParcelId().equals(inv.getArgument(0))).toList());
+        when(itemRepository.findByManifestId(any())).thenAnswer(inv -> itemStore.stream()
+                .filter(i -> i.getManifestId().equals(inv.getArgument(0))).toList());
+        when(itemRepository.save(any(VanManifestItem.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(manifestRepository.findById(any())).thenAnswer(inv -> Optional.ofNullable(manifestStore.get(inv.getArgument(0))));
+        when(manifestRepository.save(any(VanManifest.class))).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @Test
+    void fullDeliverChain_loadThenDeliver_advancesAndSealsManifest() {
+        UUID manifestId = newManifest(ManifestStatus.BUILDING);
+        UUID parcel = newItem(manifestId, HandoffDirection.DELIVER, ManifestItemStatus.PLANNED);
+
+        CustodyResult load = service.record(scan(parcel, ScanLedgerPort.VanScanType.VAN_LOAD, DA));
+        assertThat(load.status()).isEqualTo(CustodyResult.Status.RECORDED);
+        assertThat(item(parcel).getStatus()).isEqualTo(ManifestItemStatus.LOADED);
+        assertThat(manifestStore.get(manifestId).getStatus()).isEqualTo(ManifestStatus.LOADED); // BUILDING → LOADED
+
+        CustodyResult deliver = service.record(scan(parcel, ScanLedgerPort.VanScanType.VAN_TO_DA, DA));
+        assertThat(deliver.status()).isEqualTo(CustodyResult.Status.RECORDED);
+        assertThat(item(parcel).getStatus()).isEqualTo(ManifestItemStatus.HANDED_OFF);
+
+        verify(scanLedgerPort, times(2)).recordVanScan(any()); // every scan hits the ledger (M8)
+    }
+
+    @Test
+    void collectChain_collectThenUnload_reconcilesManifest() {
+        UUID manifestId = newManifest(ManifestStatus.IN_PROGRESS);
+        UUID parcel = newItem(manifestId, HandoffDirection.COLLECT, ManifestItemStatus.PLANNED);
+
+        service.record(scan(parcel, ScanLedgerPort.VanScanType.DA_TO_VAN, DA));
+        assertThat(item(parcel).getStatus()).isEqualTo(ManifestItemStatus.ONBOARD);
+
+        service.record(scan(parcel, ScanLedgerPort.VanScanType.VAN_UNLOAD, null));
+        assertThat(item(parcel).getStatus()).isEqualTo(ManifestItemStatus.RECONCILED);
+        assertThat(manifestStore.get(manifestId).getStatus()).isEqualTo(ManifestStatus.RECONCILED); // all items terminal
+    }
+
+    @Test
+    void outOfOrderScan_isRejected_C12() {
+        UUID manifestId = newManifest(ManifestStatus.BUILDING);
+        UUID parcel = newItem(manifestId, HandoffDirection.DELIVER, ManifestItemStatus.PLANNED);
+
+        // VAN_TO_DA before VAN_LOAD — illegal predecessor (must be LOADED).
+        CustodyResult r = service.record(scan(parcel, ScanLedgerPort.VanScanType.VAN_TO_DA, DA));
+        assertThat(r.status()).isEqualTo(CustodyResult.Status.ILLEGAL_TRANSITION);
+        assertThat(item(parcel).getStatus()).isEqualTo(ManifestItemStatus.PLANNED); // unchanged
+        verify(scanLedgerPort, times(1)).recordVanScan(any()); // scan still recorded
+    }
+
+    @Test
+    void replayedScan_isIdempotent() {
+        UUID manifestId = newManifest(ManifestStatus.BUILDING);
+        UUID parcel = newItem(manifestId, HandoffDirection.DELIVER, ManifestItemStatus.PLANNED);
+
+        service.record(scan(parcel, ScanLedgerPort.VanScanType.VAN_LOAD, DA));
+        CustodyResult replay = service.record(scan(parcel, ScanLedgerPort.VanScanType.VAN_LOAD, DA));
+        assertThat(replay.status()).isEqualTo(CustodyResult.Status.IDEMPOTENT);
+        assertThat(item(parcel).getStatus()).isEqualTo(ManifestItemStatus.LOADED);
+    }
+
+    @Test
+    void scanForParcelNotOnManifest_isUnknown() {
+        CustodyResult r = service.record(scan(UUID.randomUUID(), ScanLedgerPort.VanScanType.VAN_TO_DA, DA));
+        assertThat(r.status()).isEqualTo(CustodyResult.Status.UNKNOWN_PARCEL);
+        verify(scanLedgerPort, times(1)).recordVanScan(any()); // physical scan still logged
+    }
+
+    private VanCustodyCommand scan(UUID parcel, ScanLedgerPort.VanScanType type, UUID da) {
+        return new VanCustodyCommand(parcel, type, VAN, DRIVER, da, Instant.now());
+    }
+
+    private UUID newManifest(ManifestStatus status) {
+        UUID id = UUID.randomUUID();
+        manifestStore.put(id, VanManifest.builder().id(id).vanId(VAN).loopIndex(0).status(status).build());
+        return id;
+    }
+
+    private UUID newItem(UUID manifestId, HandoffDirection dir, ManifestItemStatus status) {
+        UUID parcel = UUID.randomUUID();
+        itemStore.add(VanManifestItem.builder().id(UUID.randomUUID()).manifestId(manifestId).parcelId(parcel)
+                .direction(dir).counterpartyDaId(DA).status(status).build());
+        return parcel;
+    }
+
+    private VanManifestItem item(UUID parcel) {
+        return itemStore.stream().filter(i -> i.getParcelId().equals(parcel)).findFirst().orElseThrow();
+    }
+}

--- a/routing/src/test/java/com/oneday/routing/service/impl/HandoffServiceImplTest.java
+++ b/routing/src/test/java/com/oneday/routing/service/impl/HandoffServiceImplTest.java
@@ -56,7 +56,6 @@ class HandoffServiceImplTest {
     private static final LocalDate DATE = LocalDate.of(2026, 6, 18);
 
     private final List<VanManifestItem> itemStore = new ArrayList<>();
-    private final List<HandoffReconciliation> recons = new ArrayList<>();
 
     private HandoffServiceImpl service;
 
@@ -71,10 +70,7 @@ class HandoffServiceImplTest {
                 .thenReturn(Optional.of(RoutePlan.builder().id(PLAN).cityId(CITY).build()));
         when(itemRepository.findByManifestIdAndStopSeq(eq(MANIFEST), eq(STOP))).thenAnswer(inv -> itemStore);
         when(itemRepository.save(any(VanManifestItem.class))).thenAnswer(inv -> inv.getArgument(0));
-        when(reconciliationRepository.save(any(HandoffReconciliation.class))).thenAnswer(inv -> {
-            recons.add(inv.getArgument(0));
-            return inv.getArgument(0);
-        });
+        when(reconciliationRepository.save(any(HandoffReconciliation.class))).thenAnswer(inv -> inv.getArgument(0));
     }
 
     @Test

--- a/routing/src/test/java/com/oneday/routing/service/impl/HandoffServiceImplTest.java
+++ b/routing/src/test/java/com/oneday/routing/service/impl/HandoffServiceImplTest.java
@@ -1,0 +1,153 @@
+package com.oneday.routing.service.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneday.routing.domain.DiscrepancyType;
+import com.oneday.routing.domain.HandoffDirection;
+import com.oneday.routing.domain.HandoffReconciliation;
+import com.oneday.routing.domain.ManifestItemStatus;
+import com.oneday.routing.domain.RoutePlan;
+import com.oneday.routing.domain.VanManifest;
+import com.oneday.routing.domain.VanManifestItem;
+import com.oneday.routing.events.CronEventProducer;
+import com.oneday.routing.repository.HandoffReconciliationRepository;
+import com.oneday.routing.repository.RoutePlanRepository;
+import com.oneday.routing.repository.VanManifestItemRepository;
+import com.oneday.routing.repository.VanManifestRepository;
+import com.oneday.routing.service.model.StopReconciliation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class HandoffServiceImplTest {
+
+    @Mock VanManifestRepository manifestRepository;
+    @Mock VanManifestItemRepository itemRepository;
+    @Mock HandoffReconciliationRepository reconciliationRepository;
+    @Mock RoutePlanRepository planRepository;
+    @Mock CronEventProducer cronEventProducer;
+
+    private static final UUID CITY = UUID.randomUUID();
+    private static final UUID PLAN = UUID.randomUUID();
+    private static final UUID VAN = UUID.randomUUID();
+    private static final UUID DA = UUID.randomUUID();
+    private static final UUID MANIFEST = UUID.randomUUID();
+    private static final int STOP = 1;
+    private static final LocalDate DATE = LocalDate.of(2026, 6, 18);
+
+    private final List<VanManifestItem> itemStore = new ArrayList<>();
+    private final List<HandoffReconciliation> recons = new ArrayList<>();
+
+    private HandoffServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new HandoffServiceImpl(manifestRepository, itemRepository, reconciliationRepository,
+                planRepository, cronEventProducer, new ObjectMapper());
+        when(manifestRepository.findByVanIdAndLoopIndexAndValidDate(VAN, 0, DATE))
+                .thenReturn(Optional.of(VanManifest.builder().id(MANIFEST).vanId(VAN).loopIndex(0)
+                        .routePlanId(PLAN).validDate(DATE).build()));
+        when(planRepository.findById(PLAN))
+                .thenReturn(Optional.of(RoutePlan.builder().id(PLAN).cityId(CITY).build()));
+        when(itemRepository.findByManifestIdAndStopSeq(eq(MANIFEST), eq(STOP))).thenAnswer(inv -> itemStore);
+        when(itemRepository.save(any(VanManifestItem.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(reconciliationRepository.save(any(HandoffReconciliation.class))).thenAnswer(inv -> {
+            recons.add(inv.getArgument(0));
+            return inv.getArgument(0);
+        });
+    }
+
+    @Test
+    void cleanStop_emitsCompleted_noDiscrepancy() {
+        UUID d = deliver(ManifestItemStatus.HANDED_OFF);
+
+        StopReconciliation r = service.reconcileStop(VAN, 0, DATE, STOP, DA, Set.of(d), Set.of(), Set.of());
+
+        assertThat(r.clean()).isTrue();
+        verify(cronEventProducer).emitHandoffCompleted(MANIFEST, VAN, CITY, STOP, DA);
+        verify(cronEventProducer, never()).emitHandoffDiscrepancy(any(), any(), any(), eq(STOP), any(), any(), any());
+    }
+
+    @Test
+    void missingDelivery_emitsDiscrepancy_marksException() {
+        UUID handed = deliver(ManifestItemStatus.HANDED_OFF);
+        UUID missing = deliver(ManifestItemStatus.LOADED);
+
+        // Only the handed parcel was scanned out; the other is MISSING.
+        StopReconciliation r = service.reconcileStop(VAN, 0, DATE, STOP, DA, Set.of(handed), Set.of(), Set.of());
+
+        assertThat(r.clean()).isFalse();
+        assertThat(r.discrepancies()).anyMatch(d -> d.type() == DiscrepancyType.MISSING && d.parcelIds().contains(missing));
+        verify(cronEventProducer).emitHandoffDiscrepancy(eq(MANIFEST), eq(VAN), eq(CITY), eq(STOP), eq(DA),
+                eq(DiscrepancyType.MISSING), eq(List.of(missing)));
+        assertThat(item(missing).getStatus()).isEqualTo(ManifestItemStatus.EXCEPTION);
+        verify(cronEventProducer, never()).emitHandoffCompleted(any(), any(), any(), eq(STOP), any());
+    }
+
+    @Test
+    void extraScan_notOnManifest_isFlaggedExtra() {
+        UUID handed = deliver(ManifestItemStatus.HANDED_OFF);
+        UUID stray = UUID.randomUUID(); // scanned but never bound to this van
+
+        StopReconciliation r = service.reconcileStop(VAN, 0, DATE, STOP, DA, Set.of(handed, stray), Set.of(), Set.of());
+
+        assertThat(r.discrepancies()).anyMatch(d -> d.type() == DiscrepancyType.EXTRA && d.parcelIds().contains(stray));
+        verify(cronEventProducer).emitHandoffDiscrepancy(eq(MANIFEST), eq(VAN), eq(CITY), eq(STOP), eq(DA),
+                eq(DiscrepancyType.EXTRA), eq(List.of(stray)));
+    }
+
+    @Test
+    void rejectedDelivery_isFlaggedRejected_andException() {
+        UUID rejected = deliver(ManifestItemStatus.LOADED);
+
+        StopReconciliation r = service.reconcileStop(VAN, 0, DATE, STOP, DA, Set.of(), Set.of(), Set.of(rejected));
+
+        assertThat(r.discrepancies()).anyMatch(d -> d.type() == DiscrepancyType.REJECTED && d.parcelIds().contains(rejected));
+        assertThat(item(rejected).getStatus()).isEqualTo(ManifestItemStatus.EXCEPTION);
+    }
+
+    @Test
+    void noShow_emptyScans_allMissing() {
+        UUID a = deliver(ManifestItemStatus.LOADED);
+        UUID b = deliver(ManifestItemStatus.LOADED);
+
+        StopReconciliation r = service.reconcileStop(VAN, 0, DATE, STOP, DA, Set.of(), Set.of(), Set.of());
+
+        assertThat(r.clean()).isFalse();
+        assertThat(r.discrepancies()).anyMatch(d -> d.type() == DiscrepancyType.MISSING
+                && d.parcelIds().containsAll(List.of(a, b)));
+        verify(cronEventProducer, times(1)).emitHandoffDiscrepancy(any(), any(), any(), eq(STOP), any(),
+                eq(DiscrepancyType.MISSING), any());
+    }
+
+    private UUID deliver(ManifestItemStatus status) {
+        UUID parcel = UUID.randomUUID();
+        itemStore.add(VanManifestItem.builder().id(UUID.randomUUID()).manifestId(MANIFEST).parcelId(parcel)
+                .direction(HandoffDirection.DELIVER).stopSeq(STOP).counterpartyDaId(DA).status(status).build());
+        return parcel;
+    }
+
+    private VanManifestItem item(UUID parcel) {
+        return itemStore.stream().filter(i -> i.getParcelId().equals(parcel)).findFirst().orElseThrow();
+    }
+}

--- a/routing/src/test/java/com/oneday/routing/service/impl/RecoveryServiceImplTest.java
+++ b/routing/src/test/java/com/oneday/routing/service/impl/RecoveryServiceImplTest.java
@@ -1,0 +1,112 @@
+package com.oneday.routing.service.impl;
+
+import com.oneday.routing.config.ClockConfig;
+import com.oneday.routing.domain.HandoffDirection;
+import com.oneday.routing.domain.ManifestItemStatus;
+import com.oneday.routing.domain.ManifestStatus;
+import com.oneday.routing.domain.VanManifest;
+import com.oneday.routing.domain.VanManifestItem;
+import com.oneday.routing.events.CronEventProducer;
+import com.oneday.routing.repository.VanManifestItemRepository;
+import com.oneday.routing.repository.VanManifestRepository;
+import com.oneday.routing.service.VanManifestService;
+import com.oneday.routing.service.model.BindOutcome;
+import com.oneday.routing.service.model.RecoverySummary;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class RecoveryServiceImplTest {
+
+    @Mock VanManifestRepository manifestRepository;
+    @Mock VanManifestItemRepository itemRepository;
+    @Mock VanManifestService manifestService;
+    @Mock CronEventProducer cronEventProducer;
+
+    private static final UUID CITY = UUID.randomUUID();
+    private static final UUID PLAN = UUID.randomUUID();
+    private static final UUID BROKEN = UUID.randomUUID();
+    private static final UUID RECOVERY = UUID.randomUUID();
+    private static final UUID DA = UUID.randomUUID();
+    private static final LocalDate DATE = LocalDate.of(2026, 6, 18);
+
+    private final Clock clock = Clock.fixed(Instant.parse("2026-06-18T10:00:00Z"), ClockConfig.IST);
+    private final List<VanManifestItem> itemStore = new ArrayList<>();
+
+    private RecoveryServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new RecoveryServiceImpl(manifestRepository, itemRepository, manifestService, cronEventProducer, clock);
+        when(itemRepository.save(any(VanManifestItem.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(manifestRepository.saveAndFlush(any(VanManifest.class))).thenAnswer(inv -> {
+            VanManifest m = inv.getArgument(0);
+            m.setId(UUID.randomUUID());
+            return m;
+        });
+    }
+
+    @Test
+    void recoverVan_emitsBreakdown_andReassignsOpenItems() {
+        UUID brokenManifest = UUID.randomUUID();
+        when(manifestRepository.findByVanIdAndValidDate(BROKEN, DATE)).thenReturn(List.of(
+                VanManifest.builder().id(brokenManifest).vanId(BROKEN).loopIndex(2).routePlanId(PLAN)
+                        .validDate(DATE).status(ManifestStatus.IN_PROGRESS).build()));
+        when(manifestRepository.findByVanIdAndLoopIndexAndValidDate(RECOVERY, 2, DATE)).thenReturn(Optional.empty());
+        VanManifestItem open = item(brokenManifest, ManifestItemStatus.LOADED);
+        VanManifestItem done = item(brokenManifest, ManifestItemStatus.HANDED_OFF); // terminal, not moved
+        when(itemRepository.findByManifestId(brokenManifest)).thenReturn(itemStore);
+
+        RecoverySummary summary = service.recoverVan(BROKEN, RECOVERY, CITY, DATE, 12.9, 77.6);
+
+        verify(cronEventProducer).emitVanBreakdown(eq(BROKEN), eq(CITY), eq(PLAN), eq(12.9), eq(77.6), any());
+        assertThat(summary.itemsReassigned()).isEqualTo(1);
+        assertThat(open.getManifestId()).isNotEqualTo(brokenManifest); // moved to recovery manifest
+        assertThat(done.getManifestId()).isEqualTo(brokenManifest);    // terminal left in place
+    }
+
+    @Test
+    void carryNoShow_rebindsUndeliveredDeliveries() {
+        UUID manifest = UUID.randomUUID();
+        when(manifestRepository.findByVanIdAndLoopIndexAndValidDate(BROKEN, 1, DATE)).thenReturn(Optional.of(
+                VanManifest.builder().id(manifest).vanId(BROKEN).loopIndex(1).validDate(DATE).build()));
+        VanManifestItem loaded = item(manifest, ManifestItemStatus.LOADED);
+        item(manifest, ManifestItemStatus.HANDED_OFF); // already delivered — not carried
+        when(itemRepository.findByManifestIdAndStopSeq(manifest, 3)).thenReturn(itemStore);
+        when(manifestService.rebindDelivery(any())).thenReturn(BindOutcome.bound(loaded.getParcelId(), 2, BROKEN, UUID.randomUUID(), List.of()));
+
+        int carried = service.carryNoShow(BROKEN, 1, DATE, 3, DA);
+
+        assertThat(carried).isEqualTo(1);
+        verify(manifestService, times(1)).rebindDelivery(loaded.getParcelId());
+    }
+
+    private VanManifestItem item(UUID manifestId, ManifestItemStatus status) {
+        VanManifestItem i = VanManifestItem.builder().id(UUID.randomUUID()).manifestId(manifestId)
+                .parcelId(UUID.randomUUID()).direction(HandoffDirection.DELIVER).stopSeq(3)
+                .counterpartyDaId(DA).status(status).build();
+        itemStore.add(i);
+        return i;
+    }
+}


### PR DESCRIPTION
…nd check movie is legal,advance state and seal manifest;Handoff service (reconcilliation between da and van); Recovery service

# Pull Request

Summary

Implements M6 PR#6 — the van's run-time custody layer: the four custody scans (LOAD/DELIVER/COLLECT/UNLOAD), per-stop handoff reconciliation between van and DA, and intraday failure handling (van breakdown → recovery van, DA no-show → carry). Builds on PR5's parcel→loop binding; no schema changes.

---
What Changed

- CustodyService (+impl) — record(VanCustodyCommand) for the 4 scan points: writes the scan to M8's ledger via ScanLedgerPort first (append-only truth), then advances the bound van_manifest_item only from its legal predecessor state (C12). Replay → IDEMPOTENT, off-manifest → UNKNOWN_PARCEL, out-of-order → ILLEGAL_TRANSITION (no state change). Seals the manifest BUILDING→LOADED on first load and →RECONCILED when all items terminal.
- HandoffService (+impl) — reconcileStop(...) does set-math of expected (manifest) vs scanned per direction → MISSING / EXTRA / REJECTED; writes append-only handoff_reconciliation rows, marks gap items EXCEPTION, emits HANDOFF_COMPLETED (clean) or HANDOFF_DISCREPANCY per bucket. Partial handoff is legal.
- RecoveryService (+impl) + RecoveryController (POST /routing/vans/{vanId}/recovery) — breakdown emits VAN_BREAKDOWN and re-points the broken van's open items to fresh recovery-van manifests (append-only); no-show carries undelivered deliveries to the next loop.
- VanManifestService.rebindDelivery — extracted bindDeliverToCron(..., afterLoopExclusive), added carry-to-next-loop rebind; alreadyBound now ignores EXCEPTION items so carried parcels re-bind.
- CronEventProducer — added emitHandoffCompleted / emitHandoffDiscrepancy / emitVanBreakdown (common payloads already existed from PR1). New models VanCustodyCommand/CustodyResult/StopReconciliation/RecoverySummary; repo finder VanManifestRepository.findByVanIdAndValidDate.

---
Why This Change?

PR5 bound parcels to van loops on paper but nothing tracked a parmoved through the chain. This PR closes that: every hand-offbecomes a validated scan (the signal M4 maps to a state and M8 stores immutably), each stop is reconciled so missing/mis-routed/rejected parcels raise tickets instead of vanishing, and the two physical failure modes (breakdopend-only recovery paths. It implements design §11.1/§13/§16(M6-D-014/-018/-019/-021).

---
Testing

- [x] Tested locally
- [x] Edge cases considered
- [x] No breaking changes introduced

Test Evidence

Tests run: 5, Failures: 0, Errors: 0, Skipped: 0 -- CustodyServic
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0 -- HandoffServiceImplTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0 -- RecoveryServi

[INFO] Tests run: 51, Failures: 0, Errors: 0, Skipped: 0   (full
[INFO] BUILD SUCCESS   (mvn clean install -pl routing,app -am → app-1.0.0-SNAPSHOT.jar assembles)
Cases covered: full LOAD→DELIVER and COLLECT→UNLOAD chains advanc; out-of-order scan rejected (C12) with no state change; replayedscan idempotent; off-manifest scan → UNKNOWN; missing/extra/rejected/no-show reconcile each emit the right event and flag items EXCEPTION; breakdown reassigns only open items (terminals left in place); no-show carries only u

---
Impact

Areas Affected

- [x] Backend
- [x] Routing
- [ ] Frontend
- [ ] Infra
- [ ] Database
- [ ] NA

Modules Affected

- [x] M6 — Routing
- [ ] M1 — Auth
- [ ] M2 — Pricing
- [ ] M3 — Grid
- [ ] M4 — Orders
- [ ] M5 — Dispatch
- [ ] M7 — Hub
- [ ] M8 — Barcode
- [ ] M9 — Airline
- [ ] M10 — SLA
- [ ] M11 — Exceptions
- [ ] NA

---
Risks / Concerns

- M8 still stubbed — scans go to NoOpScanLedgerPort (logs only); site is final, so swapping the real adapter later needs nocustody-code change. Low risk.
- No DB migration — reuses van_manifest_item / handoff_reconciliask.
- Deferred to PR7 (by design, documented): driver-app scan endpoints, manifest IN_PROGRESS/RETURNED (telemetry-driven), rebindCollect for no-show collections,
and recovery deadline-recompute. These are additive and don't blo

---
Checklist

- [x] Code follows project conventions (package layout, no cross-module internal imports — RoutingArchitectureTest still green)
- [x] Self-review completed
- [x] Append-only audit trail preserved (scans → M8 ledger; handoff_reconciliation is insert-only; broken-van manifest rows kept on recovery)
- [x] No sensitive data or credentials exposed
- [x] Documentation updated if behaviour changed
- [x] Ready for review
