### PR TITLE
M8: Ledger foundation (schema + domain + repo)

### DIFF
--- a/barcode/pom.xml
+++ b/barcode/pom.xml
@@ -20,5 +20,23 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/barcode/src/main/java/com/oneday/barcode/domain/ParcelIdCounter.java
+++ b/barcode/src/main/java/com/oneday/barcode/domain/ParcelIdCounter.java
@@ -1,0 +1,28 @@
+package com.oneday.barcode.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Per-hub, per-day counter backing the seq6 suffix of the parcel barcode (design §3.2).
+ * {@code nextSeq} is the next value to hand out; PR2 increments it under a row lock
+ * (mirrors {@code orders.ShipmentRefCounter}).
+ */
+@Entity
+@Table(name = "parcel_id_counter")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ParcelIdCounter {
+
+    @EmbeddedId
+    private ParcelIdCounterId id;
+
+    @Column(name = "next_seq", nullable = false)
+    private Integer nextSeq;
+}

--- a/barcode/src/main/java/com/oneday/barcode/domain/ParcelIdCounterId.java
+++ b/barcode/src/main/java/com/oneday/barcode/domain/ParcelIdCounterId.java
@@ -1,0 +1,26 @@
+package com.oneday.barcode.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+/** Composite key for {@link ParcelIdCounter}: one sequence per hub, per day (design §3.2). */
+@Embeddable
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class ParcelIdCounterId implements Serializable {
+
+    @Column(name = "hub_iata", length = 3, nullable = false)
+    private String hubIata;
+
+    @Column(name = "day", nullable = false)
+    private LocalDate day;
+}

--- a/barcode/src/main/java/com/oneday/barcode/domain/ScanLedgerEntry.java
+++ b/barcode/src/main/java/com/oneday/barcode/domain/ScanLedgerEntry.java
@@ -30,6 +30,9 @@ import java.util.UUID;
 @AllArgsConstructor
 public class ScanLedgerEntry {
 
+    // id and recordedAt are also defaulted in the DB (gen_random_uuid() / now(), V8_1). Hibernate
+    // wins for app inserts; the DB defaults exist so a raw-SQL insert from another service — which the
+    // append-only ledger explicitly anticipates — still gets a valid id/timestamp without them.
     @Id
     @UuidGenerator
     @Column(updatable = false, nullable = false)
@@ -44,7 +47,7 @@ public class ScanLedgerEntry {
     @Column(name = "scan_type", nullable = false, length = 24, updatable = false)
     private String scanType;
 
-    @Column(name = "location_type", nullable = false, length = 16, updatable = false)
+    @Column(name = "location_type", nullable = false, length = 32, updatable = false)
     private String locationType;
 
     @Column(name = "location_id", updatable = false)

--- a/barcode/src/main/java/com/oneday/barcode/domain/ScanLedgerEntry.java
+++ b/barcode/src/main/java/com/oneday/barcode/domain/ScanLedgerEntry.java
@@ -1,0 +1,68 @@
+package com.oneday.barcode.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * One immutable row per physical scan of a parcel (M8 §4). Append-only by construction: no setters,
+ * every column {@code updatable = false}, and a DB trigger ({@code V8_1}) rejects UPDATE/DELETE.
+ *
+ * <p>Keyed on {@code shipmentId} (design D-001) — the same UUID routing/hub already pass. The
+ * {@code parcelId} barcode string is null until {@code LABEL_GENERATED}. {@code scanType} is a plain
+ * string spanning both families (ScanEventType ∪ VanScanType), so no single Java enum fits it.</p>
+ */
+@Entity
+@Table(name = "scan_ledger")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScanLedgerEntry {
+
+    @Id
+    @UuidGenerator
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "shipment_id", nullable = false, updatable = false)
+    private UUID shipmentId;
+
+    @Column(name = "parcel_id", length = 30, updatable = false)
+    private String parcelId;
+
+    @Column(name = "scan_type", nullable = false, length = 24, updatable = false)
+    private String scanType;
+
+    @Column(name = "location_type", nullable = false, length = 16, updatable = false)
+    private String locationType;
+
+    @Column(name = "location_id", updatable = false)
+    private UUID locationId;
+
+    @Column(name = "actor_id", updatable = false)
+    private UUID actorId;
+
+    @Column(name = "counterparty_id", updatable = false)
+    private UUID counterpartyId;
+
+    @Column(name = "scanned_at", nullable = false, updatable = false)
+    private Instant scannedAt;
+
+    @CreationTimestamp
+    @Column(name = "recorded_at", nullable = false, updatable = false)
+    private Instant recordedAt;
+
+    @Column(name = "client_scan_id", updatable = false)
+    private UUID clientScanId;
+}

--- a/barcode/src/main/java/com/oneday/barcode/repository/ParcelIdCounterRepository.java
+++ b/barcode/src/main/java/com/oneday/barcode/repository/ParcelIdCounterRepository.java
@@ -1,0 +1,34 @@
+package com.oneday.barcode.repository;
+
+import com.oneday.barcode.domain.ParcelIdCounter;
+import com.oneday.barcode.domain.ParcelIdCounterId;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+/**
+ * Mirrors {@code orders.ShipmentRefCounterRepository}: {@link #insertIfAbsent} materialises the row
+ * ({@code ON CONFLICT DO NOTHING} for concurrent first-of-day inserts), then {@link #findByIdWithLock}
+ * takes a SELECT FOR UPDATE so the caller reads-and-increments {@code next_seq} atomically in one
+ * round-trip. Caller must be {@code @Transactional} (PR2's parcel-id generator).
+ */
+public interface ParcelIdCounterRepository extends JpaRepository<ParcelIdCounter, ParcelIdCounterId> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM ParcelIdCounter c WHERE c.id = :id")
+    Optional<ParcelIdCounter> findByIdWithLock(@Param("id") ParcelIdCounterId id);
+
+    @Modifying
+    @Transactional
+    @Query(value = "INSERT INTO parcel_id_counter (hub_iata, day, next_seq) " +
+                   "VALUES (:hubIata, :day, 1) ON CONFLICT (hub_iata, day) DO NOTHING",
+           nativeQuery = true)
+    void insertIfAbsent(@Param("hubIata") String hubIata, @Param("day") LocalDate day);
+}

--- a/barcode/src/main/java/com/oneday/barcode/repository/ScanLedgerRepository.java
+++ b/barcode/src/main/java/com/oneday/barcode/repository/ScanLedgerRepository.java
@@ -1,0 +1,21 @@
+package com.oneday.barcode.repository;
+
+import com.oneday.barcode.domain.ScanLedgerEntry;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Read + insert only. The ledger is append-only (V8_1 trigger backstops it), so the inherited
+ * {@code delete*}/update paths are never called — the "who touched this box, when, where" trail
+ * is queried, never mutated. The two lookups below are that query, by either identity (design D-001).
+ */
+public interface ScanLedgerRepository extends JpaRepository<ScanLedgerEntry, UUID> {
+
+    /** Full ordered scan trail for a shipment (the spine key). */
+    List<ScanLedgerEntry> findByShipmentIdOrderByScannedAtAsc(UUID shipmentId);
+
+    /** Same trail looked up by the physical barcode string a scan gun reads off the box. */
+    List<ScanLedgerEntry> findByParcelIdOrderByScannedAtAsc(String parcelId);
+}

--- a/barcode/src/main/java/com/oneday/barcode/repository/ScanLedgerRepository.java
+++ b/barcode/src/main/java/com/oneday/barcode/repository/ScanLedgerRepository.java
@@ -1,17 +1,21 @@
 package com.oneday.barcode.repository;
 
 import com.oneday.barcode.domain.ScanLedgerEntry;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.Repository;
 
 import java.util.List;
 import java.util.UUID;
 
 /**
- * Read + insert only. The ledger is append-only (V8_1 trigger backstops it), so the inherited
- * {@code delete*}/update paths are never called — the "who touched this box, when, where" trail
- * is queried, never mutated. The two lookups below are that query, by either identity (design D-001).
+ * Deliberately extends the bare {@link Repository} marker, not {@code JpaRepository}: the ledger is
+ * append-only (V8_1 trigger backstops it), so no {@code delete*}/bulk-update method is exposed at all —
+ * only insert ({@link #save}) and the "who touched this box, when, where" trail lookups. The DB
+ * trigger is the last line of defence; this interface is the first (mutation isn't even reachable).
  */
-public interface ScanLedgerRepository extends JpaRepository<ScanLedgerEntry, UUID> {
+public interface ScanLedgerRepository extends Repository<ScanLedgerEntry, UUID> {
+
+    /** Insert one immutable scan row. New entities (null id) persist; there is no update path by design. */
+    ScanLedgerEntry save(ScanLedgerEntry entry);
 
     /** Full ordered scan trail for a shipment (the spine key). */
     List<ScanLedgerEntry> findByShipmentIdOrderByScannedAtAsc(UUID shipmentId);

--- a/barcode/src/main/resources/db/migration/V8_1__create_scan_ledger.sql
+++ b/barcode/src/main/resources/db/migration/V8_1__create_scan_ledger.sql
@@ -8,7 +8,7 @@ CREATE TABLE scan_ledger (
     shipment_id     UUID         NOT NULL,               -- spine: joins to orders.shipments.id
     parcel_id       VARCHAR(30),                         -- barcode string, NULL until LABEL_GENERATED
     scan_type       VARCHAR(24)  NOT NULL,               -- ScanEventType (6) ∪ VanScanType (4)
-    location_type   VARCHAR(16)  NOT NULL,               -- HUB | VAN | DA | AIRPORT | CUSTOMER_COUNTER
+    location_type   VARCHAR(32)  NOT NULL,               -- HUB | VAN | DA | AIRPORT | CUSTOMER_COUNTER (CUSTOMER_COUNTER is 16 chars; 32 leaves headroom)
     location_id     UUID,                                -- hub / van / DA id
     actor_id        UUID,                                -- who held the gun
     counterparty_id UUID,                                -- the other party in a van handoff (the DA)
@@ -18,8 +18,13 @@ CREATE TABLE scan_ledger (
 );
 
 CREATE INDEX idx_scan_ledger_shipment ON scan_ledger (shipment_id, scanned_at);
-CREATE INDEX idx_scan_ledger_parcel   ON scan_ledger (parcel_id) WHERE parcel_id IS NOT NULL;
--- Idempotency + van-scan replay dedup: a retried scan carrying the same client_scan_id is one row.
+-- Ordered by scanned_at so the "who touched this box, in order" trail lookup needs no sort.
+CREATE INDEX idx_scan_ledger_parcel   ON scan_ledger (parcel_id, scanned_at) WHERE parcel_id IS NOT NULL;
+-- Idempotency: a retried REST scan carrying the same client_scan_id is collapsed to one row.
+-- NOTE: van custody scans (VAN_LOAD/VAN_TO_DA/DA_TO_VAN/VAN_UNLOAD) carry NO client_scan_id
+-- (routing's VanCustodyScan has no such field), so this index does not dedup them. PR4's adapter
+-- MUST guard van inserts with an existsByShipmentIdAndScanType read-check — there is no DB backstop
+-- here on purpose (RTO re-loads can legitimately repeat a scan_type, so a hard unique index is wrong).
 CREATE UNIQUE INDEX uq_scan_ledger_client ON scan_ledger (client_scan_id) WHERE client_scan_id IS NOT NULL;
 
 -- M8's load-bearing invariant. Beyond the app's updatable=false mapping, this rejects any

--- a/barcode/src/main/resources/db/migration/V8_1__create_scan_ledger.sql
+++ b/barcode/src/main/resources/db/migration/V8_1__create_scan_ledger.sql
@@ -1,0 +1,35 @@
+-- M8 §4.1 — the append-only scan ledger: one immutable row per physical scan of a parcel, forever.
+-- The single source of truth for "who touched this box, when, where" (design D-001: keyed on
+-- shipment_id — the same UUID routing/hub already pass; the human barcode string in parcel_id is
+-- layered on from LABEL_GENERATED onward). Two write paths feed it (design §4.3): REST lifecycle
+-- scans (M8 PR3) and the in-process van custody port (M8 PR4). Never updated, never deleted.
+CREATE TABLE scan_ledger (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    shipment_id     UUID         NOT NULL,               -- spine: joins to orders.shipments.id
+    parcel_id       VARCHAR(30),                         -- barcode string, NULL until LABEL_GENERATED
+    scan_type       VARCHAR(24)  NOT NULL,               -- ScanEventType (6) ∪ VanScanType (4)
+    location_type   VARCHAR(16)  NOT NULL,               -- HUB | VAN | DA | AIRPORT | CUSTOMER_COUNTER
+    location_id     UUID,                                -- hub / van / DA id
+    actor_id        UUID,                                -- who held the gun
+    counterparty_id UUID,                                -- the other party in a van handoff (the DA)
+    scanned_at      TIMESTAMPTZ  NOT NULL,               -- device wall-clock (when it physically happened)
+    recorded_at     TIMESTAMPTZ  NOT NULL DEFAULT now(), -- server insert time
+    client_scan_id  UUID                                 -- device idempotency key (design §4.1 / §6)
+);
+
+CREATE INDEX idx_scan_ledger_shipment ON scan_ledger (shipment_id, scanned_at);
+CREATE INDEX idx_scan_ledger_parcel   ON scan_ledger (parcel_id) WHERE parcel_id IS NOT NULL;
+-- Idempotency + van-scan replay dedup: a retried scan carrying the same client_scan_id is one row.
+CREATE UNIQUE INDEX uq_scan_ledger_client ON scan_ledger (client_scan_id) WHERE client_scan_id IS NOT NULL;
+
+-- M8's load-bearing invariant. Beyond the app's updatable=false mapping, this rejects any
+-- UPDATE/DELETE at the DB — even raw SQL from another service — so the audit trail cannot be doctored.
+CREATE OR REPLACE FUNCTION scan_ledger_append_only() RETURNS trigger AS $$
+BEGIN
+    RAISE EXCEPTION 'scan_ledger is append-only: % is not permitted', TG_OP;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_scan_ledger_append_only
+    BEFORE UPDATE OR DELETE ON scan_ledger
+    FOR EACH ROW EXECUTE FUNCTION scan_ledger_append_only();

--- a/barcode/src/main/resources/db/migration/V8_2__create_parcel_id_counter.sql
+++ b/barcode/src/main/resources/db/migration/V8_2__create_parcel_id_counter.sql
@@ -1,0 +1,10 @@
+-- M8 §3.2 — per-hub, per-day sequence backing the seq6 suffix of the parcel barcode
+-- (1DD-{destHubIATA}-{yyMMdd}-{seq6}). Same row-lock pattern as orders.shipment_ref_counters:
+-- INSERT ... ON CONFLICT DO NOTHING to materialise the row, then SELECT FOR UPDATE to increment
+-- (M8 PR2 owns the generation logic; this PR only provides the table).
+CREATE TABLE parcel_id_counter (
+    hub_iata  VARCHAR(3) NOT NULL,
+    day       DATE       NOT NULL,
+    next_seq  INTEGER    NOT NULL DEFAULT 1,
+    PRIMARY KEY (hub_iata, day)
+);


### PR DESCRIPTION
# Pull Request

## Summary

M8 (barcode) **PR1 of 4** — the ledger foundation. Creates the two append-only storage tables that the rest of M8 writes to, plus their JPA entities and repositories. No write path is wired yet (that's PR2–4); this PR only builds the drawer the scan records go in.

**Business anchor:** a ₹1,200 shipment goes missing between the origin-hub dock and the takeoff bag. Six weeks later the station manager must answer *"who physically last touched box `1DD-BLR-260710-000042`, when, and where?"* — unanswerable unless every scan is stored the instant it happens and can never be edited. This PR guarantees the "can never be edited" half.

Design + plan: `docs/M8/M8-BARCODE-DESIGN.md`, `M8-IMPLEMENTATION-PLAN.md`, `M8-DATA-LIFECYCLE.md`.

---

## What Changed

- **`V8_1__create_scan_ledger.sql`** — `scan_ledger`: one immutable row per physical scan. Keyed on `shipment_id` (spine, design D-001); `parcel_id` holds the barcode string (NULL until `LABEL_GENERATED`); `scan_type` is a single column spanning both families (`ScanEventType` ∪ `VanScanType`). Indexed on `(shipment_id, scanned_at)` and `parcel_id`; partial-unique on `client_scan_id` for replay dedup.
- **Append-only enforced at the DB** — a `BEFORE UPDATE OR DELETE` trigger raises, so the audit trail can't be doctored even by raw SQL from another service. Backs up the app-side `updatable=false` mapping.
- **`V8_2__create_parcel_id_counter.sql`** — `parcel_id_counter (hub_iata, day, next_seq)`: per-hub/day sequence for the barcode's `seq6` suffix. Mirrors `orders.shipment_ref_counters`.
- **Entities** — `ScanLedgerEntry` (no setters, all columns `updatable=false`), `ParcelIdCounter` + `ParcelIdCounterId` (`@EmbeddedId`).
- **Repositories** — `ScanLedgerRepository` (the two audit-trail lookups, read+insert only); `ParcelIdCounterRepository` (`insertIfAbsent` + `findByIdWithLock`, same row-lock pattern as the orders counter).
- **`pom.xml`** — added `spring-boot-starter-data-jpa`, `flyway-core`, `postgresql` (runtime), test starter.

---

## Why This Change?

Every other M8 seam depends on this store existing first: M4 state advances off scan events (PR3), routing's `ScanLedgerPort` records van custody here (PR4), and the parcel-ID generator draws from the counter (PR2). Building the schema + immutability guarantee up front means those PRs are thin writers over a proven, append-only foundation rather than each reinventing storage.

---

## Testing
- [x] Tested locally
- [x] Edge cases considered
- [x] No breaking changes introduced

### Test Evidence

`mvn install -pl barcode` (JDK 21) → **BUILD SUCCESS**.

Both migrations were applied inside a **rolled-back transaction** against the shared dev DB (nothing left behind, Flyway untouched — the real checksum-recorded apply happens on next app boot):

```
✅ INSERT works                → rows=1
✅ UPDATE  → ERROR: scan_ledger is append-only: UPDATE is not permitted
✅ DELETE  → ERROR: scan_ledger is append-only: DELETE is not permitted
✅ counter ON CONFLICT DO NOTHING → 2 inserts = 1 row
✅ ROLLBACK — shared DB untouched
```

---

## Impact

### Areas Affected

- [x] Backend
- [ ] Frontend
- [ ] Routing
- [ ] Infra
- [x] Database
- [ ] NA

### Modules Affected

- [ ] M1 — Auth
- [ ] M2 — Pricing
- [ ] M3 — Grid
- [ ] M4 — Orders
- [ ] M5 — Dispatch
- [ ] M6 — Routing
- [ ] M7 — Hub
- [x] M8 — Barcode
- [ ] M9 — Airline
- [ ] M10 — SLA
- [ ] M11 — Exceptions
- [ ] NA

---

## Risks / Concerns

- **New tables on the shared dev DB.** They apply on the next app boot (Flyway `V8_1`→`V8_2`); both are additive `CREATE TABLE`s in the unused `V8_*` namespace — no collision, no existing-data impact.
- **No runtime writers yet** — tables stay empty until PR2. Intentional; keeps PR1 non-destructive.
- **`parcel_id` NULL on van-scan rows** is expected (routing passes the shipment UUID, not the barcode string, per the documented `v1: parcelId == shipmentId` contract) — the trail is still complete via `shipment_id`.

---

## Checklist
- [x] Code follows project conventions (package layout, no cross-module internal imports)
- [x] Self-review completed
- [x] Append-only audit trail preserved (no mutations to scan/manifest/role-change records)
- [x] No sensitive data or credentials exposed
- [x] Documentation updated if behaviour changed
- [x] Ready for review
