### PR TITLE
Carry shipment_ref on DA task list for ref-keyed delivery-OTP verify

### DIFF
--- a/common/src/main/java/com/oneday/common/port/ShipmentRefPort.java
+++ b/common/src/main/java/com/oneday/common/port/ShipmentRefPort.java
@@ -1,0 +1,17 @@
+package com.oneday.common.port;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Resolve shipments' human-readable reference numbers (e.g. {@code "1DD-BLR-20260530-00042"}) in
+ * bulk, without importing the orders module. Implemented in orders (M4); consumed in dispatch (M5)
+ * so the DA app can address the ref-keyed delivery-OTP endpoint. Batch (one {@code findAllById}) to
+ * avoid an N+1 over a DA's task list. Same cross-module pattern as {@link ShipmentLocationPort}.
+ */
+public interface ShipmentRefPort {
+
+    /** Ref number per shipment id; ids without a shipment (or ref) are simply absent from the map. */
+    Map<UUID, String> refsFor(Collection<UUID> shipmentIds);
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/service/DaTaskView.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/DaTaskView.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 public record DaTaskView(
         UUID taskId,
         UUID shipmentId,
+        String shipmentRef,
         TaskType taskType,
         TaskStatus status,
         int queuePosition,
@@ -23,8 +24,13 @@ public record DaTaskView(
         double taskLon,
         String paymentMode) {
 
+    /** Mutation responses don't need the ref (the app already holds it from listTasks). */
     public static DaTaskView of(DispatchQueue row) {
-        return new DaTaskView(row.getId(), row.getShipmentId(), row.getTaskType(),
+        return of(row, null);
+    }
+
+    public static DaTaskView of(DispatchQueue row, String shipmentRef) {
+        return new DaTaskView(row.getId(), row.getShipmentId(), shipmentRef, row.getTaskType(),
                 row.getStatus(), row.getQueuePosition(), row.getExpectedEta(),
                 row.getTaskLat(), row.getTaskLon(), row.getPaymentMode());
     }

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
@@ -15,6 +15,7 @@ import com.oneday.dispatch.service.DaStatusService;
 import com.oneday.dispatch.service.DaTaskService;
 import com.oneday.dispatch.service.DaTaskView;
 import com.oneday.dispatch.service.model.DaQueue;
+import com.oneday.common.port.ShipmentRefPort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -29,6 +30,7 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -47,27 +49,31 @@ class DaTaskServiceImpl implements DaTaskService {
     private final DaEventProducer daEventProducer;
     private final DispatchProperties props;
     private final HubScanSeamProducer hubScanSeamProducer;
+    private final ShipmentRefPort shipmentRefPort;
 
     DaTaskServiceImpl(DispatchQueueRepository queueRepository,
                       DaCronAssignmentRepository cronRepository,
                       DaStatusService daStatusService,
                       DaEventProducer daEventProducer,
                       DispatchProperties props,
-                      HubScanSeamProducer hubScanSeamProducer) {
+                      HubScanSeamProducer hubScanSeamProducer,
+                      ShipmentRefPort shipmentRefPort) {
         this.queueRepository = queueRepository;
         this.cronRepository = cronRepository;
         this.daStatusService = daStatusService;
         this.daEventProducer = daEventProducer;
         this.props = props;
         this.hubScanSeamProducer = hubScanSeamProducer;
+        this.shipmentRefPort = shipmentRefPort;
     }
 
     @Override
     @Transactional(readOnly = true)
     public List<DaTaskView> listTasks(UUID daId, LocalDate date) {
         LocalDate day = date != null ? date : LocalDate.now(ZoneId.of(props.getShift().getZone()));
-        return queueRepository.findByDaIdAndOperatingDateOrderByQueuePosition(daId, day)
-                .stream().map(DaTaskView::of).toList();
+        List<DispatchQueue> rows = queueRepository.findByDaIdAndOperatingDateOrderByQueuePosition(daId, day);
+        Map<UUID, String> refs = shipmentRefPort.refsFor(rows.stream().map(DispatchQueue::getShipmentId).toList());
+        return rows.stream().map(r -> DaTaskView.of(r, refs.get(r.getShipmentId()))).toList();
     }
 
     @Override

--- a/dispatch/src/test/java/com/oneday/dispatch/api/DaDispatchControllerTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/api/DaDispatchControllerTest.java
@@ -143,7 +143,7 @@ class DaDispatchControllerTest {
     }
 
     private DaTaskView sampleView() {
-        return new DaTaskView(taskId, UUID.randomUUID(), TaskType.PICKUP, TaskStatus.IN_PROGRESS, 0, null,
-                12.9716, 77.5946, "PREPAID");
+        return new DaTaskView(taskId, UUID.randomUUID(), "1DD-BLR-20260716-00001", TaskType.PICKUP,
+                TaskStatus.IN_PROGRESS, 0, null, 12.9716, 77.5946, "PREPAID");
     }
 }

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaTaskServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaTaskServiceImplTest.java
@@ -58,7 +58,8 @@ class DaTaskServiceImplTest {
         daStatus.initShift(da, city, today, "MORNING", null);
         events = mock(DaEventProducer.class);
         scanSeam = mock(com.oneday.dispatch.events.HubScanSeamProducer.class);
-        service = new DaTaskServiceImpl(queueRepo, cronRepo, daStatus, events, props, scanSeam);
+        service = new DaTaskServiceImpl(queueRepo, cronRepo, daStatus, events, props, scanSeam,
+                ids -> java.util.Map.of());
     }
 
     @Test

--- a/orders/src/main/java/com/oneday/orders/service/impl/ShipmentRefAdapter.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/ShipmentRefAdapter.java
@@ -1,0 +1,37 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.port.ShipmentRefPort;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.repository.ShipmentRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Orders-side implementation of {@link ShipmentRefPort}: batch-reads shipment ref numbers so M5's
+ * DA task list can carry the ref for the ref-keyed delivery-OTP verify call.
+ */
+@Component
+class ShipmentRefAdapter implements ShipmentRefPort {
+
+    private final ShipmentRepository shipmentRepository;
+
+    ShipmentRefAdapter(ShipmentRepository shipmentRepository) {
+        this.shipmentRepository = shipmentRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<UUID, String> refsFor(Collection<UUID> shipmentIds) {
+        if (shipmentIds == null || shipmentIds.isEmpty()) {
+            return Map.of();
+        }
+        return shipmentRepository.findAllById(shipmentIds).stream()
+                .filter(s -> s.getShipmentRef() != null)
+                .collect(Collectors.toMap(Shipment::getId, Shipment::getShipmentRef));
+    }
+}


### PR DESCRIPTION
## What

The delivery-OTP verify endpoint is keyed by shipment ref (`POST /internal/v1/shipments/{ref}/delivery-otp/verify`, `DeliveryOtpController`), but `DaTaskView` only carried `shipmentId` (UUID) — so the DA app couldn't address it and was falling back to a client-side OTP gate.

This adds the ref onto the DA's task list so the app can call the real server-side verify.

## Changes
- **common** — `ShipmentRefPort`: `Map<UUID,String> refsFor(Collection<UUID>)` (same cross-module pattern as `ShipmentLocationPort`).
- **orders** — `ShipmentRefAdapter`: batch `findAllById` → id:ref map (one query, avoids N+1 over a DA's task list).
- **dispatch** — `DaTaskView` gains a `shipmentRef` field (`of(row)` → null for mutation responses; `of(row, ref)` for `listTasks`); `DaTaskServiceImpl.listTasks` does one batch resolve and populates it.
- Test ctor fixups for the new `DaTaskView` arity / injected port.

Compiles `common,orders,dispatch` (main + tests).

## Not included
Frontend half (add `shipment_ref` to the TS `DaTask` type + switch the delivery-OTP from the local gate to `verifyDeliveryOtp(task.shipment_ref, otp)`) — `demo-ui/` source isn't tracked, so it lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)