### PR TITLE
fix: assembled-app boot (ClockConfig collision) + M5→M6 collect contract (#50 regression)

### DIFF
--- a/routing/src/main/java/com/oneday/routing/config/ClockConfig.java
+++ b/routing/src/main/java/com/oneday/routing/config/ClockConfig.java
@@ -12,7 +12,9 @@ import java.time.ZoneId;
  * calling {@code Instant.now()} so the simulation harness (§21) can drive a 16h day in seconds with
  * a fixed/accelerated clock. {@code @ConditionalOnMissingBean} lets tests supply their own.
  */
-@Configuration
+// Explicit bean name — hub.config.ClockConfig also default-names "clockConfig", and both
+// modules assemble in the app → ConflictingBeanDefinitionException without this.
+@Configuration("routingClockConfig")
 public class ClockConfig {
 
     /** IST — the operating window (07:00–20:00) and all cron times are wall-clock India time. */

--- a/routing/src/main/java/com/oneday/routing/events/DaFeedConsumer.java
+++ b/routing/src/main/java/com/oneday/routing/events/DaFeedConsumer.java
@@ -1,8 +1,9 @@
 package com.oneday.routing.events;
 
+import com.oneday.common.kafka.enums.DaEventType;
+import com.oneday.common.kafka.events.DaLifecycleEvent;
 import com.oneday.routing.domain.InboundKind;
 import com.oneday.routing.domain.InboundParcel;
-import com.oneday.routing.events.payload.DaParcelPickedUpEvent;
 import com.oneday.routing.repository.InboundParcelRepository;
 import com.oneday.routing.service.VanManifestService;
 import org.slf4j.Logger;
@@ -10,7 +11,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
 
+import java.util.UUID;
+
 // M5 DA-pickup → record (audit) + bind the parcel immediately to its latest feasible loop (§12.2).
+// DA_EVENTS carries the whole DA lifecycle on one #-bound queue; this consumer takes the rich
+// DaLifecycleEvent and acts ONLY on PICKUP_COMPLETED (the collect-bind trigger), ignoring the rest
+// (DA_ABSENT, QUEUE_REORDERED, VAN_HANDOFF_COMPLETED, …). v1: parcelId == shipmentId (no M8 barcode).
 @Component
 public class DaFeedConsumer {
 
@@ -25,18 +31,27 @@ public class DaFeedConsumer {
     }
 
     @RabbitListener(queues = RoutingMessagingTopology.DA_FEED_QUEUE)
-    public void onDaPickup(DaParcelPickedUpEvent event) {
-        if (!repository.existsByKindAndParcelId(InboundKind.COLLECT, event.parcelId())) {
+    public void onDaEvent(DaLifecycleEvent event) {
+        if (event.eventType() != DaEventType.PICKUP_COMPLETED) {
+            return;   // not a collect-bind trigger
+        }
+        UUID parcelId = event.parcelId() != null ? event.parcelId() : event.shipmentId();
+        if (parcelId == null || event.cityId() == null || event.validDate() == null) {
+            log.warn("PICKUP_COMPLETED missing parcelId/cityId/validDate (parcel={} city={} date={}) — skipping bind",
+                    parcelId, event.cityId(), event.validDate());
+            return;
+        }
+        if (!repository.existsByKindAndParcelId(InboundKind.COLLECT, parcelId)) {
             repository.save(InboundParcel.builder()
                     .kind(InboundKind.COLLECT)
-                    .parcelId(event.parcelId())
+                    .parcelId(parcelId)
                     .cityId(event.cityId())
                     .daId(event.daId())
-                    .pickedUpAt(event.pickedUpAt())
+                    .pickedUpAt(event.occurredAt())
                     .validDate(event.validDate())
                     .build());
         }
-        manifestService.bindCollect(event.cityId(), event.validDate(), event.parcelId(), event.daId());
-        log.debug("Bound COLLECT parcel {} da {} date {}", event.parcelId(), event.daId(), event.validDate());
+        manifestService.bindCollect(event.cityId(), event.validDate(), parcelId, event.daId());
+        log.debug("Bound COLLECT parcel {} da {} date {}", parcelId, event.daId(), event.validDate());
     }
 }


### PR DESCRIPTION
## Summary

Two **production defects on `main`**, both found by driving the demo end-to-end against a real broker (CloudAMQP). Neither is demo-specific.

## 1. Assembled app can't boot — `ClockConfig` bean-name collision

`hub.config.ClockConfig` and `routing.config.ClockConfig` both register the default bean name `clockConfig`, so the app fails Spring context refresh on startup:

```
ConflictingBeanDefinitionException: Annotation-specified bean name 'clockConfig'
for bean class [com.oneday.hub.config.ClockConfig] conflicts with existing,
non-compatible bean definition of same name and class [com.oneday.routing.config.ClockConfig]
```

Surfaced when M7 (#48) added hub's `ClockConfig` alongside routing's. **`mvn clean install` is green** — the collision only fires at context startup, so CI (compile + unit tests, no full-context boot) never caught it. Fix: `@Configuration("routingClockConfig")`. routing's `Clock` is `@ConditionalOnMissingBean`, so hub's `Clock` wins → no type ambiguity.

## 2. M5→M6 collect binding broken — half-migrated contract from #50

#50 shipped M5's `DaEventProducer` emitting `DaLifecycleEvent` on `oneday.da.events` with `publishDaEvents=true`, but left M6's `DaFeedConsumer` expecting the old `DaParcelPickedUpEvent`. Every real `PICKUP_COMPLETED`:

```
MessageConversionException: Cannot convert from [DaLifecycleEvent] to [DaParcelPickedUpEvent]
  receivedExchange=oneday.da.events  receivedRoutingKey=PICKUP_COMPLETED
→ Retries exhausted → DLQ
```

So **M6 never binds a collected first-mile parcel in production.** Fix: `DaFeedConsumer` takes `DaLifecycleEvent` and binds on `PICKUP_COMPLETED` (`parcelId == shipmentId` in v1). The `DaParcelPickedUpEvent` record is retained — hub's `HubEventPayloadJacksonTest` still references the `routing.events.payload` package; it's just no longer this consumer's wire type.

## Verification
With both fixes: app boots (`Started … in 15s`), and the full pickup → collect-bind → drop-dispatch → deliver-bind flow runs with **DLQ delta 0**.

## Testing
- [x] `mvn clean install` (all modules, JDK 21) — compiles
- [x] `routing` suite 56/56 green
- [x] Booted the assembled app + drove the M4→M5→M6 demo flow end-to-end against the real broker

## Not included
The M6↔M7 delivery-event duplication (`routing.events.payload.ParcelSortedForDeliveryEvent` vs `hub`'s) — M6's `HubFeedConsumer` won't bind M7's sorted-for-delivery events. Pre-existing integration debt, separate reconciliation, tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)