### PR TITLE
M8: parcel-ID generation + scan write engine + LABEL_GENERATED 

### DIFF
--- a/barcode/pom.xml
+++ b/barcode/pom.xml
@@ -25,6 +25,14 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
         </dependency>

--- a/barcode/src/main/java/com/oneday/barcode/api/LabelRequest.java
+++ b/barcode/src/main/java/com/oneday/barcode/api/LabelRequest.java
@@ -1,0 +1,19 @@
+package com.oneday.barcode.api;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.UUID;
+
+/**
+ * "Generate Label" from the DA app at pickup. {@code destCity} is the destination hub IATA (e.g.
+ * "DEL"); the app already shows it on the pickup task. {@code actorId} is the DA (ponytail: from the
+ * request until PR3 wires the auth principal). {@code clientScanId} makes the call idempotent.
+ */
+public record LabelRequest(
+        @NotNull UUID shipmentId,
+        @NotBlank @Size(min = 3, max = 3) String destCity,
+        UUID actorId,
+        UUID clientScanId) {
+}

--- a/barcode/src/main/java/com/oneday/barcode/api/LabelResponse.java
+++ b/barcode/src/main/java/com/oneday/barcode/api/LabelResponse.java
@@ -1,0 +1,7 @@
+package com.oneday.barcode.api;
+
+import java.util.UUID;
+
+/** The minted (or existing) barcode for the shipment — the DA app renders/prints {@code parcelId}. */
+public record LabelResponse(UUID shipmentId, String parcelId) {
+}

--- a/barcode/src/main/java/com/oneday/barcode/api/ScanController.java
+++ b/barcode/src/main/java/com/oneday/barcode/api/ScanController.java
@@ -1,0 +1,30 @@
+package com.oneday.barcode.api;
+
+import com.oneday.barcode.service.LabelService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * M8 scan entry doors. PR2 ships {@code /label} (parcel-ID generation at first-mile pickup); the
+ * generic {@code POST /api/v1/scan} for lifecycle scans lands in PR3.
+ */
+@RestController
+@RequestMapping("/api/v1/scan")
+class ScanController {
+
+    private final LabelService labelService;
+
+    ScanController(LabelService labelService) {
+        this.labelService = labelService;
+    }
+
+    @PostMapping("/label")
+    LabelResponse label(@Valid @RequestBody LabelRequest req) {
+        String parcelId = labelService.generateLabel(
+                req.shipmentId(), req.destCity(), req.actorId(), req.clientScanId());
+        return new LabelResponse(req.shipmentId(), parcelId);
+    }
+}

--- a/barcode/src/main/java/com/oneday/barcode/events/BarcodeMessagingConfig.java
+++ b/barcode/src/main/java/com/oneday/barcode/events/BarcodeMessagingConfig.java
@@ -1,0 +1,20 @@
+package com.oneday.barcode.events;
+
+import com.oneday.common.kafka.EventStreams;
+import com.oneday.common.kafka.RabbitStreamSupport;
+import org.springframework.amqp.core.Declarables;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Declares M8's producing exchange so publishes aren't dropped before any consumer binds. Idempotent
+ * with orders' consumer-side declaration of the same durable topic exchange (RabbitAdmin dedups).
+ */
+@Configuration
+class BarcodeMessagingConfig {
+
+    @Bean
+    Declarables scanEventsExchange() {
+        return RabbitStreamSupport.exchange(EventStreams.SCAN_EVENTS);
+    }
+}

--- a/barcode/src/main/java/com/oneday/barcode/events/ScanEventProducer.java
+++ b/barcode/src/main/java/com/oneday/barcode/events/ScanEventProducer.java
@@ -1,0 +1,47 @@
+package com.oneday.barcode.events;
+
+import com.oneday.common.kafka.EventPublisher;
+import com.oneday.common.kafka.EventStreams;
+import com.oneday.common.kafka.enums.ScanEventType;
+import com.oneday.common.kafka.events.ScanEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * Publishes {@code ScanEvent} to {@code oneday.scan.events} once the ledger write has committed
+ * (mirrors {@code orders.ShipmentEventProducer}). Only scans whose type is a {@link ScanEventType}
+ * are broadcast — van custody scans (VAN_LOAD/…) are ledger-only (D-004), so they fall through.
+ */
+@Component
+public class ScanEventProducer {
+
+    private static final Logger log = LoggerFactory.getLogger(ScanEventProducer.class);
+
+    private final EventPublisher eventPublisher;
+
+    ScanEventProducer(EventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onScanRecorded(ScanRecorded e) {
+        ScanEventType type = broadcastType(e.scanType());
+        if (type == null) {
+            return; // not a broadcastable type (e.g. a van custody scan) — ledger-only
+        }
+        log.debug("Publishing ScanEvent {} shipmentId={} parcelId={}", type, e.shipmentId(), e.parcelId());
+        eventPublisher.publish(EventStreams.SCAN_EVENTS,
+                new ScanEvent(e.shipmentId(), type, e.parcelId(), e.scannedAt()));
+    }
+
+    private static ScanEventType broadcastType(String scanType) {
+        try {
+            return ScanEventType.valueOf(scanType);
+        } catch (IllegalArgumentException notBroadcastable) {
+            return null; // VanScanType values live outside ScanEventType
+        }
+    }
+}

--- a/barcode/src/main/java/com/oneday/barcode/events/ScanRecorded.java
+++ b/barcode/src/main/java/com/oneday/barcode/events/ScanRecorded.java
@@ -1,0 +1,12 @@
+package com.oneday.barcode.events;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * In-process Spring event raised inside the ledger-write transaction. {@link ScanEventProducer}
+ * consumes it AFTER_COMMIT and decides whether to broadcast an outbound {@code ScanEvent} — the
+ * ledger is the durable truth, the event is a downstream signal.
+ */
+public record ScanRecorded(UUID shipmentId, String parcelId, String scanType, Instant scannedAt) {
+}

--- a/barcode/src/main/java/com/oneday/barcode/repository/ScanLedgerRepository.java
+++ b/barcode/src/main/java/com/oneday/barcode/repository/ScanLedgerRepository.java
@@ -4,6 +4,7 @@ import com.oneday.barcode.domain.ScanLedgerEntry;
 import org.springframework.data.repository.Repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -22,4 +23,10 @@ public interface ScanLedgerRepository extends Repository<ScanLedgerEntry, UUID> 
 
     /** Same trail looked up by the physical barcode string a scan gun reads off the box. */
     List<ScanLedgerEntry> findByParcelIdOrderByScannedAtAsc(String parcelId);
+
+    /** Idempotent replay guard: a device retry re-sends the same client key. */
+    Optional<ScanLedgerEntry> findByClientScanId(UUID clientScanId);
+
+    /** Label idempotency: a shipment gets exactly one LABEL_GENERATED — return it instead of re-minting. */
+    Optional<ScanLedgerEntry> findFirstByShipmentIdAndScanType(UUID shipmentId, String scanType);
 }

--- a/barcode/src/main/java/com/oneday/barcode/service/LabelService.java
+++ b/barcode/src/main/java/com/oneday/barcode/service/LabelService.java
@@ -1,0 +1,20 @@
+package com.oneday.barcode.service;
+
+import java.util.UUID;
+
+/**
+ * The DA's "Generate Label" action at first-mile pickup (M8 §3.1). Mints the barcode, writes the
+ * {@code LABEL_GENERATED} scan, and (after commit) emits the {@code ScanEvent} that M4 uses to fill
+ * {@code shipments.parcel_id}. Idempotent per shipment — a retry returns the same barcode.
+ */
+public interface LabelService {
+
+    /**
+     * @param shipmentId  the shipment being labelled
+     * @param destCity    destination hub IATA (e.g. "DEL") — the barcode's human-readable segment
+     * @param actorId     the DA who scanned (recorded as the ledger actor)
+     * @param clientScanId device idempotency key (may be null)
+     * @return the barcode string, e.g. {@code 1DD-DEL-260711-000042}
+     */
+    String generateLabel(UUID shipmentId, String destCity, UUID actorId, UUID clientScanId);
+}

--- a/barcode/src/main/java/com/oneday/barcode/service/LabelServiceImpl.java
+++ b/barcode/src/main/java/com/oneday/barcode/service/LabelServiceImpl.java
@@ -1,0 +1,41 @@
+package com.oneday.barcode.service;
+
+import com.oneday.barcode.repository.ScanLedgerRepository;
+import com.oneday.common.kafka.enums.ScanEventType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Service
+class LabelServiceImpl implements LabelService {
+
+    private final ScanLedgerRepository repository;
+    private final ParcelIdGenerator generator;
+    private final ScanLedgerService ledger;
+
+    LabelServiceImpl(ScanLedgerRepository repository, ParcelIdGenerator generator, ScanLedgerService ledger) {
+        this.repository = repository;
+        this.generator = generator;
+        this.ledger = ledger;
+    }
+
+    @Override
+    @Transactional
+    public String generateLabel(UUID shipmentId, String destCity, UUID actorId, UUID clientScanId) {
+        // Idempotent: a shipment is labelled once. A retry returns the existing barcode and — crucially
+        // — does NOT bump the per-hub counter (which would burn a sequence number for no parcel).
+        var existing = repository.findFirstByShipmentIdAndScanType(shipmentId, ScanEventType.LABEL_GENERATED.name());
+        if (existing.isPresent()) {
+            return existing.get().getParcelId();
+        }
+
+        String hubIata = destCity.trim().toUpperCase();
+        String parcelId = generator.next(hubIata);
+        ledger.record(new ScanCommand(
+                shipmentId, parcelId, null, ScanEventType.LABEL_GENERATED.name(),
+                "DA", actorId, actorId, null, Instant.now(), clientScanId));
+        return parcelId;
+    }
+}

--- a/barcode/src/main/java/com/oneday/barcode/service/ParcelIdGenerator.java
+++ b/barcode/src/main/java/com/oneday/barcode/service/ParcelIdGenerator.java
@@ -1,0 +1,41 @@
+package com.oneday.barcode.service;
+
+import com.oneday.barcode.domain.ParcelIdCounter;
+import com.oneday.barcode.domain.ParcelIdCounterId;
+import com.oneday.barcode.repository.ParcelIdCounterRepository;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Mints the parcel barcode {@code 1DD-{destHubIATA}-{yyMMdd}-{seq6}} (D-002). {@code seq6} comes from
+ * a per-hub, per-day counter under a row lock (mirrors {@code orders.ShipmentRefService}). Must run
+ * inside the caller's transaction — the lock is held until commit.
+ */
+@Component
+class ParcelIdGenerator {
+
+    private static final DateTimeFormatter YYMMDD = DateTimeFormatter.ofPattern("yyMMdd");
+    // ponytail: hardcoded IST; all 5 launch cities are in one zone. Make configurable if we go global.
+    private static final ZoneId IST = ZoneId.of("Asia/Kolkata");
+
+    private final ParcelIdCounterRepository counters;
+
+    ParcelIdGenerator(ParcelIdCounterRepository counters) {
+        this.counters = counters;
+    }
+
+    /** Next barcode for a dest hub, for today (IST). Bumps the counter; call once per label. */
+    String next(String hubIata) {
+        LocalDate day = LocalDate.now(IST);
+        counters.insertIfAbsent(hubIata, day);                       // materialise the row (ON CONFLICT DO NOTHING)
+        ParcelIdCounter counter = counters.findByIdWithLock(new ParcelIdCounterId(hubIata, day))
+                .orElseThrow(() -> new IllegalStateException(
+                        "parcel_id_counter row missing after insertIfAbsent: " + hubIata + " " + day));
+        int seq = counter.getNextSeq();
+        counter.setNextSeq(seq + 1);                                 // flushed on commit under the lock
+        return "1DD-%s-%s-%06d".formatted(hubIata, day.format(YYMMDD), seq);
+    }
+}

--- a/barcode/src/main/java/com/oneday/barcode/service/ScanCommand.java
+++ b/barcode/src/main/java/com/oneday/barcode/service/ScanCommand.java
@@ -1,0 +1,22 @@
+package com.oneday.barcode.service;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * One physical scan to append to the ledger (M8 §4) — the single input to {@link ScanLedgerService}.
+ * {@code parcelId}/{@code bagId} are set per scan family (barcode string on parcel scans, bag id on
+ * bag scans, both null on van scans). {@code clientScanId} is the device idempotency key.
+ */
+public record ScanCommand(
+        UUID shipmentId,
+        String parcelId,
+        UUID bagId,
+        String scanType,
+        String locationType,
+        UUID locationId,
+        UUID actorId,
+        UUID counterpartyId,
+        Instant scannedAt,
+        UUID clientScanId) {
+}

--- a/barcode/src/main/java/com/oneday/barcode/service/ScanLedgerService.java
+++ b/barcode/src/main/java/com/oneday/barcode/service/ScanLedgerService.java
@@ -1,0 +1,14 @@
+package com.oneday.barcode.service;
+
+import com.oneday.barcode.domain.ScanLedgerEntry;
+
+/**
+ * The append-only write engine (M8 §4.3) — built once, reused by every scan entry door: the label
+ * path (PR2), the REST lifecycle scans (PR3), and the van custody port (PR4). Idempotent on
+ * {@code clientScanId}; emits a {@code ScanEvent} after commit for broadcastable scan types.
+ */
+public interface ScanLedgerService {
+
+    /** Append one immutable scan row (idempotent replay on {@code clientScanId}). */
+    ScanLedgerEntry record(ScanCommand cmd);
+}

--- a/barcode/src/main/java/com/oneday/barcode/service/ScanLedgerServiceImpl.java
+++ b/barcode/src/main/java/com/oneday/barcode/service/ScanLedgerServiceImpl.java
@@ -1,0 +1,51 @@
+package com.oneday.barcode.service;
+
+import com.oneday.barcode.domain.ScanLedgerEntry;
+import com.oneday.barcode.events.ScanRecorded;
+import com.oneday.barcode.repository.ScanLedgerRepository;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+class ScanLedgerServiceImpl implements ScanLedgerService {
+
+    private final ScanLedgerRepository repository;
+    private final ApplicationEventPublisher events;
+
+    ScanLedgerServiceImpl(ScanLedgerRepository repository, ApplicationEventPublisher events) {
+        this.repository = repository;
+        this.events = events;
+    }
+
+    @Override
+    @Transactional
+    public ScanLedgerEntry record(ScanCommand cmd) {
+        // The scan physically happened — record it. Replay guard first (a flaky-signal retry re-sends
+        // the same clientScanId): return the row that already stands rather than a duplicate.
+        if (cmd.clientScanId() != null) {
+            var existing = repository.findByClientScanId(cmd.clientScanId());
+            if (existing.isPresent()) {
+                return existing.get();
+            }
+        }
+
+        ScanLedgerEntry entry = repository.save(ScanLedgerEntry.builder()
+                .shipmentId(cmd.shipmentId())
+                .parcelId(cmd.parcelId())
+                .bagId(cmd.bagId())
+                .scanType(cmd.scanType())
+                .locationType(cmd.locationType())
+                .locationId(cmd.locationId())
+                .actorId(cmd.actorId())
+                .counterpartyId(cmd.counterpartyId())
+                .scannedAt(cmd.scannedAt())
+                .clientScanId(cmd.clientScanId())
+                .build());
+
+        // In-process signal; the outbound ScanEvent is published only AFTER this tx commits.
+        events.publishEvent(new ScanRecorded(
+                entry.getShipmentId(), entry.getParcelId(), entry.getScanType(), entry.getScannedAt()));
+        return entry;
+    }
+}

--- a/barcode/src/test/java/com/oneday/barcode/events/ScanEventJacksonTest.java
+++ b/barcode/src/test/java/com/oneday/barcode/events/ScanEventJacksonTest.java
@@ -1,0 +1,41 @@
+package com.oneday.barcode.events;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.oneday.common.kafka.enums.ScanEventType;
+import com.oneday.common.kafka.events.ScanEvent;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Mirrors the app's Rabbit ObjectMapper (SNAKE_CASE + JavaTime) to prove ScanEvent round-trips —
+ * i.e. the consumer can deserialize exactly what M8 publishes. Guards against a creator-ambiguity
+ * regression from the record's extra constructor.
+ */
+class ScanEventJacksonTest {
+
+    private final JsonMapper mapper = JsonMapper.builder()
+            .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+            .addModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .build();
+
+    @Test
+    void roundTrips_labelEvent() throws Exception {
+        ScanEvent original = new ScanEvent(UUID.randomUUID(), ScanEventType.LABEL_GENERATED,
+                "1DD-BOM-260711-000001", Instant.parse("2026-07-11T16:35:59.449781Z"));
+
+        String wire = mapper.writeValueAsString(original);
+        ScanEvent back = mapper.readValue(wire, ScanEvent.class);
+
+        assertThat(back.eventType()).isEqualTo(ScanEventType.LABEL_GENERATED);
+        assertThat(back.parcelId()).isEqualTo("1DD-BOM-260711-000001");
+        assertThat(back.occurredAt()).isEqualTo(original.occurredAt());
+    }
+}

--- a/barcode/src/test/java/com/oneday/barcode/events/ScanEventProducerTest.java
+++ b/barcode/src/test/java/com/oneday/barcode/events/ScanEventProducerTest.java
@@ -1,0 +1,44 @@
+package com.oneday.barcode.events;
+
+import com.oneday.common.kafka.EventPublisher;
+import com.oneday.common.kafka.EventStreams;
+import com.oneday.common.kafka.enums.ScanEventType;
+import com.oneday.common.kafka.events.ScanEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class ScanEventProducerTest {
+
+    @Mock EventPublisher publisher;
+    @InjectMocks ScanEventProducer producer;
+
+    @Test
+    void broadcasts_whenScanTypeIsAScanEventType() {
+        UUID shipment = UUID.randomUUID();
+        producer.onScanRecorded(new ScanRecorded(shipment, "1DD-DEL-260711-000042", "LABEL_GENERATED", Instant.now()));
+
+        ArgumentCaptor<ScanEvent> sent = ArgumentCaptor.forClass(ScanEvent.class);
+        verify(publisher).publish(eq(EventStreams.SCAN_EVENTS), sent.capture());
+        assertThat(sent.getValue().eventType()).isEqualTo(ScanEventType.LABEL_GENERATED);
+        assertThat(sent.getValue().parcelId()).isEqualTo("1DD-DEL-260711-000042");
+    }
+
+    @Test
+    void skips_whenScanTypeIsAVanCustodyScan() {
+        producer.onScanRecorded(new ScanRecorded(UUID.randomUUID(), null, "VAN_LOAD", Instant.now()));
+        verifyNoInteractions(publisher); // van scans are ledger-only (D-004)
+    }
+}

--- a/barcode/src/test/java/com/oneday/barcode/service/LabelServiceImplTest.java
+++ b/barcode/src/test/java/com/oneday/barcode/service/LabelServiceImplTest.java
@@ -1,0 +1,61 @@
+package com.oneday.barcode.service;
+
+import com.oneday.barcode.domain.ScanLedgerEntry;
+import com.oneday.barcode.repository.ScanLedgerRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LabelServiceImplTest {
+
+    @Mock ScanLedgerRepository repository;
+    @Mock ParcelIdGenerator generator;
+    @Mock ScanLedgerService ledger;
+    @InjectMocks LabelServiceImpl service;
+
+    final UUID shipment = UUID.randomUUID();
+
+    @Test
+    void returnsExistingBarcode_whenAlreadyLabelled_withoutMintingOrBumping() {
+        ScanLedgerEntry existing = ScanLedgerEntry.builder().parcelId("1DD-DEL-260711-000007").build();
+        when(repository.findFirstByShipmentIdAndScanType(shipment, "LABEL_GENERATED"))
+                .thenReturn(Optional.of(existing));
+
+        String barcode = service.generateLabel(shipment, "DEL", UUID.randomUUID(), null);
+
+        assertThat(barcode).isEqualTo("1DD-DEL-260711-000007");
+        verifyNoInteractions(generator, ledger); // idempotent: no new mint, no counter bump
+    }
+
+    @Test
+    void mintsAndRecords_onFirstLabel_normalisingDestCity() {
+        UUID actor = UUID.randomUUID();
+        when(repository.findFirstByShipmentIdAndScanType(shipment, "LABEL_GENERATED"))
+                .thenReturn(Optional.empty());
+        when(generator.next("DEL")).thenReturn("1DD-DEL-260711-000042");
+
+        String barcode = service.generateLabel(shipment, " del ", actor, null);
+
+        assertThat(barcode).isEqualTo("1DD-DEL-260711-000042");
+        verify(generator).next("DEL"); // trimmed + uppercased
+
+        ArgumentCaptor<ScanCommand> cmd = ArgumentCaptor.forClass(ScanCommand.class);
+        verify(ledger).record(cmd.capture());
+        assertThat(cmd.getValue().scanType()).isEqualTo("LABEL_GENERATED");
+        assertThat(cmd.getValue().parcelId()).isEqualTo("1DD-DEL-260711-000042");
+        assertThat(cmd.getValue().actorId()).isEqualTo(actor);
+        assertThat(cmd.getValue().locationType()).isEqualTo("DA");
+    }
+}

--- a/barcode/src/test/java/com/oneday/barcode/service/ParcelIdGeneratorTest.java
+++ b/barcode/src/test/java/com/oneday/barcode/service/ParcelIdGeneratorTest.java
@@ -1,0 +1,41 @@
+package com.oneday.barcode.service;
+
+import com.oneday.barcode.domain.ParcelIdCounter;
+import com.oneday.barcode.repository.ParcelIdCounterRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ParcelIdGeneratorTest {
+
+    @Mock ParcelIdCounterRepository counters;
+    @InjectMocks ParcelIdGenerator generator;
+
+    @Test
+    void mintsFormattedBarcode_andBumpsCounter() {
+        ParcelIdCounter counter = new ParcelIdCounter();
+        counter.setNextSeq(42);
+        when(counters.findByIdWithLock(any())).thenReturn(Optional.of(counter));
+
+        String barcode = generator.next("DEL");
+
+        String today = LocalDate.now(ZoneId.of("Asia/Kolkata")).format(DateTimeFormatter.ofPattern("yyMMdd"));
+        assertThat(barcode).isEqualTo("1DD-DEL-" + today + "-000042"); // 6-digit zero-padded seq
+        assertThat(counter.getNextSeq()).isEqualTo(43);                // counter advanced
+        verify(counters).insertIfAbsent(eq("DEL"), any());             // row materialised first
+    }
+}

--- a/common/src/main/java/com/oneday/common/kafka/events/ScanEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/ScanEvent.java
@@ -4,17 +4,24 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.oneday.common.kafka.DomainEvent;
 import com.oneday.common.kafka.enums.ScanEventType;
 
+import java.time.Instant;
 import java.util.UUID;
 
 /**
  * Inbound event consumed by M4 from {@code oneday.scan.events} (produced by M8).
  *
- * <p>Minimal consumption contract — see {@link DaEvent} for the tolerant-reader rationale.
- * Note {@code LABEL_GENERATED} is not a state transition; it carries the generated
- * {@code parcelId} and is handled separately (TODO) rather than via the state machine.</p>
+ * <p>{@code parcelId} carries the generated barcode on {@code LABEL_GENERATED} (M4 stores it on the
+ * shipment, no state transition); it is null on the state-transition scans. {@code occurredAt} is
+ * the physical scan time. Tolerant reader — extra fields ignored (D-005).</p>
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record ScanEvent(UUID shipmentId, ScanEventType eventType) implements DomainEvent {
+public record ScanEvent(UUID shipmentId, ScanEventType eventType, String parcelId, Instant occurredAt)
+        implements DomainEvent {
+
+    /** Convenience for state-transition scans that carry no barcode. */
+    public ScanEvent(UUID shipmentId, ScanEventType eventType) {
+        this(shipmentId, eventType, null, Instant.now());
+    }
 
     @Override
     public String partitionKey() {

--- a/orders/src/main/java/com/oneday/orders/events/ScanEventsConsumer.java
+++ b/orders/src/main/java/com/oneday/orders/events/ScanEventsConsumer.java
@@ -1,13 +1,16 @@
 package com.oneday.orders.events;
 
 import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.kafka.enums.ScanEventType;
 import com.oneday.common.kafka.events.ScanEvent;
+import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.service.ShipmentStateMachine;
 import com.oneday.orders.service.TransitionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Consumes M8 scan events from the {@code oneday.scan.events} exchange (queue {@code orders.scan})
@@ -22,22 +25,28 @@ public class ScanEventsConsumer {
     private static final String SOURCE = "m8-scan-consumer";
 
     private final ShipmentStateMachine stateMachine;
+    private final ShipmentRepository shipmentRepository;
 
-    ScanEventsConsumer(ShipmentStateMachine stateMachine) {
+    ScanEventsConsumer(ShipmentStateMachine stateMachine, ShipmentRepository shipmentRepository) {
         this.stateMachine = stateMachine;
+        this.shipmentRepository = shipmentRepository;
     }
 
     @RabbitListener(queues = OrdersMessagingTopology.SCAN_QUEUE)
+    @Transactional
     public void onScanEvent(ScanEvent event) {
+        // LABEL_GENERATED is not a state transition — it carries the barcode M8 minted; stamp it.
+        if (event.eventType() == ScanEventType.LABEL_GENERATED) {
+            applyLabel(event);
+            return;
+        }
         ShipmentState target = switch (event.eventType()) {
             case HUB_ORIGIN_IN         -> ShipmentState.AT_ORIGIN_HUB;   // TODO: recalc ETA + notify customer
             case SELF_DROP_ACCEPTED    -> ShipmentState.AT_ORIGIN_HUB;   // TODO: recalc ETA + notify customer
             case GHA_ACCEPTANCE        -> ShipmentState.AT_AIRPORT;
             case HUB_DEST_IN           -> ShipmentState.AT_DEST_HUB;
             case HUB_COLLECT_COMPLETED -> ShipmentState.HUB_COLLECTED;
-            // Not a state transition — carries the generated parcelId (sets shipment.parcel_id).
-            // TODO: handle once ScanEvent is extended with the parcelId field.
-            case LABEL_GENERATED       -> null;
+            case LABEL_GENERATED       -> null; // handled above
         };
         if (target == null) {
             log.debug("Scan event {} ignored for shipment {}", event.eventType(), event.shipmentId());
@@ -45,5 +54,17 @@ public class ScanEventsConsumer {
         }
         stateMachine.transition(event.shipmentId(), target,
                 TransitionContext.fromKafka(SOURCE, String.valueOf(event.shipmentId())));
+    }
+
+    private void applyLabel(ScanEvent event) {
+        if (event.parcelId() == null) {
+            log.warn("LABEL_GENERATED for shipment {} carried no parcelId — ignoring", event.shipmentId());
+            return;
+        }
+        shipmentRepository.findById(event.shipmentId()).ifPresentOrElse(s -> {
+            s.setParcelId(event.parcelId());
+            shipmentRepository.save(s);
+            log.debug("Stamped parcelId {} on shipment {}", event.parcelId(), event.shipmentId());
+        }, () -> log.warn("LABEL_GENERATED for unknown shipment {}", event.shipmentId()));
     }
 }

--- a/orders/src/test/java/com/oneday/orders/events/ScanEventsConsumerTest.java
+++ b/orders/src/test/java/com/oneday/orders/events/ScanEventsConsumerTest.java
@@ -1,0 +1,59 @@
+package com.oneday.orders.events;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.kafka.enums.ScanEventType;
+import com.oneday.common.kafka.events.ScanEvent;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.service.ShipmentStateMachine;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * The M8 seam: LABEL_GENERATED stamps the barcode on the shipment (no state transition); every other
+ * scan type drives the state machine and never touches parcel_id.
+ */
+class ScanEventsConsumerTest {
+
+    private final ShipmentStateMachine stateMachine = mock(ShipmentStateMachine.class);
+    private final ShipmentRepository shipmentRepository = mock(ShipmentRepository.class);
+    private final ScanEventsConsumer consumer = new ScanEventsConsumer(stateMachine, shipmentRepository);
+
+    @Test
+    void labelGenerated_stampsParcelId_withNoTransition() {
+        UUID id = UUID.randomUUID();
+        Shipment shipment = mock(Shipment.class);
+        when(shipmentRepository.findById(id)).thenReturn(Optional.of(shipment));
+
+        consumer.onScanEvent(new ScanEvent(id, ScanEventType.LABEL_GENERATED, "1DD-DEL-260711-000042", Instant.now()));
+
+        verify(shipment).setParcelId("1DD-DEL-260711-000042");
+        verify(shipmentRepository).save(shipment);
+        verifyNoInteractions(stateMachine);
+    }
+
+    @Test
+    void hubOriginIn_transitions_andNeverStampsParcelId() {
+        UUID id = UUID.randomUUID();
+
+        consumer.onScanEvent(new ScanEvent(id, ScanEventType.HUB_ORIGIN_IN));
+
+        verify(stateMachine).transition(eq(id), eq(ShipmentState.AT_ORIGIN_HUB), any());
+        verify(shipmentRepository, never()).save(any());
+    }
+
+    @Test
+    void labelGenerated_withNullParcelId_isIgnored() {
+        UUID id = UUID.randomUUID();
+
+        consumer.onScanEvent(new ScanEvent(id, ScanEventType.LABEL_GENERATED)); // parcelId null
+
+        verifyNoInteractions(stateMachine);
+        verify(shipmentRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
# Pull Request

## Summary

M8 **PR2 of 4** — parcel-ID generation + the append-only scan **write engine** + the M4 `LABEL_GENERATED` seam. This is the first PR that actually **writes** to the ledger PR1 built.

**Business moment:** a DA reaches a customer's door, taps "Generate Label", a sticker prints — `1DD-BOM-260711-000001` — and that barcode becomes the parcel's identity for its whole journey. On the customer's tracking page the id appears. Technically: the DA app calls M8, M8 mints the string under a per-hub/day counter lock, writes the `LABEL_GENERATED` scan, and (after commit) emits a `ScanEvent` that M4 uses to stamp `shipments.parcel_id`.

## What Changed

**`common`** — `ScanEvent` gains `parcelId` + `occurredAt` (D-005); tolerant reader intact + a 2-arg convenience ctor for PR3/PR4's non-label scans. Nothing constructed it before, so no breakage.

**`barcode`** — the write engine + label path:
- `ScanLedgerService`/`Impl` — the **write engine, built once** (reused by PR3/PR4): idempotent on `clientScanId`, insert, then raise an in-process `ScanRecorded`.
- `ParcelIdGenerator` — `1DD-{IATA}-{yyMMdd}-{seq6}` under the counter's `SELECT FOR UPDATE`.
- `LabelService`/`Impl` — **idempotent per shipment**: a retry returns the same barcode and does *not* burn a counter value.
- `ScanEventProducer` — `@TransactionalEventListener(AFTER_COMMIT)`; broadcasts only types that are a `ScanEventType` (van scans fall through, D-004).
- `BarcodeMessagingConfig` — declares the `oneday.scan.events` exchange.
- `ScanController` — `POST /api/v1/scan/label`. pom: +amqp, +validation.

**`orders`** — `ScanEventsConsumer` stamps `shipments.parcel_id` on `LABEL_GENERATED` (no state transition); closes the pre-existing TODO.

## Why This Change?

Every remaining M8 seam writes through `ScanLedgerService`, so building it once here (idempotent, event-after-commit) means PR3 (REST lifecycle scans) and PR4 (van custody) are thin doors over a proven engine.

## Testing
- [x] Tested locally
- [x] Edge cases considered
- [x] No breaking changes introduced

### Test Evidence

Unit (11 new): parcel-ID format + counter bump; label idempotency (existing → no re-mint); producer broadcast-vs-skip; `ScanEvent` JSON round-trip (jsr310 + snake_case); **orders consumer stamps `parcel_id` / other scans transition without stamping**. Full `common,barcode,orders` suites green.

**Live boot-verify** against the dev DB (Flyway applied `V8_1`/`V8_2`):
```
POST /api/v1/scan/label {shipment_id, dest_city:"BOM"}  → 1DD-BOM-260711-000001
re-POST (new idem key)                                   → SAME barcode (idempotent)
scan_ledger: exactly 1 row (LABEL_GENERATED, DA), parcel_id set
parcel_id_counter: (BOM, today) next_seq = 2  (bumped once, not twice)
ScanEventProducer: "Publishing ScanEvent LABEL_GENERATED …" (AFTER_COMMIT fired)
```

> **Note on the async M4 stamp:** in the live run the `ScanEvent` reached the DLQ instead of stamping `shipments.parcel_id`. Root cause is **environmental, not this code**: a remote/deployed instance running pre-PR2 code is connected to the shared CloudAMQP and consuming `orders.scan` (confirmed — `orders.scan` keeps a consumer with no local app running), and it dead-letters the extended `ScanEvent` it can't handle. The producer side is live-verified, the payload round-trips, and the consumer stamp is unit-proven — so the hop works on an isolated broker / once PR2 is deployed everywhere.

## Impact

### Areas Affected
- [x] Backend
- [ ] Frontend
- [ ] Routing
- [ ] Infra
- [x] Database
- [ ] NA

### Modules Affected
- [ ] M1 — Auth
- [ ] M2 — Pricing
- [ ] M3 — Grid
- [x] M4 — Orders
- [ ] M5 — Dispatch
- [ ] M6 — Routing
- [ ] M7 — Hub
- [x] M8 — Barcode
- [ ] M9 — Airline
- [ ] M10 — SLA
- [ ] M11 — Exceptions
- [ ] NA

## Risks / Concerns

- **`destCity` rides the request** (no cross-module shipment-lookup port) — safe because per D-002 the barcode's hub segment is human-convenience, never parsed for routing. Marked with a `ponytail:` note. Also surfaced: `shipments.dest_city` stores city **names** ("MUMBAI"), not IATA — the DA app must supply the 3-letter code (worth a follow-up to standardise).
- **Auth gating deferred to PR3** (per plan) — `actorId` rides the request for now.
- **`common` change** — one field-add to `ScanEvent`; tolerant reader means existing consumers don't break, but the deployed app should be updated (see the async-stamp note).

## Checklist
- [x] Code follows project conventions (package layout, no cross-module internal imports)
- [x] Self-review completed
- [x] Append-only audit trail preserved (no mutations to scan records)
- [x] No sensitive data or credentials exposed
- [x] Documentation updated if behaviour changed
- [x] Ready for review
