### PR TITLE
fix(auth): permit /error — real error statuses instead of masked 401s

### DIFF
--- a/auth/src/main/java/com/oneday/auth/security/SecurityConfig.java
+++ b/auth/src/main/java/com/oneday/auth/security/SecurityConfig.java
@@ -45,6 +45,10 @@ public class SecurityConfig {
                         .requestMatchers("/auth/login", "/auth/register", "/auth/health", "/auth/request-onboarding").permitAll()
                         .requestMatchers("/auth/oauth/google", "/auth/otp/request", "/auth/otp/verify").permitAll()
                         .requestMatchers("/", "/index.html", "/*.js", "/*.css", "/css/**", "/js/**").permitAll()
+                        // Permit the error dispatch (Spring Boot's default). The JWT filter is skipped
+                        // on the ERROR dispatch, so without this any 404/500 on an authenticated
+                        // endpoint would be masked as a misleading 401.
+                        .requestMatchers("/error").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();


### PR DESCRIPTION
## Root cause (the "stops/confirm 401")
`JwtAuthenticationFilter extends OncePerRequestFilter`, which by default is **skipped on the ERROR dispatch**, and `/error` was **not** in the security allow-list. So when an authenticated endpoint 404s/500s, Spring forwards to `/error` with no authentication in context, and the chain re-evaluates it as a **401** — masking the real status.

That's why `POST /routing/vans/{vanId}/stops/confirm` returned 401 with a valid token (my test used a fake van → `reconcileStop` threw → masked), while sibling endpoints that don't throw returned 200. Same reason `GET /` returned 401 instead of 404.

## Fix
Permit `/error` in `authorizeHttpRequests` (this is Spring Boot's default; it was dropped in the custom config). One line.

## Verified (build booted against the staging DB)
| Request | Before | After |
|---|---|---|
| `GET /` | 401 | **404** |
| `POST …/stops/confirm` (missing manifest) | 401 | **500** (real error) |
| authenticated `GET …/tasks` | 200 | **200** |
| protected, no token | 401 | **401** |

Compile EXIT=0. (Local auth e2e tests fail on unrelated schema drift — local test DB missing `auth_otp` from PR #65 — not this change.)

## Follow-up (separate, minor)
`reconcileStop` returns 500 for a missing manifest; it should be a 404. Out of scope here — this PR just unmasks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)