### PR TITLE
M8 PR3: scan ingestion 

### DIFF
--- a/barcode/src/main/java/com/oneday/barcode/api/ScanController.java
+++ b/barcode/src/main/java/com/oneday/barcode/api/ScanController.java
@@ -1,24 +1,38 @@
 package com.oneday.barcode.api;
 
+import com.oneday.barcode.service.ScanCommand;
 import com.oneday.barcode.service.LabelService;
+import com.oneday.barcode.service.ScanLedgerService;
+import com.oneday.common.kafka.enums.ScanEventType;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
 
 /**
- * M8 scan entry doors. PR2 ships {@code /label} (parcel-ID generation at first-mile pickup); the
- * generic {@code POST /api/v1/scan} for lifecycle scans lands in PR3.
+ * M8 scan entry doors. {@code /label} mints the parcel ID at first-mile pickup (PR2); the generic
+ * {@code POST /api/v1/scan} records every other lifecycle scan (PR3) — hub gun, GHA, shuttle, DA,
+ * hub counter — and lets {@link ScanEventProducer} fan the resulting {@code ScanEvent} to M4.
+ *
+ * <p>ponytail: authentication is the app-level JWT filter (same as {@code /label}); role-granular
+ * gating (hub-operator vs GHA vs counter) is deferred — add when a non-DA role must be blocked here.</p>
  */
 @RestController
 @RequestMapping("/api/v1/scan")
 class ScanController {
 
     private final LabelService labelService;
+    private final ScanLedgerService ledger;
 
-    ScanController(LabelService labelService) {
+    ScanController(LabelService labelService, ScanLedgerService ledger) {
         this.labelService = labelService;
+        this.ledger = ledger;
     }
 
     @PostMapping("/label")
@@ -26,5 +40,34 @@ class ScanController {
         String parcelId = labelService.generateLabel(
                 req.shipmentId(), req.destCity(), req.actorId(), req.clientScanId());
         return new LabelResponse(req.shipmentId(), parcelId);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    void scan(@Valid @RequestBody ScanRequest req) {
+        ledger.record(new ScanCommand(
+                req.shipmentId(), req.parcelId(), req.bagId(), validScanType(req.scanType()),
+                req.locationType(), req.locationId(), req.actorId(), req.counterpartyId(),
+                req.scannedAt() != null ? req.scannedAt() : Instant.now(), req.clientScanId()));
+    }
+
+    /**
+     * This door records lifecycle scans only: the type must be a {@link ScanEventType} (van custody
+     * scans arrive via the sync port), and {@code LABEL_GENERATED} has its own {@code /label} door
+     * because it mints an id. Anything else → 400.
+     */
+    private static String validScanType(String scanType) {
+        ScanEventType type;
+        try {
+            type = ScanEventType.valueOf(scanType);
+        } catch (IllegalArgumentException notLifecycle) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Unknown or non-lifecycle scan type: " + scanType);
+        }
+        if (type == ScanEventType.LABEL_GENERATED) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "LABEL_GENERATED must use POST /api/v1/scan/label");
+        }
+        return type.name();
     }
 }

--- a/barcode/src/main/java/com/oneday/barcode/api/ScanRequest.java
+++ b/barcode/src/main/java/com/oneday/barcode/api/ScanRequest.java
@@ -1,0 +1,29 @@
+package com.oneday.barcode.api;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * One lifecycle scan from a physical scanner app (hub gun, GHA, shuttle, DA, hub counter) —
+ * {@code POST /api/v1/scan}. Discriminated by {@code scanType}, which must be a {@code ScanEventType}
+ * (van custody scans use the sync port, not this door; {@code LABEL_GENERATED} uses {@code /label}).
+ *
+ * <p>{@code bagId} is set on bag scans (M7 fans one bag QR out to N per-parcel calls, D-006).
+ * {@code scannedAt} is the device wall-clock (defaults to now if omitted); {@code clientScanId}
+ * makes the call idempotent on flaky signal.</p>
+ */
+public record ScanRequest(
+        @NotNull UUID shipmentId,
+        @NotBlank String scanType,
+        @NotBlank String locationType,
+        UUID locationId,
+        UUID actorId,
+        UUID counterpartyId,
+        UUID bagId,
+        String parcelId,
+        Instant scannedAt,
+        UUID clientScanId) {
+}

--- a/barcode/src/test/java/com/oneday/barcode/api/ScanControllerTest.java
+++ b/barcode/src/test/java/com/oneday/barcode/api/ScanControllerTest.java
@@ -1,0 +1,63 @@
+package com.oneday.barcode.api;
+
+import com.oneday.barcode.service.LabelService;
+import com.oneday.barcode.service.ScanCommand;
+import com.oneday.barcode.service.ScanLedgerService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+/**
+ * The generic scan door only accepts lifecycle {@code ScanEventType}s — van custody scans and
+ * {@code LABEL_GENERATED} (its own door) are rejected before the ledger is touched.
+ */
+class ScanControllerTest {
+
+    private final ScanLedgerService ledger = mock(ScanLedgerService.class);
+    private final ScanController controller = new ScanController(mock(LabelService.class), ledger);
+
+    private ScanRequest req(String scanType) {
+        return new ScanRequest(UUID.randomUUID(), scanType, "HUB",
+                UUID.randomUUID(), UUID.randomUUID(), null, null, null, Instant.now(), UUID.randomUUID());
+    }
+
+    @Test
+    void lifecycleScan_isRecorded() {
+        controller.scan(req("HUB_ORIGIN_IN"));
+
+        ArgumentCaptor<ScanCommand> cmd = ArgumentCaptor.forClass(ScanCommand.class);
+        verify(ledger).record(cmd.capture());
+        assertThat(cmd.getValue().scanType()).isEqualTo("HUB_ORIGIN_IN");
+    }
+
+    @Test
+    void scannedAt_defaultsToNow_whenOmitted() {
+        controller.scan(new ScanRequest(UUID.randomUUID(), "HUB_DEST_IN", "HUB",
+                null, null, null, null, null, null, null));
+
+        ArgumentCaptor<ScanCommand> cmd = ArgumentCaptor.forClass(ScanCommand.class);
+        verify(ledger).record(cmd.capture());
+        assertThat(cmd.getValue().scannedAt()).isNotNull();
+    }
+
+    @Test
+    void vanScanType_isRejected() {
+        assertThatThrownBy(() -> controller.scan(req("VAN_LOAD")))
+                .isInstanceOf(ResponseStatusException.class);
+        verifyNoInteractions(ledger);
+    }
+
+    @Test
+    void labelGenerated_isRejected_hasItsOwnDoor() {
+        assertThatThrownBy(() -> controller.scan(req("LABEL_GENERATED")))
+                .isInstanceOf(ResponseStatusException.class);
+        verifyNoInteractions(ledger);
+    }
+}

--- a/common/src/main/java/com/oneday/common/kafka/enums/ScanEventType.java
+++ b/common/src/main/java/com/oneday/common/kafka/enums/ScanEventType.java
@@ -3,8 +3,11 @@ package com.oneday.common.kafka.enums;
 public enum ScanEventType {
     HUB_ORIGIN_IN,          // DA pickup path: HANDED_TO_PICKUP_VAN → AT_ORIGIN_HUB
     SELF_DROP_ACCEPTED,     // self-drop path: AWAITING_SELF_DROP → AT_ORIGIN_HUB
+    HUB_ORIGIN_OUT,         // bag dispatched from origin hub → DISPATCHED_TO_AIRPORT (D-007)
     GHA_ACCEPTANCE,
+    DEST_SHUTTLE_IN,        // bag loaded on dest-hub shuttle → DISPATCHED_TO_HUB (D-007)
     HUB_DEST_IN,
     LABEL_GENERATED,
+    DELIVERED,              // DA delivered the box (custody fact only, Option A — DROPPED stays OTP-owned)
     HUB_COLLECT_COMPLETED   // hub-collect path: AWAITING_HUB_COLLECT → HUB_COLLECTED
 }

--- a/orders/src/main/java/com/oneday/orders/events/ScanEventsConsumer.java
+++ b/orders/src/main/java/com/oneday/orders/events/ScanEventsConsumer.java
@@ -41,11 +41,16 @@ public class ScanEventsConsumer {
             return;
         }
         ShipmentState target = switch (event.eventType()) {
-            case HUB_ORIGIN_IN         -> ShipmentState.AT_ORIGIN_HUB;   // TODO: recalc ETA + notify customer
-            case SELF_DROP_ACCEPTED    -> ShipmentState.AT_ORIGIN_HUB;   // TODO: recalc ETA + notify customer
+            case HUB_ORIGIN_IN         -> ShipmentState.AT_ORIGIN_HUB;        // TODO: recalc ETA + notify customer
+            case SELF_DROP_ACCEPTED    -> ShipmentState.AT_ORIGIN_HUB;        // TODO: recalc ETA + notify customer
+            case HUB_ORIGIN_OUT        -> ShipmentState.DISPATCHED_TO_AIRPORT; // D-007
             case GHA_ACCEPTANCE        -> ShipmentState.AT_AIRPORT;
+            case DEST_SHUTTLE_IN       -> ShipmentState.DISPATCHED_TO_HUB;    // D-007
             case HUB_DEST_IN           -> ShipmentState.AT_DEST_HUB;
             case HUB_COLLECT_COMPLETED -> ShipmentState.HUB_COLLECTED;
+            // DELIVERED is a custody fact only (Option A) — DROPPED stays owned by the delivery-OTP
+            // verify path (scan = right box, OTP = right customer, mirroring LABEL_GENERATED/PICKED_UP).
+            case DELIVERED             -> null;
             case LABEL_GENERATED       -> null; // handled above
         };
         if (target == null) {

--- a/orders/src/test/java/com/oneday/orders/events/ScanEventsConsumerTest.java
+++ b/orders/src/test/java/com/oneday/orders/events/ScanEventsConsumerTest.java
@@ -48,6 +48,33 @@ class ScanEventsConsumerTest {
     }
 
     @Test
+    void hubOriginOut_transitionsToDispatchedToAirport() {
+        UUID id = UUID.randomUUID();
+
+        consumer.onScanEvent(new ScanEvent(id, ScanEventType.HUB_ORIGIN_OUT));
+
+        verify(stateMachine).transition(eq(id), eq(ShipmentState.DISPATCHED_TO_AIRPORT), any());
+    }
+
+    @Test
+    void destShuttleIn_transitionsToDispatchedToHub() {
+        UUID id = UUID.randomUUID();
+
+        consumer.onScanEvent(new ScanEvent(id, ScanEventType.DEST_SHUTTLE_IN));
+
+        verify(stateMachine).transition(eq(id), eq(ShipmentState.DISPATCHED_TO_HUB), any());
+    }
+
+    @Test
+    void delivered_isCustodyFactOnly_noTransition() {
+        // Option A: DELIVERED is recorded in M8 but DROPPED stays owned by the delivery-OTP path.
+        consumer.onScanEvent(new ScanEvent(UUID.randomUUID(), ScanEventType.DELIVERED));
+
+        verifyNoInteractions(stateMachine);
+        verify(shipmentRepository, never()).save(any());
+    }
+
+    @Test
     void labelGenerated_withNullParcelId_isIgnored() {
         UUID id = UUID.randomUUID();
 


### PR DESCRIPTION
# Pull Request

## Summary
M8 PR3 — the generic lifecycle-scan door. `POST /api/v1/scan` records every non-label, non-van scan (hub gun, GHA, shuttle, DA, hub counter) into the append-only ledger and fans the resulting `ScanEvent` to M4's state machine.

---

## What Changed
- **`common`** — `ScanEventType` gains `HUB_ORIGIN_OUT`, `DEST_SHUTTLE_IN`, `DELIVERED` (D-007).
- **`barcode`** — new `POST /api/v1/scan` (`ScanController#scan` + `ScanRequest`), reusing PR2's `ScanLedgerService.record` → immutable insert + AFTER_COMMIT `ScanEvent`. A guard rejects van scan types (they arrive via the sync port, PR4) and `LABEL_GENERATED` (it has its own `/label` door) → `400`. Accepts `bagId` for M7-driven bag fan-out; no new migration (`bag_id` already lives in `V8_1`).
- **`orders`** — `ScanEventsConsumer` adds `HUB_ORIGIN_OUT → DISPATCHED_TO_AIRPORT` and `DEST_SHUTTLE_IN → DISPATCHED_TO_HUB`. **`DELIVERED` is ledger-only (Option A)**: recorded + broadcast, but the `DROPPED` transition stays owned by the delivery-OTP verify path.

---

## Why This Change?
M4's `ScanEventsConsumer` was already wired to `oneday.scan.events` but nothing external produced to it — real hub/airport/counter scans had no way in. This adds that door over PR2's write engine, so a dock gun beep now writes an immutable custody row *and* advances the shipment state (arrived-at-hub, dispatched-to-airport, etc.).

**On `DELIVERED` (D-007 co-gating decision):** the design wanted the `DELIVERED` scan to own `DROPPED`, but the working code already reaches `DROPPED` via the delivery-OTP verify (`DROP_COLLECTED → DROPPED`), and the state machine throws on a second/duplicate transition. We mirror the **first mile**, where the two concerns are already split cleanly: `LABEL_GENERATED` (scan = right box, no transition) + `PICKED_UP` (OTP = right person, the transition). So last-mile becomes `DELIVERED` (custody fact, ledger-only) + delivery-OTP (owns `DROPPED`). Zero change to the delivery flow, demo stays intact.

---

## Testing
- [x] Tested locally
- [x] Edge cases considered
- [x] No breaking changes introduced

### Test Evidence
```
ScanControllerTest      Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
  - lifecycleScan_isRecorded
  - scannedAt_defaultsToNow_whenOmitted
  - vanScanType_isRejected
  - labelGenerated_isRejected_hasItsOwnDoor

ScanEventsConsumerTest  Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
  - hubOriginOut_transitionsToDispatchedToAirport
  - destShuttleIn_transitionsToDispatchedToHub
  - delivered_isCustodyFactOnly_noTransition
  - (+ 3 pre-existing label/hub-in cases)

mvn install -pl app -am -DskipTests  →  BUILD SUCCESS  (assembled app compiles; enum additions leave no non-exhaustive switch)
```

---

## Impact

### Areas Affected
- [x] Backend

### Modules Affected
- [x] M4 — Orders
- [x] M8 — Barcode

---

## Risks / Concerns
- **Cross-module coordination (not code in this PR):** per D-007, once M7 hub / M9 flight modules wire in, they must **stop** emitting the transitions the promoted scans now own (`HUB_ORIGIN_OUT`, `DEST_SHUTTLE_IN`) to avoid double-emit; they keep the internal states.
- **Deferred:** role-granular authz at this door (hub-op vs GHA vs counter). Endpoint sits behind the app-level JWT filter and takes `actorId` from the body — same precedent as PR2's `/label`. Marked with a `ponytail:` comment; add when a specific role must be blocked here.

---

## Checklist
- [x] Code follows project conventions (package layout, no cross-module internal imports)
- [x] Self-review completed
- [x] Append-only audit trail preserved (no mutations to scan/manifest/role-change records)
- [x] No sensitive data or credentials exposed
- [x] Documentation updated if behaviour changed
- [x] Ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
