### PR TITLE
M6 IMPL - EDIT  PR #7 - SLA condition in loop binding changed

### DIFF
--- a/routing/src/main/java/com/oneday/routing/service/impl/LoopBinder.java
+++ b/routing/src/main/java/com/oneday/routing/service/impl/LoopBinder.java
@@ -2,51 +2,21 @@ package com.oneday.routing.service.impl;
 
 import com.oneday.routing.service.model.LoopSlot;
 
-import java.time.Duration;
-import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
-import java.util.OptionalInt;
-import java.util.function.IntPredicate;
 
-// SLA-first, capacity-bounded loop choice (§12.3, M6-D-016). Pure: no DB, no clock.
+// v1 fastest-greedy loop choice (§12.3, M6-D-016). BOTH directions bind the SOONEST loop with room:
+// a freshly-sorted delivery rides the next van out; a just-collected parcel rides the next van back.
+// The SLA deadline / flight cutoff is advisory — stored on the manifest item for M10/M9 to act on,
+// never a gate, so a late (or deadline-less) parcel still moves instead of being dropped. Pure: no
+// DB, no clock. Overflow is decided by the caller and means only "no loop had capacity".
 final class LoopBinder {
 
     private LoopBinder() {}
 
-    // Deliver: feasible loops (vanArrival + daDelivery ≤ deadline) earliest-first — the per-parcel
-    // binder walks these and stops at the first with live capacity.
-    static List<LoopSlot> feasibleDeliverLoopsAsc(List<LoopSlot> slots, Instant deadline, Duration daDelivery) {
+    static List<LoopSlot> loopsEarliestFirst(List<LoopSlot> slots) {
         return slots.stream()
-                .filter(s -> !s.vanArrival().plus(daDelivery).isAfter(deadline))
                 .sorted(Comparator.comparingInt(LoopSlot::loopIndex))
                 .toList();
-    }
-
-    // Collect: feasible loops (hubReturn ≤ deadline) latest-first.
-    static List<LoopSlot> feasibleCollectLoopsDesc(List<LoopSlot> slots, Instant deadline) {
-        return slots.stream()
-                .filter(s -> !s.hubReturn().isAfter(deadline))
-                .sorted(Comparator.comparingInt(LoopSlot::loopIndex).reversed())
-                .toList();
-    }
-
-    // Deliver (§12.1): earliest loop where vanArrival + daDelivery ≤ deadline and the loop has room.
-    static OptionalInt earliestDeliverLoop(List<LoopSlot> slots, Instant deadline,
-                                           Duration daDelivery, IntPredicate hasCapacity) {
-        return slots.stream()
-                .filter(s -> !s.vanArrival().plus(daDelivery).isAfter(deadline))
-                .filter(s -> hasCapacity.test(s.loopIndex()))
-                .mapToInt(LoopSlot::loopIndex)
-                .min();
-    }
-
-    // Collect (§12.2): latest loop whose hub return ≤ deadline and that still has room.
-    static OptionalInt latestCollectLoop(List<LoopSlot> slots, Instant deadline, IntPredicate hasCapacity) {
-        return slots.stream()
-                .filter(s -> !s.hubReturn().isAfter(deadline))
-                .filter(s -> hasCapacity.test(s.loopIndex()))
-                .mapToInt(LoopSlot::loopIndex)
-                .max();
     }
 }

--- a/routing/src/main/java/com/oneday/routing/service/impl/VanManifestServiceImpl.java
+++ b/routing/src/main/java/com/oneday/routing/service/impl/VanManifestServiceImpl.java
@@ -101,23 +101,30 @@ class VanManifestServiceImpl implements VanManifestService {
         return bindDeliverToCron(ctx, cityId, date, parcelId, cron, slaDeadline, -1);
     }
 
-    // Greedy earliest-feasible deliver loop with live capacity (FCFS, §12.3); loops ≤ afterLoopExclusive
-    // are skipped so a carried/no-show parcel lands strictly after its failed loop (§13.2).
+    // Deliver: ride the soonest loop with room (FCFS, §12.3). loops ≤ afterLoopExclusive are skipped so
+    // a carried/no-show parcel lands strictly after its failed loop (§13.2). slaDeadline is stored, not
+    // gated — a late/null deadline still binds (the box is here and must go out).
     private BindOutcome bindDeliverToCron(PlanCtx ctx, UUID cityId, LocalDate date, UUID parcelId,
                                           DaCronSchedule cron, Instant slaDeadline, int afterLoopExclusive) {
-        UUID van = cron.getVanId();
-        Duration daDelivery = Duration.ofMinutes(properties.getBinding().getDaDeliveryMinutes());
-        List<LoopSlot> feasible = LoopBinder.feasibleDeliverLoopsAsc(
-                ctx.deliverSlots(van, cron.getHexVertexId()), slaDeadline, daDelivery);
-        for (LoopSlot slot : feasible) {
+        return bindEarliest(ctx, cityId, date, parcelId, cron.getVanId(),
+                ctx.deliverSlots(cron.getVanId(), cron.getHexVertexId()),
+                HandoffDirection.DELIVER, cron.getDaId(), slaDeadline, afterLoopExclusive);
+    }
+
+    // Shared fastest-greedy core (both directions): bind the earliest loop with live capacity, else
+    // overflow only when every loop is full. The deadline rides onto the item for M9/M10 but never gates.
+    private BindOutcome bindEarliest(PlanCtx ctx, UUID cityId, LocalDate date, UUID parcelId, UUID van,
+                                     List<LoopSlot> slots, HandoffDirection direction, UUID counterpartyDaId,
+                                     Instant deadline, int afterLoopExclusive) {
+        for (LoopSlot slot : LoopBinder.loopsEarliestFirst(slots)) {
             if (slot.loopIndex() <= afterLoopExclusive) continue;
             VanManifest manifest = lockOrCreate(ctx, van, slot.loopIndex(), date);
-            if (itemRepository.countByManifestIdAndDirection(manifest.getId(), HandoffDirection.DELIVER) < ctx.capacity) {
-                VanManifestItem item = appendItem(manifest, HandoffDirection.DELIVER, parcelId, slot, cron.getDaId(), slaDeadline);
+            if (itemRepository.countByManifestIdAndDirection(manifest.getId(), direction) < ctx.capacity) {
+                VanManifestItem item = appendItem(manifest, direction, parcelId, slot, counterpartyDaId, deadline);
                 return BindOutcome.bound(parcelId, slot.loopIndex(), van, item.getId(), List.of());
             }
         }
-        return overflow(cityId, van, parcelId, slaDeadline);
+        return overflow(cityId, van, parcelId, deadline);
     }
 
     @Override
@@ -157,21 +164,14 @@ class VanManifestServiceImpl implements VanManifestService {
             return BindOutcome.unresolved(parcelId);
         }
         UUID van = cron.getVanId();
+        // Flight cutoff (− hub tail) is recorded on the item for M9/M10; missing cutoff → window end.
+        // Advisory only: v1 binds the soonest loop back regardless, same as deliver. See §12.
         Instant deadline = flightCutoffPort.outboundFlightCutoff(cityId, date)
                 .map(c -> c.minus(Duration.ofMinutes(properties.getBinding().getHubTailMinutes())))
                 .orElse(ctx.windowEnd);
-        List<LoopSlot> feasible = LoopBinder.feasibleCollectLoopsDesc(ctx.collectSlots(van, cron.getHexVertexId()), deadline);
-
-        // v1: greedy latest-feasible loop with live capacity, else overflow (FCFS). Same shape as
-        // bindDelivery — no reactive bump in v1. See docs/M6/M6-ROUTING-DESIGN.md §12.
-        for (LoopSlot slot : feasible) {
-            VanManifest manifest = lockOrCreate(ctx, van, slot.loopIndex(), date);
-            if (itemRepository.countByManifestIdAndDirection(manifest.getId(), HandoffDirection.COLLECT) < ctx.capacity) {
-                VanManifestItem item = appendItem(manifest, HandoffDirection.COLLECT, parcelId, slot, daId, deadline);
-                return BindOutcome.bound(parcelId, slot.loopIndex(), van, item.getId(), List.of());
-            }
-        }
-        return overflow(cityId, van, parcelId, deadline);
+        return bindEarliest(ctx, cityId, date, parcelId, van,
+                ctx.collectSlots(van, cron.getHexVertexId()),
+                HandoffDirection.COLLECT, daId, deadline, -1);
     }
 
     @Override

--- a/routing/src/test/java/com/oneday/routing/service/impl/LoopBinderTest.java
+++ b/routing/src/test/java/com/oneday/routing/service/impl/LoopBinderTest.java
@@ -6,9 +6,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
-import java.util.OptionalInt;
 import java.util.UUID;
-import java.util.function.IntPredicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,63 +15,21 @@ class LoopBinderTest {
     private static final UUID VAN = UUID.randomUUID();
     private static final UUID VERTEX = UUID.randomUUID();
     private static final Instant T0 = Instant.parse("2026-06-18T02:00:00Z"); // 07:30 IST
-    private static final IntPredicate ROOM = l -> true;
 
-    // arrival = T0 + loop hours; hubReturn = T0 + loop hours + 30m.
     private LoopSlot slot(int loop) {
         Instant arrival = T0.plus(Duration.ofHours(loop));
         return new LoopSlot(loop, VAN, VERTEX, loop + 1, arrival, arrival.plus(Duration.ofMinutes(30)));
     }
 
     @Test
-    void deliver_picksEarliestFeasibleLoop() {
-        List<LoopSlot> slots = List.of(slot(0), slot(1), slot(2));
-        Instant deadline = T0.plus(Duration.ofHours(5));
-        OptionalInt loop = LoopBinder.earliestDeliverLoop(slots, deadline, Duration.ofMinutes(30), ROOM);
-        assertThat(loop).hasValue(0);
+    void ordersLoopsEarliestFirst_regardlessOfInputOrder() {
+        List<Integer> order = LoopBinder.loopsEarliestFirst(List.of(slot(2), slot(0), slot(1)))
+                .stream().map(LoopSlot::loopIndex).toList();
+        assertThat(order).containsExactly(0, 1, 2);
     }
 
     @Test
-    void deliver_excludesLoopsPastDeadline() {
-        List<LoopSlot> slots = List.of(slot(0), slot(1), slot(2));
-        // deadline only loop 0 makes once daDelivery (30m) is added: arrival 07:30 + 30m = 08:00.
-        Instant deadline = T0.plus(Duration.ofMinutes(45));
-        OptionalInt loop = LoopBinder.earliestDeliverLoop(slots, deadline, Duration.ofMinutes(30), ROOM);
-        assertThat(loop).hasValue(0);
-    }
-
-    @Test
-    void deliver_skipsFullLoopAndTakesNext() {
-        List<LoopSlot> slots = List.of(slot(0), slot(1), slot(2));
-        Instant deadline = T0.plus(Duration.ofHours(5));
-        IntPredicate loop0Full = l -> l != 0;
-        OptionalInt loop = LoopBinder.earliestDeliverLoop(slots, deadline, Duration.ofMinutes(30), loop0Full);
-        assertThat(loop).hasValue(1);
-    }
-
-    @Test
-    void deliver_emptyWhenNoLoopBeatsDeadline() {
-        List<LoopSlot> slots = List.of(slot(0), slot(1));
-        Instant deadline = T0.minus(Duration.ofMinutes(1)); // before any arrival
-        OptionalInt loop = LoopBinder.earliestDeliverLoop(slots, deadline, Duration.ofMinutes(30), ROOM);
-        assertThat(loop).isEmpty();
-    }
-
-    @Test
-    void collect_picksLatestLoopThatStillMakesTheCutoff() {
-        List<LoopSlot> slots = List.of(slot(0), slot(1), slot(2));
-        // hubReturn(loop2) = T0 + 2h30m; deadline at 2h45m admits loops 0,1,2 → latest = 2.
-        Instant deadline = T0.plus(Duration.ofHours(2)).plus(Duration.ofMinutes(45));
-        OptionalInt loop = LoopBinder.latestCollectLoop(slots, deadline, ROOM);
-        assertThat(loop).hasValue(2);
-    }
-
-    @Test
-    void collect_excludesLoopsReturningAfterCutoff() {
-        List<LoopSlot> slots = List.of(slot(0), slot(1), slot(2));
-        // deadline at 1h45m: loop0 (30m) + loop1 (1h30m) make it, loop2 (2h30m) does not → latest = 1.
-        Instant deadline = T0.plus(Duration.ofHours(1)).plus(Duration.ofMinutes(45));
-        OptionalInt loop = LoopBinder.latestCollectLoop(slots, deadline, ROOM);
-        assertThat(loop).hasValue(1);
+    void emptyWhenNoSlots() {
+        assertThat(LoopBinder.loopsEarliestFirst(List.of())).isEmpty();
     }
 }

--- a/routing/src/test/java/com/oneday/routing/service/impl/VanManifestServiceImplTest.java
+++ b/routing/src/test/java/com/oneday/routing/service/impl/VanManifestServiceImplTest.java
@@ -125,15 +125,45 @@ class VanManifestServiceImplTest {
     }
 
     @Test
-    void greedyEarliestFeasibleLoop_thenOverflow_neverDrops() {
-        // v1 FCFS: capacity 1/loop, both parcels feasible only for loop 0 → first binds, second overflows.
-        UUID first = bind(LocalTime.of(8, 15)).parcelId();
-        UUID second = UUID.randomUUID();
-        BindOutcome out2 = service.bindDelivery(CITY, DATE, second, HEX, instant(LocalTime.of(8, 15)));
+    void bindsEarliestLoopWithRoom_overflowsOnlyWhenAllLoopsFull() {
+        // capacity 1/loop, 2 loops. p1 fills loop 0, p2 rides the next loop out (1), p3 overflows.
+        UUID p1 = bind(LocalTime.of(8, 15)).parcelId();
+        UUID p2 = bind(LocalTime.of(8, 15)).parcelId();
+        UUID p3 = UUID.randomUUID();
+        BindOutcome out3 = service.bindDelivery(CITY, DATE, p3, HEX, instant(LocalTime.of(8, 15)));
 
-        assertThat(out2.outcome()).isEqualTo(BindOutcome.Outcome.OVERFLOW);
-        verify(cronEventProducer, times(1)).emitLoopOverflow(eq(CITY), eq(VAN), eq(second), eq(-1), any());
-        assertThat(loopOfParcel(first)).isEqualTo(0); // first one still bound, not displaced
+        assertThat(loopOfParcel(p1)).isEqualTo(0);
+        assertThat(loopOfParcel(p2)).isEqualTo(1); // earliest loop WITH ROOM — deadline no longer blocks loop 1
+        assertThat(out3.outcome()).isEqualTo(BindOutcome.Outcome.OVERFLOW);
+        verify(cronEventProducer, times(1)).emitLoopOverflow(eq(CITY), eq(VAN), eq(p3), eq(-1), any());
+    }
+
+    @Test
+    void pastDeadline_stillBindsEarliest_noOverflow() {
+        // Deadline already in the past (06:00). Old behaviour overflowed; now it rides the next loop out.
+        BindOutcome out = service.bindDelivery(CITY, DATE, UUID.randomUUID(), HEX, instant(LocalTime.of(6, 0)));
+
+        assertThat(out.outcome()).isEqualTo(BindOutcome.Outcome.BOUND);
+        assertThat(out.loopIndex()).isZero();
+        verify(cronEventProducer, never()).emitLoopOverflow(any(), any(), any(), anyInt(), any());
+    }
+
+    @Test
+    void nullDeadline_bindsEarliest_noNpe() {
+        BindOutcome out = service.bindDelivery(CITY, DATE, UUID.randomUUID(), HEX, null);
+
+        assertThat(out.outcome()).isEqualTo(BindOutcome.Outcome.BOUND);
+        assertThat(out.loopIndex()).isZero();
+    }
+
+    @Test
+    void collect_bindsEarliestLoop_evenWithNoFlightCutoff() {
+        when(flightCutoffPort.outboundFlightCutoff(CITY, DATE)).thenReturn(Optional.empty());
+
+        BindOutcome out = service.bindCollect(CITY, DATE, UUID.randomUUID(), DA);
+
+        assertThat(out.outcome()).isEqualTo(BindOutcome.Outcome.BOUND);
+        assertThat(out.loopIndex()).isZero(); // earliest loop back, not the latest
     }
 
     @Test


### PR DESCRIPTION
# Pull Request

## Summary
Makes the SLA deadline / flight cutoff advisory in M6 parcel→loop binding: both deliver and collect now bind the soonest van out and never drop a parcel because of a missed or absent deadline. Overflow is narrowed to true capacity exhaustion.

---

## What Changed
- **Unified both directions to fastest-greedy (earliest loop).** Collect changed from "latest feasible loop" (consolidation) to "earliest loop with room"; deliver stays earliest. `LoopBinder` collapses from four deadline-aware methods to one `loopsEarliestFirst(slots)`; `VanManifestServiceImpl` gains a shared `bindEarliest(...)` core that both `bindDeliverToCron` and `bindCollect` call.
- **Deadline is now advisory, never a gate.** The SLA deadline (deliver) / flight cutoff (collect) is still stored on `van_manifest_item.sla_deadline` for M9/M10 to act on, but no longer filters loops. A missed deadline binds the next loop out instead of overflowing; a null deadline binds (no NPE) instead of crashing.
- **Overflow narrowed to capacity exhaustion only.** `LOOP_OVERFLOW` now fires solely when every loop is full (effectively never in v1, where capacity is set high) — it no longer fires on lateness.
- **Tests updated.** `LoopBinderTest` rewritten to the new single method; `VanManifestServiceImplTest` gains `pastDeadline_stillBindsEarliest_noOverflow`, `nullDeadline_bindsEarliest_noNpe`, `collect_bindsEarliestLoop_evenWithNoFlightCutoff`, and the overflow case reframed to all-loops-full.
- **Docs updated.** `M6-ROUTING-DESIGN.md` §12 binding rule + `CLAUDE.md` M6 row.

---

## Why This Change?
M9 (flight cutoffs) is unbuilt and the deliver-side SLA accuracy is unproven, so a deadline computed from those inputs was an unreliable value being used as a hard gate. As written, a parcel that missed (or lacked) a deadline was kicked to `LOOP_OVERFLOW` and never placed on a van — i.e., the system quietly dropped physically-present parcels on the floor over a number we don't yet trust. A late delivery is still a delivery, and a late pickup still has to reach the hub; binding must reflect that. This mirrors the earlier greedy-over-capacity decision: don't let an untrusted input block physical movement — record it, let M10/M11 own the SLA-breach reaction.

---

## Testing
- [x] Tested locally
- [x] Edge cases considered
- [x] No breaking changes introduced

### Test Evidence
$ mvn test -pl routing
[INFO] Tests run: 2, ... -- in LoopBinderTest
[INFO] Tests run: 6, ... -- in VanManifestServiceImplTest
[INFO] Tests run: 55, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS

$ mvn install -pl app -am -DskipTests
[INFO] BUILD SUCCESS
Key new cases: deadline already in the past → `BOUND` to loop 0, ver deadline → `BOUND` (no NPE); collect with no flight cutoff →`BOUND` to earliest loop; overflow only when all loops full.

---

## Impact

### Areas Affected
- [x] Backend
- [x] Routing

### Modules Affected
- [x] M6 — Routing

---

## Risks / Concerns
- **Breach signalling moves to M10/M11.** With overflow no longer firing on lateness, a breached-but-bound parcel emits no M6 event — downstream relies on the
stored `sla_deadline` to detect the breach. Acceptable: M10 alreaadline M4 sets at booking; no new event invented for unbuiltmodules.
- **Collect loses consolidation.** Earliest-loop collect means a an than "latest feasible" would have. Non-issue in v1 (notfleet-constrained); revisit as a tuning knob if capacity ever bites.
- **Already-departed loop not guarded.** The binder (a pure functle bind "loop 0" even if it has already left — a pre-existingcondition, unchanged here, mooted in practice by real-time event-driven binding through the day.
- **No migration / no schema change**, so no data risk; `sla_deadent.

---

## Checklist
- [x] Code follows project conventions (package layout, no cross-module internal imports)
- [x] Self-review completed
- [x] Append-only audit trail preserved (no mutations to scan/manifest/role-change records)
- [x] No sensitive data or credentials exposed
- [x] Documentation updated if behaviour changed
- [x] Ready for review