### PR TITLE
M4: fix: store JSON null for empty response bodies in idempotencyfilter

### DIFF
--- a/orders/src/main/java/com/oneday/orders/api/filter/IdempotencyFilter.java
+++ b/orders/src/main/java/com/oneday/orders/api/filter/IdempotencyFilter.java
@@ -97,6 +97,14 @@ public class IdempotencyFilter extends OncePerRequestFilter {
     /** Maximum allowed length for the Idempotency-Key header value (matches DB column). */
     private static final int MAX_KEY_LENGTH = 100;
 
+    /**
+     * Stand-in stored for an empty response body. {@code response_body} is a {@code NOT NULL jsonb}
+     * column, and an empty string is not valid JSON — a handler returning no content (e.g. a 202/204)
+     * would otherwise fail the insert with {@code invalid input syntax for type json}. We store the
+     * JSON {@code null} literal and reproduce an empty body on replay.
+     */
+    private static final String JSON_NULL_LITERAL = "null";
+
     // Deliberately a bare ObjectMapper (no custom serializers) so the fingerprint is
     // unaffected by application-level Jackson configuration on the injected objectMapper.
     // Key sorting is done explicitly in sortKeysRecursively(), not via a mapper feature.
@@ -212,9 +220,12 @@ public class IdempotencyFilter extends OncePerRequestFilter {
                 log.debug("Idempotency hit — replaying key={}**** userId={}",
                         key.substring(0, Math.min(4, key.length())), userId);
                 wrappedResponse.setStatus(cached.getResponseStatus());
-                wrappedResponse.setContentType(MediaType.APPLICATION_JSON_VALUE);
                 wrappedResponse.addHeader(HEADER_IDEMPOTENCY_REPLAYED, "true");
-                wrappedResponse.getWriter().write(cached.getResponseBody());
+                String cachedBody = cached.getResponseBody();
+                if (cachedBody != null && !JSON_NULL_LITERAL.equals(cachedBody)) {
+                    wrappedResponse.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                    wrappedResponse.getWriter().write(cachedBody);
+                }
                 wrappedResponse.copyBodyToResponse();
                 return;
             }
@@ -235,7 +246,9 @@ public class IdempotencyFilter extends OncePerRequestFilter {
             record.setId(keyId);
             record.setRequestFingerprint(incomingFingerprint);
             record.setResponseStatus((short) status);
-            record.setResponseBody(responseBody);
+            // Empty body (e.g. a 202/204 with no content) isn't valid JSON for the jsonb column —
+            // store the JSON null literal and reproduce an empty body on replay (see JSON_NULL_LITERAL).
+            record.setResponseBody(responseBody.isBlank() ? JSON_NULL_LITERAL : responseBody);
             record.setExpiresAt(Instant.now().plus(properties.getTtl()));
             try {
                 repository.save(record);


### PR DESCRIPTION
# Pull Request

## Summary
Fix `IdempotencyFilter` so empty response bodies (e.g. 202/204 from M8's scan endpoints) persist correctly to the `NOT NULL jsonb` `idempotency_keys.response_body` column, restoring HTTP-level replay protection on those routes.

---

## What Changed
- On write: store the JSON `null` literal instead of an empty string when a handler returns no content (empty string isn't valid `jsonb`).
- On replay: skip writing a body (and the JSON content-type) when the cached body is the `null` sentinel, faithfully reproducing an empty response.

---

## Why This Change?
`response_body` is `JSONB NOT NULL`. The filter stored the raw body verbatim, so an empty-body POST tried to insert `""` — which Postgres rejects as `invalid input syntax for type json`. The insert failed silently on every empty-body POST: the request still succeeded, but no idempotency record was persisted, so replay protection didn't apply to those routes. JSON-body endpoints (e.g. booking) were never affected.

---

## Testing
- [x] Tested locally
- [x] Edge cases considered
- [x] No breaking changes introduced

### Test Evidence
Replaying an M8 202 scan POST with the same `Idempotency-Key` now returns the cached 202 with an empty body and `X-Idempotency-Replayed: true`; the record is present in `idempotency_keys` with `response_body = null`.

---

## Impact

### Areas Affected
- [x] Backend
- [x] Database

### Modules Affected
- [x] M4 — Orders (surfaced by M8 — Barcode)

---

## Risks / Concerns
- Low. Single-file change; JSON-body endpoints unchanged. The `null` literal is used as an in-band sentinel — a handler that deliberately returns a JSON `null` payload would replay as an empty body, which no current endpoint does.

---

## Checklist
- [x] Code follows project conventions (package layout, no cross-module internal imports)
- [x] Self-review completed
- [x] Append-only audit trail preserved (no mutations to scan/manifest/role-change records)
- [x] No sensitive data or credentials exposed
- [x] Documentation updated if behaviour changed
- [x] Ready for review
