### PR TITLE
Live tracking addition

### DIFF
--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -62,3 +62,15 @@ dispatch:
       - bangalore
       - hyderabad
       - chennai
+
+# Live tracking (M4). Per-city hub + airport coordinates for the static-node fallbacks and the
+# route line; keyed by IATA code (the catalog also accepts DELHI/MUMBAI/... forms). Coordinates are
+# approximate placeholders — confirm the real hub facility locations with ops before the pilot.
+tracking:
+  gps-stale-seconds: 180          # a GPS fix older than this shows the static node, not a live dot
+  city-nodes:
+    DEL: { hub-lat: 28.5000, hub-lon: 77.1500, airport-lat: 28.5562, airport-lon: 77.1000 }
+    BOM: { hub-lat: 19.0760, hub-lon: 72.8777, airport-lat: 19.0896, airport-lon: 72.8656 }
+    BLR: { hub-lat: 12.9716, hub-lon: 77.5946, airport-lat: 13.1986, airport-lon: 77.7066 }
+    HYD: { hub-lat: 17.3850, hub-lon: 78.4867, airport-lat: 17.2403, airport-lon: 78.4294 }
+    MAA: { hub-lat: 13.0827, hub-lon: 80.2707, airport-lat: 12.9941, airport-lon: 80.1709 }

--- a/common/src/main/java/com/oneday/common/port/LiveDaPositionPort.java
+++ b/common/src/main/java/com/oneday/common/port/LiveDaPositionPort.java
@@ -1,0 +1,16 @@
+package com.oneday.common.port;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * The live GPS of the DA currently carrying a shipment (first-mile pickup or last-mile delivery).
+ * Implemented in M5 (dispatch) over {@code da_status}; consumed by the M4 tracking read path. Same
+ * cross-module pattern as {@link ShipmentLocationPort} — both sides depend only on {@code common},
+ * so M4 never imports dispatch internals.
+ */
+public interface LiveDaPositionPort {
+
+    /** The carrying DA's latest GPS, or empty if no DA is currently on this shipment / no fix yet. */
+    Optional<LivePosition> forShipment(UUID shipmentId);
+}

--- a/common/src/main/java/com/oneday/common/port/LivePosition.java
+++ b/common/src/main/java/com/oneday/common/port/LivePosition.java
@@ -1,0 +1,21 @@
+package com.oneday.common.port;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * A live GPS point for whatever is currently carrying a parcel (a DA or a van). Returned by the
+ * live-position ports so the tracking read path (M4) can plot a moving marker without importing the
+ * dispatch/routing modules. {@code lastSeenAt} lets the reader decide whether the fix is fresh
+ * enough to show as "live" or has gone stale and should fall back to a static node.
+ *
+ * @param minutesLate lateness vs plan where the source tracks it (van); null for a DA
+ * @param sourceId    the da/van id the fix came from (diagnostics only)
+ */
+public record LivePosition(
+        double lat,
+        double lon,
+        Instant lastSeenAt,
+        Integer minutesLate,
+        UUID sourceId) {
+}

--- a/common/src/main/java/com/oneday/common/port/LiveVanPositionPort.java
+++ b/common/src/main/java/com/oneday/common/port/LiveVanPositionPort.java
@@ -1,0 +1,16 @@
+package com.oneday.common.port;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * The live GPS of the van currently carrying a shipment (between hub and DA meeting points).
+ * Implemented in M6 (routing) over {@code van_manifest_item → van_manifest → van_live_status};
+ * consumed by the M4 tracking read path. In v1 a routing {@code parcelId} is the shipment UUID
+ * (routing D-001), so the shipment id is passed straight through.
+ */
+public interface LiveVanPositionPort {
+
+    /** The carrying van's latest GPS, or empty if the shipment isn't on a van / no fix yet. */
+    Optional<LivePosition> forShipment(UUID shipmentId);
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/adapter/LiveDaPositionAdapter.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/adapter/LiveDaPositionAdapter.java
@@ -1,0 +1,50 @@
+package com.oneday.dispatch.adapter;
+
+import com.oneday.common.port.LiveDaPositionPort;
+import com.oneday.common.port.LivePosition;
+import com.oneday.dispatch.domain.DaStatus;
+import com.oneday.dispatch.domain.DispatchQueue;
+import com.oneday.dispatch.repository.DaStatusRepository;
+import com.oneday.dispatch.repository.DispatchQueueRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * M5-side implementation of {@link LiveDaPositionPort}: resolves the shipment to its currently
+ * assigned DA ({@code dispatch_queue}) and reads that DA's last GPS fix from {@code da_status}.
+ * Empty when no DA is actively carrying the parcel or no GPS has been reported yet — the tracker
+ * then falls back to a static node.
+ */
+@Component
+class LiveDaPositionAdapter implements LiveDaPositionPort {
+
+    private final DispatchQueueRepository queueRepository;
+    private final DaStatusRepository daStatusRepository;
+
+    LiveDaPositionAdapter(DispatchQueueRepository queueRepository, DaStatusRepository daStatusRepository) {
+        this.queueRepository = queueRepository;
+        this.daStatusRepository = daStatusRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<LivePosition> forShipment(UUID shipmentId) {
+        List<DispatchQueue> active = queueRepository.findActiveByShipmentId(shipmentId);
+        if (active.isEmpty()) {
+            return Optional.empty();
+        }
+        UUID daId = active.get(0).getDaId();
+        return daStatusRepository.findByDaId(daId)
+                .filter(LiveDaPositionAdapter::hasFix)
+                .map(s -> new LivePosition(
+                        s.getLastGpsLat(), s.getLastGpsLon(), s.getLastHeartbeat(), null, daId));
+    }
+
+    private static boolean hasFix(DaStatus s) {
+        return s.getLastGpsLat() != null && s.getLastGpsLon() != null;
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/repository/DispatchQueueRepository.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/repository/DispatchQueueRepository.java
@@ -52,4 +52,17 @@ public interface DispatchQueueRepository extends JpaRepository<DispatchQueue, UU
             """)
     Optional<DispatchQueue> findActiveByShipmentIdAndTaskType(
             @Param("shipmentId") UUID shipmentId, @Param("taskType") TaskType taskType);
+
+    /**
+     * Active tasks for a shipment across both legs (pickup + delivery), newest assignment first.
+     * Used by live tracking to find the DA currently carrying the parcel; QUEUED/IN_PROGRESS only.
+     */
+    @Query("""
+            select d from DispatchQueue d
+            where d.shipmentId = :shipmentId
+              and d.status in (com.oneday.dispatch.domain.TaskStatus.QUEUED,
+                               com.oneday.dispatch.domain.TaskStatus.IN_PROGRESS)
+            order by d.assignedAt desc
+            """)
+    List<DispatchQueue> findActiveByShipmentId(@Param("shipmentId") UUID shipmentId);
 }

--- a/orders/src/main/java/com/oneday/orders/api/TrackingController.java
+++ b/orders/src/main/java/com/oneday/orders/api/TrackingController.java
@@ -1,0 +1,37 @@
+package com.oneday.orders.api;
+
+import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.orders.dto.ShipmentTrackResponse;
+import com.oneday.orders.service.TrackingService;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Live tracking for a customer's own shipment — current position, route, and milestone timeline.
+ * Scoped like the rest of the customer read path: booking roles only, and only the caller's own
+ * shipments (a ref the caller did not book is a 404).
+ */
+@RestController
+@RequestMapping("/api/v1/shipments")
+class TrackingController {
+
+    private final TrackingService trackingService;
+
+    TrackingController(TrackingService trackingService) {
+        this.trackingService = trackingService;
+    }
+
+    @GetMapping("/mine/{ref}/track")
+    public ShipmentTrackResponse track(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @PathVariable("ref") String ref) {
+        Authz.requireCustomerRole(principal, "C2C_CUSTOMER", "B2C_CUSTOMER", "B2B_USER");
+        return trackingService.track(Authz.requireUserId(principal), ref)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No such shipment: " + ref));
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/config/TrackingProperties.java
+++ b/orders/src/main/java/com/oneday/orders/config/TrackingProperties.java
@@ -1,0 +1,67 @@
+package com.oneday.orders.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Live-tracking configuration.
+ *
+ * <pre>{@code
+ * tracking:
+ *   gps-stale-seconds: 180
+ *   city-nodes:
+ *     DEL: { hub-lat: 28.50, hub-lon: 77.15, airport-lat: 28.5562, airport-lon: 77.1000 }
+ * }</pre>
+ *
+ * <p>{@code city-nodes} is keyed by IATA city code; {@link com.oneday.orders.tracking.CityNodeCatalog}
+ * also accepts the full city name (DELHI → DEL) since older shipment rows stored either form.</p>
+ */
+@Component
+@ConfigurationProperties(prefix = "tracking")
+public class TrackingProperties {
+
+    /** A fix older than this is treated as stale — the tracker shows the static node, not the dot. */
+    private int gpsStaleSeconds = 180;
+
+    /** Per-city hub + airport coordinates, keyed by IATA city code (DEL, BOM, BLR, HYD, MAA). */
+    private Map<String, CityNode> cityNodes = new HashMap<>();
+
+    public int getGpsStaleSeconds() {
+        return gpsStaleSeconds;
+    }
+
+    public void setGpsStaleSeconds(int gpsStaleSeconds) {
+        this.gpsStaleSeconds = gpsStaleSeconds;
+    }
+
+    public Map<String, CityNode> getCityNodes() {
+        return cityNodes;
+    }
+
+    public void setCityNodes(Map<String, CityNode> cityNodes) {
+        this.cityNodes = cityNodes;
+    }
+
+    /** Fixed hub + airport coordinates for one city. Approximate placeholders — confirm with ops. */
+    public static class CityNode {
+        private double hubLat;
+        private double hubLon;
+        private double airportLat;
+        private double airportLon;
+
+        public double getHubLat() { return hubLat; }
+        public void setHubLat(double hubLat) { this.hubLat = hubLat; }
+
+        public double getHubLon() { return hubLon; }
+        public void setHubLon(double hubLon) { this.hubLon = hubLon; }
+
+        public double getAirportLat() { return airportLat; }
+        public void setAirportLat(double airportLat) { this.airportLat = airportLat; }
+
+        public double getAirportLon() { return airportLon; }
+        public void setAirportLon(double airportLon) { this.airportLon = airportLon; }
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/dto/ShipmentTrackResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/ShipmentTrackResponse.java
@@ -1,0 +1,53 @@
+package com.oneday.orders.dto;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.tracking.LocationKind;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Live-tracking view of one of the caller's shipments ({@code GET /api/v1/shipments/mine/{ref}/track}).
+ * Combines the current state, a resolved current position (static node or live dot), the route to
+ * draw, and the milestone timeline. Field names serialise to snake_case via the global Jackson config.
+ */
+public record ShipmentTrackResponse(
+        String shipmentRef,
+        ShipmentState state,
+        String stateLabel,
+        Location location,
+        Route route,
+        List<Milestone> milestones,
+        Eta eta) {
+
+    /**
+     * The current position. {@code lat}/{@code lon} are null for the air leg (draw the arc) or when no
+     * coordinate is available. {@code live} = a fresh GPS fix; {@code moving} = the parcel is in motion.
+     */
+    public record Location(
+            LocationKind kind,
+            Double lat,
+            Double lon,
+            boolean live,
+            boolean moving,
+            String label,
+            Instant lastUpdatedAt,
+            Integer minutesLate) {}
+
+    /** Endpoints + the fixed waypoints (hubs/airports) between them, for drawing the journey line. */
+    public record Route(
+            Double originLat,
+            Double originLon,
+            String originCity,
+            Double destLat,
+            Double destLon,
+            String destCity,
+            List<Waypoint> waypoints) {}
+
+    public record Waypoint(double lat, double lon, String label) {}
+
+    /** One timeline row. {@code occurredAt} is null for a step not yet reached. */
+    public record Milestone(String label, Instant occurredAt, boolean done) {}
+
+    public record Eta(Instant promised, Instant updated) {}
+}

--- a/orders/src/main/java/com/oneday/orders/service/TrackingService.java
+++ b/orders/src/main/java/com/oneday/orders/service/TrackingService.java
@@ -1,0 +1,20 @@
+package com.oneday.orders.service;
+
+import com.oneday.orders.dto.ShipmentTrackResponse;
+
+import java.util.Optional;
+
+/**
+ * Live-tracking read model for a customer's own shipment: current position (static node or live dot),
+ * the route to draw, and the milestone timeline. Scoped to the caller — a shipment the caller did not
+ * book is treated as not found.
+ */
+public interface TrackingService {
+
+    /**
+     * @param userId      the authenticated caller's id (M1 user UUID, as a string)
+     * @param shipmentRef the shipment reference
+     * @return the tracking view, or empty if no such ref exists for this caller
+     */
+    Optional<ShipmentTrackResponse> track(String userId, String shipmentRef);
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
@@ -258,7 +258,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
         response.setPricing(pricing);
         response.setEtaPromised(etaPromised);
         response.setSlaCommitmentMinutes(slaCommitmentMinutes);
-        response.setTrackingUrl("/api/v1/shipments/" + shipment.getShipmentRef() + "/track");
+        response.setTrackingUrl("/api/v1/shipments/mine/" + shipment.getShipmentRef() + "/track");
         response.setParcelId(null);
         response.setLabelStatus("PENDING");
         response.setPayment(null);  // omitted from JSON via @JsonInclude(NON_NULL) on the field

--- a/orders/src/main/java/com/oneday/orders/service/impl/BookingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/BookingServiceImpl.java
@@ -344,7 +344,7 @@ class BookingServiceImpl implements BookingService {
         response.setPricing(pricing);
         response.setEtaPromised(etaPromised);
         response.setSlaCommitmentMinutes(slaCommitmentMinutes);
-        response.setTrackingUrl("/api/v1/shipments/" + shipment.getShipmentRef() + "/track");
+        response.setTrackingUrl("/api/v1/shipments/mine/" + shipment.getShipmentRef() + "/track");
         response.setParcelId(null);
         response.setLabelStatus("PENDING");
         response.setPayment(paymentSummary);

--- a/orders/src/main/java/com/oneday/orders/service/impl/TrackingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/TrackingServiceImpl.java
@@ -1,0 +1,100 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.enums.DeliveryType;
+import com.oneday.orders.domain.Address;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.dto.ShipmentTrackResponse;
+import com.oneday.orders.dto.ShipmentTrackResponse.Eta;
+import com.oneday.orders.dto.ShipmentTrackResponse.Location;
+import com.oneday.orders.dto.ShipmentTrackResponse.Route;
+import com.oneday.orders.dto.ShipmentTrackResponse.Waypoint;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.service.CustomerVisibleStateMapper;
+import com.oneday.orders.service.TrackingService;
+import com.oneday.orders.tracking.CityNodeCatalog;
+import com.oneday.orders.tracking.CityNodeCatalog.Coord;
+import com.oneday.orders.tracking.LocationResolver;
+import com.oneday.orders.tracking.LocationResolver.ResolvedLocation;
+import com.oneday.orders.tracking.MilestoneBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+/**
+ * @see TrackingService
+ */
+@Service
+class TrackingServiceImpl implements TrackingService {
+
+    private final ShipmentRepository shipmentRepository;
+    private final CustomerVisibleStateMapper stateMapper;
+    private final LocationResolver locationResolver;
+    private final MilestoneBuilder milestoneBuilder;
+    private final CityNodeCatalog cities;
+
+    TrackingServiceImpl(ShipmentRepository shipmentRepository,
+                        CustomerVisibleStateMapper stateMapper,
+                        LocationResolver locationResolver,
+                        MilestoneBuilder milestoneBuilder,
+                        CityNodeCatalog cities) {
+        this.shipmentRepository = shipmentRepository;
+        this.stateMapper = stateMapper;
+        this.locationResolver = locationResolver;
+        this.milestoneBuilder = milestoneBuilder;
+        this.cities = cities;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<ShipmentTrackResponse> track(String userId, String shipmentRef) {
+        UUID id = UserIds.parse(userId);
+        if (id == null) {
+            return Optional.empty();
+        }
+        return shipmentRepository.findByShipmentRef(shipmentRef)
+                .filter(s -> id.equals(s.getBookedByUserId()))   // ownership scope: not yours → not found
+                .map(this::toResponse);
+    }
+
+    private ShipmentTrackResponse toResponse(Shipment s) {
+        String stateLabel = stateMapper.labelFor(s.getState());
+        ResolvedLocation r = locationResolver.resolve(s);
+        Location location = new Location(
+                r.kind(), r.lat(), r.lon(), r.live(), r.moving(), stateLabel, r.lastUpdatedAt(), r.minutesLate());
+
+        List<ShipmentTrackResponse.Milestone> milestones = milestoneBuilder.build(s).stream()
+                .map(m -> new ShipmentTrackResponse.Milestone(m.label(), m.occurredAt(), m.done()))
+                .toList();
+
+        return new ShipmentTrackResponse(
+                s.getShipmentRef(), s.getState(), stateLabel, location, route(s), milestones,
+                new Eta(s.getEtaPromised(), s.getEtaUpdated()));
+    }
+
+    private Route route(Shipment s) {
+        List<Waypoint> waypoints = new ArrayList<>();
+        Consumer<Waypoint> add = waypoints::add;
+        cities.hub(s.getOriginCity()).ifPresent(c -> add.accept(waypoint(c, "Origin hub")));
+        if (s.getDeliveryType() == DeliveryType.INTERCITY) {
+            cities.airport(s.getOriginCity()).ifPresent(c -> add.accept(waypoint(c, s.getOriginCity() + " airport")));
+            cities.airport(s.getDestCity()).ifPresent(c -> add.accept(waypoint(c, s.getDestCity() + " airport")));
+        }
+        cities.hub(s.getDestCity()).ifPresent(c -> add.accept(waypoint(c, "Destination hub")));
+
+        Address o = s.getOriginAddress();
+        Address d = s.getDestAddress();
+        return new Route(
+                o != null ? o.getLatitude() : null, o != null ? o.getLongitude() : null, s.getOriginCity(),
+                d != null ? d.getLatitude() : null, d != null ? d.getLongitude() : null, s.getDestCity(),
+                waypoints);
+    }
+
+    private static Waypoint waypoint(Coord c, String label) {
+        return new Waypoint(c.lat(), c.lon(), label);
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/tracking/CityNodeCatalog.java
+++ b/orders/src/main/java/com/oneday/orders/tracking/CityNodeCatalog.java
@@ -1,0 +1,55 @@
+package com.oneday.orders.tracking;
+
+import com.oneday.orders.config.TrackingProperties;
+import com.oneday.orders.config.TrackingProperties.CityNode;
+import org.springframework.stereotype.Component;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Resolves a shipment's city code to that city's fixed hub / airport coordinates. Config is keyed by
+ * IATA code (DEL, BOM, …); this catalog also accepts the full city name (DELHI → DEL) and is
+ * case-insensitive, because {@code shipments.origin_city} has historically stored either form.
+ */
+@Component
+public class CityNodeCatalog {
+
+    // Full city name → IATA code, so a row storing "DELHI" resolves to the DEL node.
+    private static final Map<String, String> NAME_TO_IATA = Map.of(
+            "DELHI", "DEL",
+            "MUMBAI", "BOM",
+            "BANGALORE", "BLR",
+            "BENGALURU", "BLR",
+            "HYDERABAD", "HYD",
+            "CHENNAI", "MAA");
+
+    private final TrackingProperties properties;
+
+    CityNodeCatalog(TrackingProperties properties) {
+        this.properties = properties;
+    }
+
+    private Optional<CityNode> node(String cityCode) {
+        if (cityCode == null || cityCode.isBlank()) {
+            return Optional.empty();
+        }
+        String key = cityCode.trim().toUpperCase(Locale.ROOT);
+        key = NAME_TO_IATA.getOrDefault(key, key);
+        return Optional.ofNullable(properties.getCityNodes().get(key));
+    }
+
+    /** Hub coordinates for the city, if configured. */
+    public Optional<Coord> hub(String cityCode) {
+        return node(cityCode).map(n -> new Coord(n.getHubLat(), n.getHubLon()));
+    }
+
+    /** Airport coordinates for the city, if configured. */
+    public Optional<Coord> airport(String cityCode) {
+        return node(cityCode).map(n -> new Coord(n.getAirportLat(), n.getAirportLon()));
+    }
+
+    /** A plain lat/lon pair. */
+    public record Coord(double lat, double lon) {}
+}

--- a/orders/src/main/java/com/oneday/orders/tracking/LocationKind.java
+++ b/orders/src/main/java/com/oneday/orders/tracking/LocationKind.java
@@ -1,0 +1,29 @@
+package com.oneday.orders.tracking;
+
+/**
+ * What kind of place a shipment is at right now — the shape the tracking UI draws. Derived from the
+ * M4 {@link com.oneday.common.domain.enums.ShipmentState} by {@link LocationResolver}.
+ */
+public enum LocationKind {
+
+    /** Resting with the sender before pickup (or awaiting self-drop). Static origin pin. */
+    WITH_CUSTOMER,
+
+    /** Sitting at a hub (origin or destination). Static hub pin. */
+    STATIONARY_HUB,
+
+    /** Waiting at an airport. Static airport pin. */
+    STATIONARY_AIRPORT,
+
+    /** On the move with a delivery associate. Live dot when GPS is fresh, else static fallback. */
+    MOVING_DA,
+
+    /** On the move on a van between hub and DA. Live dot when GPS is fresh, else static fallback. */
+    MOVING_VAN,
+
+    /** In the air. No live point in v1 — the UI shows the route arc + "In transit by air". */
+    ON_FLIGHT,
+
+    /** Delivered (or collected from hub). Static destination pin. */
+    DELIVERED
+}

--- a/orders/src/main/java/com/oneday/orders/tracking/LocationResolver.java
+++ b/orders/src/main/java/com/oneday/orders/tracking/LocationResolver.java
@@ -1,0 +1,178 @@
+package com.oneday.orders.tracking;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.port.LiveDaPositionPort;
+import com.oneday.common.port.LivePosition;
+import com.oneday.common.port.LiveVanPositionPort;
+import com.oneday.orders.config.TrackingProperties;
+import com.oneday.orders.domain.Address;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.tracking.CityNodeCatalog.Coord;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * The heart of live tracking: given a shipment's current M4 state, decide what kind of place it's at
+ * and produce a coordinate. Resting states (with the customer, at a hub, at an airport) yield a static
+ * pin; the with-a-DA and on-a-van states yield a live dot from {@link LiveDaPositionPort} /
+ * {@link LiveVanPositionPort}, degrading to the nearest static node when the GPS fix is missing or
+ * stale. The air leg has no live point in v1 — the UI draws the route arc instead.
+ *
+ * <p>Ports are injected lazily ({@link ObjectProvider}) so the orders module (and any profile without
+ * dispatch/routing on the classpath) resolves to static fallbacks rather than failing to wire.</p>
+ */
+@Component
+public class LocationResolver {
+
+    private final CityNodeCatalog cities;
+    private final ObjectProvider<LiveDaPositionPort> daPort;
+    private final ObjectProvider<LiveVanPositionPort> vanPort;
+    private final Duration staleAfter;
+
+    LocationResolver(CityNodeCatalog cities,
+                     ObjectProvider<LiveDaPositionPort> daPort,
+                     ObjectProvider<LiveVanPositionPort> vanPort,
+                     TrackingProperties properties) {
+        this.cities = cities;
+        this.daPort = daPort;
+        this.vanPort = vanPort;
+        this.staleAfter = Duration.ofSeconds(properties.getGpsStaleSeconds());
+    }
+
+    /** Where the shipment is right now. */
+    public ResolvedLocation resolve(Shipment s) {
+        LocationKind kind = kindOf(s.getState());
+        return switch (kind) {
+            case WITH_CUSTOMER -> staticAt(kind, originAddr(s));
+            case DELIVERED -> staticAt(kind, deliveredCoord(s));
+            case STATIONARY_HUB -> staticAt(kind, hubCoord(s));
+            case STATIONARY_AIRPORT -> staticAt(kind, airportCoord(s));
+            case ON_FLIGHT -> new ResolvedLocation(kind, null, null, false, true, null, null);
+            case MOVING_DA -> moving(kind, s, movingDaFallback(s));
+            case MOVING_VAN -> moving(kind, s, movingVanFallback(s));
+        };
+    }
+
+    // ── state → kind ────────────────────────────────────────────────────────
+    static LocationKind kindOf(ShipmentState st) {
+        return switch (st) {
+            case BOOKED, PICKUP_ASSIGNED, AWAITING_SELF_DROP, PICKUP_FAILED, CANCELLED -> LocationKind.WITH_CUSTOMER;
+            case PICKED_UP,
+                 DROP_ASSIGNED, HUB_DELIVERY_ASSIGNED, DROP_COLLECTED, COLLECTED_FROM_HUB -> LocationKind.MOVING_DA;
+            case HANDED_TO_PICKUP_VAN, RETURNED_TO_HUB,
+                 DISPATCHED_TO_AIRPORT, DISPATCHED_TO_HUB, HANDED_TO_DROP_VAN -> LocationKind.MOVING_VAN;
+            case AT_ORIGIN_HUB, ORIGIN_HUB_PROCESSING, IN_TAKEOFF_BAG,
+                 AT_DEST_HUB, DEST_HUB_PROCESSING, AWAITING_HUB_COLLECT,
+                 DELIVERY_FAILED, RTO_INITIATED -> LocationKind.STATIONARY_HUB;
+            case AT_AIRPORT, LANDED -> LocationKind.STATIONARY_AIRPORT;
+            case DEPARTED, RTO_IN_TRANSIT -> LocationKind.ON_FLIGHT;
+            case DROPPED, HUB_COLLECTED, RTO_COMPLETED -> LocationKind.DELIVERED;
+        };
+    }
+
+    // ── moving legs ─────────────────────────────────────────────────────────
+    private ResolvedLocation moving(LocationKind kind, Shipment s, Optional<Coord> fallback) {
+        Optional<LivePosition> fix = livePosition(kind, s.getId());
+        if (fix.isPresent() && isFresh(fix.get().lastSeenAt())) {
+            LivePosition p = fix.get();
+            return new ResolvedLocation(kind, p.lat(), p.lon(), true, true, p.lastSeenAt(), p.minutesLate());
+        }
+        // No fresh fix — show the nearest static node, not a stale dot.
+        Coord c = fallback.orElse(null);
+        return new ResolvedLocation(kind, latOf(c), lonOf(c), false, false, null, null);
+    }
+
+    private Optional<LivePosition> livePosition(LocationKind kind, java.util.UUID shipmentId) {
+        if (kind == LocationKind.MOVING_DA) {
+            LiveDaPositionPort p = daPort.getIfAvailable();
+            return p == null ? Optional.empty() : p.forShipment(shipmentId);
+        }
+        LiveVanPositionPort p = vanPort.getIfAvailable();
+        return p == null ? Optional.empty() : p.forShipment(shipmentId);
+    }
+
+    private boolean isFresh(Instant lastSeenAt) {
+        return lastSeenAt != null && Duration.between(lastSeenAt, Instant.now()).compareTo(staleAfter) <= 0;
+    }
+
+    private Optional<Coord> movingDaFallback(Shipment s) {
+        // Pickup leg falls back to the sender's address; delivery leg to the receiver's.
+        return s.getState() == ShipmentState.PICKED_UP ? originAddr(s) : destAddr(s);
+    }
+
+    private Optional<Coord> movingVanFallback(Shipment s) {
+        return switch (s.getState()) {
+            case HANDED_TO_PICKUP_VAN, RETURNED_TO_HUB -> cities.hub(s.getOriginCity()).or(() -> originAddr(s));
+            case DISPATCHED_TO_AIRPORT -> cities.airport(s.getOriginCity()).or(() -> originAddr(s));
+            case DISPATCHED_TO_HUB -> cities.airport(s.getDestCity()).or(() -> destAddr(s));
+            case HANDED_TO_DROP_VAN -> cities.hub(s.getDestCity()).or(() -> destAddr(s));
+            default -> Optional.empty();
+        };
+    }
+
+    // ── static nodes ────────────────────────────────────────────────────────
+    private Optional<Coord> hubCoord(Shipment s) {
+        boolean origin = switch (s.getState()) {
+            case AT_ORIGIN_HUB, ORIGIN_HUB_PROCESSING, IN_TAKEOFF_BAG -> true;
+            default -> false;   // dest hub for AT_DEST_HUB, DEST_HUB_PROCESSING, AWAITING_HUB_COLLECT, DELIVERY_FAILED, RTO_INITIATED
+        };
+        return origin ? cities.hub(s.getOriginCity()).or(() -> originAddr(s))
+                      : cities.hub(s.getDestCity()).or(() -> destAddr(s));
+    }
+
+    private Optional<Coord> airportCoord(Shipment s) {
+        // AT_AIRPORT is the origin airport; LANDED is the destination airport.
+        return s.getState() == ShipmentState.AT_AIRPORT
+                ? cities.airport(s.getOriginCity()).or(() -> originAddr(s))
+                : cities.airport(s.getDestCity()).or(() -> destAddr(s));
+    }
+
+    private Optional<Coord> deliveredCoord(Shipment s) {
+        // RTO ends back with the sender; a normal delivery ends at the receiver.
+        return s.getState() == ShipmentState.RTO_COMPLETED ? originAddr(s) : destAddr(s);
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+    private static ResolvedLocation staticAt(LocationKind kind, Optional<Coord> c) {
+        Coord coord = c.orElse(null);
+        return new ResolvedLocation(kind, latOf(coord), lonOf(coord), false, false, null, null);
+    }
+
+    private static Optional<Coord> originAddr(Shipment s) {
+        return coordOf(s.getOriginAddress());
+    }
+
+    private static Optional<Coord> destAddr(Shipment s) {
+        return coordOf(s.getDestAddress());
+    }
+
+    private static Optional<Coord> coordOf(Address a) {
+        if (a == null || a.getLatitude() == null || a.getLongitude() == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new Coord(a.getLatitude(), a.getLongitude()));
+    }
+
+    private static Double latOf(Coord c) {
+        return c == null ? null : c.lat();
+    }
+
+    private static Double lonOf(Coord c) {
+        return c == null ? null : c.lon();
+    }
+
+    /** The resolved current position. Coordinates may be null when nothing geocoded is available. */
+    public record ResolvedLocation(
+            LocationKind kind,
+            Double lat,
+            Double lon,
+            boolean live,
+            boolean moving,
+            Instant lastUpdatedAt,
+            Integer minutesLate) {
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/tracking/MilestoneBuilder.java
+++ b/orders/src/main/java/com/oneday/orders/tracking/MilestoneBuilder.java
@@ -1,0 +1,90 @@
+package com.oneday.orders.tracking;
+
+import com.oneday.common.domain.enums.DeliveryType;
+import com.oneday.common.domain.enums.DropType;
+import com.oneday.common.domain.enums.PickupType;
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.domain.ShipmentStateHistory;
+import com.oneday.orders.repository.ShipmentStateHistoryRepository;
+import com.oneday.orders.service.CustomerVisibleStateMapper;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Builds the customer-facing tracking timeline: the states the shipment has actually reached (from the
+ * append-only {@code shipment_state_history}, with real timestamps) followed by the checkpoints still
+ * to come (from a per-shipment template shaped by delivery/pickup/drop type). Terminal shipments show
+ * no pending steps. Labels come from {@link CustomerVisibleStateMapper} so the timeline and the rest
+ * of the product speak the same language.
+ */
+@Component
+public class MilestoneBuilder {
+
+    private static final Set<ShipmentState> TERMINAL = Set.of(
+            ShipmentState.DROPPED, ShipmentState.HUB_COLLECTED,
+            ShipmentState.RTO_COMPLETED, ShipmentState.CANCELLED);
+
+    private final ShipmentStateHistoryRepository historyRepository;
+    private final CustomerVisibleStateMapper stateMapper;
+
+    MilestoneBuilder(ShipmentStateHistoryRepository historyRepository, CustomerVisibleStateMapper stateMapper) {
+        this.historyRepository = historyRepository;
+        this.stateMapper = stateMapper;
+    }
+
+    public List<Milestone> build(Shipment s) {
+        // Done spine: every reached state that carries a customer label, deduped by label (keep the
+        // earliest occurrence), in the order they happened.
+        Map<String, Milestone> done = new LinkedHashMap<>();
+        for (ShipmentStateHistory h : historyRepository.findByShipmentIdOrderByOccurredAtAsc(s.getId())) {
+            String label = stateMapper.labelFor(h.getToState());
+            done.putIfAbsent(label, new Milestone(label, h.getOccurredAt(), true));
+        }
+
+        List<Milestone> out = new ArrayList<>(done.values());
+
+        // Pending checkpoints: the remaining expected steps, unless the shipment is already terminal.
+        if (!TERMINAL.contains(s.getState())) {
+            for (ShipmentState step : template(s)) {
+                String label = stateMapper.labelFor(step);
+                if (!done.containsKey(label)) {
+                    out.add(new Milestone(label, null, false));
+                    done.put(label, null); // guard against duplicate pending labels within the template
+                }
+            }
+        }
+        return out;
+    }
+
+    /** The expected happy-path checkpoints for this shipment, shaped by its routing choices. */
+    private static List<ShipmentState> template(Shipment s) {
+        List<ShipmentState> t = new ArrayList<>();
+        t.add(ShipmentState.BOOKED);
+        t.add(s.getPickupType() == PickupType.SELF_DROP
+                ? ShipmentState.AWAITING_SELF_DROP
+                : ShipmentState.PICKED_UP);
+        t.add(ShipmentState.AT_ORIGIN_HUB);
+        if (s.getDeliveryType() == DeliveryType.INTERCITY) {
+            t.add(ShipmentState.DEPARTED);      // "In transit by air"
+            t.add(ShipmentState.AT_DEST_HUB);
+        }
+        if (s.getDropType() == DropType.HUB_COLLECT) {
+            t.add(ShipmentState.AWAITING_HUB_COLLECT);
+            t.add(ShipmentState.HUB_COLLECTED);
+        } else {
+            t.add(ShipmentState.HANDED_TO_DROP_VAN);  // "Out for delivery"
+            t.add(ShipmentState.DROPPED);
+        }
+        return t;
+    }
+
+    /** One row in the tracking timeline. {@code occurredAt} is null for a step not yet reached. */
+    public record Milestone(String label, Instant occurredAt, boolean done) {}
+}

--- a/orders/src/test/java/com/oneday/orders/tracking/LocationResolverTest.java
+++ b/orders/src/test/java/com/oneday/orders/tracking/LocationResolverTest.java
@@ -1,0 +1,163 @@
+package com.oneday.orders.tracking;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.port.LiveDaPositionPort;
+import com.oneday.common.port.LivePosition;
+import com.oneday.common.port.LiveVanPositionPort;
+import com.oneday.orders.config.TrackingProperties;
+import com.oneday.orders.config.TrackingProperties.CityNode;
+import com.oneday.orders.domain.Address;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.tracking.LocationResolver.ResolvedLocation;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("LocationResolver")
+class LocationResolverTest {
+
+    private final LiveDaPositionPort daPort = mock(LiveDaPositionPort.class);
+    private final LiveVanPositionPort vanPort = mock(LiveVanPositionPort.class);
+
+    private LocationResolver resolver(boolean daAvailable, boolean vanAvailable) {
+        TrackingProperties props = new TrackingProperties();
+        props.setGpsStaleSeconds(180);
+        props.setCityNodes(Map.of("DEL", node(28.50, 77.15, 28.5562, 77.10)));
+        CityNodeCatalog cities = new CityNodeCatalog(props);
+        return new LocationResolver(cities, provider(daAvailable ? daPort : null),
+                provider(vanAvailable ? vanPort : null), props);
+    }
+
+    @Test
+    void bookedIsWithCustomerAtOrigin() {
+        ResolvedLocation r = resolver(true, true).resolve(shipment(ShipmentState.BOOKED));
+        assertThat(r.kind()).isEqualTo(LocationKind.WITH_CUSTOMER);
+        assertThat(r.lat()).isEqualTo(28.60);   // origin address
+        assertThat(r.live()).isFalse();
+        assertThat(r.moving()).isFalse();
+    }
+
+    @Test
+    void atOriginHubUsesConfiguredHub() {
+        ResolvedLocation r = resolver(true, true).resolve(shipment(ShipmentState.AT_ORIGIN_HUB));
+        assertThat(r.kind()).isEqualTo(LocationKind.STATIONARY_HUB);
+        assertThat(r.lat()).isEqualTo(28.50);   // DEL hub from config
+        assertThat(r.lon()).isEqualTo(77.15);
+    }
+
+    @Test
+    void atAirportUsesConfiguredAirport() {
+        ResolvedLocation r = resolver(true, true).resolve(shipment(ShipmentState.AT_AIRPORT));
+        assertThat(r.kind()).isEqualTo(LocationKind.STATIONARY_AIRPORT);
+        assertThat(r.lat()).isEqualTo(28.5562);
+    }
+
+    @Test
+    void departedIsOnFlightWithNoPoint() {
+        ResolvedLocation r = resolver(true, true).resolve(shipment(ShipmentState.DEPARTED));
+        assertThat(r.kind()).isEqualTo(LocationKind.ON_FLIGHT);
+        assertThat(r.lat()).isNull();
+        assertThat(r.moving()).isTrue();
+        assertThat(r.live()).isFalse();
+    }
+
+    @Test
+    void droppedIsDeliveredAtDestination() {
+        ResolvedLocation r = resolver(true, true).resolve(shipment(ShipmentState.DROPPED));
+        assertThat(r.kind()).isEqualTo(LocationKind.DELIVERED);
+        assertThat(r.lat()).isEqualTo(19.10);   // dest address
+    }
+
+    @Test
+    void pickedUpWithFreshDaFixShowsLiveDot() {
+        when(daPort.forShipment(any())).thenReturn(Optional.of(
+                new LivePosition(28.61, 77.21, Instant.now(), null, null)));
+        ResolvedLocation r = resolver(true, true).resolve(shipment(ShipmentState.PICKED_UP));
+        assertThat(r.kind()).isEqualTo(LocationKind.MOVING_DA);
+        assertThat(r.live()).isTrue();
+        assertThat(r.moving()).isTrue();
+        assertThat(r.lat()).isEqualTo(28.61);
+    }
+
+    @Test
+    void pickedUpWithStaleDaFixFallsBackToOrigin() {
+        when(daPort.forShipment(any())).thenReturn(Optional.of(
+                new LivePosition(28.61, 77.21, Instant.now().minus(30, ChronoUnit.MINUTES), null, null)));
+        ResolvedLocation r = resolver(true, true).resolve(shipment(ShipmentState.PICKED_UP));
+        assertThat(r.kind()).isEqualTo(LocationKind.MOVING_DA);
+        assertThat(r.live()).isFalse();
+        assertThat(r.moving()).isFalse();
+        assertThat(r.lat()).isEqualTo(28.60);   // origin address fallback
+    }
+
+    @Test
+    void movingLegWithNoPortFallsBackToStaticNode() {
+        // No dispatch port bean available at all — must not blow up, falls back.
+        ResolvedLocation r = resolver(false, false).resolve(shipment(ShipmentState.PICKED_UP));
+        assertThat(r.kind()).isEqualTo(LocationKind.MOVING_DA);
+        assertThat(r.live()).isFalse();
+        assertThat(r.lat()).isEqualTo(28.60);
+    }
+
+    @Test
+    void handedToDropVanWithFreshFixCarriesLateness() {
+        when(vanPort.forShipment(any())).thenReturn(Optional.of(
+                new LivePosition(19.05, 72.88, Instant.now(), 7, null)));
+        ResolvedLocation r = resolver(true, true).resolve(shipment(ShipmentState.HANDED_TO_DROP_VAN));
+        assertThat(r.kind()).isEqualTo(LocationKind.MOVING_VAN);
+        assertThat(r.live()).isTrue();
+        assertThat(r.minutesLate()).isEqualTo(7);
+    }
+
+    @Test
+    void everyStateResolvesWithoutThrowing() {
+        LocationResolver res = resolver(false, false);
+        for (ShipmentState st : ShipmentState.values()) {
+            assertThat(res.resolve(shipment(st))).as("resolve %s", st).isNotNull();
+        }
+    }
+
+    // ── fixtures ──────────────────────────────────────────────────────────
+    private static Shipment shipment(ShipmentState state) {
+        Shipment s = new Shipment();
+        s.setState(state);
+        s.setOriginCity("DEL");
+        s.setDestCity("BOM");
+        s.setOriginAddress(address(28.60, 77.20));
+        s.setDestAddress(address(19.10, 72.85));
+        return s;
+    }
+
+    private static Address address(double lat, double lon) {
+        Address a = new Address();
+        a.setLatitude(lat);
+        a.setLongitude(lon);
+        return a;
+    }
+
+    private static CityNode node(double hubLat, double hubLon, double airLat, double airLon) {
+        CityNode n = new CityNode();
+        n.setHubLat(hubLat);
+        n.setHubLon(hubLon);
+        n.setAirportLat(airLat);
+        n.setAirportLon(airLon);
+        return n;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> ObjectProvider<T> provider(T value) {
+        ObjectProvider<T> p = mock(ObjectProvider.class);
+        when(p.getIfAvailable()).thenReturn(value);
+        return p;
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/tracking/MilestoneBuilderTest.java
+++ b/orders/src/test/java/com/oneday/orders/tracking/MilestoneBuilderTest.java
@@ -1,0 +1,97 @@
+package com.oneday.orders.tracking;
+
+import com.oneday.common.domain.enums.DeliveryType;
+import com.oneday.common.domain.enums.DropType;
+import com.oneday.common.domain.enums.PickupType;
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.domain.ShipmentStateHistory;
+import com.oneday.orders.repository.ShipmentStateHistoryRepository;
+import com.oneday.orders.service.CustomerVisibleStateMapper;
+import com.oneday.orders.tracking.MilestoneBuilder.Milestone;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("MilestoneBuilder")
+class MilestoneBuilderTest {
+
+    private final ShipmentStateHistoryRepository historyRepository = mock(ShipmentStateHistoryRepository.class);
+    private final MilestoneBuilder builder = new MilestoneBuilder(historyRepository, new CustomerVisibleStateMapper());
+
+    @Test
+    void freshBookingShowsDoneOrderConfirmedThenPendingSteps() {
+        history(hist(ShipmentState.BOOKED));
+        List<Milestone> out = builder.build(intercity(ShipmentState.BOOKED));
+
+        assertThat(out.get(0).label()).isEqualTo("Order confirmed");
+        assertThat(out.get(0).done()).isTrue();
+        assertThat(out.get(0).occurredAt()).isNotNull();
+        // Everything after is a pending preview of the journey.
+        assertThat(out.subList(1, out.size())).allMatch(m -> !m.done() && m.occurredAt() == null);
+        assertThat(labels(out)).contains("Parcel collected", "In transit by air", "Out for delivery", "Delivered");
+    }
+
+    @Test
+    void deliveredShipmentHasNoPendingSteps() {
+        history(
+                hist(ShipmentState.BOOKED), hist(ShipmentState.PICKED_UP), hist(ShipmentState.AT_ORIGIN_HUB),
+                hist(ShipmentState.DEPARTED), hist(ShipmentState.AT_DEST_HUB),
+                hist(ShipmentState.HANDED_TO_DROP_VAN), hist(ShipmentState.DROPPED));
+        List<Milestone> out = builder.build(intercity(ShipmentState.DROPPED));
+
+        assertThat(out).allMatch(Milestone::done);
+        assertThat(out.get(out.size() - 1).label()).isEqualTo("Delivered");
+    }
+
+    @Test
+    void sameCityHasNoAirStepsInPreview() {
+        history(hist(ShipmentState.BOOKED));
+        List<Milestone> out = builder.build(
+                shipment(ShipmentState.BOOKED, DeliveryType.SAME_CITY, PickupType.DA_PICKUP, DropType.DA_DELIVERY));
+        assertThat(labels(out)).doesNotContain("In transit by air", "Arrived at destination hub");
+        assertThat(labels(out)).contains("Out for delivery", "Delivered");
+    }
+
+    @Test
+    void hubCollectPreviewsCollectionNotDelivery() {
+        history(hist(ShipmentState.BOOKED));
+        List<Milestone> out = builder.build(
+                shipment(ShipmentState.BOOKED, DeliveryType.INTERCITY, PickupType.DA_PICKUP, DropType.HUB_COLLECT));
+        assertThat(labels(out)).contains("Your parcel is ready — collect from the hub", "Collected from hub");
+        assertThat(labels(out)).doesNotContain("Out for delivery");
+    }
+
+    // ── fixtures ──────────────────────────────────────────────────────────
+    private void history(ShipmentStateHistory... rows) {
+        when(historyRepository.findByShipmentIdOrderByOccurredAtAsc(any())).thenReturn(List.of(rows));
+    }
+
+    private static List<String> labels(List<Milestone> out) {
+        return out.stream().map(Milestone::label).toList();
+    }
+
+    private static ShipmentStateHistory hist(ShipmentState to) {
+        return ShipmentStateHistory.builder().toState(to).occurredAt(Instant.now()).build();
+    }
+
+    private static Shipment intercity(ShipmentState state) {
+        return shipment(state, DeliveryType.INTERCITY, PickupType.DA_PICKUP, DropType.DA_DELIVERY);
+    }
+
+    private static Shipment shipment(ShipmentState state, DeliveryType dt, PickupType pt, DropType drt) {
+        Shipment s = new Shipment();
+        s.setState(state);
+        s.setDeliveryType(dt);
+        s.setPickupType(pt);
+        s.setDropType(drt);
+        return s;
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/adapter/LiveVanPositionAdapter.java
+++ b/routing/src/main/java/com/oneday/routing/adapter/LiveVanPositionAdapter.java
@@ -1,0 +1,63 @@
+package com.oneday.routing.adapter;
+
+import com.oneday.common.port.LivePosition;
+import com.oneday.common.port.LiveVanPositionPort;
+import com.oneday.routing.domain.ManifestItemStatus;
+import com.oneday.routing.domain.VanLiveStatus;
+import com.oneday.routing.domain.VanManifestItem;
+import com.oneday.routing.repository.VanLiveStatusRepository;
+import com.oneday.routing.repository.VanManifestItemRepository;
+import com.oneday.routing.repository.VanManifestRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * M6-side implementation of {@link LiveVanPositionPort}: finds the manifest item currently on a van
+ * for this parcel ({@code van_manifest_item} in LOADED/ONBOARD), walks to its {@code van_manifest}
+ * for the van id, and reads that van's live row from {@code van_live_status}. Empty when the parcel
+ * isn't riding a van right now or the van has no GPS fix yet.
+ */
+@Component
+class LiveVanPositionAdapter implements LiveVanPositionPort {
+
+    // A parcel is physically on the van only in these item states (loaded at the hub, riding onboard).
+    private static final Set<ManifestItemStatus> ON_VAN = Set.of(ManifestItemStatus.LOADED, ManifestItemStatus.ONBOARD);
+
+    private final VanManifestItemRepository itemRepository;
+    private final VanManifestRepository manifestRepository;
+    private final VanLiveStatusRepository liveStatusRepository;
+
+    LiveVanPositionAdapter(VanManifestItemRepository itemRepository,
+                           VanManifestRepository manifestRepository,
+                           VanLiveStatusRepository liveStatusRepository) {
+        this.itemRepository = itemRepository;
+        this.manifestRepository = manifestRepository;
+        this.liveStatusRepository = liveStatusRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<LivePosition> forShipment(UUID shipmentId) {
+        // parcelId == shipment UUID in v1 (routing D-001).
+        Optional<VanManifestItem> onVan = itemRepository.findByParcelId(shipmentId).stream()
+                .filter(i -> ON_VAN.contains(i.getStatus()))
+                .max(Comparator.comparing(VanManifestItem::getUpdatedAt));
+        if (onVan.isEmpty()) {
+            return Optional.empty();
+        }
+        return manifestRepository.findById(onVan.get().getManifestId())
+                .flatMap(m -> liveStatusRepository.findById(m.getVanId()))
+                .filter(LiveVanPositionAdapter::hasFix)
+                .map(v -> new LivePosition(
+                        v.getLastLat(), v.getLastLon(), v.getLastSeenAt(), v.getMinutesLate(), v.getVanId()));
+    }
+
+    private static boolean hasFix(VanLiveStatus v) {
+        return v.getLastLat() != null && v.getLastLon() != null;
+    }
+}


### PR DESCRIPTION
# Pull Request

## Summary
Adds **LiveTrack v1** — a customer-facing live-tracking endpoint that resolves *where a parcel is right now* from its M4 state (with the customer, at a hub/airport, moving with a DA, or on a van), plus the milestone timeline — and wires the Godspeed customer web Track screen to it, replacing the hardcoded mock.

---

## What Changed
- **New tracking read API (M4):** `GET /api/v1/shipments/mine/{ref}/track` → current position + route + milestone timeline. Customer-role, ownership-scoped (401 unauth / 404 if not the caller's booking).
- **`LocationResolver` (the core):** maps all 31 `ShipmentState` values to a `LocationKind` (WITH_CUSTOMER / STATIONARY_HUB / STATIONARY_AIRPORT / MOVING_DA / MOVING_VAN / ON_FLIGHT / DELIVERED) and resolves the coordinate. Fresh DA/van GPS → a live dot; **stale (> `tracking.gps-stale-seconds`, default 180s) or missing GPS → graceful fallback to the nearest static node** (never a blank map). The air leg has no live point (M9 unbuilt) — the UI draws the route arc.
- **Cross-module live position via new `common` ports:** `LivePosition`, `LiveDaPositionPort` (impl in M5 dispatch over `da_status`), `LiveVanPositionPort` (impl in M6 routing over `van_manifest_item → van_manifest → van_live_status`). Same port pattern as `ServiceabilityPort`/`ShipmentLocationPort` — keeps the dependency direction correct (M4 never imports M5/M6 internals). Injected via `ObjectProvider`, so the orders module resolves to static fallbacks when those beans are absent.
- **`MilestoneBuilder`:** real timeline — done steps come from the append-only `shipment_state_history` (with timestamps), pending steps from a per-shipment template shaped by delivery/pickup/drop type; terminal shipments show no pending steps.
- **`CityNodeCatalog` + `tracking.city-nodes` config:** per-city hub/airport coordinates for the static nodes and route line (DEL/BOM/BLR/HYD/MAA), accepting both IATA (`DEL`) and full-name (`DELHI`) city codes since `origin_city` has historically stored either.
- **Fixed the dangling `trackingUrl`:** `BookingServiceImpl` / `B2bBookingServiceImpl` now emit `/api/v1/shipments/mine/{ref}/track` (previously pointed at a path with no handler).
- **Frontend (Godspeed customer app):** added `ShipmentTrack` type + `api.shipments.track(ref)`; rewrote the mock `track/[ref]` page to real data, **moved it under the guarded `(app)` shell**, polling every 12s; new read-only `TrackMap` component (route polyline through hub/airport waypoints + current-position marker); honest "flight leg shows the route, not a live plane" note.

---

## Why This Change?
The Track screen was a hardcoded mock and the backend had **no tracking endpoint at all** — `BookingServiceImpl` even advertised a `trackingUrl` that nothing served. Meanwhile every signal a real tracker needs already existed but was never aggregated: DA live GPS (`da_status`), van live GPS (`van_live_status`), and per-state timestamps (`shipment_state_history`). This PR aggregates them behind one honest read model so customers get a real "where is my parcel" view for the Sept 1 pilot. Scope is deliberately **LiveTrack only** — the M10 SLA engine is a separate, larger effort and reuses the state grouping introduced here.

---

## Testing
- [x] Tested locally
- [x] Edge cases considered
- [x] No breaking changes introduced

Edge cases covered: stale GPS fallback, missing DA/van bean, unowned ref → 404, unauthenticated → 401, terminal states (no pending milestones), SAME_CITY vs INTERCITY templates, HUB_COLLECT vs DA_DELIVERY, city code stored as `DEL` vs `DELHI`.

### Test Evidence

Unit tests (new) + regression suites — all green:
```
LocationResolverTest ....... Tests run: 10, Failures: 0, Errors: 0
MilestoneBuilderTest ....... Tests run: 4,  Failures: 0, Errors: 0
dispatch + routing suites .. Tests run: 59, Failures: 0, Errors: 0   BUILD SUCCESS
full orders suite .......... 0 failures, 0 errors                    BUILD SUCCESS
frontend ................... pnpm typecheck GREEN + customer build GREEN
```

End-to-end against a real DB (booted app, real controller → service → repo):

BOOKED → static `WITH_CUSTOMER` at origin, full route + timeline:
```
GET /api/v1/shipments/mine/1DD-DEL-20260716-00001/track
location  : { kind: WITH_CUSTOMER, lat: 28.6139, lon: 77.209, live: false, moving: false }
route     : DEL → [Origin hub, DEL airport, BOM airport, Destination hub] → BOM
milestones: ✓ Order confirmed (18:45:05Z) · Parcel collected · Arrived at origin hub · In transit
            by air · Arrived at destination hub · Out for delivery · Delivered  (rest pending)
```

PICKED_UP + fresh DA GPS → `MOVING_DA` live:
```
location  : { kind: MOVING_DA, lat: 28.58, lon: 77.185, live: true, moving: true,
              last_updated_at: 2026-07-15T18:46:06Z }
```

Aged the DA heartbeat past 180s → graceful static fallback:
```
location  : { kind: MOVING_DA, lat: 28.6139, lon: 77.209, live: false, moving: false }
```

Frontend rendered end-to-end (Godspeed track screen — DEL→BOM route line, live position dot, "Parcel collected / Live" badges, real two-step timeline with timestamps, honest flight-leg note, inside the guarded shell). Verified via headless-Chrome screenshot; auth checks: 401 unauth, 404 for a ref the caller didn't book.

---

## Impact

### Areas Affected
- [x] Backend
- [x] Frontend
- [ ] Routing
- [ ] Infra
- [ ] Database
- [ ] NA

_No schema change — the feature reads existing tables; only config (`tracking.*` in the app `application.yml`) and one derived-query method were added._

### Modules Affected
- [ ] M1 — Auth
- [ ] M2 — Pricing
- [ ] M3 — Grid
- [x] M4 — Orders
- [x] M5 — Dispatch
- [x] M6 — Routing
- [ ] M7 — Hub
- [ ] M8 — Barcode
- [ ] M9 — Airline
- [ ] M10 — SLA
- [ ] M11 — Exceptions
- [ ] NA

_Plus shared `common` (three new ports + `LivePosition` DTO)._

---

## Risks / Concerns
- **City hub/airport coordinates are approximate placeholders** (`tracking.city-nodes`) — should be confirmed with ops before the pilot. Low blast radius: they only affect the static-node pins and the drawn route line, never routing/pricing/SLA.
- **No live flight position** — M9 is unbuilt, so the air leg shows the route arc + status only (documented as a v1 non-goal).
- Live dots depend on M5/M6 GPS being populated by the real lifecycle; where it isn't yet, the endpoint degrades to static nodes (safe by design).
- Frontend polls (12s) rather than using WebSockets — deliberate for v1.
- Not a tracking risk, but a heads-up for reviewers: this branch also carries the earlier Google-auth/OTP work (`V1_11`), which currently fails to apply against the DEV (Render Oregon) DB due to that DB's prior state — pre-existing and unrelated to this feature.

---

## Checklist
- [x] Code follows project conventions (package layout, no cross-module internal imports)
- [x] Self-review completed
- [x] Append-only audit trail preserved (no mutations to scan/manifest/role-change records)
- [x] No sensitive data or credentials exposed
- [ ] Documentation updated if behaviour changed
- [x] Ready for review
