### PR TITLE
f-no_cron_city_scoped_gate

### DIFF
--- a/common/src/main/java/com/oneday/common/domain/MeetingMode.java
+++ b/common/src/main/java/com/oneday/common/domain/MeetingMode.java
@@ -1,0 +1,20 @@
+package com.oneday.common.domain;
+
+/**
+ * Per-city gate for M6 (van meeting points). Shared cross-module vocabulary so both routing (which
+ * owns the setting on {@code city_fleet_config}) and dispatch (which reads it via
+ * {@link com.oneday.common.port.CityMeetingModePort}) speak the same enum without a compile-time
+ * dependency between the two modules.
+ *
+ * <ul>
+ *   <li>{@code VAN_MEETING} — full M6: nightly van route plan + meeting-point set-cover; DAs
+ *       rendezvous with a van at a grid vertex.</li>
+ *   <li>{@code HUB_RETURN} — no M6: the DA periodically returns to the hub to drop collected
+ *       pickups and collect their territory's deliveries. The hub is the rendezvous and the
+ *       "meeting times" are a fixed periodic cadence.</li>
+ * </ul>
+ */
+public enum MeetingMode {
+    VAN_MEETING,
+    HUB_RETURN
+}

--- a/common/src/main/java/com/oneday/common/domain/enums/ShipmentState.java
+++ b/common/src/main/java/com/oneday/common/domain/enums/ShipmentState.java
@@ -10,6 +10,11 @@ public enum ShipmentState {
     PICKED_UP,
     HANDED_TO_PICKUP_VAN,
 
+    // HUB_RETURN first-mile path — replaces HANDED_TO_PICKUP_VAN in cities with no van (M6 gate off).
+    // There is no pickup van: the DA carries the collected parcel back to the origin hub on their
+    // scheduled return and hands it off there.
+    RETURNED_TO_HUB,
+
     // SELF_DROP path — skips the three states above
     AWAITING_SELF_DROP,
 
@@ -31,6 +36,12 @@ public enum ShipmentState {
     DROP_ASSIGNED,
     DROP_COLLECTED,
     DROPPED,
+
+    // HUB_RETURN last-mile path — replaces HANDED_TO_DROP_VAN/DROP_ASSIGNED/DROP_COLLECTED in cities
+    // with no van (M6 gate off). There is no drop van: a territory DA is assigned the delivery, collects
+    // the parcel at the destination hub on their next visit, then delivers it (→ DROPPED).
+    HUB_DELIVERY_ASSIGNED,  // territory DA assigned; parcel waiting at dest hub for the DA's next visit
+    COLLECTED_FROM_HUB,     // DA collected the parcel from the hub — out for delivery
 
     // HUB_COLLECT path — skips the four states above
     AWAITING_HUB_COLLECT,  // parcel ready at dest hub; customer yet to arrive

--- a/common/src/main/java/com/oneday/common/kafka/enums/DaEventType.java
+++ b/common/src/main/java/com/oneday/common/kafka/enums/DaEventType.java
@@ -14,6 +14,11 @@ public enum DaEventType {
     // M4 consumer: PICKED_UP → HANDED_TO_PICKUP_VAN  [QR scan — DA scans parcel in DA app]
     VAN_HANDOFF_COMPLETED,
 
+    // HUB_RETURN cities only (M6 gate off — no van). The DA carries the pickup back to the hub and
+    // hands it off there; same custody progression as a van handoff → M4 (HANDED_TO_PICKUP_VAN).
+    // A distinct type so consumers aren't told a "van" received the parcel when none exists.
+    HUB_RETURN_HANDOFF_COMPLETED,
+
     // M4 consumer: HANDED_TO_DROP_VAN → DROP_ASSIGNED
     DROP_ASSIGNED,
 

--- a/common/src/main/java/com/oneday/common/kafka/enums/ScanEventType.java
+++ b/common/src/main/java/com/oneday/common/kafka/enums/ScanEventType.java
@@ -6,5 +6,6 @@ public enum ScanEventType {
     GHA_ACCEPTANCE,
     HUB_DEST_IN,
     LABEL_GENERATED,
-    HUB_COLLECT_COMPLETED   // hub-collect path: AWAITING_HUB_COLLECT → HUB_COLLECTED
+    HUB_COLLECT_COMPLETED,  // hub-collect path: AWAITING_HUB_COLLECT → HUB_COLLECTED
+    HUB_DEST_OUT            // HUB_RETURN: DA collected a dest parcel from the hub for last-mile (ledger only)
 }

--- a/common/src/main/java/com/oneday/common/port/CityMeetingModePort.java
+++ b/common/src/main/java/com/oneday/common/port/CityMeetingModePort.java
@@ -1,0 +1,25 @@
+package com.oneday.common.port;
+
+import com.oneday.common.domain.MeetingMode;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Read a city's M6 gate ({@link MeetingMode}) and — for {@code HUB_RETURN} cities — the hub
+ * coordinates, without importing the routing module. Implemented in routing over
+ * {@code city_fleet_config} + {@code city_logistics_node}; consumed in dispatch (M5) so the
+ * delivery-from-hub path can tell whether a city runs van meetings or periodic hub returns.
+ * Same cross-module pattern as {@link DaCronSchedulePort} — both sides depend only on {@code common}.
+ */
+public interface CityMeetingModePort {
+
+    /** Hub rendezvous location for a {@code HUB_RETURN} city. */
+    record HubLocation(double lat, double lon) {}
+
+    /** The city's mode. Defaults to {@link MeetingMode#VAN_MEETING} when no fleet config exists. */
+    MeetingMode modeFor(UUID cityId);
+
+    /** The city's hub coordinates, if known (present for cities with a HUB logistics node). */
+    Optional<HubLocation> hubLocation(UUID cityId);
+}

--- a/common/src/main/java/com/oneday/common/port/ShipmentLocationPort.java
+++ b/common/src/main/java/com/oneday/common/port/ShipmentLocationPort.java
@@ -1,0 +1,20 @@
+package com.oneday.common.port;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Resolve a shipment's real drop location (the receiver's address), without importing the orders
+ * module. Implemented in orders (M4) over the {@code Shipment} destination address; consumed in
+ * dispatch (M5) so the delivery-from-hub path assigns against the actual lat/lon rather than a hex
+ * centroid. Same cross-module pattern as {@link DaCronSchedulePort} — both sides depend only on
+ * {@code common}.
+ */
+public interface ShipmentLocationPort {
+
+    /** Real drop coordinates + destination tile of a shipment. */
+    record DropLocation(double lat, double lon, UUID destTileId) {}
+
+    /** The shipment's drop location, if the shipment exists and carries geocoded dest coordinates. */
+    Optional<DropLocation> dropLocation(UUID shipmentId);
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/api/DaDispatchController.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/api/DaDispatchController.java
@@ -1,8 +1,11 @@
 package com.oneday.dispatch.api;
 
 import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.common.domain.MeetingMode;
+import com.oneday.common.port.CityMeetingModePort;
 import com.oneday.dispatch.dto.request.DropCompletedRequest;
 import com.oneday.dispatch.dto.request.GpsPingRequest;
+import com.oneday.dispatch.dto.request.HubHandoffRequest;
 import com.oneday.dispatch.dto.request.OtpVerifyRequest;
 import com.oneday.dispatch.dto.request.TaskFailedRequest;
 import com.oneday.dispatch.dto.request.VanHandoffRequest;
@@ -11,6 +14,7 @@ import com.oneday.dispatch.service.DaTaskService;
 import com.oneday.dispatch.service.DaTaskView;
 import com.oneday.dispatch.service.OtpVerificationService;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,6 +22,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -35,12 +40,15 @@ public class DaDispatchController {
     private final DaStatusService daStatusService;
     private final DaTaskService daTaskService;
     private final OtpVerificationService otpVerificationService;
+    private final CityMeetingModePort meetingModePort;
 
     public DaDispatchController(DaStatusService daStatusService, DaTaskService daTaskService,
-                               OtpVerificationService otpVerificationService) {
+                               OtpVerificationService otpVerificationService,
+                               CityMeetingModePort meetingModePort) {
         this.daStatusService = daStatusService;
         this.daTaskService = daTaskService;
         this.otpVerificationService = otpVerificationService;
+        this.meetingModePort = meetingModePort;
     }
 
     @PostMapping("/gps")
@@ -68,6 +76,15 @@ public class DaDispatchController {
         return daTaskService.recordVanHandoff(daId, taskId, request.parcelScans(), request.vanId());
     }
 
+    @PostMapping("/tasks/{taskId}/hub-handoff")
+    public DaTaskView hubHandoff(@PathVariable UUID daId, @PathVariable UUID taskId,
+                                 @AuthenticationPrincipal AuthUserDetails principal,
+                                 @RequestBody HubHandoffRequest request) {
+        Authz.requireDaSelf(principal, daId);
+        requireHubReturnCity(daId);
+        return daTaskService.recordHubHandoff(daId, taskId, request.parcelScans());
+    }
+
     @PostMapping("/tasks/{taskId}/failed")
     public DaTaskView failed(@PathVariable UUID daId, @PathVariable UUID taskId,
                              @AuthenticationPrincipal AuthUserDetails principal,
@@ -82,6 +99,14 @@ public class DaDispatchController {
                                     @AuthenticationPrincipal AuthUserDetails principal) {
         Authz.requireDaSelf(principal, daId);
         return daTaskService.markDropCollected(daId, taskId);
+    }
+
+    @PostMapping("/tasks/{taskId}/hub-collect")
+    public DaTaskView hubCollect(@PathVariable UUID daId, @PathVariable UUID taskId,
+                                 @AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireDaSelf(principal, daId);
+        requireHubReturnCity(daId);
+        return daTaskService.recordHubCollect(daId, taskId);
     }
 
     @PostMapping("/tasks/{taskId}/drop-completed")
@@ -108,5 +133,18 @@ public class DaDispatchController {
         Authz.requireDaSelf(principal, daId);
         otpVerificationService.resendOtp(daId, taskId);
         return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * Cheap edge guard: the hub-handoff / hub-collect endpoints are only valid in a HUB_RETURN city.
+     * The DA's city (from their live status) resolves the mode; a VAN_MEETING city → 409 so a misrouted
+     * client can't emit hub events where a van rendezvous is expected. The service itself stays mode-agnostic.
+     */
+    private void requireHubReturnCity(UUID daId) {
+        UUID cityId = daStatusService.getLiveStatus(daId).getCityId();
+        if (meetingModePort.modeFor(cityId) != MeetingMode.HUB_RETURN) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Hub handoff/collect is only valid in a HUB_RETURN city");
+        }
     }
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/config/DispatchConfig.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/config/DispatchConfig.java
@@ -1,5 +1,7 @@
 package com.oneday.dispatch.config;
 
+import com.oneday.common.domain.MeetingMode;
+import com.oneday.common.port.CityMeetingModePort;
 import com.oneday.dispatch.service.AdjacentDaProvider;
 import com.oneday.dispatch.service.OsrmRoutingPort;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -10,6 +12,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.OptionalLong;
 
 /**
@@ -51,5 +54,27 @@ public class DispatchConfig {
     @ConditionalOnMissingBean(MeterRegistry.class)
     MeterRegistry simpleMeterRegistry() {
         return new SimpleMeterRegistry();
+    }
+
+    /**
+     * Fallback for M5's isolated module tests: dispatch cannot depend on routing, which owns the real
+     * {@link CityMeetingModePort} (over {@code city_fleet_config}). Absent that, every city reads as
+     * VAN_MEETING — so {@code HubDeliveryFeedConsumer} no-ops. In the assembled app routing's
+     * {@code @Primary CityMeetingModeAdapter} is present, so this backs off.
+     */
+    @Bean
+    @ConditionalOnMissingBean(CityMeetingModePort.class)
+    CityMeetingModePort vanMeetingModePort() {
+        return new CityMeetingModePort() {
+            @Override
+            public MeetingMode modeFor(java.util.UUID cityId) {
+                return MeetingMode.VAN_MEETING;
+            }
+
+            @Override
+            public Optional<HubLocation> hubLocation(java.util.UUID cityId) {
+                return Optional.empty();
+            }
+        };
     }
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/dto/request/HubHandoffRequest.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/dto/request/HubHandoffRequest.java
@@ -1,0 +1,10 @@
+package com.oneday.dispatch.dto.request;
+
+import java.time.Instant;
+import java.util.List;
+
+/** DA's hub drop (HUB_RETURN city, no van): the parcel barcodes scanned and when. */
+public record HubHandoffRequest(
+        List<String> parcelScans,
+        Instant timestamp) {
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/events/DaEventProducer.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/events/DaEventProducer.java
@@ -72,6 +72,11 @@ public class DaEventProducer {
         emit(DaEventType.VAN_HANDOFF_COMPLETED, daId, cityId, shipmentId, null, null);
     }
 
+    /** HUB_RETURN city: DA dropped the picked-up parcel at the hub (no van). → M4 (HANDED_TO_PICKUP_VAN), M10. */
+    public void emitHubReturnHandoffCompleted(UUID daId, UUID cityId, UUID shipmentId) {
+        emit(DaEventType.HUB_RETURN_HANDOFF_COMPLETED, daId, cityId, shipmentId, null, null);
+    }
+
     /** A pickup could not be completed by the DA. → M4 (PICKUP_FAILED), M11. */
     public void emitPickupFailed(UUID daId, UUID cityId, UUID shipmentId, String reason) {
         emit(DaEventType.PICKUP_FAILED, daId, cityId, shipmentId, null, reason);

--- a/dispatch/src/main/java/com/oneday/dispatch/events/DispatchMessagingTopology.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/events/DispatchMessagingTopology.java
@@ -24,6 +24,13 @@ public class DispatchMessagingTopology {
     /** M5's queue on M6's cron stream (M5 acts only on DA_CRON_SCHEDULED; the rest are ignored). */
     public static final String CRON_QUEUE = "m5.cron";
 
+    /**
+     * M5's queue on M7's hub stream. M5 acts only on PARCEL_SORTED_FOR_DELIVERY and only for
+     * HUB_RETURN cities (no van — the territory DA collects the delivery at the hub); the rest are
+     * ignored. In VAN_MEETING cities M6 owns this event, so this consumer no-ops.
+     */
+    public static final String HUB_QUEUE = "m5.hub";
+
     /** Exchange M5 publishes DA lifecycle events to (gated — see DaEventProducer). */
     @Bean
     Declarables daEventsExchange() {
@@ -40,5 +47,11 @@ public class DispatchMessagingTopology {
     @Bean
     Declarables cronBinding() {
         return RabbitStreamSupport.consumer(CRON_QUEUE, EventStreams.CRON_EVENTS);
+    }
+
+    /** All hub events on one queue; the consumer acts only on PARCEL_SORTED_FOR_DELIVERY (HUB_RETURN). */
+    @Bean
+    Declarables hubBinding() {
+        return RabbitStreamSupport.consumer(HUB_QUEUE, EventStreams.HUB_EVENTS);
     }
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/events/HubDeliveryFeedConsumer.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/events/HubDeliveryFeedConsumer.java
@@ -4,6 +4,7 @@ import com.oneday.common.domain.MeetingMode;
 import com.oneday.common.kafka.events.hub.HubEventPayload;
 import com.oneday.common.kafka.events.hub.ParcelSortedForDeliveryEvent;
 import com.oneday.common.port.CityMeetingModePort;
+import com.oneday.common.port.ShipmentLocationPort;
 import com.oneday.dispatch.service.AssignmentResult;
 import com.oneday.dispatch.service.DispatchService;
 import com.oneday.grid.dto.response.DaTerritoryResponse;
@@ -24,10 +25,12 @@ import java.util.UUID;
  * delivery on the territory DA — who collects it on their next hub visit. In VAN_MEETING cities M6's
  * {@code HubFeedConsumer} owns this event (binds it to a van loop), so this consumer no-ops there.
  *
- * <p>Reuses the existing {@link DispatchService#assignDelivery} engine: the destination hex resolves
- * to the territory DA via M3, and the DA's hub-return cron gates the queue exactly like a pickup. The
- * assignment is idempotent (an already-active DELIVERY task is skipped), so it is safe even if M4's
- * own delivery path also fires for the shipment.</p>
+ * <p>Reuses the existing {@link DispatchService#assignDelivery} engine, assigning against the
+ * shipment's <b>real</b> drop lat/lon (via {@link ShipmentLocationPort}) exactly like M4's own
+ * delivery path — the hex centroid is only a fallback when the shipment carries no geocoded address.
+ * The DA's hub-return cron gates the queue exactly like a pickup. The assignment is idempotent (an
+ * already-active DELIVERY task is skipped), so it is safe even if M4's own delivery path also fires
+ * for the shipment.</p>
  */
 @Component
 public class HubDeliveryFeedConsumer {
@@ -37,13 +40,16 @@ public class HubDeliveryFeedConsumer {
     private final DispatchService dispatchService;
     private final GridService gridService;
     private final CityMeetingModePort meetingModePort;
+    private final ShipmentLocationPort shipmentLocationPort;
 
     public HubDeliveryFeedConsumer(DispatchService dispatchService,
                                    GridService gridService,
-                                   CityMeetingModePort meetingModePort) {
+                                   CityMeetingModePort meetingModePort,
+                                   ShipmentLocationPort shipmentLocationPort) {
         this.dispatchService = dispatchService;
         this.gridService = gridService;
         this.meetingModePort = meetingModePort;
+        this.shipmentLocationPort = shipmentLocationPort;
     }
 
     @RabbitListener(queues = DispatchMessagingTopology.HUB_QUEUE)
@@ -60,14 +66,26 @@ public class HubDeliveryFeedConsumer {
             return;   // VAN_MEETING → M6 binds this parcel to a van; nothing for M5 to do
         }
 
-        double[] centroid = hexCentroid(e.cityId(), e.validDate(), e.destinationHexId());
-        if (centroid == null) {
-            log.error("HUB_RETURN delivery parcel {} — destination hex {} not in any active territory for {}; cannot assign",
+        // Assign against the real drop lat/lon (v1: parcelId == shipmentId, no M8 barcode). The hex
+        // centroid is only a fallback when the shipment has no geocoded address, so the DA's queue
+        // sequences on the actual delivery point — matching M4's own delivery path.
+        double[] coords = shipmentLocationPort.dropLocation(e.parcelId())
+                .map(loc -> new double[]{loc.lat(), loc.lon()})
+                .orElseGet(() -> {
+                    double[] centroid = hexCentroid(e.cityId(), e.validDate(), e.destinationHexId());
+                    if (centroid != null) {
+                        log.warn("HUB_RETURN delivery parcel {} has no geocoded drop address — "
+                                + "falling back to hex {} centroid", e.parcelId(), e.destinationHexId());
+                    }
+                    return centroid;
+                });
+        if (coords == null) {
+            log.error("HUB_RETURN delivery parcel {} — no drop coords and hex {} not in any active territory for {}; cannot assign",
                     e.parcelId(), e.destinationHexId(), e.validDate());
             return;
         }
         AssignmentResult result = dispatchService.assignDelivery(
-                e.parcelId(), e.cityId(), centroid[0], centroid[1], e.destinationHexId());
+                e.parcelId(), e.cityId(), coords[0], coords[1], e.destinationHexId());
         log.debug("HUB_RETURN delivery assignment for parcel {}: {}", e.parcelId(), result.outcome());
     }
 

--- a/dispatch/src/main/java/com/oneday/dispatch/events/HubDeliveryFeedConsumer.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/events/HubDeliveryFeedConsumer.java
@@ -1,0 +1,96 @@
+package com.oneday.dispatch.events;
+
+import com.oneday.common.domain.MeetingMode;
+import com.oneday.common.kafka.events.hub.HubEventPayload;
+import com.oneday.common.kafka.events.hub.ParcelSortedForDeliveryEvent;
+import com.oneday.common.port.CityMeetingModePort;
+import com.oneday.dispatch.service.AssignmentResult;
+import com.oneday.dispatch.service.DispatchService;
+import com.oneday.grid.dto.response.DaTerritoryResponse;
+import com.oneday.grid.dto.response.GridVertexResponse;
+import com.oneday.grid.dto.response.TerritoryHexResponse;
+import com.oneday.grid.service.GridService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Delivery-from-hub for HUB_RETURN cities. In a city with no van (the M6 gate off), M7 sorting a
+ * destination parcel for last-mile ({@code PARCEL_SORTED_FOR_DELIVERY}) is the trigger to queue the
+ * delivery on the territory DA — who collects it on their next hub visit. In VAN_MEETING cities M6's
+ * {@code HubFeedConsumer} owns this event (binds it to a van loop), so this consumer no-ops there.
+ *
+ * <p>Reuses the existing {@link DispatchService#assignDelivery} engine: the destination hex resolves
+ * to the territory DA via M3, and the DA's hub-return cron gates the queue exactly like a pickup. The
+ * assignment is idempotent (an already-active DELIVERY task is skipped), so it is safe even if M4's
+ * own delivery path also fires for the shipment.</p>
+ */
+@Component
+public class HubDeliveryFeedConsumer {
+
+    private static final Logger log = LoggerFactory.getLogger(HubDeliveryFeedConsumer.class);
+
+    private final DispatchService dispatchService;
+    private final GridService gridService;
+    private final CityMeetingModePort meetingModePort;
+
+    public HubDeliveryFeedConsumer(DispatchService dispatchService,
+                                   GridService gridService,
+                                   CityMeetingModePort meetingModePort) {
+        this.dispatchService = dispatchService;
+        this.gridService = gridService;
+        this.meetingModePort = meetingModePort;
+    }
+
+    @RabbitListener(queues = DispatchMessagingTopology.HUB_QUEUE)
+    public void onHubEvent(HubEventPayload event) {
+        if (!(event instanceof ParcelSortedForDeliveryEvent e)) {
+            return;   // other hub events are not M5's concern
+        }
+        if (e.cityId() == null || e.destinationHexId() == null || e.parcelId() == null) {
+            log.warn("PARCEL_SORTED_FOR_DELIVERY missing parcelId/cityId/hex (parcel={} city={} hex={}) — skipping",
+                    e.parcelId(), e.cityId(), e.destinationHexId());
+            return;
+        }
+        if (meetingModePort.modeFor(e.cityId()) != MeetingMode.HUB_RETURN) {
+            return;   // VAN_MEETING → M6 binds this parcel to a van; nothing for M5 to do
+        }
+
+        double[] centroid = hexCentroid(e.cityId(), e.validDate(), e.destinationHexId());
+        if (centroid == null) {
+            log.error("HUB_RETURN delivery parcel {} — destination hex {} not in any active territory for {}; cannot assign",
+                    e.parcelId(), e.destinationHexId(), e.validDate());
+            return;
+        }
+        AssignmentResult result = dispatchService.assignDelivery(
+                e.parcelId(), e.cityId(), centroid[0], centroid[1], e.destinationHexId());
+        log.debug("HUB_RETURN delivery assignment for parcel {}: {}", e.parcelId(), result.outcome());
+    }
+
+    /** Representative coordinate for a hex: the mean of its H3 corner vertices (null if not found). */
+    private double[] hexCentroid(UUID cityId, java.time.LocalDate date, UUID hexId) {
+        List<DaTerritoryResponse> territories = gridService.getDaTerritories(cityId, date);
+        for (DaTerritoryResponse t : territories) {
+            for (TerritoryHexResponse hex : t.hexes()) {
+                if (hex.hexId().equals(hexId)) {
+                    return centroidOf(hex.vertices());
+                }
+            }
+        }
+        return null;
+    }
+
+    private double[] centroidOf(List<GridVertexResponse> vertices) {
+        if (vertices == null || vertices.isEmpty()) return null;
+        double lat = 0, lon = 0;
+        for (GridVertexResponse v : vertices) {
+            lat += v.lat();
+            lon += v.lon();
+        }
+        return new double[]{lat / vertices.size(), lon / vertices.size()};
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/events/HubScanSeamProducer.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/events/HubScanSeamProducer.java
@@ -28,12 +28,12 @@ public class HubScanSeamProducer {
     }
 
     /** DA dropped a collected pickup at the origin hub → M4 (HANDED_TO_PICKUP_VAN → AT_ORIGIN_HUB). */
-    public void hubOriginIn(UUID shipmentId) {
+    public void emitHubOriginIn(UUID shipmentId) {
         emit(shipmentId, ScanEventType.HUB_ORIGIN_IN);
     }
 
     /** DA collected a dest parcel from the hub for last-mile (ledger only — M4 ignores it). */
-    public void hubDestOut(UUID shipmentId) {
+    public void emitHubDestOut(UUID shipmentId) {
         emit(shipmentId, ScanEventType.HUB_DEST_OUT);
     }
 

--- a/dispatch/src/main/java/com/oneday/dispatch/events/HubScanSeamProducer.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/events/HubScanSeamProducer.java
@@ -1,0 +1,48 @@
+package com.oneday.dispatch.events;
+
+import com.oneday.common.kafka.EventPublisher;
+import com.oneday.common.kafka.EventStreams;
+import com.oneday.common.kafka.enums.ScanEventType;
+import com.oneday.common.kafka.events.ScanEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+/**
+ * M8-SEAM. In HUB_RETURN cities (the M6 gate off) the DA is the physical carrier to/from the hub, so
+ * the hub-custody scans that M8 (barcode) will own are emitted here on {@code oneday.scan.events} as a
+ * bridge until M8 lands — the M8 owner relocates these into M8 proper. Every emit is best-effort: a
+ * publish failure is logged and swallowed so it can never block the DA's custody flow.
+ */
+@Component
+public class HubScanSeamProducer {
+
+    private static final Logger log = LoggerFactory.getLogger(HubScanSeamProducer.class);
+
+    private final EventPublisher eventPublisher;
+
+    public HubScanSeamProducer(EventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    /** DA dropped a collected pickup at the origin hub → M4 (HANDED_TO_PICKUP_VAN → AT_ORIGIN_HUB). */
+    public void hubOriginIn(UUID shipmentId) {
+        emit(shipmentId, ScanEventType.HUB_ORIGIN_IN);
+    }
+
+    /** DA collected a dest parcel from the hub for last-mile (ledger only — M4 ignores it). */
+    public void hubDestOut(UUID shipmentId) {
+        emit(shipmentId, ScanEventType.HUB_DEST_OUT);
+    }
+
+    private void emit(UUID shipmentId, ScanEventType type) {
+        try {
+            eventPublisher.publish(EventStreams.SCAN_EVENTS, new ScanEvent(shipmentId, type));
+        } catch (Exception e) {   // M8-SEAM: never block custody on a scan publish failure
+            log.warn("M8-SEAM hub scan {} for shipment {} failed (non-blocking): {}",
+                    type, shipmentId, e.getMessage());
+        }
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/service/DaTaskService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/DaTaskService.java
@@ -15,17 +15,30 @@ public interface DaTaskService {
     DaTaskView markEnRoute(UUID daId, UUID taskId);
 
     /**
-     * PICKUP task IN_PROGRESS → COMPLETED at the rendezvous. Records the cron handoff and emits
-     * VAN_HANDOFF_COMPLETED (or, in a HUB_RETURN city with no van, HUB_RETURN_HANDOFF_COMPLETED).
-     * {@code parcelScans} must be non-empty (full M8 scan-ledger validation lands with barcode integration).
+     * VAN_MEETING city: PICKUP task IN_PROGRESS → COMPLETED at the cron van. Records the cron handoff
+     * and emits VAN_HANDOFF_COMPLETED. {@code parcelScans} must be non-empty (full M8 scan-ledger
+     * validation lands with barcode integration).
      */
     DaTaskView recordVanHandoff(UUID daId, UUID taskId, List<String> parcelScans, UUID vanId);
+
+    /**
+     * HUB_RETURN city (no van): PICKUP task IN_PROGRESS → COMPLETED when the DA drops the collected
+     * pickups AT the hub. Same lifecycle as {@link #recordVanHandoff} but emits HUB_RETURN_HANDOFF_COMPLETED
+     * and the origin-hub scan. {@code parcelScans} must be non-empty.
+     */
+    DaTaskView recordHubHandoff(UUID daId, UUID taskId, List<String> parcelScans);
 
     /** Any active task → FAILED; emits PICKUP_FAILED or DROP_FAILED by task type. */
     DaTaskView markFailed(UUID daId, UUID taskId, String reason);
 
-    /** DELIVERY task QUEUED → IN_PROGRESS (collected from the van); emits DROP_COLLECTED. */
+    /** VAN_MEETING city: DELIVERY task QUEUED → IN_PROGRESS (collected from the van); emits DROP_COLLECTED. */
     DaTaskView markDropCollected(UUID daId, UUID taskId);
+
+    /**
+     * HUB_RETURN city (no van): DELIVERY task QUEUED → IN_PROGRESS when the DA collects the parcel FROM
+     * the hub for last-mile. Emits DROP_COLLECTED plus the hub-dest custody scan.
+     */
+    DaTaskView recordHubCollect(UUID daId, UUID taskId);
 
     /** DELIVERY task IN_PROGRESS → COMPLETED; emits DROP_COMPLETED (+ COD_COLLECTED if cash taken). */
     DaTaskView markDropCompleted(UUID daId, UUID taskId, boolean codCollected);

--- a/dispatch/src/main/java/com/oneday/dispatch/service/DaTaskService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/DaTaskService.java
@@ -15,9 +15,9 @@ public interface DaTaskService {
     DaTaskView markEnRoute(UUID daId, UUID taskId);
 
     /**
-     * PICKUP task IN_PROGRESS → COMPLETED at the cron van. Records the cron handoff and emits
-     * VAN_HANDOFF_COMPLETED. {@code parcelScans} must be non-empty (full M8 scan-ledger validation
-     * lands with barcode integration).
+     * PICKUP task IN_PROGRESS → COMPLETED at the rendezvous. Records the cron handoff and emits
+     * VAN_HANDOFF_COMPLETED (or, in a HUB_RETURN city with no van, HUB_RETURN_HANDOFF_COMPLETED).
+     * {@code parcelScans} must be non-empty (full M8 scan-ledger validation lands with barcode integration).
      */
     DaTaskView recordVanHandoff(UUID daId, UUID taskId, List<String> parcelScans, UUID vanId);
 

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
@@ -98,11 +98,15 @@ class DaTaskServiceImpl implements DaTaskService {
             task.setCompletedAt(Instant.now());
             DaTaskView view = save(task);
             recordCronHandoff(daId, task.getOperatingDate(), parcelScans.size());
-            daEventProducer.emitVanHandoffCompleted(daId, task.getCityId(), task.getShipmentId());
-            // M8-SEAM: in HUB_RETURN cities the DA drops collected pickups AT the hub, so this handoff
-            // is the origin-hub inbound scan (advances the shipment to AT_ORIGIN_HUB → M7/M9).
+            // HUB_RETURN cities have no van — the DA hands off AT the hub, so emit the neutral
+            // hub-return handoff event (not VAN_HANDOFF_COMPLETED, which would claim a van received it).
+            // Both map to HANDED_TO_PICKUP_VAN in M4; only the event label differs.
             if (isHubReturn(task)) {
-                hubScanSeamProducer.hubOriginIn(task.getShipmentId());
+                daEventProducer.emitHubReturnHandoffCompleted(daId, task.getCityId(), task.getShipmentId());
+                // M8-SEAM: the hub drop is the origin-hub inbound scan (advances to AT_ORIGIN_HUB → M7/M9).
+                hubScanSeamProducer.emitHubOriginIn(task.getShipmentId());
+            } else {
+                daEventProducer.emitVanHandoffCompleted(daId, task.getCityId(), task.getShipmentId());
             }
             log.debug("Van handoff: task {} (van {}) completed with {} scan(s)", taskId, vanId, parcelScans.size());
             return view;
@@ -141,7 +145,7 @@ class DaTaskServiceImpl implements DaTaskService {
             // M8-SEAM: in HUB_RETURN cities the DA collects the delivery FROM the hub, so record the
             // hub-dest custody scan (ledger only — the DA's later DROP_* events drive the state).
             if (isHubReturn(task)) {
-                hubScanSeamProducer.hubDestOut(task.getShipmentId());
+                hubScanSeamProducer.emitHubDestOut(task.getShipmentId());
             }
             return view;
         });

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
@@ -1,16 +1,22 @@
 package com.oneday.dispatch.service.impl;
 
+import com.oneday.common.domain.MeetingMode;
+import com.oneday.common.port.CityMeetingModePort;
+import com.oneday.dispatch.config.DispatchProperties;
 import com.oneday.dispatch.domain.CronAssignmentStatus;
 import com.oneday.dispatch.domain.DaCronAssignment;
+import com.oneday.dispatch.domain.DaStatusEnum;
 import com.oneday.dispatch.domain.DispatchQueue;
 import com.oneday.dispatch.domain.TaskStatus;
 import com.oneday.dispatch.domain.TaskType;
 import com.oneday.dispatch.events.DaEventProducer;
+import com.oneday.dispatch.events.HubScanSeamProducer;
 import com.oneday.dispatch.repository.DaCronAssignmentRepository;
 import com.oneday.dispatch.repository.DispatchQueueRepository;
 import com.oneday.dispatch.service.DaStatusService;
 import com.oneday.dispatch.service.DaTaskService;
 import com.oneday.dispatch.service.DaTaskView;
+import com.oneday.dispatch.service.model.DaQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -20,6 +26,10 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 
@@ -37,15 +47,28 @@ class DaTaskServiceImpl implements DaTaskService {
     private final DaCronAssignmentRepository cronRepository;
     private final DaStatusService daStatusService;
     private final DaEventProducer daEventProducer;
+    private final DispatchProperties props;
+    private final HubScanSeamProducer hubScanSeamProducer;
+    private final CityMeetingModePort meetingModePort;
 
     DaTaskServiceImpl(DispatchQueueRepository queueRepository,
                       DaCronAssignmentRepository cronRepository,
                       DaStatusService daStatusService,
-                      DaEventProducer daEventProducer) {
+                      DaEventProducer daEventProducer,
+                      DispatchProperties props,
+                      HubScanSeamProducer hubScanSeamProducer,
+                      CityMeetingModePort meetingModePort) {
         this.queueRepository = queueRepository;
         this.cronRepository = cronRepository;
         this.daStatusService = daStatusService;
         this.daEventProducer = daEventProducer;
+        this.props = props;
+        this.hubScanSeamProducer = hubScanSeamProducer;
+        this.meetingModePort = meetingModePort;
+    }
+
+    private boolean isHubReturn(DispatchQueue task) {
+        return meetingModePort.modeFor(task.getCityId()) == MeetingMode.HUB_RETURN;
     }
 
     @Override
@@ -76,6 +99,11 @@ class DaTaskServiceImpl implements DaTaskService {
             DaTaskView view = save(task);
             recordCronHandoff(daId, task.getOperatingDate(), parcelScans.size());
             daEventProducer.emitVanHandoffCompleted(daId, task.getCityId(), task.getShipmentId());
+            // M8-SEAM: in HUB_RETURN cities the DA drops collected pickups AT the hub, so this handoff
+            // is the origin-hub inbound scan (advances the shipment to AT_ORIGIN_HUB → M7/M9).
+            if (isHubReturn(task)) {
+                hubScanSeamProducer.hubOriginIn(task.getShipmentId());
+            }
             log.debug("Van handoff: task {} (van {}) completed with {} scan(s)", taskId, vanId, parcelScans.size());
             return view;
         });
@@ -110,6 +138,11 @@ class DaTaskServiceImpl implements DaTaskService {
             task.setStartedAt(Instant.now());
             DaTaskView view = save(task);
             daEventProducer.emitDropCollected(daId, task.getCityId(), task.getShipmentId());
+            // M8-SEAM: in HUB_RETURN cities the DA collects the delivery FROM the hub, so record the
+            // hub-dest custody scan (ledger only — the DA's later DROP_* events drive the state).
+            if (isHubReturn(task)) {
+                hubScanSeamProducer.hubDestOut(task.getShipmentId());
+            }
             return view;
         });
     }
@@ -152,12 +185,51 @@ class DaTaskServiceImpl implements DaTaskService {
 
     private void recordCronHandoff(UUID daId, LocalDate date, int parcelCount) {
         cronRepository.findByDaIdAndOperatingDate(daId, date).ifPresent(cron -> {
-            cron.setStatus(CronAssignmentStatus.COMPLETED);
             cron.setHandoffCompletedAt(Instant.now());
             int prior = cron.getParcelCountHanded() != null ? cron.getParcelCountHanded() : 0;
             cron.setParcelCountHanded(prior + parcelCount);
-            cronRepository.save(cron);
+
+            // HUB_RETURN crons carry no van and recur through the day (M6 gate off). A hub drop that
+            // still has a later return today only COMPLETES this leg: roll the meeting to the next slot
+            // and stay SCHEDULED so the hard constraint keeps gating, and free the DA to work until then.
+            // The last return (no later slot) — and every van rendezvous (v1, single meeting) — is terminal.
+            Instant next = (cron.getVanId() == null) ? nextSlotAfter(cron, cron.getScheduledMeetingTime()) : null;
+            if (next != null) {
+                cron.setScheduledMeetingTime(next);
+                cron.setStatus(CronAssignmentStatus.SCHEDULED);
+                cronRepository.save(cron);
+                refreshMemCron(daId, next);
+                if (daStatusService.getStatus(daId) == DaStatusEnum.AT_CRON) {
+                    daStatusService.updateStatus(daId, DaStatusEnum.IDLE);
+                }
+            } else {
+                cron.setStatus(CronAssignmentStatus.COMPLETED);
+                cronRepository.save(cron);
+            }
         });
+    }
+
+    /** First periodic meeting strictly after {@code reference} (the just-completed slot); null if none left. */
+    private Instant nextSlotAfter(DaCronAssignment cron, Instant reference) {
+        if (cron.getMeetingTimes() == null || cron.getMeetingTimes().isEmpty() || reference == null) {
+            return null;
+        }
+        ZoneId zone = ZoneId.of(props.getShift().getZone());
+        return cron.getMeetingTimes().stream()
+                .map(LocalTime::parse)
+                .map(t -> LocalDateTime.of(cron.getOperatingDate(), t).atZone(zone).toInstant())
+                .filter(i -> i.isAfter(reference))
+                .min(Comparator.naturalOrder())
+                .orElse(null);
+    }
+
+    /** Keep the in-memory queue's cron in step so CronMonitorJob re-freezes ahead of the next return. */
+    private void refreshMemCron(UUID daId, Instant nextMeeting) {
+        DaQueue q = daStatusService.getQueue(daId);
+        if (q != null && q.getCron() != null) {
+            q.getCron().setScheduledMeetingTime(nextMeeting);
+            q.getCron().setStatus(CronAssignmentStatus.SCHEDULED);
+        }
     }
 
     private static void requireType(DispatchQueue task, TaskType expected) {

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
@@ -1,7 +1,5 @@
 package com.oneday.dispatch.service.impl;
 
-import com.oneday.common.domain.MeetingMode;
-import com.oneday.common.port.CityMeetingModePort;
 import com.oneday.dispatch.config.DispatchProperties;
 import com.oneday.dispatch.domain.CronAssignmentStatus;
 import com.oneday.dispatch.domain.DaCronAssignment;
@@ -49,26 +47,19 @@ class DaTaskServiceImpl implements DaTaskService {
     private final DaEventProducer daEventProducer;
     private final DispatchProperties props;
     private final HubScanSeamProducer hubScanSeamProducer;
-    private final CityMeetingModePort meetingModePort;
 
     DaTaskServiceImpl(DispatchQueueRepository queueRepository,
                       DaCronAssignmentRepository cronRepository,
                       DaStatusService daStatusService,
                       DaEventProducer daEventProducer,
                       DispatchProperties props,
-                      HubScanSeamProducer hubScanSeamProducer,
-                      CityMeetingModePort meetingModePort) {
+                      HubScanSeamProducer hubScanSeamProducer) {
         this.queueRepository = queueRepository;
         this.cronRepository = cronRepository;
         this.daStatusService = daStatusService;
         this.daEventProducer = daEventProducer;
         this.props = props;
         this.hubScanSeamProducer = hubScanSeamProducer;
-        this.meetingModePort = meetingModePort;
-    }
-
-    private boolean isHubReturn(DispatchQueue task) {
-        return meetingModePort.modeFor(task.getCityId()) == MeetingMode.HUB_RETURN;
     }
 
     @Override
@@ -87,28 +78,43 @@ class DaTaskServiceImpl implements DaTaskService {
     @Override
     @Transactional
     public DaTaskView recordVanHandoff(UUID daId, UUID taskId, List<String> parcelScans, UUID vanId) {
+        return completePickupHandoff(daId, taskId, parcelScans, task -> {
+            daEventProducer.emitVanHandoffCompleted(daId, task.getCityId(), task.getShipmentId());
+            log.debug("Van handoff: task {} (van {}) completed with {} scan(s)", taskId, vanId, parcelScans.size());
+        });
+    }
+
+    @Override
+    @Transactional
+    public DaTaskView recordHubHandoff(UUID daId, UUID taskId, List<String> parcelScans) {
+        // HUB_RETURN city (no van): the DA drops the collected pickups AT the hub. Same pickup-handoff
+        // lifecycle as the van path, but a neutral event (not VAN_HANDOFF_COMPLETED) + the origin-hub scan.
+        return completePickupHandoff(daId, taskId, parcelScans, task -> {
+            daEventProducer.emitHubReturnHandoffCompleted(daId, task.getCityId(), task.getShipmentId());
+            // M8-SEAM: the hub drop is the origin-hub inbound scan (advances to AT_ORIGIN_HUB → M7/M9).
+            hubScanSeamProducer.emitHubOriginIn(task.getShipmentId());
+            log.debug("Hub handoff: task {} completed with {} scan(s)", taskId, parcelScans.size());
+        });
+    }
+
+    /**
+     * Shared PICKUP handoff at a rendezvous (van meeting point or hub): validate scans, complete the
+     * task, roll the cron handoff, then run {@code onComplete} for the mode-specific event/scan emission.
+     */
+    private DaTaskView completePickupHandoff(UUID daId, UUID taskId, List<String> parcelScans,
+                                             java.util.function.Consumer<DispatchQueue> onComplete) {
         if (parcelScans == null || parcelScans.isEmpty()) {
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "At least one parcel scan is required");
         }
         return daStatusService.withDaLock(daId, () -> {
-            DispatchQueue task = ownedTask(daId, taskId); 
+            DispatchQueue task = ownedTask(daId, taskId);
             requireType(task, TaskType.PICKUP);
             requireStatus(task, TaskStatus.IN_PROGRESS);
             task.setStatus(TaskStatus.COMPLETED);
             task.setCompletedAt(Instant.now());
             DaTaskView view = save(task);
             recordCronHandoff(daId, task.getOperatingDate(), parcelScans.size());
-            // HUB_RETURN cities have no van — the DA hands off AT the hub, so emit the neutral
-            // hub-return handoff event (not VAN_HANDOFF_COMPLETED, which would claim a van received it).
-            // Both map to HANDED_TO_PICKUP_VAN in M4; only the event label differs.
-            if (isHubReturn(task)) {
-                daEventProducer.emitHubReturnHandoffCompleted(daId, task.getCityId(), task.getShipmentId());
-                // M8-SEAM: the hub drop is the origin-hub inbound scan (advances to AT_ORIGIN_HUB → M7/M9).
-                hubScanSeamProducer.emitHubOriginIn(task.getShipmentId());
-            } else {
-                daEventProducer.emitVanHandoffCompleted(daId, task.getCityId(), task.getShipmentId());
-            }
-            log.debug("Van handoff: task {} (van {}) completed with {} scan(s)", taskId, vanId, parcelScans.size());
+            onComplete.accept(task);
             return view;
         });
     }
@@ -134,6 +140,24 @@ class DaTaskServiceImpl implements DaTaskService {
     @Override
     @Transactional
     public DaTaskView markDropCollected(UUID daId, UUID taskId) {
+        return collectDelivery(daId, taskId, task -> { /* van pickup from the loop — no extra scan */ });
+    }
+
+    @Override
+    @Transactional
+    public DaTaskView recordHubCollect(UUID daId, UUID taskId) {
+        // HUB_RETURN city (no van): the DA collects the delivery FROM the hub for last-mile.
+        return collectDelivery(daId, taskId, task ->
+                // M8-SEAM: hub-dest custody scan (ledger only — the DA's later DROP_* events drive state).
+                hubScanSeamProducer.emitHubDestOut(task.getShipmentId()));
+    }
+
+    /**
+     * Shared DELIVERY collect (from a van loop or the hub): QUEUED → IN_PROGRESS, emit DROP_COLLECTED,
+     * then run {@code onCollected} for any mode-specific scan.
+     */
+    private DaTaskView collectDelivery(UUID daId, UUID taskId,
+                                       java.util.function.Consumer<DispatchQueue> onCollected) {
         return daStatusService.withDaLock(daId, () -> {
             DispatchQueue task = ownedTask(daId, taskId);
             requireType(task, TaskType.DELIVERY);
@@ -142,11 +166,7 @@ class DaTaskServiceImpl implements DaTaskService {
             task.setStartedAt(Instant.now());
             DaTaskView view = save(task);
             daEventProducer.emitDropCollected(daId, task.getCityId(), task.getShipmentId());
-            // M8-SEAM: in HUB_RETURN cities the DA collects the delivery FROM the hub, so record the
-            // hub-dest custody scan (ledger only — the DA's later DROP_* events drive the state).
-            if (isHubReturn(task)) {
-                hubScanSeamProducer.emitHubDestOut(task.getShipmentId());
-            }
+            onCollected.accept(task);
             return view;
         });
     }

--- a/dispatch/src/test/java/com/oneday/dispatch/api/DaDispatchControllerTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/api/DaDispatchControllerTest.java
@@ -1,8 +1,12 @@
 package com.oneday.dispatch.api;
 
 import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.common.domain.MeetingMode;
+import com.oneday.common.port.CityMeetingModePort;
 import com.oneday.dispatch.dto.request.GpsPingRequest;
+import com.oneday.dispatch.dto.request.HubHandoffRequest;
 import com.oneday.dispatch.dto.request.OtpVerifyRequest;
+import com.oneday.dispatch.service.model.DaLiveStatus;
 import com.oneday.dispatch.service.DaStatusService;
 import com.oneday.dispatch.service.DaTaskService;
 import com.oneday.dispatch.service.DaTaskView;
@@ -32,9 +36,11 @@ class DaDispatchControllerTest {
     private DaStatusService daStatusService;
     private DaTaskService daTaskService;
     private OtpVerificationService otpVerificationService;
+    private CityMeetingModePort meetingModePort;
     private DaDispatchController controller;
 
     private final UUID da = UUID.randomUUID();
+    private final UUID city = UUID.randomUUID();
     private final UUID taskId = UUID.randomUUID();
 
     @BeforeEach
@@ -42,7 +48,8 @@ class DaDispatchControllerTest {
         daStatusService = mock(DaStatusService.class);
         daTaskService = mock(DaTaskService.class);
         otpVerificationService = mock(OtpVerificationService.class);
-        controller = new DaDispatchController(daStatusService, daTaskService, otpVerificationService);
+        meetingModePort = mock(CityMeetingModePort.class);
+        controller = new DaDispatchController(daStatusService, daTaskService, otpVerificationService, meetingModePort);
         when(daTaskService.markEnRoute(any(), any())).thenReturn(sampleView());
     }
 
@@ -93,6 +100,39 @@ class DaDispatchControllerTest {
         var resp = controller.resendOtp(da, taskId, principal(da, "DELIVERY_ASSOCIATE"));
         assertThat(resp.getStatusCode().value()).isEqualTo(204);
         verify(otpVerificationService).resendOtp(da, taskId);
+    }
+
+    @Test
+    void hubHandoffDelegatesWhenCityIsHubReturn() {
+        stubCityMode(MeetingMode.HUB_RETURN);
+        controller.hubHandoff(da, taskId, principal(da, "DELIVERY_ASSOCIATE"),
+                new HubHandoffRequest(java.util.List.of("P-1"), null));
+        verify(daTaskService).recordHubHandoff(da, taskId, java.util.List.of("P-1"));
+    }
+
+    @Test
+    void hubHandoffRejectedWithConflictInVanCity() {
+        stubCityMode(MeetingMode.VAN_MEETING);
+        assertThatThrownBy(() -> controller.hubHandoff(da, taskId, principal(da, "DELIVERY_ASSOCIATE"),
+                new HubHandoffRequest(java.util.List.of("P-1"), null)))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("409");
+        verify(daTaskService, org.mockito.Mockito.never()).recordHubHandoff(any(), any(), any());
+    }
+
+    @Test
+    void hubCollectDelegatesWhenCityIsHubReturn() {
+        stubCityMode(MeetingMode.HUB_RETURN);
+        controller.hubCollect(da, taskId, principal(da, "DELIVERY_ASSOCIATE"));
+        verify(daTaskService).recordHubCollect(da, taskId);
+    }
+
+    /** Wire the DA's live status → city → meeting mode (flat, to avoid nested stubbing). */
+    private void stubCityMode(MeetingMode mode) {
+        DaLiveStatus status = mock(DaLiveStatus.class);
+        when(status.getCityId()).thenReturn(city);
+        when(daStatusService.getLiveStatus(da)).thenReturn(status);
+        when(meetingModePort.modeFor(city)).thenReturn(mode);
     }
 
     private AuthUserDetails principal(UUID userId, String role) {

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaTaskServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaTaskServiceImplTest.java
@@ -31,6 +31,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /** Real-Postgres tests of the DA task-lifecycle transitions, guards, and (gated) event emission. */
 @Tag("e2e")
@@ -56,7 +57,12 @@ class DaTaskServiceImplTest {
         DaStatusServiceImpl daStatus = new DaStatusServiceImpl(daStatusRepo, props);
         daStatus.initShift(da, city, today, "MORNING", null);
         events = mock(DaEventProducer.class);
-        service = new DaTaskServiceImpl(queueRepo, cronRepo, daStatus, events);
+        com.oneday.dispatch.events.HubScanSeamProducer scanSeam =
+                mock(com.oneday.dispatch.events.HubScanSeamProducer.class);
+        com.oneday.common.port.CityMeetingModePort meetingMode =
+                mock(com.oneday.common.port.CityMeetingModePort.class);
+        when(meetingMode.modeFor(any())).thenReturn(com.oneday.common.domain.MeetingMode.VAN_MEETING);
+        service = new DaTaskServiceImpl(queueRepo, cronRepo, daStatus, events, props, scanSeam, meetingMode);
     }
 
     @Test
@@ -111,6 +117,36 @@ class DaTaskServiceImplTest {
         assertThat(cron.getHandoffCompletedAt()).isNotNull();
         assertThat(cron.getParcelCountHanded()).isEqualTo(1);
         verify(events).emitVanHandoffCompleted(eq(da), eq(city), eq(task.getShipmentId()));
+    }
+
+    @Test
+    void hubReturnHandoffRollsCronToNextSlotAndStaysScheduled() {
+        // HUB_RETURN cron (no van) with a later return today: the handoff completes THIS leg but keeps
+        // the assignment SCHEDULED, rolling the meeting to the next slot so the hard constraint holds.
+        DispatchQueue task = persist(TaskType.PICKUP, TaskStatus.IN_PROGRESS);
+        persistHubReturnCron("10:00", java.util.List.of("10:00", "13:00"));
+
+        service.recordVanHandoff(da, task.getId(), java.util.List.of("P-1"), null);
+
+        DaCronAssignment cron = cronRepo.findByDaIdAndOperatingDate(da, today).orElseThrow();
+        assertThat(cron.getStatus()).isEqualTo(CronAssignmentStatus.SCHEDULED);
+        java.time.ZoneId zone = java.time.ZoneId.of(new DispatchProperties().getShift().getZone());
+        java.time.Instant expectedNext = java.time.LocalTime.parse("13:00")
+                .atDate(today).atZone(zone).toInstant();
+        assertThat(cron.getScheduledMeetingTime()).isEqualTo(expectedNext);
+        assertThat(cron.getParcelCountHanded()).isEqualTo(1);
+    }
+
+    @Test
+    void hubReturnHandoffOnLastSlotCompletesCron() {
+        // Final return of the day (no later slot) is terminal, like a van rendezvous.
+        DispatchQueue task = persist(TaskType.PICKUP, TaskStatus.IN_PROGRESS);
+        persistHubReturnCron("19:00", java.util.List.of("19:00"));
+
+        service.recordVanHandoff(da, task.getId(), java.util.List.of("P-1"), null);
+
+        DaCronAssignment cron = cronRepo.findByDaIdAndOperatingDate(da, today).orElseThrow();
+        assertThat(cron.getStatus()).isEqualTo(CronAssignmentStatus.COMPLETED);
     }
 
     @Test
@@ -182,6 +218,22 @@ class DaTaskServiceImplTest {
         c.setMeetingLon(77.60);
         c.setScheduledMeetingTime(Instant.now().plus(2, ChronoUnit.HOURS));
         c.setStatus(status);
+        cronRepo.saveAndFlush(c);
+    }
+
+    private void persistHubReturnCron(String currentSlot, java.util.List<String> meetingTimes) {
+        java.time.ZoneId zone = java.time.ZoneId.of(new DispatchProperties().getShift().getZone());
+        DaCronAssignment c = new DaCronAssignment();
+        c.setDaId(da);
+        c.setCityId(city);
+        c.setOperatingDate(today);
+        c.setCronVertexId(UUID.randomUUID());
+        c.setMeetingLat(12.96);
+        c.setMeetingLon(77.60);
+        c.setScheduledMeetingTime(java.time.LocalTime.parse(currentSlot).atDate(today).atZone(zone).toInstant());
+        c.setMeetingTimes(meetingTimes);
+        c.setVanId(null);   // HUB_RETURN crons carry no van
+        c.setStatus(CronAssignmentStatus.SCHEDULED);
         cronRepo.saveAndFlush(c);
     }
 

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaTaskServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaTaskServiceImplTest.java
@@ -27,11 +27,9 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /** Real-Postgres tests of the DA task-lifecycle transitions, guards, and (gated) event emission. */
 @Tag("e2e")
@@ -49,6 +47,7 @@ class DaTaskServiceImplTest {
     private final LocalDate today = LocalDate.now();
 
     private DaEventProducer events;
+    private com.oneday.dispatch.events.HubScanSeamProducer scanSeam;
     private DaTaskService service;
 
     @BeforeEach
@@ -57,12 +56,8 @@ class DaTaskServiceImplTest {
         DaStatusServiceImpl daStatus = new DaStatusServiceImpl(daStatusRepo, props);
         daStatus.initShift(da, city, today, "MORNING", null);
         events = mock(DaEventProducer.class);
-        com.oneday.dispatch.events.HubScanSeamProducer scanSeam =
-                mock(com.oneday.dispatch.events.HubScanSeamProducer.class);
-        com.oneday.common.port.CityMeetingModePort meetingMode =
-                mock(com.oneday.common.port.CityMeetingModePort.class);
-        when(meetingMode.modeFor(any())).thenReturn(com.oneday.common.domain.MeetingMode.VAN_MEETING);
-        service = new DaTaskServiceImpl(queueRepo, cronRepo, daStatus, events, props, scanSeam, meetingMode);
+        scanSeam = mock(com.oneday.dispatch.events.HubScanSeamProducer.class);
+        service = new DaTaskServiceImpl(queueRepo, cronRepo, daStatus, events, props, scanSeam);
     }
 
     @Test
@@ -126,7 +121,7 @@ class DaTaskServiceImplTest {
         DispatchQueue task = persist(TaskType.PICKUP, TaskStatus.IN_PROGRESS);
         persistHubReturnCron("10:00", java.util.List.of("10:00", "13:00"));
 
-        service.recordVanHandoff(da, task.getId(), java.util.List.of("P-1"), null);
+        service.recordHubHandoff(da, task.getId(), java.util.List.of("P-1"));
 
         DaCronAssignment cron = cronRepo.findByDaIdAndOperatingDate(da, today).orElseThrow();
         assertThat(cron.getStatus()).isEqualTo(CronAssignmentStatus.SCHEDULED);
@@ -135,6 +130,9 @@ class DaTaskServiceImplTest {
                 .atDate(today).atZone(zone).toInstant();
         assertThat(cron.getScheduledMeetingTime()).isEqualTo(expectedNext);
         assertThat(cron.getParcelCountHanded()).isEqualTo(1);
+        // Hub handoff emits the neutral (non-van) event + the origin-hub M8 seam.
+        verify(events).emitHubReturnHandoffCompleted(eq(da), eq(city), eq(task.getShipmentId()));
+        verify(scanSeam).emitHubOriginIn(eq(task.getShipmentId()));
     }
 
     @Test
@@ -143,10 +141,19 @@ class DaTaskServiceImplTest {
         DispatchQueue task = persist(TaskType.PICKUP, TaskStatus.IN_PROGRESS);
         persistHubReturnCron("19:00", java.util.List.of("19:00"));
 
-        service.recordVanHandoff(da, task.getId(), java.util.List.of("P-1"), null);
+        service.recordHubHandoff(da, task.getId(), java.util.List.of("P-1"));
 
         DaCronAssignment cron = cronRepo.findByDaIdAndOperatingDate(da, today).orElseThrow();
         assertThat(cron.getStatus()).isEqualTo(CronAssignmentStatus.COMPLETED);
+    }
+
+    @Test
+    void hubCollectMovesDeliveryToInProgressAndEmitsScanSeam() {
+        DispatchQueue task = persist(TaskType.DELIVERY, TaskStatus.QUEUED);
+        service.recordHubCollect(da, task.getId());
+        assertThat(reload(task).getStatus()).isEqualTo(TaskStatus.IN_PROGRESS);
+        verify(events).emitDropCollected(eq(da), eq(city), eq(task.getShipmentId()));
+        verify(scanSeam).emitHubDestOut(eq(task.getShipmentId()));
     }
 
     @Test

--- a/orders/src/main/java/com/oneday/orders/config/MeetingModeConfig.java
+++ b/orders/src/main/java/com/oneday/orders/config/MeetingModeConfig.java
@@ -1,0 +1,36 @@
+package com.oneday.orders.config;
+
+import com.oneday.common.domain.MeetingMode;
+import com.oneday.common.port.CityMeetingModePort;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Fallback {@link CityMeetingModePort} for M4's isolated module tests. Orders cannot depend on routing,
+ * which owns the real adapter (over {@code city_fleet_config}) — absent it, every city reads as
+ * VAN_MEETING, so {@code DaEventsConsumer} keeps mapping DROP_ASSIGNED/DROP_COLLECTED to the van states.
+ * In the assembled app routing's {@code @Primary CityMeetingModeAdapter} is present, so this backs off.
+ */
+@Configuration
+public class MeetingModeConfig {
+
+    @Bean
+    @ConditionalOnMissingBean(CityMeetingModePort.class)
+    CityMeetingModePort vanMeetingModePort() {
+        return new CityMeetingModePort() {
+            @Override
+            public MeetingMode modeFor(UUID cityId) {
+                return MeetingMode.VAN_MEETING;
+            }
+
+            @Override
+            public Optional<HubLocation> hubLocation(UUID cityId) {
+                return Optional.empty();
+            }
+        };
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/events/DaEventsConsumer.java
+++ b/orders/src/main/java/com/oneday/orders/events/DaEventsConsumer.java
@@ -1,7 +1,9 @@
 package com.oneday.orders.events;
 
+import com.oneday.common.domain.MeetingMode;
 import com.oneday.common.domain.enums.ShipmentState;
 import com.oneday.common.kafka.events.DaLifecycleEvent;
+import com.oneday.common.port.CityMeetingModePort;
 import com.oneday.orders.service.PickupOtpService;
 import com.oneday.orders.service.ShipmentStateMachine;
 import com.oneday.orders.service.TransitionContext;
@@ -33,22 +35,30 @@ public class DaEventsConsumer {
 
     private final ShipmentStateMachine stateMachine;
     private final PickupOtpService pickupOtpService;
+    private final CityMeetingModePort meetingModePort;
 
-    DaEventsConsumer(ShipmentStateMachine stateMachine, PickupOtpService pickupOtpService) {
+    DaEventsConsumer(ShipmentStateMachine stateMachine, PickupOtpService pickupOtpService,
+                     CityMeetingModePort meetingModePort) {
         this.stateMachine = stateMachine;
         this.pickupOtpService = pickupOtpService;
+        this.meetingModePort = meetingModePort;
     }
 
     @RabbitListener(queues = OrdersMessagingTopology.DA_QUEUE)
     public void onDaEvent(DaLifecycleEvent event) {
+        // The delivery-side events (DROP_ASSIGNED / DROP_COLLECTED) are shared between VAN_MEETING and
+        // HUB_RETURN cities — only the delivery city's mode distinguishes them. Resolve it once so the
+        // parcel's M4 state honestly reflects "on a drop van" vs "collected at the hub". Null/unknown → van.
+        boolean hubReturn = event.cityId() != null
+                && meetingModePort.modeFor(event.cityId()) == MeetingMode.HUB_RETURN;
         ShipmentState target = switch (event.eventType()) {
             case PICKUP_ASSIGNED       -> ShipmentState.PICKUP_ASSIGNED;
             case PICKUP_FAILED         -> ShipmentState.PICKUP_FAILED;
             case VAN_HANDOFF_COMPLETED -> ShipmentState.HANDED_TO_PICKUP_VAN;
-            // HUB_RETURN city: DA dropped at the hub (no van) — same custody step as a van handoff.
-            case HUB_RETURN_HANDOFF_COMPLETED -> ShipmentState.HANDED_TO_PICKUP_VAN;
-            case DROP_ASSIGNED         -> ShipmentState.DROP_ASSIGNED;
-            case DROP_COLLECTED        -> ShipmentState.DROP_COLLECTED;
+            // HUB_RETURN city: DA carried the pickup back to the hub itself — no pickup van involved.
+            case HUB_RETURN_HANDOFF_COMPLETED -> ShipmentState.RETURNED_TO_HUB;
+            case DROP_ASSIGNED         -> hubReturn ? ShipmentState.HUB_DELIVERY_ASSIGNED : ShipmentState.DROP_ASSIGNED;
+            case DROP_COLLECTED        -> hubReturn ? ShipmentState.COLLECTED_FROM_HUB    : ShipmentState.DROP_COLLECTED;
             case DROP_COMPLETED        -> ShipmentState.DROPPED;
             case DROP_FAILED           -> ShipmentState.DELIVERY_FAILED;
             // Not consumed by M4 — PICKED_UP is driven exclusively by the OTP verify endpoint.

--- a/orders/src/main/java/com/oneday/orders/events/DaEventsConsumer.java
+++ b/orders/src/main/java/com/oneday/orders/events/DaEventsConsumer.java
@@ -45,6 +45,8 @@ public class DaEventsConsumer {
             case PICKUP_ASSIGNED       -> ShipmentState.PICKUP_ASSIGNED;
             case PICKUP_FAILED         -> ShipmentState.PICKUP_FAILED;
             case VAN_HANDOFF_COMPLETED -> ShipmentState.HANDED_TO_PICKUP_VAN;
+            // HUB_RETURN city: DA dropped at the hub (no van) — same custody step as a van handoff.
+            case HUB_RETURN_HANDOFF_COMPLETED -> ShipmentState.HANDED_TO_PICKUP_VAN;
             case DROP_ASSIGNED         -> ShipmentState.DROP_ASSIGNED;
             case DROP_COLLECTED        -> ShipmentState.DROP_COLLECTED;
             case DROP_COMPLETED        -> ShipmentState.DROPPED;

--- a/orders/src/main/java/com/oneday/orders/events/ScanEventsConsumer.java
+++ b/orders/src/main/java/com/oneday/orders/events/ScanEventsConsumer.java
@@ -38,6 +38,9 @@ public class ScanEventsConsumer {
             // Not a state transition — carries the generated parcelId (sets shipment.parcel_id).
             // TODO: handle once ScanEvent is extended with the parcelId field.
             case LABEL_GENERATED       -> null;
+            // HUB_RETURN custody ledger record (DA collected a dest parcel from the hub); the DA's
+            // later DROP_* events drive the last-mile state, so this is not an M4 transition.
+            case HUB_DEST_OUT          -> null;
         };
         if (target == null) {
             log.debug("Scan event {} ignored for shipment {}", event.eventType(), event.shipmentId());

--- a/orders/src/main/java/com/oneday/orders/service/CustomerVisibleStateMapper.java
+++ b/orders/src/main/java/com/oneday/orders/service/CustomerVisibleStateMapper.java
@@ -24,6 +24,7 @@ public class CustomerVisibleStateMapper {
         LABELS.put(ShipmentState.PICKUP_ASSIGNED,          "Pickup agent assigned");
         LABELS.put(ShipmentState.PICKED_UP,                "Parcel collected");
         LABELS.put(ShipmentState.HANDED_TO_PICKUP_VAN,     "Parcel handed to transport");
+        LABELS.put(ShipmentState.RETURNED_TO_HUB,          "Parcel handed to transport");
         LABELS.put(ShipmentState.AWAITING_SELF_DROP,       "Please bring your parcel to the origin hub");
         LABELS.put(ShipmentState.AT_ORIGIN_HUB,            "Arrived at origin hub");
         LABELS.put(ShipmentState.ORIGIN_HUB_PROCESSING,    "Being processed at hub");
@@ -38,6 +39,8 @@ public class CustomerVisibleStateMapper {
         LABELS.put(ShipmentState.HANDED_TO_DROP_VAN,       "Out for delivery");
         LABELS.put(ShipmentState.DROP_ASSIGNED,            "Delivery agent assigned");
         LABELS.put(ShipmentState.DROP_COLLECTED,           "Delivery agent en route");
+        LABELS.put(ShipmentState.HUB_DELIVERY_ASSIGNED,    "Delivery agent assigned");
+        LABELS.put(ShipmentState.COLLECTED_FROM_HUB,       "Delivery agent en route");
         LABELS.put(ShipmentState.DROPPED,                  "Delivered");
         LABELS.put(ShipmentState.AWAITING_HUB_COLLECT,     "Your parcel is ready — collect from the hub");
         LABELS.put(ShipmentState.HUB_COLLECTED,            "Collected from hub");

--- a/orders/src/main/java/com/oneday/orders/service/TransitionRegistry.java
+++ b/orders/src/main/java/com/oneday/orders/service/TransitionRegistry.java
@@ -51,10 +51,12 @@ public class TransitionRegistry {
         register(ShipmentState.PICKUP_ASSIGNED,       ShipmentState.PICKUP_FAILED);
         register(ShipmentState.PICKUP_ASSIGNED,       ShipmentState.CANCELLED);
 
-        register(ShipmentState.PICKED_UP,             ShipmentState.HANDED_TO_PICKUP_VAN);
+        register(ShipmentState.PICKED_UP,             ShipmentState.HANDED_TO_PICKUP_VAN);   // VAN_MEETING
+        register(ShipmentState.PICKED_UP,             ShipmentState.RETURNED_TO_HUB);        // HUB_RETURN
         register(ShipmentState.PICKED_UP,             ShipmentState.CANCELLED);
 
         register(ShipmentState.HANDED_TO_PICKUP_VAN,  ShipmentState.AT_ORIGIN_HUB);
+        register(ShipmentState.RETURNED_TO_HUB,       ShipmentState.AT_ORIGIN_HUB);
 
         // ── Hub processing ────────────────────────────────────────────────────
         register(ShipmentState.AT_ORIGIN_HUB,         ShipmentState.ORIGIN_HUB_PROCESSING);
@@ -73,9 +75,11 @@ public class TransitionRegistry {
         register(ShipmentState.AT_DEST_HUB,           ShipmentState.DEST_HUB_PROCESSING);
 
         // ── Last-mile delivery (drop_type branching at DEST_HUB_PROCESSING) ───
-        // Both targets are registered; impl filters to one at runtime.
-        register(ShipmentState.DEST_HUB_PROCESSING,   ShipmentState.HANDED_TO_DROP_VAN);    // DA_DELIVERY
-        register(ShipmentState.DEST_HUB_PROCESSING,   ShipmentState.AWAITING_HUB_COLLECT);  // HUB_COLLECT
+        // Three targets are registered; the producer/mode picks one (impl filters HUB_COLLECT out for
+        // DA_DELIVERY, but DA_DELIVERY itself splits VAN_MEETING vs HUB_RETURN by the delivery city's mode).
+        register(ShipmentState.DEST_HUB_PROCESSING,   ShipmentState.HANDED_TO_DROP_VAN);      // DA_DELIVERY · VAN_MEETING
+        register(ShipmentState.DEST_HUB_PROCESSING,   ShipmentState.HUB_DELIVERY_ASSIGNED);   // DA_DELIVERY · HUB_RETURN
+        register(ShipmentState.DEST_HUB_PROCESSING,   ShipmentState.AWAITING_HUB_COLLECT);    // HUB_COLLECT
 
         register(ShipmentState.AWAITING_HUB_COLLECT,  ShipmentState.HUB_COLLECTED);
 
@@ -84,12 +88,18 @@ public class TransitionRegistry {
         register(ShipmentState.DROP_COLLECTED,        ShipmentState.DROPPED);
         register(ShipmentState.DROP_COLLECTED,        ShipmentState.DELIVERY_FAILED);
 
+        // HUB_RETURN last-mile: no drop van — DA collects at the hub and delivers.
+        register(ShipmentState.HUB_DELIVERY_ASSIGNED, ShipmentState.COLLECTED_FROM_HUB);
+        register(ShipmentState.COLLECTED_FROM_HUB,    ShipmentState.DROPPED);
+        register(ShipmentState.COLLECTED_FROM_HUB,    ShipmentState.DELIVERY_FAILED);
+
         // ── Exception / failure paths (M11-driven) ───────────────────────────
         register(ShipmentState.PICKUP_FAILED,         ShipmentState.PICKUP_ASSIGNED);
         register(ShipmentState.PICKUP_FAILED,         ShipmentState.CANCELLED);
 
         register(ShipmentState.DELIVERY_FAILED,       ShipmentState.RTO_INITIATED);
-        register(ShipmentState.DELIVERY_FAILED,       ShipmentState.DROP_ASSIGNED);
+        register(ShipmentState.DELIVERY_FAILED,       ShipmentState.DROP_ASSIGNED);          // VAN_MEETING redelivery
+        register(ShipmentState.DELIVERY_FAILED,       ShipmentState.HUB_DELIVERY_ASSIGNED);  // HUB_RETURN redelivery
 
         // ── RTO path (delivery_type branching at RTO_INITIATED) ──────────────
         // Both targets registered; impl filters to one at runtime.

--- a/orders/src/main/java/com/oneday/orders/service/impl/ShipmentLocationAdapter.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/ShipmentLocationAdapter.java
@@ -1,0 +1,40 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.port.ShipmentLocationPort;
+import com.oneday.orders.domain.Address;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.repository.ShipmentRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Orders-side implementation of {@link ShipmentLocationPort}: reads the receiver's geocoded address
+ * off the shipment so M5 can assign a hub-return delivery against the real drop lat/lon.
+ */
+@Component
+class ShipmentLocationAdapter implements ShipmentLocationPort {
+
+    private final ShipmentRepository shipmentRepository;
+
+    ShipmentLocationAdapter(ShipmentRepository shipmentRepository) {
+        this.shipmentRepository = shipmentRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<DropLocation> dropLocation(UUID shipmentId) {
+        return shipmentRepository.findById(shipmentId)
+                .filter(s -> hasCoords(s.getDestAddress()))
+                .map(s -> new DropLocation(
+                        s.getDestAddress().getLatitude(),
+                        s.getDestAddress().getLongitude(),
+                        s.getDestTileId()));
+    }
+
+    private static boolean hasCoords(Address a) {
+        return a != null && a.getLatitude() != null && a.getLongitude() != null;
+    }
+}

--- a/orders/src/main/resources/db/migration/orders/V4_22__add_hub_return_shipment_states.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_22__add_hub_return_shipment_states.sql
@@ -1,0 +1,10 @@
+-- HUB_RETURN meeting-mode states (per-city M6 gate). In cities with no van/meeting-point
+-- infrastructure the DA carries pickups back to the hub and collects deliveries there, so the
+-- shipment_state enum needs custody states that replace the van ones:
+--   RETURNED_TO_HUB        first-mile: DA carried the pickup back to the origin hub (no pickup van)
+--   HUB_DELIVERY_ASSIGNED  last-mile:  territory DA assigned; parcel waits at dest hub for their visit
+--   COLLECTED_FROM_HUB     last-mile:  DA collected the parcel at the hub — out for delivery
+-- PG 12+ allows ADD VALUE inside Flyway's transaction (the values are only added here, not used).
+ALTER TYPE shipment_state ADD VALUE IF NOT EXISTS 'RETURNED_TO_HUB';
+ALTER TYPE shipment_state ADD VALUE IF NOT EXISTS 'HUB_DELIVERY_ASSIGNED';
+ALTER TYPE shipment_state ADD VALUE IF NOT EXISTS 'COLLECTED_FROM_HUB';

--- a/orders/src/test/java/com/oneday/orders/events/DaEventsConsumerTest.java
+++ b/orders/src/test/java/com/oneday/orders/events/DaEventsConsumerTest.java
@@ -21,7 +21,9 @@ class DaEventsConsumerTest {
 
     private final ShipmentStateMachine stateMachine = mock(ShipmentStateMachine.class);
     private final PickupOtpService otp = mock(PickupOtpService.class);
-    private final DaEventsConsumer consumer = new DaEventsConsumer(stateMachine, otp);
+    private final com.oneday.common.port.CityMeetingModePort meetingMode =
+            mock(com.oneday.common.port.CityMeetingModePort.class);
+    private final DaEventsConsumer consumer = new DaEventsConsumer(stateMachine, otp, meetingMode);
 
     private DaLifecycleEvent pickupAssigned(UUID shipmentId) {
         return new DaLifecycleEvent(UUID.randomUUID(), DaEventType.PICKUP_ASSIGNED, "1.0", Instant.now(),

--- a/routing/src/main/java/com/oneday/routing/api/RoutingFleetController.java
+++ b/routing/src/main/java/com/oneday/routing/api/RoutingFleetController.java
@@ -86,6 +86,8 @@ public class RoutingFleetController {
         if (req.shuttleCadenceMinutes() != null) fleet.setShuttleCadenceMinutes(req.shuttleCadenceMinutes());
         if (req.maxDaToVertexMinutes() != null) fleet.setMaxDaToVertexMinutes(req.maxDaToVertexMinutes());
         if (req.dwellMinutes() != null) fleet.setDwellMinutes(req.dwellMinutes());
+        if (req.meetingMode() != null) fleet.setMeetingMode(req.meetingMode());
+        if (req.hubReturnIntervalMinutes() != null) fleet.setHubReturnIntervalMinutes(req.hubReturnIntervalMinutes());
         return FleetConfigResponse.from(fleetRepository.save(fleet));
     }
 

--- a/routing/src/main/java/com/oneday/routing/api/RoutingFleetController.java
+++ b/routing/src/main/java/com/oneday/routing/api/RoutingFleetController.java
@@ -2,6 +2,7 @@ package com.oneday.routing.api;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneday.common.domain.MeetingMode;
 import com.oneday.routing.domain.CityFleetConfig;
 import com.oneday.routing.domain.RoutePlan;
 import com.oneday.routing.dto.FleetConfigResponse;
@@ -88,6 +89,10 @@ public class RoutingFleetController {
         if (req.dwellMinutes() != null) fleet.setDwellMinutes(req.dwellMinutes());
         if (req.meetingMode() != null) fleet.setMeetingMode(req.meetingMode());
         if (req.hubReturnIntervalMinutes() != null) fleet.setHubReturnIntervalMinutes(req.hubReturnIntervalMinutes());
+        // The cadence belongs to HUB_RETURN only — a city switched (back) to VAN_MEETING carries no
+        // interval. Enforce the invariant here so a flip doesn't leave a stale interval behind (the
+        // client can't clear it via a null partial-update field).
+        if (fleet.getMeetingMode() == MeetingMode.VAN_MEETING) fleet.setHubReturnIntervalMinutes(null);
         return FleetConfigResponse.from(fleetRepository.save(fleet));
     }
 

--- a/routing/src/main/java/com/oneday/routing/domain/CityFleetConfig.java
+++ b/routing/src/main/java/com/oneday/routing/domain/CityFleetConfig.java
@@ -1,5 +1,6 @@
 package com.oneday.routing.domain;
 
+import com.oneday.common.domain.MeetingMode;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -49,6 +50,15 @@ public class CityFleetConfig {
 
     @Column(name = "dwell_minutes", nullable = false)
     private int dwellMinutes;
+
+    // Per-city M6 gate (V6_15). VAN_MEETING = full routing; HUB_RETURN = no M6, periodic hub return.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "meeting_mode", nullable = false, length = 20)
+    private MeetingMode meetingMode;
+
+    // HUB_RETURN cadence in minutes (null → code default). Ignored in VAN_MEETING.
+    @Column(name = "hub_return_interval_minutes")
+    private Integer hubReturnIntervalMinutes;
 
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;

--- a/routing/src/main/java/com/oneday/routing/dto/FleetConfigResponse.java
+++ b/routing/src/main/java/com/oneday/routing/dto/FleetConfigResponse.java
@@ -1,5 +1,6 @@
 package com.oneday.routing.dto;
 
+import com.oneday.common.domain.MeetingMode;
 import com.oneday.routing.domain.CityFleetConfig;
 
 import java.time.Instant;
@@ -15,12 +16,15 @@ public record FleetConfigResponse(
         int shuttleCadenceMinutes,
         int maxDaToVertexMinutes,
         int dwellMinutes,
+        MeetingMode meetingMode,
+        Integer hubReturnIntervalMinutes,
         Instant updatedAt) {
 
     public static FleetConfigResponse from(CityFleetConfig c) {
         return new FleetConfigResponse(
                 c.getCityId(), c.getVansAvailable(), c.getCapacityPackets(),
                 c.getCycleTimeMinMinutes(), c.getCycleTimeMaxMinutes(), c.getShuttleCadenceMinutes(),
-                c.getMaxDaToVertexMinutes(), c.getDwellMinutes(), c.getUpdatedAt());
+                c.getMaxDaToVertexMinutes(), c.getDwellMinutes(),
+                c.getMeetingMode(), c.getHubReturnIntervalMinutes(), c.getUpdatedAt());
     }
 }

--- a/routing/src/main/java/com/oneday/routing/dto/FleetConfigUpdateRequest.java
+++ b/routing/src/main/java/com/oneday/routing/dto/FleetConfigUpdateRequest.java
@@ -1,9 +1,11 @@
 package com.oneday.routing.dto;
 
+import com.oneday.common.domain.MeetingMode;
+
 /**
  * Partial fleet update ({@code PUT /routing/fleet/{cityId}}). Every field is nullable so the ops
- * console can change just the van count (the demo's primary control) without resending the rest.
- * Null fields keep their stored value.
+ * console can change just the van count (the demo's primary control) — or flip {@code meetingMode}
+ * — without resending the rest. Null fields keep their stored value.
  */
 public record FleetConfigUpdateRequest(
         Integer vansAvailable,
@@ -12,4 +14,6 @@ public record FleetConfigUpdateRequest(
         Integer cycleTimeMaxMinutes,
         Integer shuttleCadenceMinutes,
         Integer maxDaToVertexMinutes,
-        Integer dwellMinutes) {}
+        Integer dwellMinutes,
+        MeetingMode meetingMode,
+        Integer hubReturnIntervalMinutes) {}

--- a/routing/src/main/java/com/oneday/routing/events/DaFeedConsumer.java
+++ b/routing/src/main/java/com/oneday/routing/events/DaFeedConsumer.java
@@ -1,7 +1,9 @@
 package com.oneday.routing.events;
 
+import com.oneday.common.domain.MeetingMode;
 import com.oneday.common.kafka.enums.DaEventType;
 import com.oneday.common.kafka.events.DaLifecycleEvent;
+import com.oneday.common.port.CityMeetingModePort;
 import com.oneday.routing.domain.InboundKind;
 import com.oneday.routing.domain.InboundParcel;
 import com.oneday.routing.repository.InboundParcelRepository;
@@ -24,10 +26,13 @@ public class DaFeedConsumer {
 
     private final InboundParcelRepository repository;
     private final VanManifestService manifestService;
+    private final CityMeetingModePort meetingModePort;
 
-    public DaFeedConsumer(InboundParcelRepository repository, VanManifestService manifestService) {
+    public DaFeedConsumer(InboundParcelRepository repository, VanManifestService manifestService,
+                          CityMeetingModePort meetingModePort) {
         this.repository = repository;
         this.manifestService = manifestService;
+        this.meetingModePort = meetingModePort;
     }
 
     @RabbitListener(queues = RoutingMessagingTopology.DA_FEED_QUEUE)
@@ -39,6 +44,13 @@ public class DaFeedConsumer {
         if (parcelId == null || event.cityId() == null || event.validDate() == null) {
             log.warn("PICKUP_COMPLETED missing parcelId/cityId/validDate (parcel={} city={} date={}) — skipping bind",
                     parcelId, event.cityId(), event.validDate());
+            return;
+        }
+        // HUB_RETURN cities have no van — the DA carries the collected parcel to the hub on the next
+        // return, so there is nothing to bind here.
+        if (meetingModePort.modeFor(event.cityId()) == MeetingMode.HUB_RETURN) {
+            log.debug("Skipping van bind for COLLECT parcel {} — city {} is HUB_RETURN",
+                    parcelId, event.cityId());
             return;
         }
         if (!repository.existsByKindAndParcelId(InboundKind.COLLECT, parcelId)) {

--- a/routing/src/main/java/com/oneday/routing/events/HubFeedConsumer.java
+++ b/routing/src/main/java/com/oneday/routing/events/HubFeedConsumer.java
@@ -1,5 +1,7 @@
 package com.oneday.routing.events;
 
+import com.oneday.common.domain.MeetingMode;
+import com.oneday.common.port.CityMeetingModePort;
 import com.oneday.routing.domain.InboundKind;
 import com.oneday.routing.domain.InboundParcel;
 import com.oneday.common.kafka.events.hub.ParcelSortedForDeliveryEvent;
@@ -18,14 +20,24 @@ public class HubFeedConsumer {
 
     private final InboundParcelRepository repository;
     private final VanManifestService manifestService;
+    private final CityMeetingModePort meetingModePort;
 
-    public HubFeedConsumer(InboundParcelRepository repository, VanManifestService manifestService) {
+    public HubFeedConsumer(InboundParcelRepository repository, VanManifestService manifestService,
+                           CityMeetingModePort meetingModePort) {
         this.repository = repository;
         this.manifestService = manifestService;
+        this.meetingModePort = meetingModePort;
     }
 
     @RabbitListener(queues = RoutingMessagingTopology.HUB_FEED_QUEUE)
     public void onSortedForDelivery(ParcelSortedForDeliveryEvent event) {
+        // HUB_RETURN cities have no van to bind to — M5 assigns the delivery straight to the
+        // territory DA (HubDeliveryFeedConsumer), so M6 stays out of it.
+        if (meetingModePort.modeFor(event.cityId()) == MeetingMode.HUB_RETURN) {
+            log.debug("Skipping van bind for DELIVER parcel {} — city {} is HUB_RETURN",
+                    event.parcelId(), event.cityId());
+            return;
+        }
         if (!repository.existsByKindAndParcelId(InboundKind.DELIVER, event.parcelId())) {
             repository.save(InboundParcel.builder()
                     .kind(InboundKind.DELIVER)

--- a/routing/src/main/java/com/oneday/routing/service/impl/CityMeetingModeAdapter.java
+++ b/routing/src/main/java/com/oneday/routing/service/impl/CityMeetingModeAdapter.java
@@ -1,0 +1,45 @@
+package com.oneday.routing.service.impl;
+
+import com.oneday.common.domain.MeetingMode;
+import com.oneday.common.port.CityMeetingModePort;
+import com.oneday.routing.domain.LogisticsNodeKind;
+import com.oneday.routing.repository.CityFleetConfigRepository;
+import com.oneday.routing.repository.CityLogisticsNodeRepository;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Routing-side implementation of {@link CityMeetingModePort}: reads the per-city M6 gate off
+ * {@code city_fleet_config} and the hub coordinates off {@code city_logistics_node}. A city with
+ * no fleet config is treated as {@link MeetingMode#VAN_MEETING} (the safe default — nothing changes
+ * for cities the gate was never set on).
+ */
+@Component
+@Primary   // wins over dispatch's VAN_MEETING fallback in the assembled app
+public class CityMeetingModeAdapter implements CityMeetingModePort {
+
+    private final CityFleetConfigRepository fleetRepository;
+    private final CityLogisticsNodeRepository nodeRepository;
+
+    public CityMeetingModeAdapter(CityFleetConfigRepository fleetRepository,
+                                  CityLogisticsNodeRepository nodeRepository) {
+        this.fleetRepository = fleetRepository;
+        this.nodeRepository = nodeRepository;
+    }
+
+    @Override
+    public MeetingMode modeFor(UUID cityId) {
+        return fleetRepository.findByCityId(cityId)
+                .map(c -> c.getMeetingMode() != null ? c.getMeetingMode() : MeetingMode.VAN_MEETING)
+                .orElse(MeetingMode.VAN_MEETING);
+    }
+
+    @Override
+    public Optional<HubLocation> hubLocation(UUID cityId) {
+        return nodeRepository.findByCityIdAndKind(cityId, LogisticsNodeKind.HUB)
+                .map(n -> new HubLocation(n.getLat(), n.getLon()));
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/service/impl/HubReturnScheduleService.java
+++ b/routing/src/main/java/com/oneday/routing/service/impl/HubReturnScheduleService.java
@@ -1,0 +1,167 @@
+package com.oneday.routing.service.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneday.routing.config.RoutingProperties;
+import com.oneday.routing.domain.CityFleetConfig;
+import com.oneday.routing.domain.CityLogisticsNode;
+import com.oneday.routing.domain.DaCronSchedule;
+import com.oneday.routing.domain.ProvisioningFlag;
+import com.oneday.routing.domain.RoutePlan;
+import com.oneday.routing.domain.RoutePlanSource;
+import com.oneday.routing.domain.RoutePlanStatus;
+import com.oneday.routing.domain.RoutingSolverType;
+import com.oneday.routing.events.CronEventProducer;
+import com.oneday.routing.repository.DaCronScheduleRepository;
+import com.oneday.routing.repository.RoutePlanRepository;
+import com.oneday.routing.service.GridDataAdapter;
+import com.oneday.routing.service.model.DaTerritory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * HUB_RETURN mode (the M6 gate off, M6-D-020): a city with no van/meeting-point infrastructure.
+ * There is no van route to solve — the DA collects in their territory and periodically returns to
+ * the hub. This produces the minimal thing M5's hard-constraint engine needs: a per-DA cron whose
+ * rendezvous is the <b>hub</b> and whose "meeting times" are a <b>fixed periodic cadence</b>
+ * (every {@code hubReturnIntervalMinutes}). No CVRP, no meeting-point set-cover, no shuttle.
+ *
+ * <p>Unlike VAN_MEETING (which yields a PROPOSED plan an ops user approves), a hub-return plan has
+ * nothing to review, so it is written APPROVED and its {@code DA_CRON_SCHEDULED} events fire
+ * immediately — carrying the hub coordinates so M5 gates each pickup on "reach the hub by the next
+ * return slot" (its feasibility path is coordinate-agnostic, so no M5 change is needed).</p>
+ */
+@Service
+public class HubReturnScheduleService {
+
+    private static final Logger log = LoggerFactory.getLogger(HubReturnScheduleService.class);
+
+    /** Fallback cadence when a HUB_RETURN city has no explicit {@code hub_return_interval_minutes}. */
+    static final int DEFAULT_INTERVAL_MINUTES = 180;
+
+    private final GridDataAdapter gridDataAdapter;
+    private final RoutePlanRepository routePlanRepository;
+    private final DaCronScheduleRepository daCronScheduleRepository;
+    private final CronEventProducer cronEventProducer;
+    private final RoutingProperties properties;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    HubReturnScheduleService(GridDataAdapter gridDataAdapter,
+                             RoutePlanRepository routePlanRepository,
+                             DaCronScheduleRepository daCronScheduleRepository,
+                             CronEventProducer cronEventProducer,
+                             RoutingProperties properties,
+                             ObjectMapper objectMapper,
+                             Clock clock) {
+        this.gridDataAdapter = gridDataAdapter;
+        this.routePlanRepository = routePlanRepository;
+        this.daCronScheduleRepository = daCronScheduleRepository;
+        this.cronEventProducer = cronEventProducer;
+        this.properties = properties;
+        this.objectMapper = objectMapper;
+        this.clock = clock;
+    }
+
+    /**
+     * Build (or rebuild) the day's hub-return schedule for a gated city. Supersedes any prior plan
+     * for the same city/date, writes an APPROVED plan + one cron per active DA (hub as rendezvous),
+     * and emits {@code DA_CRON_SCHEDULED} with the hub coordinates.
+     */
+    @Transactional
+    public RoutePlan planHubReturn(UUID cityId, LocalDate date, CityFleetConfig fleet, CityLogisticsNode hub) {
+        supersedeExisting(cityId, date);
+
+        int interval = fleet.getHubReturnIntervalMinutes() != null
+                ? fleet.getHubReturnIntervalMinutes() : DEFAULT_INTERVAL_MINUTES;
+        List<String> meetingTimes = hubReturnTimes(interval);
+        String meetingTimesJson = serialize(meetingTimes);
+
+        List<DaTerritory> territories = gridDataAdapter.getDaTerritories(cityId, date);
+
+        UUID planId = UUID.randomUUID();
+        RoutePlan plan = RoutePlan.builder()
+                .id(planId)
+                .cityId(cityId)
+                .validForDate(date)
+                .status(RoutePlanStatus.APPROVED)   // nothing to review — deterministic config
+                .source(RoutePlanSource.NIGHTLY)
+                .solverType(RoutingSolverType.SAVINGS)
+                .revision(1)
+                .vansUsed(0)
+                .recommendedVanCount(0)
+                .provisioningFlag(ProvisioningFlag.OK)
+                .nLoops(meetingTimes.size())
+                .realisedCycleMinutes(interval)
+                .notes("HUB_RETURN mode: DA returns to hub every " + interval + "min (" + meetingTimes + ")")
+                .approvedAt(Instant.now(clock))
+                .build();
+        routePlanRepository.save(plan);
+
+        // hex_vertex_id has no FK; the hub node id is a stable non-null sentinel (M5 uses the event's
+        // lat/lon, not this id, for feasibility). van_id is null — there is no van.
+        List<DaCronSchedule> crons = new ArrayList<>(territories.size());
+        for (DaTerritory t : territories) {
+            crons.add(DaCronSchedule.builder()
+                    .routePlanId(planId)
+                    .daId(t.daId())
+                    .hexVertexId(hub.getId())
+                    .vanId(null)
+                    .meetingTimes(meetingTimesJson)
+                    .cityId(cityId)
+                    .validDate(date)
+                    .build());
+        }
+        if (!crons.isEmpty()) daCronScheduleRepository.saveAll(crons);
+
+        for (DaCronSchedule cron : crons) {
+            cronEventProducer.emitDaCronScheduled(cron, hub.getLat(), hub.getLon());
+        }
+
+        log.info("HUB_RETURN plan {} for cityId={} date={}: {} DA(s), returns at {}",
+                planId, cityId, date, crons.size(), meetingTimes);
+        return plan;
+    }
+
+    private void supersedeExisting(UUID cityId, LocalDate date) {
+        for (RoutePlan p : routePlanRepository.findByCityIdAndValidForDate(cityId, date)) {
+            if (p.getStatus() == RoutePlanStatus.PROPOSED || p.getStatus() == RoutePlanStatus.APPROVED) {
+                p.setStatus(RoutePlanStatus.SUPERSEDED);
+                routePlanRepository.save(p);
+            }
+        }
+    }
+
+    /** Periodic hub-return slots ("HH:mm") within the operating window, one every {@code interval} min. */
+    List<String> hubReturnTimes(int interval) {
+        int start = properties.getWindow().getStartHour() * 60;
+        int end = properties.getWindow().getEndHour() * 60;
+        List<String> times = new ArrayList<>();
+        // First return is one interval into the shift (the DA collects before their first drop);
+        // last is at/before shift end. Always yield at least the shift-end slot.
+        for (int m = start + interval; m <= end; m += interval) {
+            times.add(LocalTime.of(m / 60, m % 60).toString());
+        }
+        if (times.isEmpty()) {
+            times.add(LocalTime.of(end / 60, end % 60).toString());
+        }
+        return times;
+    }
+
+    private String serialize(List<String> times) {
+        try {
+            return objectMapper.writeValueAsString(times);
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not serialize hub-return meeting times", e);
+        }
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/service/impl/RoutePlanningServiceImpl.java
+++ b/routing/src/main/java/com/oneday/routing/service/impl/RoutePlanningServiceImpl.java
@@ -1,6 +1,7 @@
 package com.oneday.routing.service.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneday.common.domain.MeetingMode;
 import com.oneday.routing.config.RoutingProperties;
 import com.oneday.routing.domain.CityFleetConfig;
 import com.oneday.routing.domain.CityLogisticsNode;
@@ -71,6 +72,7 @@ class RoutePlanningServiceImpl implements RoutePlanningService {
     private final RoutePlanRepository routePlanRepository;
     private final RoutePlanStopRepository routePlanStopRepository;
     private final DaCronScheduleRepository daCronScheduleRepository;
+    private final HubReturnScheduleService hubReturnScheduleService;
     private final RoutingProperties properties;
     private final ObjectMapper objectMapper;
 
@@ -84,6 +86,7 @@ class RoutePlanningServiceImpl implements RoutePlanningService {
                              RoutePlanRepository routePlanRepository,
                              RoutePlanStopRepository routePlanStopRepository,
                              DaCronScheduleRepository daCronScheduleRepository,
+                             HubReturnScheduleService hubReturnScheduleService,
                              RoutingProperties properties,
                              ObjectMapper objectMapper) {
         this.gridDataAdapter = gridDataAdapter;
@@ -96,6 +99,7 @@ class RoutePlanningServiceImpl implements RoutePlanningService {
         this.routePlanRepository = routePlanRepository;
         this.routePlanStopRepository = routePlanStopRepository;
         this.daCronScheduleRepository = daCronScheduleRepository;
+        this.hubReturnScheduleService = hubReturnScheduleService;
         this.properties = properties;
         this.objectMapper = objectMapper;
     }
@@ -107,6 +111,12 @@ class RoutePlanningServiceImpl implements RoutePlanningService {
                 .orElseThrow(() -> new IllegalStateException("No city_fleet_config for cityId=" + cityId));
         CityLogisticsNode hub = logisticsNodeRepository.findByCityIdAndKind(cityId, LogisticsNodeKind.HUB)
                 .orElseThrow(() -> new IllegalStateException("No HUB logistics node for cityId=" + cityId));
+
+        // M6 gate: HUB_RETURN cities have no van route to solve — the DA periodically returns to the
+        // hub instead. Emit the degenerate hub-return schedule and skip the whole §7 pipeline.
+        if (fleet.getMeetingMode() == MeetingMode.HUB_RETURN) {
+            return hubReturnScheduleService.planHubReturn(cityId, date, fleet, hub);
+        }
 
         List<DaTerritory> territories = gridDataAdapter.getDaTerritories(cityId, date);
         Map<UUID, TerritoryDemand> demandByDa = demandAggregationService.aggregate(territories).stream()

--- a/routing/src/main/resources/db/migration/V6_15__add_meeting_mode.sql
+++ b/routing/src/main/resources/db/migration/V6_15__add_meeting_mode.sql
@@ -1,0 +1,6 @@
+-- Per-city gate for M6 (van meeting points). VAN_MEETING = full M6 routing (default, all 5
+-- launch cities). HUB_RETURN = no M6: the DA periodically returns to the hub instead of
+-- meeting a van; the hub is the rendezvous and hub_return_interval_minutes sets the cadence.
+ALTER TABLE city_fleet_config
+    ADD COLUMN meeting_mode               VARCHAR(20) NOT NULL DEFAULT 'VAN_MEETING',
+    ADD COLUMN hub_return_interval_minutes INT;   -- HUB_RETURN only; null → code default

--- a/routing/src/test/java/com/oneday/routing/service/impl/HubFeedToManifestWiringTest.java
+++ b/routing/src/test/java/com/oneday/routing/service/impl/HubFeedToManifestWiringTest.java
@@ -115,7 +115,10 @@ class HubFeedToManifestWiringTest {
         VanManifestServiceImpl service = new VanManifestServiceImpl(mock(com.oneday.routing.service.port.HubSortPort.class),
                 mock(DaAccumulationPort.class), mock(FlightCutoffPort.class), planRepo, stopRepo, cronRepo, fleetRepo,
                 manifestRepo, itemRepo, grid, producer, new RoutingProperties());
-        HubFeedConsumer consumer = new HubFeedConsumer(inboundRepo, service);
+        com.oneday.common.port.CityMeetingModePort meetingMode =
+                mock(com.oneday.common.port.CityMeetingModePort.class);
+        when(meetingMode.modeFor(any())).thenReturn(com.oneday.common.domain.MeetingMode.VAN_MEETING);
+        HubFeedConsumer consumer = new HubFeedConsumer(inboundRepo, service, meetingMode);
 
         // The broker would hand this to the @RabbitListener; invoke it directly.
         UUID parcelId = UUID.randomUUID();

--- a/routing/src/test/java/com/oneday/routing/service/impl/HubReturnScheduleServiceTest.java
+++ b/routing/src/test/java/com/oneday/routing/service/impl/HubReturnScheduleServiceTest.java
@@ -1,0 +1,110 @@
+package com.oneday.routing.service.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneday.routing.config.RoutingProperties;
+import com.oneday.routing.domain.CityFleetConfig;
+import com.oneday.routing.domain.CityLogisticsNode;
+import com.oneday.routing.domain.DaCronSchedule;
+import com.oneday.routing.domain.LogisticsNodeKind;
+import com.oneday.routing.domain.RoutePlan;
+import com.oneday.routing.domain.RoutePlanStatus;
+import com.oneday.routing.events.CronEventProducer;
+import com.oneday.routing.repository.DaCronScheduleRepository;
+import com.oneday.routing.repository.RoutePlanRepository;
+import com.oneday.routing.service.GridDataAdapter;
+import com.oneday.routing.service.model.DaTerritory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HubReturnScheduleServiceTest {
+
+    @Mock GridDataAdapter gridDataAdapter;
+    @Mock RoutePlanRepository routePlanRepository;
+    @Mock DaCronScheduleRepository daCronScheduleRepository;
+    @Mock CronEventProducer cronEventProducer;
+
+    RoutingProperties properties;
+    HubReturnScheduleService service;
+
+    private final UUID cityId = UUID.randomUUID();
+    private final LocalDate date = LocalDate.of(2026, 6, 10);
+    private final UUID da1 = UUID.randomUUID();
+    private final UUID da2 = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        properties = new RoutingProperties();   // window 07:00–20:00
+        service = new HubReturnScheduleService(gridDataAdapter, routePlanRepository,
+                daCronScheduleRepository, cronEventProducer, properties, new ObjectMapper(),
+                Clock.fixed(Instant.parse("2026-06-09T20:00:00Z"), ZoneOffset.UTC));
+    }
+
+    private CityFleetConfig fleet(Integer intervalMinutes) {
+        return CityFleetConfig.builder().cityId(cityId).hubReturnIntervalMinutes(intervalMinutes).build();
+    }
+
+    private CityLogisticsNode hub() {
+        return CityLogisticsNode.builder().id(UUID.randomUUID()).cityId(cityId)
+                .kind(LogisticsNodeKind.HUB).lat(28.61).lon(77.20).name("Delhi Hub").build();
+    }
+
+    @Test
+    void producesApprovedPlanWithHubCronPerDa_noVan() {
+        CityLogisticsNode hub = hub();
+        when(gridDataAdapter.getDaTerritories(cityId, date))
+                .thenReturn(List.of(new DaTerritory(da1, List.of()), new DaTerritory(da2, List.of())));
+        when(routePlanRepository.findByCityIdAndValidForDate(cityId, date)).thenReturn(List.of());
+
+        RoutePlan plan = service.planHubReturn(cityId, date, fleet(180), hub);
+
+        assertThat(plan.getStatus()).isEqualTo(RoutePlanStatus.APPROVED);
+        assertThat(plan.getVansUsed()).isZero();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<DaCronSchedule>> captor = ArgumentCaptor.forClass(List.class);
+        verify(daCronScheduleRepository).saveAll(captor.capture());
+        List<DaCronSchedule> crons = captor.getValue();
+        assertThat(crons).hasSize(2);
+        assertThat(crons).allSatisfy(c -> {
+            assertThat(c.getVanId()).isNull();                   // no van in HUB_RETURN
+            assertThat(c.getHexVertexId()).isEqualTo(hub.getId());
+            assertThat(c.getCityId()).isEqualTo(cityId);
+            assertThat(c.getMeetingTimes()).contains("10:00", "13:00", "16:00", "19:00");
+        });
+
+        // Every DA gets a DA_CRON_SCHEDULED carrying the HUB coordinates.
+        verify(cronEventProducer, times(2)).emitDaCronScheduled(any(), eq(28.61), eq(77.20));
+    }
+
+    @Test
+    void hubReturnTimes_defaultIntervalWhenNull() {
+        // null interval → 180-min default → 10:00, 13:00, 16:00, 19:00 over the 07–20 window.
+        assertThat(service.hubReturnTimes(HubReturnScheduleService.DEFAULT_INTERVAL_MINUTES))
+                .containsExactly("10:00", "13:00", "16:00", "19:00");
+    }
+
+    @Test
+    void hubReturnTimes_alwaysYieldsAtLeastOneSlot() {
+        // Interval larger than the window still returns the shift-end slot rather than nothing.
+        assertThat(service.hubReturnTimes(24 * 60)).containsExactly("20:00");
+    }
+}


### PR DESCRIPTION
# Pull Request

## Summary
Adds a **per-city gate** (`city_fleet_config.meeting_mode`) that turns M6 van meeting-points on/off. In `HUB_RETURN` cities (no van/meeting-point infra) the DA periodically returns to the hub — the hub is the rendezvous — instead of meeting a van, reusing the **same M5 hard-constraint engine and custody chain, minus M6 routing**. Also introduces dedicated M4 custody states so a hub-return parcel no longer masquerades as a van state.

---

## What Changed
- **The gate:** `city_fleet_config.meeting_mode` (`VAN_MEETING` default | `HUB_RETURN`) + `hub_return_interval_minutes` (migration `routing/V6_15`); shared enum `common.domain.MeetingMode`. Ops flips a city via `PUT /routing/fleet/{cityId}`; a `VAN_MEETING` invariant clears any stale interval on flip-back.
- **M6 skips van routing for HUB_RETURN:** `RoutePlanningServiceImpl.plan()` branches to the new `HubReturnScheduleService`, which writes an auto-APPROVED degenerate plan + one `da_cron_schedule` per DA (hub coords, periodic slots) and emits `DA_CRON_SCHEDULED` — no CVRP / set-cover / shuttle. Binding consumers (`HubFeedConsumer` / `DaFeedConsumer`) skip HUB_RETURN cities.
- **M5 pickup feasibility unchanged:** `DispatchServiceImpl.buildFeasibility`/`activeMeetingTime` are coordinate-agnostic — hub coords + periodic times flow through the existing `da_cron_assignment` path. `DaTaskServiceImpl` roll-forward advances a periodic cron to its next slot (COMPLETED only on the final slot) so the hard constraint holds across multiple daily returns.
- **Delivery-from-hub:** new dispatch `HubDeliveryFeedConsumer` assigns `ParcelSortedForDeliveryEvent` to the territory DA (real drop coords via new `common.port.ShipmentLocationPort` + `ShipmentLocationAdapter`), **for HUB_RETURN cities only** — non-gated cities stay on M6.
- **Mode-appropriate DA endpoints:** `POST /dispatch/da/{daId}/tasks/{taskId}/hub-handoff` (pickup drop at hub) + `/hub-collect` (delivery collect at hub), vs the van `/van-handoff` + `/drop-collected`. A 409 guard rejects hub endpoints in a VAN_MEETING city.
- **Dedicated M4 custody states:** `RETURNED_TO_HUB`, `HUB_DELIVERY_ASSIGNED`, `COLLECTED_FROM_HUB` (common `ShipmentState` enum + **`V4_22` Postgres `ALTER TYPE ... ADD VALUE`** migration — the Java enum alone silently failed transitions without the DB type change). `TransitionRegistry` edges; `DaEventsConsumer` maps `HUB_RETURN_HANDOFF_COMPLETED → RETURNED_TO_HUB` and mode-resolves `DROP_ASSIGNED`/`DROP_COLLECTED` to the hub states; customer-visible labels for all three.
- **Cross-module port:** `common.port.CityMeetingModePort` — routing `CityMeetingModeAdapter` is `@Primary`; dispatch (`DispatchConfig`) and orders (`MeetingModeConfig`) ship `@ConditionalOnMissingBean` VAN_MEETING fallbacks so their isolated test contexts boot without depending on routing.
- **M8 scan seams (best-effort, non-blocking):** `HubScanSeamProducer` emits `HUB_ORIGIN_IN` (DA→hub drop) and `HUB_DEST_OUT` (hub→DA collect), gated on HUB_RETURN.

---

## Why This Change?
Some of the 5 cities have no van/meeting-point infrastructure, but they still need the full logistics chain — same M5 feasibility, same custody — with the **hub as the rendezvous** instead of a van loop. A per-city config gate lets ops flip a city into HUB_RETURN without introducing new branches in M5's hard-constraint engine (the feasibility path is coordinate-agnostic, so hub coords + a periodic cadence "just work"). Dedicated M4 states keep the parcel's status honest: previously hub-return reused van states like `HANDED_TO_PICKUP_VAN`, which lied about a van that never existed.

---

## Testing
- [x] Tested locally
- [x] Edge cases considered
- [x] No breaking changes introduced

### Test Evidence
Full `mvn clean install` assembles; module suites green.

```
[INFO] Tests run: 87, Failures: 0, Errors: 0, Skipped: 0   -- orders  (incl. DaEventsConsumerTest)
[INFO] Tests run: 59, Failures: 0, Errors: 0, Skipped: 0   -- routing (incl. HubReturnScheduleServiceTest x3)
[INFO] Tests run: 110, Failures: 0, Errors: 0, Skipped: 0  -- dispatch (incl. DaTaskServiceImplTest roll-forward, DA controller hub-endpoint tests)
[INFO] BUILD SUCCESS
```

Edge cases exercised: null/unknown city mode → `VAN_MEETING` fallback; flip-back to VAN clears a stale `hub_return_interval_minutes`; multi-return-per-day roll-forward keeps the hard constraint after the first hub visit; HUB_RETURN vs VAN_MEETING city yield disjoint plans (BLR = 0 vans / cron-at-hub vs DEL = van loops). Live E2E on the demo branch drove both directions (VAN→HUB and HUB→VAN) to `DROPPED`.

---

## Impact

### Areas Affected
- [x] Backend
- [ ] Frontend
- [x] Routing
- [ ] Infra
- [x] Database

### Modules Affected
- [ ] M1 — Auth
- [ ] M2 — Pricing
- [ ] M3 — Grid
- [x] M4 — Orders
- [x] M5 — Dispatch
- [x] M6 — Routing
- [ ] M7 — Hub
- [x] M8 — Barcode
- [ ] M9 — Airline
- [ ] M10 — SLA
- [ ] M11 — Exceptions

---

## Risks / Concerns
- **VAN_MEETING cities unchanged** — the gate defaults via the column default; existing van edges/states are untouched, so the 5 current cities regress to no behaviour change.
- **Additive migrations** — `V6_15` (fleet columns) and `V4_22` (`ALTER TYPE shipment_state ADD VALUE`, PG 12+ safe inside Flyway's tx) are both additive; no data backfill.
- **`routing.hub` queue binds `#`** (pre-existing) — under a live real-M7, non-`ParcelSortedForDeliveryEvent` payloads can reach the single-type consumer and land in the DLQ. Tighten to specific routing keys before M7 goes live.
- **Delivery-from-hub idempotency** relies on mode gating so exactly one consumer acts per city (dispatch `HubDeliveryFeedConsumer` for HUB_RETURN vs M6's `HubFeedConsumer` for VAN_MEETING).

---

## Checklist
- [x] Code follows project conventions (package layout, no cross-module internal imports)
- [x] Self-review completed
- [x] Append-only audit trail preserved (no mutations to scan/manifest/role-change records)
- [x] No sensitive data or credentials exposed
- [x] Documentation updated if behaviour changed
- [x] Ready for review
