### PR TITLE
feat(dispatch): remove 200m geofence + manual Mark-arrived (Jul 20)

### DIFF
--- a/dispatch/src/main/java/com/oneday/dispatch/api/DaDispatchController.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/api/DaDispatchController.java
@@ -75,6 +75,15 @@ public class DaDispatchController {
         return ResponseEntity.noContent().build();
     }
 
+    /** Manual "Mark arrived" at the van meeting vertex (replaces the removed geofence). */
+    @PostMapping("/arrived")
+    public ResponseEntity<Void> arrived(@PathVariable UUID daId,
+                                        @AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireDaSelf(principal, daId);
+        daStatusService.markArrivedAtCron(daId);
+        return ResponseEntity.noContent().build();
+    }
+
     @PostMapping("/tasks/{taskId}/en-route")
     public DaTaskView enRoute(@PathVariable UUID daId, @PathVariable UUID taskId,
                               @AuthenticationPrincipal AuthUserDetails principal) {

--- a/dispatch/src/main/java/com/oneday/dispatch/service/DaStatusService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/DaStatusService.java
@@ -28,11 +28,18 @@ public interface DaStatusService {
                    DaCronAssignment cronAssignment);
 
     /**
-     * Record a GPS ping: update the live position + heartbeat and mark the DA dirty. If the DA is
-     * {@code CRON_LOCKED} and now within the configured proximity of its cron vertex, flips to
-     * {@code AT_CRON}. A ping while {@code OFFLINE}/{@code ABSENT} resumes the DA to {@code IDLE}.
+     * Record a GPS ping: update the live position + heartbeat and mark the DA dirty. GPS is
+     * display/tracking only (Jul-20: the proximity geofence was removed). A ping while
+     * {@code OFFLINE}/{@code ABSENT} resumes the DA to {@code IDLE}.
      */
     void updateGps(UUID daId, double lat, double lon, Instant timestamp);
+
+    /**
+     * Manual "Mark arrived" — the DA taps it at the van meeting vertex, replacing the removed
+     * geofence. {@code CRON_LOCKED → AT_CRON}; already {@code AT_CRON} is a no-op; any other
+     * status → 409.
+     */
+    void markArrivedAtCron(UUID daId);
 
     /** Set a DA's status in memory and synchronously through to {@code da_status} (under the DA lock). */
     void updateStatus(UUID daId, DaStatusEnum newStatus);

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaStatusServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaStatusServiceImpl.java
@@ -10,9 +10,11 @@ import com.oneday.dispatch.service.model.DaLiveStatus;
 import com.oneday.dispatch.service.model.DaQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -100,18 +102,9 @@ class DaStatusServiceImpl implements DaStatusService {
         // Heartbeat resumes a silent DA back to IDLE (absent-recovery, design §12.4).
         if (status == DaStatusEnum.OFFLINE || status == DaStatusEnum.ABSENT) {
             updateStatus(daId, DaStatusEnum.IDLE);
-            return;
         }
-        // Proximity to the cron vertex closes the CRON_LOCKED → AT_CRON transition.
-        if (status == DaStatusEnum.CRON_LOCKED) {
-            DaQueue q = queues.get(daId);
-            DaCronAssignment cron = q != null ? q.getCron() : null;
-            if (cron != null
-                    && GeoDistance.meters(lat, lon, cron.getMeetingLat(), cron.getMeetingLon())
-                       <= props.getCron().getProximityMeters()) {
-                updateStatus(daId, DaStatusEnum.AT_CRON);
-            }
-        }
+        // Jul-20: the 200 m geofence is removed. CRON_LOCKED → AT_CRON is now a manual
+        // "Mark arrived" (see markArrivedAtCron) — GPS is display/tracking only, not a gate.
     }
 
     @Override
@@ -140,6 +133,22 @@ class DaStatusServiceImpl implements DaStatusService {
     public DaStatusEnum getStatus(UUID daId) {
         DaLiveStatus live = liveStatus.get(daId);
         return live != null ? live.getStatus() : null;
+    }
+
+    @Override
+    public void markArrivedAtCron(UUID daId) {
+        withDaLock(daId, () -> {
+            DaStatusEnum status = getStatus(daId);
+            if (status == DaStatusEnum.AT_CRON) {
+                return null; // already arrived — idempotent
+            }
+            if (status != DaStatusEnum.CRON_LOCKED) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT,
+                        "DA must be at the meeting (CRON_LOCKED) to mark arrived; was " + status);
+            }
+            updateStatus(daId, DaStatusEnum.AT_CRON);
+            return null;
+        });
     }
 
     @Override

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaStatusServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaStatusServiceImplTest.java
@@ -110,7 +110,7 @@ class DaStatusServiceImplTest {
     }
 
     @Test
-    void gpsWithinProximityWhileCronLockedFlipsToAtCron() {
+    void markArrivedFlipsCronLockedToAtCron() {
         UUID da = UUID.randomUUID();
         UUID city = UUID.randomUUID();
         LocalDate today = LocalDate.now();
@@ -119,8 +119,12 @@ class DaStatusServiceImplTest {
         service.initShift(da, city, today, "A", cron);
         service.updateStatus(da, DaStatusEnum.CRON_LOCKED);
 
-        // ~30 m away (well inside the 200 m default) → AT_CRON.
+        // Geofence removed (Jul-20): a GPS ping near the vertex no longer flips status.
         service.updateGps(da, 12.97187, 77.5946, Instant.now());
+        assertThat(service.getStatus(da)).isEqualTo(DaStatusEnum.CRON_LOCKED);
+
+        // Manual "Mark arrived" makes the CRON_LOCKED → AT_CRON transition.
+        service.markArrivedAtCron(da);
         assertThat(service.getStatus(da)).isEqualTo(DaStatusEnum.AT_CRON);
     }
 


### PR DESCRIPTION
Jul 20: GPS drives tracking only — arrival at the van meeting is now a manual tap.

## What
- **Removed** the 200 m geofence in `DaStatusServiceImpl.updateGps` (the `CRON_LOCKED → AT_CRON` proximity auto-flip). GPS pings still update live position/heartbeat but no longer gate status.
- **`DaStatusService.markArrivedAtCron(daId)`** — manual `CRON_LOCKED → AT_CRON` (idempotent if already `AT_CRON`; `409` otherwise).
- **`POST /dispatch/da/{daId}/arrived`** (DA-self auth) → the app's "Mark arrived" button calls this.
- Converted the geofence test: a near-vertex GPS ping now leaves status `CRON_LOCKED`; `markArrivedAtCron` makes the transition.

## Verified
- `mvn clean install -pl dispatch,app -am -DskipTests` → EXIT 0
- `DaStatusServiceImplTest` 5/5, `DaDispatchControllerTest` 10/10.

App side (Mark-arrived button) ships in the oneday-driver-app PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)