### PR TITLE
M10:SLA : Initial Commit: Backbone + Design doc +IMpl plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ dist/
 
 # Legacy demo UI — removed from main; keep it from being re-added here.
 demo-ui/
+
+# Personal progress tracker (do not commit)
+docs/SID-PROGRESS.md

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -74,3 +74,19 @@ tracking:
     BLR: { hub-lat: 12.9716, hub-lon: 77.5946, airport-lat: 13.1986, airport-lon: 77.7066 }
     HYD: { hub-lat: 17.3850, hub-lon: 78.4867, airport-lat: 17.2403, airport-lon: 78.4294 }
     MAA: { hub-lat: 13.0827, hub-lon: 80.2707, airport-lat: 12.9941, airport-lon: 80.1709 }
+
+# M10 SLA monitoring. Per-leg budgets (minutes) sum to 13.5h, leaving a 2.5h internal cushion under
+# the 16h target — that cushion is what AMBER eats before RED (M10-D-005). A further 8h (16h→24h)
+# is the customer-facing engineered buffer. Both clocks anchor at booking (M10-D-006).
+sla:
+  internal-target-hours: 16
+  public-promise-hours: 24
+  sweeper-fixed-delay-ms: 60000
+  legs:
+    FIRST_MILE: 180        # pickup DA → origin hub
+    ORIGIN_HUB: 60         # origin hub processing → bag seal
+    ORIGIN_AIRPORT: 120    # hub → airport, tender/screen/stage/load
+    AIR: 150               # wheels-up → landing
+    DEST_AIRPORT: 90       # landing → unload/break/sort/release
+    DEST_HUB: 60           # dest hub processing
+    LAST_MILE: 150         # hub out-scan → delivered   (Σ = 810m = 13.5h)

--- a/common/src/main/java/com/oneday/common/domain/enums/EscalationLevel.java
+++ b/common/src/main/java/com/oneday/common/domain/enums/EscalationLevel.java
@@ -1,0 +1,11 @@
+package com.oneday.common.domain.enums;
+
+/**
+ * Who an SLA escalation is routed to (M10, PRD RACI). RED goes to the city's Supervisor /
+ * Station Manager; a confirmed breach (or a lane with repeated RED) is raised to Admin / control tower.
+ */
+public enum EscalationLevel {
+    SUPERVISOR,
+    STATION_MANAGER,
+    ADMIN
+}

--- a/common/src/main/java/com/oneday/common/domain/enums/SlaLegType.java
+++ b/common/src/main/java/com/oneday/common/domain/enums/SlaLegType.java
@@ -1,0 +1,18 @@
+package com.oneday.common.domain.enums;
+
+/**
+ * The monitored legs of a parcel's journey (M10, Annexure G). Ordered origin→destination.
+ *
+ * <p>An INTERCITY shipment traverses all seven; a SAME_CITY shipment traverses only
+ * {@code FIRST_MILE → ORIGIN_HUB → LAST_MILE} (the air legs and the second hub collapse away —
+ * M10 builds the leg plan per shipment from its {@code DeliveryType}).</p>
+ */
+public enum SlaLegType {
+    FIRST_MILE,      // pickup DA → origin hub in-scan
+    ORIGIN_HUB,      // origin hub processing → bag seal
+    ORIGIN_AIRPORT,  // hub → airport, tender/screen/stage/load
+    AIR,             // wheels-up → landing
+    DEST_AIRPORT,    // landing → unload/break/sort/DO/release
+    DEST_HUB,        // dest hub processing
+    LAST_MILE        // hub out-scan → delivered
+}

--- a/common/src/main/java/com/oneday/common/domain/enums/SlaState.java
+++ b/common/src/main/java/com/oneday/common/domain/enums/SlaState.java
@@ -1,0 +1,21 @@
+package com.oneday.common.domain.enums;
+
+/**
+ * SLA colour for a single leg or the whole shipment (M10).
+ *
+ * <ul>
+ *   <li>{@code GREEN}    — on budget.</li>
+ *   <li>{@code AMBER}    — a leg has overrun its own budget (eating the engineered buffer), but the
+ *       projected end-to-end finish still clears the 16h internal target (M10-D-005).</li>
+ *   <li>{@code RED}      — the projected finish crosses the 16h internal target; escalate.</li>
+ *   <li>{@code BREACHED} — the internal target has actually passed (or a hard failure occurred).</li>
+ *   <li>{@code CLOSED}   — the shipment reached a terminal state; SLA accounting is done.</li>
+ * </ul>
+ */
+public enum SlaState {
+    GREEN,
+    AMBER,
+    RED,
+    BREACHED,
+    CLOSED
+}

--- a/common/src/main/java/com/oneday/common/kafka/EventStreams.java
+++ b/common/src/main/java/com/oneday/common/kafka/EventStreams.java
@@ -29,6 +29,9 @@ public final class EventStreams {
     // ── Produced by M4 (Orders) → consumed by M3 (grid) ───────────────────
     public static final String TILE_QUEUE_DEPTH   = "orders.tile_queue_depth";
 
+    // ── Produced by M10 (SLA) → consumed by M11, ops/notification service ─
+    public static final String SLA_EVENTS         = "oneday.sla.events";        // M10
+
     // ── Notification fan-out (consumed by the notification service) ──────
     public static final String NOTIFICATIONS_EVENTS = "oneday.notifications.events";
 }

--- a/common/src/main/java/com/oneday/common/kafka/enums/SlaEventType.java
+++ b/common/src/main/java/com/oneday/common/kafka/enums/SlaEventType.java
@@ -1,0 +1,12 @@
+package com.oneday.common.kafka.enums;
+
+/**
+ * Discriminator for events M10 (SLA) publishes on {@code oneday.sla.events}
+ * ({@link com.oneday.common.kafka.EventStreams#SLA_EVENTS}).
+ */
+public enum SlaEventType {
+    /** A leg entered RED (or was raised to a higher level) — escalate. → Supervisor/Station Mgr, ops. */
+    SLA_ESCALATION_RAISED,
+    /** The internal target actually passed (or a hard failure) — a confirmed breach. → M11, Admin. */
+    SLA_BREACHED
+}

--- a/common/src/main/java/com/oneday/common/kafka/events/sla/SlaBreachedEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/sla/SlaBreachedEvent.java
@@ -1,0 +1,35 @@
+package com.oneday.common.kafka.events.sla;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.oneday.common.domain.enums.SlaLegType;
+import com.oneday.common.kafka.DomainEvent;
+import com.oneday.common.kafka.enums.SlaEventType;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * M10 → M11 (exceptions) / Admin on {@code oneday.sla.events}: a parcel's SLA is confirmed breached
+ * (the 16h internal target passed, or a hard failure). Carries the {@code reasonCode} M11 maps to a
+ * breach reason. Keyed by shipment.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SlaBreachedEvent(
+        UUID shipmentId,
+        String shipmentRef,
+        SlaLegType leg,
+        String city,
+        String reasonCode,
+        Instant internalTargetAt,
+        Instant breachedAt) implements DomainEvent {
+
+    @Override
+    public String partitionKey() {
+        return shipmentId != null ? shipmentId.toString() : null;
+    }
+
+    @Override
+    public String eventTypeName() {
+        return SlaEventType.SLA_BREACHED.name();
+    }
+}

--- a/common/src/main/java/com/oneday/common/kafka/events/sla/SlaEscalationRaisedEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/sla/SlaEscalationRaisedEvent.java
@@ -1,0 +1,42 @@
+package com.oneday.common.kafka.events.sla;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.oneday.common.domain.enums.EscalationLevel;
+import com.oneday.common.domain.enums.SlaLegType;
+import com.oneday.common.domain.enums.SlaState;
+import com.oneday.common.kafka.DomainEvent;
+import com.oneday.common.kafka.enums.SlaEventType;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * M10 → ops / notification service on {@code oneday.sla.events}: a parcel's leg went RED and an
+ * escalation was raised. Keyed by shipment so per-parcel ordering holds. The notification service
+ * resolves the on-duty {@code level} owner for {@code city} and delivers the alert; the escalation
+ * itself is already persisted append-only in {@code sla_escalation}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SlaEscalationRaisedEvent(
+        UUID escalationId,
+        UUID shipmentId,
+        String shipmentRef,
+        SlaLegType leg,
+        SlaState state,
+        EscalationLevel level,
+        String city,
+        String reasonCode,
+        Instant projectedFinishAt,
+        Instant internalTargetAt,
+        Instant raisedAt) implements DomainEvent {
+
+    @Override
+    public String partitionKey() {
+        return shipmentId != null ? shipmentId.toString() : null;
+    }
+
+    @Override
+    public String eventTypeName() {
+        return SlaEventType.SLA_ESCALATION_RAISED.name();
+    }
+}

--- a/common/src/main/java/com/oneday/common/port/dto/NotificationEventType.java
+++ b/common/src/main/java/com/oneday/common/port/dto/NotificationEventType.java
@@ -2,5 +2,8 @@ package com.oneday.common.port.dto;
 
 public enum NotificationEventType {
     OTP_GENERATED,
-    STATE_CHANGED
+    STATE_CHANGED,
+    // M10: an SLA leg went RED / breached — the notification service resolves the on-duty
+    // supervisor / station manager for the parcel's city and pushes an ops alert.
+    SLA_ESCALATION
 }

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1119,16 +1119,18 @@ _No design doc written yet. Decisions will be added when M9 design is authored._
 
 ## M10 — SLA Monitoring & Escalation
 
-_No design doc written yet. Decisions will be added when M10 design is authored._
+_Design: `docs/M10/M10-SLA-DESIGN.md`; plan: `docs/M10/M10-IMPLEMENTATION-PLAN.md`. Built on branch
+`f-m10-design`._
 
-### Placeholder Assumptions
-
-| ID | Assumption | Status | Source |
+| ID | Decision | Status | Source |
 |---|---|---|---|
 | M10-D-001 | SLA states: GREEN / AMBER / RED per leg | DECIDED | MODULES.md M10 |
-| M10-D-002 | RED state requires a supervisor action, not just a notification | DECIDED | MODULES.md M10 |
+| M10-D-002 | RED state requires a supervisor/station-manager action, not just a notification | DECIDED | MODULES.md M10 |
 | M10-D-003 | Hub-to-airport handover SLA threshold in minutes is TBD with ops | OPEN | CLAUDE.md §Open Questions |
-| M10-D-004 | All SLA events and escalation actions are audit-logged | DECIDED | CLAUDE.md |
+| M10-D-004 | All SLA events and escalation actions are append-only audit-logged | DECIDED | CLAUDE.md |
+| M10-D-005 | Buffer-aware projection: AMBER = leg over its budget; RED = projected end-to-end finish past the 16h internal target (resolves Q-S1) | DECIDED | user 2026-07-17 |
+| M10-D-006 | SLA clock start = order-placed: both 16h internal + 24h public anchor at BOOKED (resolves Q-S2) | DECIDED | user 2026-07-17 |
+| M10-D-007 | Self-contained v1: M10 owns its tables, reads other modules only via the event bus, emits escalation/breach on the new `oneday.sla.events` exchange, and changes no other module's logic (slaDeadline back-fill deferred) | DECIDED | user 2026-07-17 |
 
 ---
 

--- a/docs/M10/M10-IMPLEMENTATION-PLAN.md
+++ b/docs/M10/M10-IMPLEMENTATION-PLAN.md
@@ -1,0 +1,90 @@
+# M10 — Implementation Plan
+
+> How to use this plan: M10 shipped in **one pass** on `f-m10-design` (not phased PRs). The work is
+> recorded as ordered items W1–W6 so it stays followable; they were built together. Design:
+> `docs/M10/M10-SLA-DESIGN.md`. Decisions: `docs/DECISIONS.md` (M10-D-001…007).
+
+## Status: built ✅ (branch `f-m10-design`, uncommitted)
+- 9 unit tests green (`mvn test -pl sla`); `common` + `sla` + full `app` assemble.
+- Self-contained (M10-D-007): only additive `common` event contracts + app config touched; no other
+  module's logic changed.
+
+---
+
+## W1 — Docs ✅
+`M10-SLA-DESIGN.md`, this plan, and decisions M10-D-005/006/007 (+ the `oneday.sla.events` exchange)
+in `docs/DECISIONS.md`.
+
+## W2 — Schema + domain ✅
+### What was built
+- Flyway `sla/src/main/resources/db/migration/sla/V10_1__create_sla.sql`: `sla_shipment` + `sla_leg`
+  (mutable), `sla_escalation` + `sla_action` (append-only). Version 10.1 sorts after the existing
+  top-level `V10`; `flyway.out-of-order=true`.
+- `common` enums `SlaState`, `SlaLegType`, `EscalationLevel` (referenced by the event payloads, so
+  they live in `common`). Module enum `SlaActionType`.
+- Entities `SlaShipment`/`SlaLeg` (extend `MutableBaseEntity`), `SlaEscalation`/`SlaAction`
+  (standalone, `created_at` only). Repos with the control-tower / pass-rate / idempotency queries.
+- `SlaProperties` (`@ConfigurationProperties("sla")`) + `sla:` block in the **app** `application.yml`
+  (budgets Σ=810m=13.5h under the 16h target — the 2.5h cushion is the AMBER band).
+### Verify
+`ddl-auto: validate` passes on boot (entity columns match `V10_1`).
+
+## W3 — Ingestion + leg lifecycle ✅
+### What was built
+- `SlaMessagingTopology` — `sla.{shipments,hub,cron,flight,da,exceptions}` queues (+ the produced
+  `oneday.sla.events` exchange), each via `RabbitStreamSupport` (DLX/DLQ).
+- Consumers taking the exact concrete/sealed types the producers stamp: `SlaShipmentEventsConsumer`
+  (`BaseShipmentEvent`), `SlaHubEventsConsumer` (`HubEventPayload`), `SlaCronEventsConsumer`
+  (`CronEventPayload`), `SlaDaEventsConsumer` (`DaLifecycleEvent`), `SlaExceptionsEventsConsumer`
+  (`ExceptionsEvent`), `SlaFlightEventsConsumer` (`@RabbitHandler`, `autoStartup=false` until M9).
+- `SlaLifecycleService` — opens the SLA + leg plan on CREATED (M10-D-006), advances/closes legs on
+  STATE_CHANGED (only-advance, idempotent), closes on terminal/cancel, marks exceptions breached.
+### Verify
+Booking a shipment writes one `sla_shipment` + N `sla_leg` rows; a state change advances the legs.
+
+## W4 — Projection + derivation + sweeper ✅
+### What was built
+- `ProjectionCalculator` (pure, M10-D-005) + `SlaEngine.recompute` (writes leg colours + rollup,
+  upgrades to BREACHED once the target passes, fires escalations on entering RED/BREACHED).
+- `SlaLegCatalog` (budgets, per-`DeliveryType` plan, state→leg map, terminal/exception classification).
+- Enrichment from parcel-keyed events (last-mile deadline, flight cutoff, loop overflow).
+- `SlaSweeper` (`@Scheduled`, `sla.sweeper-fixed-delay-ms`) — catches silent overruns.
+### Verify
+`ProjectionCalculatorTest` covers GREEN, AMBER-not-RED, cushion→RED, historical AMBER, enrichment.
+
+## W5 — Escalation ✅
+### What was built
+- `EscalationService` — append-only raise (RED→STATION_MANAGER / BREACHED→ADMIN, custody city),
+  idempotent per `(shipment, leg, colour)`; `SlaEventProducer` publishes `SlaEscalationRaisedEvent`
+  / `SlaBreachedEvent` on `oneday.sla.events`.
+- `common`: `EventStreams.SLA_EVENTS`, `SlaEventType`, `events/sla/*`,
+  `NotificationEventType.SLA_ESCALATION`.
+### Verify
+Forcing a projection past 16h writes one `sla_escalation` + emits `SLA_ESCALATION_RAISED`.
+
+## W6 — Control-tower API ✅
+### What was built
+- `SlaDashboardController` (`/api/v1/sla`) + `sla.api.Authz` (role gate + city scope mirroring
+  `AdminOrdersController`) + `SlaQueryService`/impl + record DTOs.
+- Endpoints: `control-tower`, `shipments/{ref}`, `red-queue`, `metrics/pass-rate`,
+  `escalations/{id}/ack`, `escalations/{id}/act` (append-only `sla_action`; `sla:red:action` roles).
+### Verify
+ADMIN sees all cities; STATION_MANAGER sees only their `cityId` (403 if unassigned); `act` appends
+an `sla_action`.
+
+---
+
+## Build sequence & blockers
+- **Sequence:** W1 → W2 → W3 → W4 → W5 → W6 (done together on `f-m10-design`).
+- **Out of this pass:** web control-tower page (`oneday-web`); cross-module `slaDeadline` back-fill.
+- **Open blockers (don't block v1):** Q-S3 (3rd-party light-node legs); M10-D-003 (hub→airport minute
+  threshold); van/flight/bag→parcel attribution for richer enrichment.
+
+## End-to-end verification
+1. `export JAVA_HOME=/opt/homebrew/opt/openjdk@21`; `mvn clean install -pl common,sla,app -am -DskipTests`.
+2. `mvn test -pl sla` (9 green).
+3. `mvn spring-boot:run -pl app` (staging DB via `.env`); flyway applies `V10_1`.
+4. Book DEL→BOM → `GET /api/v1/sla/shipments/{ref}` shows all-GREEN legs, anchors booked+16h/+24h.
+5. Drive to `PICKED_UP` late / push `VAN_RUNNING_LATE`; force projection past 16h → leg RED,
+   `sla_escalation` row, `oneday.sla.events` (check `rabbitmqadmin -N cloudamqp` / logs).
+6. Hit `control-tower` as ADMIN (all) vs STATION_MANAGER (own city, 403 if none); `act` appends.

--- a/docs/M10/M10-SLA-DESIGN.md
+++ b/docs/M10/M10-SLA-DESIGN.md
@@ -1,0 +1,200 @@
+# M10 — SLA Monitoring & Escalation · Design (v1.0)
+
+> Status: **built** (branch `f-m10-design`). Consumes every module's lifecycle events; owns its own
+> tables; escalates to Station Manager / Admin. Self-contained — no other module's logic changes.
+> Requirements: `docs/godspeed/M10-SLA.md`, `docs/MODULES.md §M10`, PRD §12.4 + FR-11.
+
+## Table of contents
+- **Part 0 — Physical reality** (glossary, one-parcel walkthrough)
+- **Part I — What & boundaries** (scope, the leg model, key decisions)
+- **Part II — The engine** (clock, legs, projection, escalation, sweeper, dashboard)
+- **Part III — Integration & governance** (contracts, RACI, open questions, testing)
+
+---
+
+## Part 0 — Physical reality
+
+**The promise M10 guards.** Godspeed promises **24h** to the market and runs to **16h** internally.
+Reliability *is* the product: M10 watches every parcel against a per-leg time budget, colours each leg
+GREEN / AMBER / RED, and escalates a parcel to a human *before* the customer promise is at risk.
+
+**Glossary.**
+- **Leg** — one hop of the journey (pickup, origin-hub, origin-airport, air, dest-airport, dest-hub,
+  last-mile). Enum `SlaLegType`.
+- **Budget** — the minutes a leg *should* take. Config `sla.legs`. The seven budgets sum to **13.5h**,
+  leaving a **2.5h internal cushion** under the 16h target. A further **8h** (16h→24h) is the
+  customer-facing engineered buffer.
+- **Projection** — a deterministic roll-forward of when the parcel will finish (Part II).
+- **Breach** — the 16h internal target actually passes, or a hard failure (RTO, pickup/delivery fail).
+
+**One parcel (DEL→BOM).** Booked 08:00 → the 16h clock starts, internal target **00:00**, public
+promise 08:00+24h. First mile budgeted 3h. The pickup runs 2h late; at 13:00 the parcel reaches the
+origin hub. M10 closes FIRST_MILE (overran → that leg shows **AMBER**), opens ORIGIN_HUB, and projects
+the finish: 13:00 + remaining budgets (60+120+150+90+60+150 = 630m) = **23:30** — still before 00:00,
+so the parcel is **AMBER, not RED**. If instead the delay pushed the projection past 00:00, the open
+leg flips **RED**, an append-only `sla_escalation` is written, and `SLA_ESCALATION_RAISED` fires to the
+Mumbai... no — the **Delhi** station manager (custody is still origin at the hub). The parcel is
+escalated well before the 24h public promise is ever in danger.
+
+---
+
+## Part I — What & boundaries
+
+### 1. What M10 does
+Consumes lifecycle events from M4/M5/M6/M7/M9/M11, maintains a per-parcel **leg ledger**, runs a
+**buffer-aware projection** each time new information lands (and on a periodic sweep), derives
+GREEN/AMBER/RED per leg + a shipment rollup, **escalates** RED/breach to the right role, keeps an
+**append-only** escalation + action audit, and serves a **control-tower API** to Station Manager
+(own city) and Admin (all cities), including a measured **pass-rate** metric.
+
+### 2. Scope
+
+**In:** per-leg SLA state; buffer-aware projection; RED/breach escalation + notification event;
+append-only audit; control-tower/red-queue/pass-rate/detail API with acknowledge/act; the SLA clock
+and per-leg deadlines as M10's own source of truth.
+
+**Out (v1):** automated mitigation / rebooking (M9/M11 own that — M10 flags, humans act); live plane
+position (M9 is a stub → the air leg uses scheduled times / budget); a GPS breadcrumb (live stores
+overwrite in place); the web control-tower page (separate `oneday-web` repo, follow-on); back-filling
+the cross-module `slaDeadline` into other modules (deferred — M10-D-007).
+
+**Gaps this module closes:** there was **no SLA anywhere**. Every upstream module already tagged events
+"→ M10"; this is the consumer that finally acts on them.
+
+### 3. The leg model (reconciled to `ShipmentState`)
+`ShipmentState` has **30** states (roles: **12**; the requirement doc's 31/10 are stale). The seven
+legs map to state ranges; a state that isn't in a shipment's plan (e.g. the air legs of a SAME_CITY
+parcel) simply never opens.
+
+| Leg | Live during states | Budget |
+|---|---|---|
+| FIRST_MILE | BOOKED, PICKUP_ASSIGNED, PICKED_UP, HANDED_TO_PICKUP_VAN, RETURNED_TO_HUB, AWAITING_SELF_DROP | 180m |
+| ORIGIN_HUB | AT_ORIGIN_HUB, ORIGIN_HUB_PROCESSING, IN_TAKEOFF_BAG | 60m |
+| ORIGIN_AIRPORT | DISPATCHED_TO_AIRPORT, AT_AIRPORT | 120m |
+| AIR | DEPARTED | 150m |
+| DEST_AIRPORT | LANDED, DISPATCHED_TO_HUB | 90m |
+| DEST_HUB | AT_DEST_HUB, DEST_HUB_PROCESSING, AWAITING_HUB_COLLECT | 60m |
+| LAST_MILE | HANDED_TO_DROP_VAN, DROP_ASSIGNED, DROP_COLLECTED, HUB_DELIVERY_ASSIGNED, COLLECTED_FROM_HUB | 150m |
+
+Terminal success: `DROPPED`, `HUB_COLLECTED`. Exceptions (breach, stay open): `PICKUP_FAILED`,
+`DELIVERY_FAILED`, `RTO_INITIATED`, `RTO_IN_TRANSIT`. Close: `RTO_COMPLETED`, `CANCELLED`.
+Variants: **SAME_CITY** = FIRST_MILE → ORIGIN_HUB → LAST_MILE (air legs + second hub collapse);
+**HUB_RETURN** / **HUB_COLLECT** reuse the same legs via their alternate states.
+
+### 4. Key design decisions
+- **M10-D-001** — GREEN / AMBER / RED per leg. *(DECIDED)*
+- **M10-D-002** — RED requires a supervisor/station-manager *action*, not just a notice. *(DECIDED)*
+- **M10-D-003** — hub→airport handover minute threshold. *(OPEN — Q-L3)*
+- **M10-D-004** — all SLA + escalation actions are append-only audited. *(DECIDED)*
+- **M10-D-005** — **buffer-aware projection**: AMBER = a leg overran its own budget; RED = the
+  *projected* end-to-end finish crosses the 16h internal target. *(DECIDED — resolves Q-S1)*
+- **M10-D-006** — **clock start = order-placed**: both the 16h and 24h clocks anchor at `BOOKED`.
+  *(DECIDED — resolves Q-S2)*
+- **M10-D-007** — **self-contained**: M10 owns its tables and reads other modules only via the event
+  bus; it emits escalation/breach events but changes no other module's logic. *(DECIDED)*
+
+---
+
+## Part II — The engine
+
+### 5. Clock & anchors (M10-D-006)
+On `ShipmentCreatedEvent`: `booked_at = occurredAt`, `internal_target_at = booked_at + 16h`,
+`public_promise_at = booked_at + 24h`; `eta_promised` (M4's customer ETA) is kept for reference. A
+leg plan is materialised from `DeliveryType`; FIRST_MILE is live from booking.
+
+### 6. Leg lifecycle (the backbone)
+`ShipmentStateChangedEvent` drives boundaries: on a transition into a state whose leg differs from the
+current one, M10 **completes** every upstream leg (`completed_at`) and **opens** the new leg
+(`started_at`, `deadline_at = started_at + budget`). "Only-advance" semantics make it idempotent
+(re-delivery of an event never regresses a timestamp). Terminal states close the SLA; exceptions mark
+it breached but keep it open until RTO/cancel.
+
+### 7. Projection (M10-D-005)
+```
+projected_finish = expected_end_of_current_leg + Σ(budget of every downstream leg not yet started)
+RED    if projected_finish > internal_target_at
+AMBER  if a leg overran its budget but projected_finish ≤ internal_target_at
+GREEN  otherwise
+```
+`expected_end_of_current_leg` = the leg's enrichment estimate (`projected_end_at`) if present, else
+`started_at + budget`, floored at `now` (an overrunning leg finishes no earlier than now — the
+least-alarming assumption). A completed leg is GREEN if it beat its deadline, AMBER if it overran (it
+ate cushion but is done). Deterministic and explainable — no learned ETA. Implementation:
+`ProjectionCalculator` (pure, unit-tested).
+
+**Enrichment (parcel-keyed only).** `ParcelSortedForDeliveryEvent.slaDeadline` → LAST_MILE deadline;
+`FlightReassignedEvent.newCutoff` + its `parcelIds` → ORIGIN_AIRPORT deadline; `LoopOverflowEvent`
+(parcel + deadline) → tightens the open leg. Van/flight/bag-level signals with no parcel id
+(`VAN_RUNNING_LATE`, `FLIGHT_TIME_CHANGED`, `BAG_RESCHEDULED`) are **logged, not attributed** in v1 —
+attributing them needs a van/bag→parcel map M10 (self-contained) doesn't hold. *(honest v1 limit)*
+
+### 8. The sweeper
+Time is a signal events can't send: a leg can blow its deadline while nothing happens. `SlaSweeper`
+(`@Scheduled`, 60s) re-evaluates every open shipment so a silent overrun still flips AMBER→RED and
+escalates. Idempotent; cheap at pilot volume.
+
+### 9. Escalation (M10-D-002/004)
+On entering **RED** → one append-only `sla_escalation` at level **STATION_MANAGER**, city = the
+parcel's **custody city** (destination once on the dest legs, else origin), plus a
+`SLA_ESCALATION_RAISED` event and a WARN log. On **BREACHED** → level **ADMIN** + a `SLA_BREACHED`
+event (→ M11 reason code). Idempotent per `(shipment, leg, colour)` so re-evaluation never
+double-fires. A manager **acknowledges** / **acts** via the API, appending `sla_action` rows (the
+escalation row itself is never mutated). The notification service resolves the on-duty person from the
+event's `level` + `city` (contract only; no SMS provider yet, mirroring `LoggingOtpSender`).
+
+### 10. Pass-rate metric
+`passed = closed − breached` over a window (city-scoped). The 99% gate (Annexure D/L) is
+`GET /metrics/pass-rate`.
+
+---
+
+## Part III — Integration & governance
+
+### 11. Contracts
+
+**Consumed** (exact concrete payload classes — the header `__TypeId__` must resolve, so consumers take
+the sealed base / rich type the producer stamps):
+
+| Exchange | Payloads → effect |
+|---|---|
+| `oneday.shipments.events` | `ShipmentCreatedEvent` (open) · `ShipmentStateChangedEvent` (backbone) · `ShipmentCancelledEvent` (close) |
+| `oneday.hub.events` | `ParcelSortedForDeliveryEvent` (last-mile deadline) · `DestSortCompleteEvent` (re-eval) |
+| `oneday.cron.events` | `LoopOverflowEvent` (tighten open leg) |
+| `oneday.flight.events` | `FlightReassignedEvent` (airport deadline; dormant until M9) |
+| `oneday.da.events` | `DaLifecycleEvent` — PICKUP_COMPLETED / CRON_MISSED re-eval |
+| `oneday.exceptions.events` | `ExceptionsEvent` (re-eval; dormant until M11) |
+
+Grid alerts (NO_DA / TILE_OVERLOAD) are a **deferred** input — their payloads live in the grid module,
+not `common`, so a self-contained M10 does not couple to them in v1.
+
+**Produced** on `oneday.sla.events` (new): `SlaEscalationRaisedEvent` (`SLA_ESCALATION_RAISED`),
+`SlaBreachedEvent` (`SLA_BREACHED`). Plus `NotificationEventType.SLA_ESCALATION` for the notification
+service. All additive to `common`.
+
+**REST** (`/api/v1/sla`, STATION_MANAGER own-city / ADMIN all-city; actions need `sla:red:action`):
+`GET /control-tower`, `GET /shipments/{ref}`, `GET /red-queue`, `GET /metrics/pass-rate`,
+`POST /escalations/{id}/ack`, `POST /escalations/{id}/act`.
+
+**Data model** (Flyway `sla/db/migration/sla/V10_1`): `sla_shipment` + `sla_leg` (mutable),
+`sla_escalation` + `sla_action` (append-only).
+
+### 12. Cross-module RACI
+M10 is **R** for SLA state, projection, escalation raise, pass-rate. Station Manager / Supervisor are
+**R** for acting on RED (city). Admin / control tower **A** for breaches and lane-level RED. M9/M11
+are **R** for the actual mitigation (rebook / RTO); M10 only surfaces.
+
+### 13. Open questions
+- **Q-S1** buffer allocation — **resolved** by M10-D-005 (global buffer-aware; per-leg budgets = AMBER
+  trigger, projection vs 16h = RED).
+- **Q-S2** clock start — **resolved** by M10-D-006 (order-placed).
+- **Q-S3** 3rd-party light-node last-mile without own-scan coverage — **open**.
+- **M10-D-003** hub→airport handover minute threshold — **open** (Q-L3).
+- **Van/flight/bag → parcel attribution** — open; needs a shared map or a `common` payload carrying
+  parcel ids (would also let grid alerts and van-late enrich per parcel). Deferred with the back-fill.
+
+### 14. Testing
+Unit: `ProjectionCalculatorTest` (buffer-aware table incl. AMBER-not-RED, cushion→RED, historical
+AMBER, enrichment override), `SlaLegCatalogTest` (plans, state→leg, classification). Manual E2E
+(Part of the implementation plan's Verify): book → drive states + push `VAN_RUNNING_LATE` / force a
+projection past 16h → observe AMBER→RED, an `sla_escalation` row, and `oneday.sla.events`; hit the
+dashboard as ADMIN vs STATION_MANAGER.

--- a/sla/src/main/java/com/oneday/sla/api/Authz.java
+++ b/sla/src/main/java/com/oneday/sla/api/Authz.java
@@ -1,0 +1,63 @@
+package com.oneday.sla.api;
+
+import com.oneday.auth.security.AuthUserDetails;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Auth helpers for the SLA control-tower endpoints. Identity + role come from the authenticated
+ * principal (M1 JWT). Mirrors {@code orders.api.Authz}.
+ */
+final class Authz {
+
+    static final String ADMIN = "ADMIN";
+    static final String STATION_MANAGER = "STATION_MANAGER";
+    static final String SUPERVISOR = "SUPERVISOR";
+
+    private Authz() {}
+
+    static String requireUserId(AuthUserDetails principal) {
+        if (principal == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authentication required");
+        }
+        return principal.getUserId().toString();
+    }
+
+    static String role(AuthUserDetails principal) {
+        if (principal == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authentication required");
+        }
+        return principal.getUser().getRole().getName();
+    }
+
+    /** Authorize against {@code allowedRoles}; ADMIN is always allowed. */
+    static void requireRole(AuthUserDetails principal, String... allowedRoles) {
+        String role = role(principal);
+        if (ADMIN.equals(role)) {
+            return;
+        }
+        for (String allowed : allowedRoles) {
+            if (allowed.equals(role)) {
+                return;
+            }
+        }
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                "Role " + role + " is not permitted to view SLA data");
+    }
+
+    /**
+     * The city an ops query is scoped to: {@code null} for ADMIN (sees every city), else the station
+     * manager / supervisor's own city (403 if they have none assigned).
+     */
+    static String cityScope(AuthUserDetails principal) {
+        String role = role(principal);
+        if (ADMIN.equals(role)) {
+            return null;
+        }
+        String city = principal.getUser().getCityId();
+        if (city == null || city.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "No city assigned to this user");
+        }
+        return city;
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/api/SlaDashboardController.java
+++ b/sla/src/main/java/com/oneday/sla/api/SlaDashboardController.java
@@ -1,0 +1,104 @@
+package com.oneday.sla.api;
+
+import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.common.domain.enums.SlaState;
+import com.oneday.sla.dto.SlaActionRequest;
+import com.oneday.sla.dto.SlaControlTowerResponse;
+import com.oneday.sla.dto.SlaEscalationView;
+import com.oneday.sla.dto.SlaPassRateResponse;
+import com.oneday.sla.dto.SlaShipmentDetailResponse;
+import com.oneday.sla.service.SlaQueryService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * The SLA control tower for STATION_MANAGER (own city) and ADMIN (all cities). Every endpoint is
+ * role-gated and city-scoped like {@code AdminOrdersController}; action endpoints additionally require
+ * the {@code sla:red:action} capability (held by STATION_MANAGER / SUPERVISOR / ADMIN).
+ */
+@RestController
+@RequestMapping("/api/v1/sla")
+public class SlaDashboardController {
+
+    private final SlaQueryService service;
+
+    public SlaDashboardController(SlaQueryService service) {
+        this.service = service;
+    }
+
+    /** Live board of in-flight parcels; optional colour filter. */
+    @GetMapping("/control-tower")
+    public SlaControlTowerResponse controlTower(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @RequestParam(required = false) SlaState state,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "50") int size) {
+        Authz.requireRole(principal, Authz.STATION_MANAGER, Authz.SUPERVISOR);
+        return service.controlTower(state, Authz.cityScope(principal), page, size);
+    }
+
+    /** Per-parcel leg breakdown + escalation history. */
+    @GetMapping("/shipments/{ref}")
+    public SlaShipmentDetailResponse shipment(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @PathVariable String ref) {
+        Authz.requireRole(principal, Authz.STATION_MANAGER, Authz.SUPERVISOR);
+        return service.detail(ref, Authz.cityScope(principal));
+    }
+
+    /** Open escalations awaiting action (RED / BREACHED). */
+    @GetMapping("/red-queue")
+    public List<SlaEscalationView> redQueue(@AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireRole(principal, Authz.STATION_MANAGER, Authz.SUPERVISOR);
+        return service.redQueue(Authz.cityScope(principal));
+    }
+
+    /** Measured pass-rate over a window (default: last 24h). The 99% gate metric. */
+    @GetMapping("/metrics/pass-rate")
+    public SlaPassRateResponse passRate(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to) {
+        Authz.requireRole(principal, Authz.STATION_MANAGER, Authz.SUPERVISOR);
+        Instant end = to != null ? to : Instant.now();
+        Instant start = from != null ? from : end.minus(Duration.ofHours(24));
+        return service.passRate(start, end, Authz.cityScope(principal));
+    }
+
+    /** Acknowledge an escalation (records who is on it). Requires sla:red:action. */
+    @PostMapping("/escalations/{id}/ack")
+    public ResponseEntity<Void> acknowledge(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @PathVariable UUID id,
+            @RequestBody(required = false) SlaActionRequest body) {
+        Authz.requireRole(principal, Authz.STATION_MANAGER, Authz.SUPERVISOR);
+        service.acknowledge(id, Authz.cityScope(principal), Authz.requireUserId(principal),
+                Authz.role(principal), body != null ? body.notes() : null);
+        return ResponseEntity.noContent().build();
+    }
+
+    /** Resolve an escalation (the acted-on outcome). Requires sla:red:action. */
+    @PostMapping("/escalations/{id}/act")
+    public ResponseEntity<Void> act(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @PathVariable UUID id,
+            @RequestBody(required = false) SlaActionRequest body) {
+        Authz.requireRole(principal, Authz.STATION_MANAGER, Authz.SUPERVISOR);
+        service.resolve(id, Authz.cityScope(principal), Authz.requireUserId(principal),
+                Authz.role(principal), body != null ? body.notes() : null);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/config/SlaProperties.java
+++ b/sla/src/main/java/com/oneday/sla/config/SlaProperties.java
@@ -1,0 +1,51 @@
+package com.oneday.sla.config;
+
+import com.oneday.common.domain.enums.SlaLegType;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * M10 SLA configuration. The per-leg budgets (Annexure G) sum to the 16h internal target; the
+ * clocks anchor at booking (M10-D-006). Lives in the <b>app</b>'s {@code application.yml} (the
+ * runtime source of truth — the module yaml is shadowed on the classpath, per the grid precedent).
+ *
+ * <pre>{@code
+ * sla:
+ *   internal-target-hours: 16
+ *   public-promise-hours: 24
+ *   sweeper-fixed-delay-ms: 60000
+ *   legs: { FIRST_MILE: 240, ORIGIN_HUB: 60, ORIGIN_AIRPORT: 180, AIR: 150,
+ *           DEST_AIRPORT: 120, DEST_HUB: 60, LAST_MILE: 150 }
+ * }</pre>
+ */
+@Component
+@ConfigurationProperties(prefix = "sla")
+public class SlaProperties {
+
+    /** The internal "ready-to-delivered" target — RED is projected breach of this (M10-D-005/006). */
+    private int internalTargetHours = 16;
+
+    /** The public market promise. Reference only; RED keys off the internal target. */
+    private int publicPromiseHours = 24;
+
+    /** How often the sweeper recomputes open shipments to catch silent overruns. */
+    private long sweeperFixedDelayMs = 60_000;
+
+    /** Per-leg time budget in minutes, keyed by {@link SlaLegType}. Sums to the 16h target. */
+    private Map<SlaLegType, Integer> legs = new EnumMap<>(SlaLegType.class);
+
+    public int getInternalTargetHours() { return internalTargetHours; }
+    public void setInternalTargetHours(int internalTargetHours) { this.internalTargetHours = internalTargetHours; }
+
+    public int getPublicPromiseHours() { return publicPromiseHours; }
+    public void setPublicPromiseHours(int publicPromiseHours) { this.publicPromiseHours = publicPromiseHours; }
+
+    public long getSweeperFixedDelayMs() { return sweeperFixedDelayMs; }
+    public void setSweeperFixedDelayMs(long sweeperFixedDelayMs) { this.sweeperFixedDelayMs = sweeperFixedDelayMs; }
+
+    public Map<SlaLegType, Integer> getLegs() { return legs; }
+    public void setLegs(Map<SlaLegType, Integer> legs) { this.legs = legs; }
+}

--- a/sla/src/main/java/com/oneday/sla/domain/SlaAction.java
+++ b/sla/src/main/java/com/oneday/sla/domain/SlaAction.java
@@ -1,0 +1,54 @@
+package com.oneday.sla.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/** Append-only human action taken against an escalation (acknowledge / resolve / note). */
+@Entity
+@Table(name = "sla_action")
+@Getter
+@Setter
+@NoArgsConstructor
+public class SlaAction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "escalation_id", nullable = false)
+    private UUID escalationId;
+
+    @Column(name = "shipment_id", nullable = false)
+    private UUID shipmentId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "action", nullable = false)
+    private SlaActionType action;
+
+    @Column(name = "acted_by", nullable = false)
+    private String actedBy;
+
+    @Column(name = "acted_by_role")
+    private String actedByRole;
+
+    @Column(name = "notes")
+    private String notes;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private Instant createdAt;
+}

--- a/sla/src/main/java/com/oneday/sla/domain/SlaActionType.java
+++ b/sla/src/main/java/com/oneday/sla/domain/SlaActionType.java
@@ -1,0 +1,8 @@
+package com.oneday.sla.domain;
+
+/** A human action recorded against an escalation (append-only {@code sla_action}). */
+public enum SlaActionType {
+    ACKNOWLEDGE,
+    RESOLVE,
+    NOTE
+}

--- a/sla/src/main/java/com/oneday/sla/domain/SlaEscalation.java
+++ b/sla/src/main/java/com/oneday/sla/domain/SlaEscalation.java
@@ -1,0 +1,72 @@
+package com.oneday.sla.domain;
+
+import com.oneday.common.domain.enums.EscalationLevel;
+import com.oneday.common.domain.enums.SlaLegType;
+import com.oneday.common.domain.enums.SlaState;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Append-only record of one escalation raise (a leg going RED / breached). Never updated or deleted;
+ * human responses are separate rows in {@code sla_action}. Standalone (no {@code updated_at}).
+ */
+@Entity
+@Table(name = "sla_escalation")
+@Getter
+@Setter
+@NoArgsConstructor
+public class SlaEscalation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "shipment_id", nullable = false)
+    private UUID shipmentId;
+
+    @Column(name = "shipment_ref")
+    private String shipmentRef;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "leg")
+    private SlaLegType leg;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "from_state")
+    private SlaState fromState;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "to_state", nullable = false)
+    private SlaState toState;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "level", nullable = false)
+    private EscalationLevel level;
+
+    @Column(name = "city")
+    private String city;
+
+    @Column(name = "reason_code")
+    private String reasonCode;
+
+    @Column(name = "projected_finish_at")
+    private Instant projectedFinishAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private Instant createdAt;
+}

--- a/sla/src/main/java/com/oneday/sla/domain/SlaLeg.java
+++ b/sla/src/main/java/com/oneday/sla/domain/SlaLeg.java
@@ -1,0 +1,58 @@
+package com.oneday.sla.domain;
+
+import com.oneday.common.domain.MutableBaseEntity;
+import com.oneday.common.domain.enums.SlaLegType;
+import com.oneday.common.domain.enums.SlaState;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/** One monitored leg of a shipment. Mutable — timestamps and colour advance as events land. */
+@Entity
+@Table(name = "sla_leg")
+@Getter
+@Setter
+@NoArgsConstructor
+public class SlaLeg extends MutableBaseEntity {
+
+    @Column(name = "shipment_id", nullable = false)
+    private UUID shipmentId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "leg", nullable = false)
+    private SlaLegType leg;
+
+    @Column(name = "seq", nullable = false)
+    private int seq;
+
+    @Column(name = "budget_minutes", nullable = false)
+    private int budgetMinutes;
+
+    @Column(name = "started_at")
+    private Instant startedAt;
+
+    @Column(name = "deadline_at")
+    private Instant deadlineAt;
+
+    @Column(name = "completed_at")
+    private Instant completedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "state", nullable = false)
+    private SlaState state = SlaState.GREEN;
+
+    /** Best live estimate of when this (open) leg will finish; null → use started_at + budget. */
+    @Column(name = "projected_end_at")
+    private Instant projectedEndAt;
+
+    @Column(name = "source_event")
+    private String sourceEvent;
+}

--- a/sla/src/main/java/com/oneday/sla/domain/SlaShipment.java
+++ b/sla/src/main/java/com/oneday/sla/domain/SlaShipment.java
@@ -1,0 +1,77 @@
+package com.oneday.sla.domain;
+
+import com.oneday.common.domain.MutableBaseEntity;
+import com.oneday.common.domain.enums.DeliveryType;
+import com.oneday.common.domain.enums.SlaLegType;
+import com.oneday.common.domain.enums.SlaState;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/** Per-shipment SLA rollup — the live control-tower row. Mutable (M10). */
+@Entity
+@Table(name = "sla_shipment")
+@Getter
+@Setter
+@NoArgsConstructor
+public class SlaShipment extends MutableBaseEntity {
+
+    @Column(name = "shipment_id", nullable = false, unique = true)
+    private UUID shipmentId;
+
+    @Column(name = "shipment_ref")
+    private String shipmentRef;
+
+    @Column(name = "origin_city")
+    private String originCity;
+
+    @Column(name = "dest_city")
+    private String destCity;
+
+    @Column(name = "lane")
+    private String lane;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "delivery_type")
+    private DeliveryType deliveryType;
+
+    @Column(name = "booked_at", nullable = false)
+    private Instant bookedAt;
+
+    @Column(name = "internal_target_at", nullable = false)
+    private Instant internalTargetAt;
+
+    @Column(name = "public_promise_at", nullable = false)
+    private Instant publicPromiseAt;
+
+    @Column(name = "eta_promised")
+    private Instant etaPromised;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "overall_state", nullable = false)
+    private SlaState overallState = SlaState.GREEN;
+
+    @Column(name = "projected_finish_at")
+    private Instant projectedFinishAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "current_leg")
+    private SlaLegType currentLeg;
+
+    @Column(name = "delivered_at")
+    private Instant deliveredAt;
+
+    @Column(name = "closed_at")
+    private Instant closedAt;
+
+    @Column(name = "breached", nullable = false)
+    private boolean breached;
+}

--- a/sla/src/main/java/com/oneday/sla/dto/SlaActionRequest.java
+++ b/sla/src/main/java/com/oneday/sla/dto/SlaActionRequest.java
@@ -1,0 +1,5 @@
+package com.oneday.sla.dto;
+
+/** Body for acknowledging / acting on an escalation. {@code notes} is optional. */
+public record SlaActionRequest(String notes) {
+}

--- a/sla/src/main/java/com/oneday/sla/dto/SlaControlTowerResponse.java
+++ b/sla/src/main/java/com/oneday/sla/dto/SlaControlTowerResponse.java
@@ -1,0 +1,11 @@
+package com.oneday.sla.dto;
+
+import java.util.List;
+
+/** A page of the live control tower. */
+public record SlaControlTowerResponse(
+        int page,
+        int size,
+        long total,
+        List<SlaShipmentSummary> items) {
+}

--- a/sla/src/main/java/com/oneday/sla/dto/SlaEscalationView.java
+++ b/sla/src/main/java/com/oneday/sla/dto/SlaEscalationView.java
@@ -1,0 +1,31 @@
+package com.oneday.sla.dto;
+
+import com.oneday.common.domain.enums.EscalationLevel;
+import com.oneday.common.domain.enums.SlaLegType;
+import com.oneday.common.domain.enums.SlaState;
+import com.oneday.sla.domain.SlaEscalation;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/** An escalation as shown in the red queue / shipment detail, with its acknowledgement status. */
+public record SlaEscalationView(
+        UUID id,
+        UUID shipmentId,
+        String shipmentRef,
+        SlaLegType leg,
+        SlaState toState,
+        EscalationLevel level,
+        String city,
+        String reasonCode,
+        Instant projectedFinishAt,
+        Instant createdAt,
+        boolean acknowledged,
+        boolean resolved) {
+
+    public static SlaEscalationView from(SlaEscalation e, boolean acknowledged, boolean resolved) {
+        return new SlaEscalationView(e.getId(), e.getShipmentId(), e.getShipmentRef(), e.getLeg(),
+                e.getToState(), e.getLevel(), e.getCity(), e.getReasonCode(), e.getProjectedFinishAt(),
+                e.getCreatedAt(), acknowledged, resolved);
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/dto/SlaLegView.java
+++ b/sla/src/main/java/com/oneday/sla/dto/SlaLegView.java
@@ -1,0 +1,24 @@
+package com.oneday.sla.dto;
+
+import com.oneday.common.domain.enums.SlaLegType;
+import com.oneday.common.domain.enums.SlaState;
+import com.oneday.sla.domain.SlaLeg;
+
+import java.time.Instant;
+
+/** One leg's SLA view for the control tower. */
+public record SlaLegView(
+        SlaLegType leg,
+        int seq,
+        int budgetMinutes,
+        SlaState state,
+        Instant startedAt,
+        Instant deadlineAt,
+        Instant completedAt,
+        Instant projectedEndAt) {
+
+    public static SlaLegView from(SlaLeg l) {
+        return new SlaLegView(l.getLeg(), l.getSeq(), l.getBudgetMinutes(), l.getState(),
+                l.getStartedAt(), l.getDeadlineAt(), l.getCompletedAt(), l.getProjectedEndAt());
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/dto/SlaPassRateResponse.java
+++ b/sla/src/main/java/com/oneday/sla/dto/SlaPassRateResponse.java
@@ -1,0 +1,20 @@
+package com.oneday.sla.dto;
+
+import java.time.Instant;
+
+/** The measured SLA pass-rate over a window (Annexure D/L — the 99% gate). */
+public record SlaPassRateResponse(
+        Instant from,
+        Instant to,
+        String city,
+        long closed,
+        long breached,
+        long passed,
+        double passRate) {
+
+    public static SlaPassRateResponse of(Instant from, Instant to, String city, long closed, long breached) {
+        long passed = closed - breached;
+        double rate = closed == 0 ? 1.0 : (double) passed / (double) closed;
+        return new SlaPassRateResponse(from, to, city, closed, breached, passed, rate);
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/dto/SlaShipmentDetailResponse.java
+++ b/sla/src/main/java/com/oneday/sla/dto/SlaShipmentDetailResponse.java
@@ -1,0 +1,10 @@
+package com.oneday.sla.dto;
+
+import java.util.List;
+
+/** Full per-parcel SLA breakdown: the rollup, every leg, and the escalation history. */
+public record SlaShipmentDetailResponse(
+        SlaShipmentSummary shipment,
+        List<SlaLegView> legs,
+        List<SlaEscalationView> escalations) {
+}

--- a/sla/src/main/java/com/oneday/sla/dto/SlaShipmentSummary.java
+++ b/sla/src/main/java/com/oneday/sla/dto/SlaShipmentSummary.java
@@ -1,0 +1,35 @@
+package com.oneday.sla.dto;
+
+import com.oneday.common.domain.enums.DeliveryType;
+import com.oneday.common.domain.enums.SlaLegType;
+import com.oneday.common.domain.enums.SlaState;
+import com.oneday.sla.domain.SlaShipment;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/** One control-tower row: where a parcel's SLA stands right now. */
+public record SlaShipmentSummary(
+        UUID shipmentId,
+        String shipmentRef,
+        String originCity,
+        String destCity,
+        String lane,
+        DeliveryType deliveryType,
+        SlaState overallState,
+        SlaLegType currentLeg,
+        boolean breached,
+        Instant bookedAt,
+        Instant internalTargetAt,
+        Instant publicPromiseAt,
+        Instant projectedFinishAt,
+        Instant deliveredAt) {
+
+    public static SlaShipmentSummary from(SlaShipment s) {
+        return new SlaShipmentSummary(
+                s.getShipmentId(), s.getShipmentRef(), s.getOriginCity(), s.getDestCity(), s.getLane(),
+                s.getDeliveryType(), s.getOverallState(), s.getCurrentLeg(), s.isBreached(),
+                s.getBookedAt(), s.getInternalTargetAt(), s.getPublicPromiseAt(),
+                s.getProjectedFinishAt(), s.getDeliveredAt());
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/events/SlaCronEventsConsumer.java
+++ b/sla/src/main/java/com/oneday/sla/events/SlaCronEventsConsumer.java
@@ -1,0 +1,35 @@
+package com.oneday.sla.events;
+
+import com.oneday.common.kafka.events.cron.CronEventPayload;
+import com.oneday.common.kafka.events.cron.LoopOverflowEvent;
+import com.oneday.sla.service.SlaLifecycleService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * M6 routing events. {@code LOOP_OVERFLOW} is parcel-keyed and tightens the open leg's deadline;
+ * van-level signals (VAN_RUNNING_LATE, VAN_BREAKDOWN) carry no parcel id, so in v1 they are logged,
+ * not attributed (M10-D-007). Takes the sealed base.
+ */
+@Component
+public class SlaCronEventsConsumer {
+
+    private static final Logger log = LoggerFactory.getLogger(SlaCronEventsConsumer.class);
+
+    private final SlaLifecycleService lifecycle;
+
+    public SlaCronEventsConsumer(SlaLifecycleService lifecycle) {
+        this.lifecycle = lifecycle;
+    }
+
+    @RabbitListener(queues = SlaMessagingTopology.CRON_QUEUE)
+    public void onCronEvent(CronEventPayload event) {
+        if (event instanceof LoopOverflowEvent l) {
+            lifecycle.enrichLoopOverflow(l.parcelId(), l.deadline());
+        } else {
+            log.trace("Ignoring cron event {}", event.eventTypeName());
+        }
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/events/SlaDaEventsConsumer.java
+++ b/sla/src/main/java/com/oneday/sla/events/SlaDaEventsConsumer.java
@@ -1,0 +1,37 @@
+package com.oneday.sla.events;
+
+import com.oneday.common.kafka.events.DaLifecycleEvent;
+import com.oneday.sla.service.SlaLifecycleService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * M5 DA events. Parcel-scoped signals (pickup completed, cron missed) trigger a re-evaluation on the
+ * fresh information; DA-scoped signals (DA_ABSENT — no shipment) are logged. Takes the one rich type
+ * M5 produces on {@code oneday.da.events}.
+ */
+@Component
+public class SlaDaEventsConsumer {
+
+    private static final Logger log = LoggerFactory.getLogger(SlaDaEventsConsumer.class);
+
+    private final SlaLifecycleService lifecycle;
+
+    public SlaDaEventsConsumer(SlaLifecycleService lifecycle) {
+        this.lifecycle = lifecycle;
+    }
+
+    @RabbitListener(queues = SlaMessagingTopology.DA_QUEUE)
+    public void onDaEvent(DaLifecycleEvent event) {
+        if (event.eventType() == null) {
+            return;
+        }
+        switch (event.eventType()) {
+            case PICKUP_COMPLETED, CRON_MISSED -> lifecycle.touch(event.shipmentId());
+            case DA_ABSENT -> log.debug("DA_ABSENT for da {} — city-level risk, not attributed", event.daId());
+            default -> { /* other DA events don't affect SLA accounting */ }
+        }
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/events/SlaEventProducer.java
+++ b/sla/src/main/java/com/oneday/sla/events/SlaEventProducer.java
@@ -1,0 +1,26 @@
+package com.oneday.sla.events;
+
+import com.oneday.common.kafka.EventPublisher;
+import com.oneday.common.kafka.EventStreams;
+import com.oneday.common.kafka.events.sla.SlaBreachedEvent;
+import com.oneday.common.kafka.events.sla.SlaEscalationRaisedEvent;
+import org.springframework.stereotype.Component;
+
+/** Publishes M10's outbound events on {@code oneday.sla.events} (→ M11, ops/notification service). */
+@Component
+public class SlaEventProducer {
+
+    private final EventPublisher eventPublisher;
+
+    public SlaEventProducer(EventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    public void escalationRaised(SlaEscalationRaisedEvent event) {
+        eventPublisher.publish(EventStreams.SLA_EVENTS, event);
+    }
+
+    public void breached(SlaBreachedEvent event) {
+        eventPublisher.publish(EventStreams.SLA_EVENTS, event);
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/events/SlaExceptionsEventsConsumer.java
+++ b/sla/src/main/java/com/oneday/sla/events/SlaExceptionsEventsConsumer.java
@@ -1,0 +1,26 @@
+package com.oneday.sla.events;
+
+import com.oneday.common.kafka.events.ExceptionsEvent;
+import com.oneday.sla.service.SlaLifecycleService;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * M11 exception events. The shipment's own state changes (RTO_INITIATED/COMPLETED, reschedules) drive
+ * the SLA via the shipments backbone; this consumer just re-evaluates on the same signal so a failure
+ * reflects promptly even if the state event is delayed. Dormant in practice until M11 produces.
+ */
+@Component
+public class SlaExceptionsEventsConsumer {
+
+    private final SlaLifecycleService lifecycle;
+
+    public SlaExceptionsEventsConsumer(SlaLifecycleService lifecycle) {
+        this.lifecycle = lifecycle;
+    }
+
+    @RabbitListener(queues = SlaMessagingTopology.EXCEPTIONS_QUEUE)
+    public void onExceptionEvent(ExceptionsEvent event) {
+        lifecycle.touch(event.shipmentId());
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/events/SlaFlightEventsConsumer.java
+++ b/sla/src/main/java/com/oneday/sla/events/SlaFlightEventsConsumer.java
@@ -1,0 +1,44 @@
+package com.oneday.sla.events;
+
+import com.oneday.common.kafka.events.flight.FlightReassignedEvent;
+import com.oneday.common.kafka.events.flight.FlightTimeChangedEvent;
+import com.oneday.sla.service.SlaLifecycleService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitHandler;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * M9 flight events. {@code FLIGHT_REASSIGNED} carries the affected parcel ids + the new cutoff, so
+ * M10 re-baselines those parcels' airport leg; {@code FLIGHT_TIME_CHANGED} is flight-level (no parcel
+ * list) → logged. Dormant (autoStartup=false) until M9 is built, mirroring M7's flight consumer.
+ */
+@Component
+@RabbitListener(queues = SlaMessagingTopology.FLIGHT_QUEUE, autoStartup = "false")
+public class SlaFlightEventsConsumer {
+
+    private static final Logger log = LoggerFactory.getLogger(SlaFlightEventsConsumer.class);
+
+    private final SlaLifecycleService lifecycle;
+
+    public SlaFlightEventsConsumer(SlaLifecycleService lifecycle) {
+        this.lifecycle = lifecycle;
+    }
+
+    @RabbitHandler
+    public void onReassigned(FlightReassignedEvent event) {
+        // parcelId == shipmentId in v1 (no M8 barcode yet).
+        lifecycle.enrichFlightCutoff(event.parcelIds(), event.newCutoff());
+    }
+
+    @RabbitHandler
+    public void onTimeChanged(FlightTimeChangedEvent event) {
+        log.debug("FLIGHT_TIME_CHANGED for {} — no parcel list to attribute in v1", event.flightNo());
+    }
+
+    @RabbitHandler(isDefault = true)
+    public void onOther(Object event) {
+        log.trace("Ignoring flight event {}", event.getClass().getSimpleName());
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/events/SlaHubEventsConsumer.java
+++ b/sla/src/main/java/com/oneday/sla/events/SlaHubEventsConsumer.java
@@ -1,0 +1,37 @@
+package com.oneday.sla.events;
+
+import com.oneday.common.kafka.events.hub.DestSortCompleteEvent;
+import com.oneday.common.kafka.events.hub.HubEventPayload;
+import com.oneday.common.kafka.events.hub.ParcelSortedForDeliveryEvent;
+import com.oneday.sla.service.SlaLifecycleService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * M7 hub events. The parcel-keyed ones sharpen the dest-hub / last-mile legs; the rest are logged
+ * (bag/overload signals aren't attributable to a single parcel in v1). Takes the sealed base.
+ */
+@Component
+public class SlaHubEventsConsumer {
+
+    private static final Logger log = LoggerFactory.getLogger(SlaHubEventsConsumer.class);
+
+    private final SlaLifecycleService lifecycle;
+
+    public SlaHubEventsConsumer(SlaLifecycleService lifecycle) {
+        this.lifecycle = lifecycle;
+    }
+
+    @RabbitListener(queues = SlaMessagingTopology.HUB_QUEUE)
+    public void onHubEvent(HubEventPayload event) {
+        if (event instanceof ParcelSortedForDeliveryEvent p) {
+            lifecycle.enrichLastMileDeadline(p.parcelId(), p.slaDeadline());
+        } else if (event instanceof DestSortCompleteEvent d) {
+            lifecycle.touch(d.parcelId());
+        } else {
+            log.trace("Ignoring hub event {}", event.eventTypeName());
+        }
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/events/SlaMessagingTopology.java
+++ b/sla/src/main/java/com/oneday/sla/events/SlaMessagingTopology.java
@@ -1,0 +1,39 @@
+package com.oneday.sla.events;
+
+import com.oneday.common.kafka.EventStreams;
+import com.oneday.common.kafka.RabbitStreamSupport;
+import org.springframework.amqp.core.Declarables;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * M10's RabbitMQ topology: the {@code oneday.sla.events} exchange it produces to, plus the queues it
+ * consumes lifecycle events on (each bound to a source module's exchange with a DLX/DLQ). Each queue
+ * is {@code sla.<stream>} so M10 gets its own copy alongside the other modules' consumers.
+ *
+ * <p>Grid alerts (NO_DA / TILE_OVERLOAD) are a deferred input — their payloads live in the grid
+ * module, not {@code common}, so M10 (self-contained, M10-D-007) does not couple to them in v1.</p>
+ */
+@Configuration
+public class SlaMessagingTopology {
+
+    public static final String SHIPMENTS_QUEUE  = "sla.shipments";
+    public static final String HUB_QUEUE        = "sla.hub";
+    public static final String CRON_QUEUE       = "sla.cron";
+    public static final String FLIGHT_QUEUE     = "sla.flight";
+    public static final String DA_QUEUE         = "sla.da";
+    public static final String EXCEPTIONS_QUEUE = "sla.exceptions";
+
+    /** Exchange M10 publishes escalations / breaches to (→ M11, ops/notification service). */
+    @Bean
+    Declarables slaEventsExchange() {
+        return RabbitStreamSupport.exchange(EventStreams.SLA_EVENTS);
+    }
+
+    @Bean Declarables slaShipmentsBinding()  { return RabbitStreamSupport.consumer(SHIPMENTS_QUEUE, EventStreams.SHIPMENTS_EVENTS); }
+    @Bean Declarables slaHubBinding()        { return RabbitStreamSupport.consumer(HUB_QUEUE, EventStreams.HUB_EVENTS); }
+    @Bean Declarables slaCronBinding()       { return RabbitStreamSupport.consumer(CRON_QUEUE, EventStreams.CRON_EVENTS); }
+    @Bean Declarables slaFlightBinding()     { return RabbitStreamSupport.consumer(FLIGHT_QUEUE, EventStreams.FLIGHT_EVENTS); }
+    @Bean Declarables slaDaBinding()         { return RabbitStreamSupport.consumer(DA_QUEUE, EventStreams.DA_EVENTS); }
+    @Bean Declarables slaExceptionsBinding() { return RabbitStreamSupport.consumer(EXCEPTIONS_QUEUE, EventStreams.EXCEPTIONS_EVENTS); }
+}

--- a/sla/src/main/java/com/oneday/sla/events/SlaShipmentEventsConsumer.java
+++ b/sla/src/main/java/com/oneday/sla/events/SlaShipmentEventsConsumer.java
@@ -1,0 +1,41 @@
+package com.oneday.sla.events;
+
+import com.oneday.common.kafka.events.BaseShipmentEvent;
+import com.oneday.common.kafka.events.ShipmentCancelledEvent;
+import com.oneday.common.kafka.events.ShipmentCreatedEvent;
+import com.oneday.common.kafka.events.ShipmentStateChangedEvent;
+import com.oneday.sla.service.SlaLifecycleService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * The SLA backbone: M4's {@code oneday.shipments.events}. CREATED opens the SLA + leg plan;
+ * STATE_CHANGED advances/closes legs; CANCELLED closes it. Takes the abstract base so the header's
+ * concrete type deserializes; dispatches by instance.
+ */
+@Component
+public class SlaShipmentEventsConsumer {
+
+    private static final Logger log = LoggerFactory.getLogger(SlaShipmentEventsConsumer.class);
+
+    private final SlaLifecycleService lifecycle;
+
+    public SlaShipmentEventsConsumer(SlaLifecycleService lifecycle) {
+        this.lifecycle = lifecycle;
+    }
+
+    @RabbitListener(queues = SlaMessagingTopology.SHIPMENTS_QUEUE)
+    public void onShipmentEvent(BaseShipmentEvent event) {
+        if (event instanceof ShipmentCreatedEvent created) {
+            lifecycle.onCreated(created);
+        } else if (event instanceof ShipmentStateChangedEvent changed) {
+            lifecycle.onStateChanged(changed);
+        } else if (event instanceof ShipmentCancelledEvent cancelled) {
+            lifecycle.onCancelled(cancelled);
+        } else {
+            log.trace("Ignoring shipment event {}", event.eventTypeName());
+        }
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/repository/SlaActionRepository.java
+++ b/sla/src/main/java/com/oneday/sla/repository/SlaActionRepository.java
@@ -1,0 +1,15 @@
+package com.oneday.sla.repository;
+
+import com.oneday.sla.domain.SlaAction;
+import com.oneday.sla.domain.SlaActionType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface SlaActionRepository extends JpaRepository<SlaAction, UUID> {
+
+    List<SlaAction> findByEscalationIdOrderByCreatedAtAsc(UUID escalationId);
+
+    boolean existsByEscalationIdAndAction(UUID escalationId, SlaActionType action);
+}

--- a/sla/src/main/java/com/oneday/sla/repository/SlaEscalationRepository.java
+++ b/sla/src/main/java/com/oneday/sla/repository/SlaEscalationRepository.java
@@ -1,0 +1,20 @@
+package com.oneday.sla.repository;
+
+import com.oneday.common.domain.enums.SlaLegType;
+import com.oneday.common.domain.enums.SlaState;
+import com.oneday.sla.domain.SlaEscalation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SlaEscalationRepository extends JpaRepository<SlaEscalation, UUID> {
+
+    /** Idempotency guard: has this shipment already been escalated for this leg at this colour? */
+    boolean existsByShipmentIdAndLegAndToState(UUID shipmentId, SlaLegType leg, SlaState toState);
+
+    List<SlaEscalation> findByShipmentIdOrderByCreatedAtDesc(UUID shipmentId);
+
+    Optional<SlaEscalation> findFirstByShipmentIdOrderByCreatedAtDesc(UUID shipmentId);
+}

--- a/sla/src/main/java/com/oneday/sla/repository/SlaLegRepository.java
+++ b/sla/src/main/java/com/oneday/sla/repository/SlaLegRepository.java
@@ -1,0 +1,16 @@
+package com.oneday.sla.repository;
+
+import com.oneday.common.domain.enums.SlaLegType;
+import com.oneday.sla.domain.SlaLeg;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SlaLegRepository extends JpaRepository<SlaLeg, UUID> {
+
+    List<SlaLeg> findByShipmentIdOrderBySeqAsc(UUID shipmentId);
+
+    Optional<SlaLeg> findByShipmentIdAndLeg(UUID shipmentId, SlaLegType leg);
+}

--- a/sla/src/main/java/com/oneday/sla/repository/SlaShipmentRepository.java
+++ b/sla/src/main/java/com/oneday/sla/repository/SlaShipmentRepository.java
@@ -1,0 +1,64 @@
+package com.oneday.sla.repository;
+
+import com.oneday.common.domain.enums.SlaState;
+import com.oneday.sla.domain.SlaShipment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SlaShipmentRepository extends JpaRepository<SlaShipment, UUID> {
+
+    Optional<SlaShipment> findByShipmentId(UUID shipmentId);
+
+    Optional<SlaShipment> findByShipmentRef(String shipmentRef);
+
+    /** Every still-open SLA — the sweeper's working set. */
+    List<SlaShipment> findByClosedAtIsNull();
+
+    /**
+     * Control-tower page: open shipments, optionally filtered to a colour and/or a city (matched on
+     * either origin or destination — a station manager sees a parcel touching their city either way).
+     */
+    @Query("""
+            select s from SlaShipment s
+            where s.closedAt is null
+              and (:state is null or s.overallState = :state)
+              and (:city is null or s.originCity = :city or s.destCity = :city)
+            order by s.updatedAt desc
+            """)
+    Page<SlaShipment> controlTower(@Param("state") SlaState state,
+                                   @Param("city") String city,
+                                   Pageable pageable);
+
+    /** Open shipments at or past a given colour — the red queue. */
+    @Query("""
+            select s from SlaShipment s
+            where s.closedAt is null
+              and s.overallState in :states
+              and (:city is null or s.originCity = :city or s.destCity = :city)
+            order by s.projectedFinishAt asc nulls last
+            """)
+    List<SlaShipment> openByStates(@Param("states") List<SlaState> states, @Param("city") String city);
+
+    @Query("""
+            select count(s) from SlaShipment s
+            where s.closedAt between :from and :to
+              and (:city is null or s.originCity = :city or s.destCity = :city)
+            """)
+    long countClosedBetween(@Param("from") Instant from, @Param("to") Instant to, @Param("city") String city);
+
+    @Query("""
+            select count(s) from SlaShipment s
+            where s.closedAt between :from and :to
+              and s.breached = true
+              and (:city is null or s.originCity = :city or s.destCity = :city)
+            """)
+    long countBreachedBetween(@Param("from") Instant from, @Param("to") Instant to, @Param("city") String city);
+}

--- a/sla/src/main/java/com/oneday/sla/service/EscalationService.java
+++ b/sla/src/main/java/com/oneday/sla/service/EscalationService.java
@@ -1,0 +1,94 @@
+package com.oneday.sla.service;
+
+import com.oneday.common.domain.enums.EscalationLevel;
+import com.oneday.common.domain.enums.SlaLegType;
+import com.oneday.common.domain.enums.SlaState;
+import com.oneday.common.kafka.events.sla.SlaBreachedEvent;
+import com.oneday.common.kafka.events.sla.SlaEscalationRaisedEvent;
+import com.oneday.sla.domain.SlaEscalation;
+import com.oneday.sla.domain.SlaShipment;
+import com.oneday.sla.events.SlaEventProducer;
+import com.oneday.sla.repository.SlaEscalationRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Raises escalations when a shipment enters RED / BREACHED. Each raise is an append-only
+ * {@code sla_escalation} row plus an event on {@code oneday.sla.events} (the seam the notification
+ * service / M11 consume). Idempotent per (shipment, leg, colour) so re-evaluation never double-fires.
+ *
+ * <p>Level policy (PRD RACI): RED → Station Manager (Supervisor) of the parcel's custody city;
+ * a confirmed breach → Admin / control tower. The notification service resolves the on-duty person.</p>
+ */
+@Service
+public class EscalationService {
+
+    private static final Logger log = LoggerFactory.getLogger(EscalationService.class);
+
+    private final SlaEscalationRepository escalationRepo;
+    private final SlaEventProducer producer;
+
+    public EscalationService(SlaEscalationRepository escalationRepo, SlaEventProducer producer) {
+        this.escalationRepo = escalationRepo;
+        this.producer = producer;
+    }
+
+    /** A leg went RED — notify the city's station manager. Idempotent. */
+    public void raiseRed(SlaShipment ss, SlaLegType leg, SlaState from) {
+        raise(ss, leg, from, SlaState.RED, EscalationLevel.STATION_MANAGER, "PROJECTED_BREACH");
+    }
+
+    /** The SLA is confirmed breached (target passed or hard failure) — raise to Admin + emit breach. */
+    public void raiseBreach(SlaShipment ss, SlaLegType leg, SlaState from, String reasonCode) {
+        boolean raised = raise(ss, leg, from, SlaState.BREACHED, EscalationLevel.ADMIN, reasonCode);
+        if (raised) {
+            producer.breached(new SlaBreachedEvent(
+                    ss.getShipmentId(), ss.getShipmentRef(), leg, cityFor(ss, leg),
+                    reasonCode, ss.getInternalTargetAt(), Instant.now()));
+        }
+    }
+
+    private boolean raise(SlaShipment ss, SlaLegType leg, SlaState from,
+                          SlaState to, EscalationLevel level, String reasonCode) {
+        if (escalationRepo.existsByShipmentIdAndLegAndToState(ss.getShipmentId(), leg, to)) {
+            return false;
+        }
+        String city = cityFor(ss, leg);
+        SlaEscalation esc = new SlaEscalation();
+        esc.setShipmentId(ss.getShipmentId());
+        esc.setShipmentRef(ss.getShipmentRef());
+        esc.setLeg(leg);
+        esc.setFromState(from);
+        esc.setToState(to);
+        esc.setLevel(level);
+        esc.setCity(city);
+        esc.setReasonCode(reasonCode);
+        esc.setProjectedFinishAt(ss.getProjectedFinishAt());
+        esc = escalationRepo.save(esc);
+
+        producer.escalationRaised(new SlaEscalationRaisedEvent(
+                esc.getId(), ss.getShipmentId(), ss.getShipmentRef(), leg, to, level, city,
+                reasonCode, ss.getProjectedFinishAt(), ss.getInternalTargetAt(), Instant.now()));
+
+        log.warn("SLA {} escalated to {} for shipment {} leg {} (projected {}, target {})",
+                to, level, ss.getShipmentRef(), leg, ss.getProjectedFinishAt(), ss.getInternalTargetAt());
+        return true;
+    }
+
+    /** Custody city: destination side once the parcel is on the dest legs, origin otherwise. */
+    private String cityFor(SlaShipment ss, SlaLegType leg) {
+        if (leg == SlaLegType.DEST_AIRPORT || leg == SlaLegType.DEST_HUB || leg == SlaLegType.LAST_MILE) {
+            return ss.getDestCity();
+        }
+        return ss.getOriginCity();
+    }
+
+    UUID lastEscalationId(UUID shipmentId) {
+        return escalationRepo.findFirstByShipmentIdOrderByCreatedAtDesc(shipmentId)
+                .map(SlaEscalation::getId).orElse(null);
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/service/ProjectionCalculator.java
+++ b/sla/src/main/java/com/oneday/sla/service/ProjectionCalculator.java
@@ -1,0 +1,104 @@
+package com.oneday.sla.service;
+
+import com.oneday.common.domain.enums.SlaState;
+import com.oneday.sla.domain.SlaLeg;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * The heart of M10-D-005: a deterministic buffer-aware roll-forward (not a learned ETA).
+ *
+ * <pre>
+ * projected_finish = expected_end_of_current_leg + Σ(budget of every downstream leg not yet started)
+ * RED    if projected_finish &gt; internal target
+ * AMBER  if a leg overran its own budget but projected_finish ≤ target
+ * GREEN  otherwise
+ * </pre>
+ *
+ * <p>{@code expected_end_of_current_leg} prefers the leg's enrichment estimate ({@code projectedEndAt},
+ * set from van-late / flight-cutoff / hub-deadline signals); absent that it is {@code started + budget},
+ * floored at {@code now} (an overrunning leg can finish no earlier than now — the least-alarming
+ * assumption). Pure and side-effecting only on the passed legs' {@code state}; no Spring, no I/O.</p>
+ */
+@Component
+public class ProjectionCalculator {
+
+    /** Result of a projection pass. */
+    public record Projection(Instant projectedFinishAt, SlaState overall) {}
+
+    /**
+     * Evaluate the shipment from its ordered legs. Sets each leg's {@code state} and returns the
+     * projected finish + rolled-up shipment colour (before the engine's breach upgrade).
+     */
+    public Projection evaluate(List<SlaLeg> legsOrdered, Instant internalTargetAt, Instant now) {
+        Instant projected = projectFinish(legsOrdered, now);
+        for (SlaLeg leg : legsOrdered) {
+            leg.setState(legState(leg, projected, internalTargetAt, now));
+        }
+        return new Projection(projected, rollup(legsOrdered, projected, internalTargetAt));
+    }
+
+    private Instant projectFinish(List<SlaLeg> legs, Instant now) {
+        SlaLeg current = legs.stream()
+                .filter(l -> l.getStartedAt() != null && l.getCompletedAt() == null)
+                .findFirst()
+                .orElse(null);
+
+        if (current == null) {
+            boolean anyOpen = legs.stream().anyMatch(l -> l.getCompletedAt() == null);
+            if (!anyOpen && !legs.isEmpty()) {
+                // Everything completed — finish time is the last completion.
+                return legs.get(legs.size() - 1).getCompletedAt();
+            }
+            // Nothing started yet (or a gap) — project from now through every open leg's budget.
+            long remaining = legs.stream()
+                    .filter(l -> l.getCompletedAt() == null)
+                    .mapToLong(SlaLeg::getBudgetMinutes)
+                    .sum();
+            return now.plus(Duration.ofMinutes(remaining));
+        }
+
+        Instant expectedEnd = expectedEnd(current, now);
+        long remainingAfter = legs.stream()
+                .filter(l -> l.getSeq() > current.getSeq() && l.getCompletedAt() == null)
+                .mapToLong(SlaLeg::getBudgetMinutes)
+                .sum();
+        return expectedEnd.plus(Duration.ofMinutes(remainingAfter));
+    }
+
+    private Instant expectedEnd(SlaLeg leg, Instant now) {
+        if (leg.getProjectedEndAt() != null) {
+            return leg.getProjectedEndAt().isAfter(now) ? leg.getProjectedEndAt() : now;
+        }
+        Instant budgetEnd = leg.getStartedAt().plus(Duration.ofMinutes(leg.getBudgetMinutes()));
+        return budgetEnd.isAfter(now) ? budgetEnd : now;
+    }
+
+    private SlaState legState(SlaLeg leg, Instant projectedFinish, Instant target, Instant now) {
+        if (leg.getCompletedAt() != null) {
+            // Historical: within its deadline = GREEN, overran = AMBER (it ate buffer but is done).
+            boolean late = leg.getDeadlineAt() != null && leg.getCompletedAt().isAfter(leg.getDeadlineAt());
+            return late ? SlaState.AMBER : SlaState.GREEN;
+        }
+        if (leg.getStartedAt() == null) {
+            return SlaState.GREEN; // not reached yet
+        }
+        if (projectedFinish != null && projectedFinish.isAfter(target)) {
+            return SlaState.RED;
+        }
+        boolean overBudget = leg.getDeadlineAt() != null && now.isAfter(leg.getDeadlineAt());
+        return overBudget ? SlaState.AMBER : SlaState.GREEN;
+    }
+
+    private SlaState rollup(List<SlaLeg> legs, Instant projectedFinish, Instant target) {
+        boolean anyRed = legs.stream().anyMatch(l -> l.getState() == SlaState.RED);
+        if (anyRed || (projectedFinish != null && projectedFinish.isAfter(target))) {
+            return SlaState.RED;
+        }
+        boolean anyAmber = legs.stream().anyMatch(l -> l.getState() == SlaState.AMBER);
+        return anyAmber ? SlaState.AMBER : SlaState.GREEN;
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/service/SlaEngine.java
+++ b/sla/src/main/java/com/oneday/sla/service/SlaEngine.java
@@ -1,0 +1,77 @@
+package com.oneday.sla.service;
+
+import com.oneday.common.domain.enums.SlaLegType;
+import com.oneday.common.domain.enums.SlaState;
+import com.oneday.sla.domain.SlaLeg;
+import com.oneday.sla.domain.SlaShipment;
+import com.oneday.sla.repository.SlaLegRepository;
+import com.oneday.sla.repository.SlaShipmentRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Recomputes one shipment's SLA from its legs: runs the projection, writes leg colours + the rollup,
+ * upgrades to BREACHED once the internal target actually passes, and fires escalations on the
+ * transition into RED / BREACHED. Called by both the event lifecycle and the sweeper.
+ */
+@Service
+public class SlaEngine {
+
+    private final SlaShipmentRepository shipmentRepo;
+    private final SlaLegRepository legRepo;
+    private final ProjectionCalculator projection;
+    private final EscalationService escalation;
+
+    public SlaEngine(SlaShipmentRepository shipmentRepo, SlaLegRepository legRepo,
+                     ProjectionCalculator projection, EscalationService escalation) {
+        this.shipmentRepo = shipmentRepo;
+        this.legRepo = legRepo;
+        this.projection = projection;
+        this.escalation = escalation;
+    }
+
+    @Transactional
+    public void recompute(UUID shipmentId) {
+        shipmentRepo.findByShipmentId(shipmentId).ifPresent(this::recompute);
+    }
+
+    @Transactional
+    public void recompute(SlaShipment ss) {
+        if (ss.getClosedAt() != null) {
+            return; // terminal — no further evaluation
+        }
+        Instant now = Instant.now();
+        List<SlaLeg> legs = legRepo.findByShipmentIdOrderBySeqAsc(ss.getShipmentId());
+        ProjectionCalculator.Projection p = projection.evaluate(legs, ss.getInternalTargetAt(), now);
+        legRepo.saveAll(legs);
+
+        SlaState previous = ss.getOverallState();
+        SlaLegType currentLeg = legs.stream()
+                .filter(l -> l.getCompletedAt() == null)
+                .map(SlaLeg::getLeg)
+                .findFirst()
+                .orElse(null);
+        ss.setCurrentLeg(currentLeg);
+        ss.setProjectedFinishAt(p.projectedFinishAt());
+
+        SlaState overall = p.overall();
+        boolean breached = now.isAfter(ss.getInternalTargetAt());
+        if (breached) {
+            overall = SlaState.BREACHED;
+            ss.setBreached(true);
+        }
+        ss.setOverallState(overall);
+        shipmentRepo.save(ss);
+
+        // Escalate on entering RED / BREACHED (idempotent downstream).
+        if (overall == SlaState.BREACHED && previous != SlaState.BREACHED) {
+            escalation.raiseBreach(ss, currentLeg, previous, "INTERNAL_TARGET_PASSED");
+        } else if (overall == SlaState.RED && previous != SlaState.RED && previous != SlaState.BREACHED) {
+            escalation.raiseRed(ss, currentLeg, previous);
+        }
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/service/SlaLegCatalog.java
+++ b/sla/src/main/java/com/oneday/sla/service/SlaLegCatalog.java
@@ -1,0 +1,80 @@
+package com.oneday.sla.service;
+
+import com.oneday.common.domain.enums.DeliveryType;
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.domain.enums.SlaLegType;
+import com.oneday.sla.config.SlaProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.oneday.common.domain.enums.ShipmentState.*;
+import static com.oneday.common.domain.enums.SlaLegType.*;
+
+/**
+ * The leg model: which legs a shipment traverses (by {@link DeliveryType}), each leg's budget
+ * (config, Annexure G), and the mapping from a live {@link ShipmentState} to the leg it belongs to.
+ * Pure lookups — the engine drives the timestamps.
+ */
+@Component
+public class SlaLegCatalog {
+
+    private static final List<SlaLegType> INTERCITY_PLAN =
+            List.of(FIRST_MILE, ORIGIN_HUB, ORIGIN_AIRPORT, AIR, DEST_AIRPORT, DEST_HUB, LAST_MILE);
+
+    // Same-city collapses the air legs and the second hub (M10 design Part II).
+    private static final List<SlaLegType> SAME_CITY_PLAN =
+            List.of(FIRST_MILE, ORIGIN_HUB, LAST_MILE);
+
+    // Which leg is "live" while a shipment sits in a given state. Terminal / exception states map to none.
+    private static final Map<ShipmentState, SlaLegType> STATE_TO_LEG = new EnumMap<>(ShipmentState.class);
+
+    static {
+        put(FIRST_MILE, BOOKED, PICKUP_ASSIGNED, PICKED_UP, HANDED_TO_PICKUP_VAN, RETURNED_TO_HUB, AWAITING_SELF_DROP);
+        put(ORIGIN_HUB, AT_ORIGIN_HUB, ORIGIN_HUB_PROCESSING, IN_TAKEOFF_BAG);
+        put(ORIGIN_AIRPORT, DISPATCHED_TO_AIRPORT, AT_AIRPORT);
+        put(AIR, DEPARTED);
+        put(DEST_AIRPORT, LANDED, DISPATCHED_TO_HUB);
+        put(DEST_HUB, AT_DEST_HUB, DEST_HUB_PROCESSING, AWAITING_HUB_COLLECT);
+        put(LAST_MILE, HANDED_TO_DROP_VAN, DROP_ASSIGNED, DROP_COLLECTED, HUB_DELIVERY_ASSIGNED, COLLECTED_FROM_HUB);
+    }
+
+    private static void put(SlaLegType leg, ShipmentState... states) {
+        for (ShipmentState s : states) {
+            STATE_TO_LEG.put(s, leg);
+        }
+    }
+
+    private final SlaProperties props;
+
+    public SlaLegCatalog(SlaProperties props) {
+        this.props = props;
+    }
+
+    public List<SlaLegType> plan(DeliveryType deliveryType) {
+        return deliveryType == DeliveryType.SAME_CITY ? SAME_CITY_PLAN : INTERCITY_PLAN;
+    }
+
+    public int budgetMinutes(SlaLegType leg) {
+        return props.getLegs().getOrDefault(leg, 0);
+    }
+
+    /** The leg a shipment is on while in {@code state}, if any (empty for terminal/exception states). */
+    public Optional<SlaLegType> activeLeg(ShipmentState state) {
+        return Optional.ofNullable(STATE_TO_LEG.get(state));
+    }
+
+    /** Successful delivery — the SLA closes GREEN (or BREACHED if delivered past the internal target). */
+    public boolean isTerminalSuccess(ShipmentState state) {
+        return state == DROPPED || state == HUB_COLLECTED;
+    }
+
+    /** A hard failure while still in flight — the SLA is breached but stays open until RTO/cancel. */
+    public boolean isException(ShipmentState state) {
+        return state == PICKUP_FAILED || state == DELIVERY_FAILED
+                || state == RTO_INITIATED || state == RTO_IN_TRANSIT;
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/service/SlaLifecycleService.java
+++ b/sla/src/main/java/com/oneday/sla/service/SlaLifecycleService.java
@@ -1,0 +1,285 @@
+package com.oneday.sla.service;
+
+import com.oneday.common.domain.enums.DeliveryType;
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.domain.enums.SlaLegType;
+import com.oneday.common.domain.enums.SlaState;
+import com.oneday.common.kafka.events.ShipmentCancelledEvent;
+import com.oneday.common.kafka.events.ShipmentCreatedEvent;
+import com.oneday.common.kafka.events.ShipmentStateChangedEvent;
+import com.oneday.sla.config.SlaProperties;
+import com.oneday.sla.domain.SlaLeg;
+import com.oneday.sla.domain.SlaShipment;
+import com.oneday.sla.repository.SlaLegRepository;
+import com.oneday.sla.repository.SlaShipmentRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Turns the event stream into SLA state. The {@code ShipmentStateChanged} backbone opens/closes legs;
+ * parcel-keyed enrichment (hub sort deadline, flight cutoff, loop overflow) sharpens a leg's deadline.
+ * Every mutation ends in {@link SlaEngine#recompute}.
+ *
+ * <p>v1 attribution limit (M10-D-007, self-contained): van/flight/bag-level signals that carry no
+ * parcel id can't be mapped to a shipment without a cross-module map, so they are logged, not
+ * attributed. The backbone + parcel-keyed events cover the lifecycle.</p>
+ */
+@Service
+public class SlaLifecycleService {
+
+    private static final Logger log = LoggerFactory.getLogger(SlaLifecycleService.class);
+
+    private final SlaShipmentRepository shipmentRepo;
+    private final SlaLegRepository legRepo;
+    private final SlaLegCatalog catalog;
+    private final SlaProperties props;
+    private final SlaEngine engine;
+    private final EscalationService escalation;
+
+    public SlaLifecycleService(SlaShipmentRepository shipmentRepo, SlaLegRepository legRepo,
+                               SlaLegCatalog catalog, SlaProperties props, SlaEngine engine,
+                               EscalationService escalation) {
+        this.shipmentRepo = shipmentRepo;
+        this.legRepo = legRepo;
+        this.catalog = catalog;
+        this.props = props;
+        this.engine = engine;
+        this.escalation = escalation;
+    }
+
+    // ── Backbone ───────────────────────────────────────────────────────────
+
+    @Transactional
+    public void onCreated(ShipmentCreatedEvent e) {
+        if (e.getShipmentId() == null || shipmentRepo.findByShipmentId(e.getShipmentId()).isPresent()) {
+            return; // idempotent
+        }
+        Instant booked = e.getOccurredAt() != null ? e.getOccurredAt() : Instant.now();
+        DeliveryType dt = e.getDeliveryType() != null ? e.getDeliveryType() : DeliveryType.INTERCITY;
+
+        SlaShipment ss = new SlaShipment();
+        ss.setShipmentId(e.getShipmentId());
+        ss.setShipmentRef(e.getShipmentRef());
+        ss.setOriginCity(e.getOriginCity());
+        ss.setDestCity(e.getDestCity());
+        ss.setLane(lane(e.getOriginCity(), e.getDestCity()));
+        ss.setDeliveryType(dt);
+        ss.setBookedAt(booked);
+        ss.setInternalTargetAt(booked.plus(Duration.ofHours(props.getInternalTargetHours())));
+        ss.setPublicPromiseAt(booked.plus(Duration.ofHours(props.getPublicPromiseHours())));
+        ss.setEtaPromised(e.getEtaPromised());
+        ss.setOverallState(SlaState.GREEN);
+        shipmentRepo.save(ss);
+
+        List<SlaLegType> plan = catalog.plan(dt);
+        for (int i = 0; i < plan.size(); i++) {
+            SlaLegType lt = plan.get(i);
+            SlaLeg leg = new SlaLeg();
+            leg.setShipmentId(e.getShipmentId());
+            leg.setLeg(lt);
+            leg.setSeq(i);
+            leg.setBudgetMinutes(catalog.budgetMinutes(lt));
+            if (i == 0) { // first mile is live from booking (M10-D-006)
+                leg.setStartedAt(booked);
+                leg.setDeadlineAt(booked.plus(Duration.ofMinutes(leg.getBudgetMinutes())));
+            }
+            legRepo.save(leg);
+        }
+        engine.recompute(ss);
+        log.debug("Opened SLA for {} ({} legs, target {})", e.getShipmentRef(), plan.size(), ss.getInternalTargetAt());
+    }
+
+    @Transactional
+    public void onStateChanged(ShipmentStateChangedEvent e) {
+        Optional<SlaShipment> opt = shipmentRepo.findByShipmentId(e.getShipmentId());
+        if (opt.isEmpty()) {
+            return; // no SLA opened (created event not seen) — skip in v1
+        }
+        SlaShipment ss = opt.get();
+        if (ss.getClosedAt() != null) {
+            return;
+        }
+        ShipmentState to = e.getToState();
+        Instant at = e.getOccurredAt() != null ? e.getOccurredAt() : Instant.now();
+
+        if (catalog.isTerminalSuccess(to)) {
+            closeDelivered(ss, at);
+            return;
+        }
+        if (to == ShipmentState.RTO_COMPLETED) {
+            closeReturned(ss, at);
+            return;
+        }
+        if (catalog.isException(to)) {
+            markException(ss, to, at);
+            return;
+        }
+        catalog.activeLeg(to).ifPresent(legType -> advanceTo(ss, legType, at));
+        engine.recompute(ss);
+    }
+
+    @Transactional
+    public void onCancelled(ShipmentCancelledEvent e) {
+        shipmentRepo.findByShipmentId(e.getShipmentId()).ifPresent(ss -> {
+            if (ss.getClosedAt() != null) {
+                return;
+            }
+            Instant at = e.getOccurredAt() != null ? e.getOccurredAt() : Instant.now();
+            ss.setClosedAt(at);
+            ss.setOverallState(SlaState.CLOSED); // a cancellation is not a breach
+            ss.setCurrentLeg(null);
+            shipmentRepo.save(ss);
+        });
+    }
+
+    // ── Enrichment (parcel-keyed; parcelId == shipmentId in v1) ──────────────
+
+    /** Hub staged the parcel for last-mile with an authoritative deadline → sharpen LAST_MILE. */
+    @Transactional
+    public void enrichLastMileDeadline(UUID shipmentId, Instant slaDeadline) {
+        overrideDeadline(shipmentId, SlaLegType.LAST_MILE, slaDeadline);
+    }
+
+    /** A flight was (re)assigned with a new cutoff → the parcel must clear the airport by then. */
+    @Transactional
+    public void enrichFlightCutoff(List<UUID> shipmentIds, Instant newCutoff) {
+        if (shipmentIds == null || newCutoff == null) {
+            return;
+        }
+        for (UUID id : shipmentIds) {
+            overrideDeadline(id, SlaLegType.ORIGIN_AIRPORT, newCutoff);
+        }
+    }
+
+    /** A parcel can't fit a feasible loop before its deadline → tighten the open leg + re-evaluate. */
+    @Transactional
+    public void enrichLoopOverflow(UUID shipmentId, Instant deadline) {
+        shipmentRepo.findByShipmentId(shipmentId).ifPresent(ss -> {
+            if (ss.getClosedAt() != null) {
+                return;
+            }
+            openLeg(ss.getShipmentId()).ifPresent(leg -> {
+                if (deadline != null) {
+                    leg.setDeadlineAt(deadline);
+                    leg.setSourceEvent("LOOP_OVERFLOW");
+                    legRepo.save(leg);
+                }
+            });
+            engine.recompute(ss);
+        });
+    }
+
+    /** A parcel-scoped DA signal (pickup completed / cron missed) — just re-evaluate on fresh info. */
+    @Transactional
+    public void touch(UUID shipmentId) {
+        if (shipmentId != null) {
+            engine.recompute(shipmentId);
+        }
+    }
+
+    // ── internals ────────────────────────────────────────────────────────────
+
+    private void advanceTo(SlaShipment ss, SlaLegType target, Instant at) {
+        List<SlaLeg> legs = legRepo.findByShipmentIdOrderBySeqAsc(ss.getShipmentId());
+        SlaLeg targetLeg = legs.stream().filter(l -> l.getLeg() == target).findFirst().orElse(null);
+        if (targetLeg == null) {
+            return; // state maps to a leg not in this shipment's plan (variant) — ignore
+        }
+        int k = targetLeg.getSeq();
+        for (SlaLeg leg : legs) {
+            if (leg.getSeq() < k) {
+                if (leg.getStartedAt() == null) {
+                    leg.setStartedAt(at);
+                }
+                if (leg.getCompletedAt() == null) {
+                    leg.setCompletedAt(at);
+                }
+            } else if (leg.getSeq() == k && leg.getStartedAt() == null) {
+                leg.setStartedAt(at);
+                leg.setDeadlineAt(at.plus(Duration.ofMinutes(leg.getBudgetMinutes())));
+            }
+        }
+        legRepo.saveAll(legs);
+    }
+
+    private void closeDelivered(SlaShipment ss, Instant at) {
+        completeAll(ss, at);
+        ss.setDeliveredAt(at);
+        ss.setClosedAt(at);
+        ss.setCurrentLeg(null);
+        boolean late = at.isAfter(ss.getInternalTargetAt());
+        ss.setBreached(late);
+        ss.setOverallState(late ? SlaState.BREACHED : SlaState.CLOSED);
+        shipmentRepo.save(ss);
+        if (late) {
+            escalation.raiseBreach(ss, SlaLegType.LAST_MILE, SlaState.RED, "DELIVERED_LATE");
+        }
+    }
+
+    private void closeReturned(SlaShipment ss, Instant at) {
+        completeAll(ss, at);
+        ss.setClosedAt(at);
+        ss.setCurrentLeg(null);
+        ss.setBreached(true);
+        ss.setOverallState(SlaState.BREACHED);
+        shipmentRepo.save(ss);
+    }
+
+    private void markException(SlaShipment ss, ShipmentState to, Instant at) {
+        ss.setBreached(true);
+        ss.setOverallState(SlaState.BREACHED);
+        shipmentRepo.save(ss);
+        escalation.raiseBreach(ss, ss.getCurrentLeg(), SlaState.RED, to.name());
+    }
+
+    private void completeAll(SlaShipment ss, Instant at) {
+        List<SlaLeg> legs = legRepo.findByShipmentIdOrderBySeqAsc(ss.getShipmentId());
+        for (SlaLeg leg : legs) {
+            if (leg.getStartedAt() == null) {
+                leg.setStartedAt(at);
+            }
+            if (leg.getCompletedAt() == null) {
+                leg.setCompletedAt(at);
+            }
+        }
+        legRepo.saveAll(legs);
+    }
+
+    private void overrideDeadline(UUID shipmentId, SlaLegType legType, Instant deadline) {
+        if (shipmentId == null || deadline == null) {
+            return;
+        }
+        shipmentRepo.findByShipmentId(shipmentId).ifPresent(ss -> {
+            if (ss.getClosedAt() != null) {
+                return;
+            }
+            legRepo.findByShipmentIdAndLeg(shipmentId, legType).ifPresent(leg -> {
+                leg.setDeadlineAt(deadline);
+                leg.setSourceEvent("ENRICHED");
+                legRepo.save(leg);
+            });
+            engine.recompute(ss);
+        });
+    }
+
+    private Optional<SlaLeg> openLeg(UUID shipmentId) {
+        return legRepo.findByShipmentIdOrderBySeqAsc(shipmentId).stream()
+                .filter(l -> l.getStartedAt() != null && l.getCompletedAt() == null)
+                .findFirst();
+    }
+
+    private static String lane(String origin, String dest) {
+        if (origin == null || dest == null) {
+            return null;
+        }
+        return origin + "-" + dest;
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/service/SlaQueryService.java
+++ b/sla/src/main/java/com/oneday/sla/service/SlaQueryService.java
@@ -1,0 +1,29 @@
+package com.oneday.sla.service;
+
+import com.oneday.common.domain.enums.SlaState;
+import com.oneday.sla.dto.SlaControlTowerResponse;
+import com.oneday.sla.dto.SlaEscalationView;
+import com.oneday.sla.dto.SlaPassRateResponse;
+import com.oneday.sla.dto.SlaShipmentDetailResponse;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Read side of M10 for the station-manager / admin control tower. {@code cityScope == null} means
+ * admin (all cities); a non-null value restricts to a city (matched on origin or destination).
+ */
+public interface SlaQueryService {
+
+    SlaControlTowerResponse controlTower(SlaState state, String cityScope, int page, int size);
+
+    SlaShipmentDetailResponse detail(String shipmentRef, String cityScope);
+
+    List<SlaEscalationView> redQueue(String cityScope);
+
+    SlaPassRateResponse passRate(Instant from, Instant to, String cityScope);
+
+    void acknowledge(java.util.UUID escalationId, String cityScope, String userId, String role, String notes);
+
+    void resolve(java.util.UUID escalationId, String cityScope, String userId, String role, String notes);
+}

--- a/sla/src/main/java/com/oneday/sla/service/SlaSweeper.java
+++ b/sla/src/main/java/com/oneday/sla/service/SlaSweeper.java
@@ -1,0 +1,47 @@
+package com.oneday.sla.service;
+
+import com.oneday.sla.domain.SlaShipment;
+import com.oneday.sla.repository.SlaShipmentRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Time is a signal events can't send. A leg can blow its deadline while nothing happens — no state
+ * change, no scan. This periodically re-evaluates every open shipment so a silent overrun still flips
+ * AMBER→RED and escalates. Cheap at pilot volume; recompute is idempotent.
+ */
+@Component
+public class SlaSweeper {
+
+    private static final Logger log = LoggerFactory.getLogger(SlaSweeper.class);
+
+    private final SlaShipmentRepository shipmentRepo;
+    private final SlaEngine engine;
+
+    public SlaSweeper(SlaShipmentRepository shipmentRepo, SlaEngine engine) {
+        this.shipmentRepo = shipmentRepo;
+        this.engine = engine;
+    }
+
+    @Scheduled(fixedDelayString = "${sla.sweeper-fixed-delay-ms:60000}")
+    public void sweep() {
+        List<SlaShipment> open = shipmentRepo.findByClosedAtIsNull();
+        if (open.isEmpty()) {
+            return;
+        }
+        int errors = 0;
+        for (SlaShipment ss : open) {
+            try {
+                engine.recompute(ss.getShipmentId());
+            } catch (RuntimeException ex) {
+                errors++;
+                log.warn("SLA sweep failed for shipment {}: {}", ss.getShipmentId(), ex.toString());
+            }
+        }
+        log.debug("SLA sweep evaluated {} open shipments ({} errors)", open.size(), errors);
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/service/impl/SlaQueryServiceImpl.java
+++ b/sla/src/main/java/com/oneday/sla/service/impl/SlaQueryServiceImpl.java
@@ -1,0 +1,131 @@
+package com.oneday.sla.service.impl;
+
+import com.oneday.common.domain.enums.SlaState;
+import com.oneday.sla.domain.SlaAction;
+import com.oneday.sla.domain.SlaActionType;
+import com.oneday.sla.domain.SlaEscalation;
+import com.oneday.sla.domain.SlaShipment;
+import com.oneday.sla.dto.SlaControlTowerResponse;
+import com.oneday.sla.dto.SlaEscalationView;
+import com.oneday.sla.dto.SlaLegView;
+import com.oneday.sla.dto.SlaPassRateResponse;
+import com.oneday.sla.dto.SlaShipmentDetailResponse;
+import com.oneday.sla.dto.SlaShipmentSummary;
+import com.oneday.sla.repository.SlaActionRepository;
+import com.oneday.sla.repository.SlaEscalationRepository;
+import com.oneday.sla.repository.SlaLegRepository;
+import com.oneday.sla.repository.SlaShipmentRepository;
+import com.oneday.sla.service.SlaQueryService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class SlaQueryServiceImpl implements SlaQueryService {
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final SlaShipmentRepository shipmentRepo;
+    private final SlaLegRepository legRepo;
+    private final SlaEscalationRepository escalationRepo;
+    private final SlaActionRepository actionRepo;
+
+    public SlaQueryServiceImpl(SlaShipmentRepository shipmentRepo, SlaLegRepository legRepo,
+                               SlaEscalationRepository escalationRepo, SlaActionRepository actionRepo) {
+        this.shipmentRepo = shipmentRepo;
+        this.legRepo = legRepo;
+        this.escalationRepo = escalationRepo;
+        this.actionRepo = actionRepo;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SlaControlTowerResponse controlTower(SlaState state, String cityScope, int page, int size) {
+        int p = Math.max(0, page);
+        int s = Math.min(Math.max(1, size), MAX_PAGE_SIZE);
+        Page<SlaShipment> result = shipmentRepo.controlTower(state, cityScope, PageRequest.of(p, s));
+        List<SlaShipmentSummary> items = result.getContent().stream().map(SlaShipmentSummary::from).toList();
+        return new SlaControlTowerResponse(p, s, result.getTotalElements(), items);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SlaShipmentDetailResponse detail(String shipmentRef, String cityScope) {
+        SlaShipment ss = shipmentRepo.findByShipmentRef(shipmentRef)
+                .filter(s -> visible(s, cityScope))
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "SLA not found"));
+        List<SlaLegView> legs = legRepo.findByShipmentIdOrderBySeqAsc(ss.getShipmentId()).stream()
+                .map(SlaLegView::from).toList();
+        List<SlaEscalationView> escalations = escalationRepo
+                .findByShipmentIdOrderByCreatedAtDesc(ss.getShipmentId()).stream()
+                .map(this::toEscalationView).toList();
+        return new SlaShipmentDetailResponse(SlaShipmentSummary.from(ss), legs, escalations);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<SlaEscalationView> redQueue(String cityScope) {
+        List<SlaShipment> open = shipmentRepo.openByStates(List.of(SlaState.RED, SlaState.BREACHED), cityScope);
+        return open.stream()
+                .map(ss -> escalationRepo.findFirstByShipmentIdOrderByCreatedAtDesc(ss.getShipmentId()).orElse(null))
+                .filter(e -> e != null)
+                .map(this::toEscalationView)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SlaPassRateResponse passRate(Instant from, Instant to, String cityScope) {
+        long closed = shipmentRepo.countClosedBetween(from, to, cityScope);
+        long breached = shipmentRepo.countBreachedBetween(from, to, cityScope);
+        return SlaPassRateResponse.of(from, to, cityScope, closed, breached);
+    }
+
+    @Override
+    @Transactional
+    public void acknowledge(UUID escalationId, String cityScope, String userId, String role, String notes) {
+        record(escalationId, cityScope, SlaActionType.ACKNOWLEDGE, userId, role, notes);
+    }
+
+    @Override
+    @Transactional
+    public void resolve(UUID escalationId, String cityScope, String userId, String role, String notes) {
+        record(escalationId, cityScope, SlaActionType.RESOLVE, userId, role, notes);
+    }
+
+    private void record(UUID escalationId, String cityScope, SlaActionType type,
+                        String userId, String role, String notes) {
+        SlaEscalation esc = escalationRepo.findById(escalationId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Escalation not found"));
+        if (cityScope != null && !cityScope.equals(esc.getCity())) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Escalation not found");
+        }
+        SlaAction action = new SlaAction();
+        action.setEscalationId(escalationId);
+        action.setShipmentId(esc.getShipmentId());
+        action.setAction(type);
+        action.setActedBy(userId);
+        action.setActedByRole(role);
+        action.setNotes(notes);
+        actionRepo.save(action);
+    }
+
+    private SlaEscalationView toEscalationView(SlaEscalation e) {
+        boolean acknowledged = actionRepo.existsByEscalationIdAndAction(e.getId(), SlaActionType.ACKNOWLEDGE);
+        boolean resolved = actionRepo.existsByEscalationIdAndAction(e.getId(), SlaActionType.RESOLVE);
+        return SlaEscalationView.from(e, acknowledged, resolved);
+    }
+
+    private boolean visible(SlaShipment s, String cityScope) {
+        return cityScope == null
+                || cityScope.equals(s.getOriginCity())
+                || cityScope.equals(s.getDestCity());
+    }
+}

--- a/sla/src/main/resources/db/migration/sla/V10_1__create_sla.sql
+++ b/sla/src/main/resources/db/migration/sla/V10_1__create_sla.sql
@@ -1,0 +1,79 @@
+-- M10 — SLA monitoring & escalation.
+-- Self-contained (M10-D-007): M10 owns these tables and reads other modules only via the event bus.
+-- Enum-like columns are VARCHAR + app-side @Enumerated(STRING) (no Postgres enum type coupling).
+
+-- ── Per-shipment SLA rollup (mutable) ──────────────────────────────────────
+CREATE TABLE sla_shipment (
+  id                   UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  shipment_id          UUID         NOT NULL UNIQUE,
+  shipment_ref         VARCHAR(64),
+  origin_city          VARCHAR(50),
+  dest_city            VARCHAR(50),
+  lane                 VARCHAR(24),                         -- e.g. DELHI-MUMBAI (derived)
+  delivery_type        VARCHAR(20),                         -- INTERCITY | SAME_CITY
+  booked_at            TIMESTAMPTZ  NOT NULL,               -- clock start (M10-D-006)
+  internal_target_at   TIMESTAMPTZ  NOT NULL,               -- booked_at + 16h
+  public_promise_at    TIMESTAMPTZ  NOT NULL,               -- booked_at + 24h
+  eta_promised         TIMESTAMPTZ,                         -- M4's customer-shown ETA (reference)
+  overall_state        VARCHAR(16)  NOT NULL DEFAULT 'GREEN',
+  projected_finish_at  TIMESTAMPTZ,
+  current_leg          VARCHAR(24),
+  delivered_at         TIMESTAMPTZ,
+  closed_at            TIMESTAMPTZ,
+  breached             BOOLEAN      NOT NULL DEFAULT FALSE,
+  created_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_sla_shipment_state ON sla_shipment(overall_state);
+CREATE INDEX idx_sla_shipment_open  ON sla_shipment(overall_state) WHERE closed_at IS NULL;
+CREATE INDEX idx_sla_shipment_city  ON sla_shipment(origin_city, dest_city);
+
+-- ── Per-shipment, per-leg SLA row (mutable) ────────────────────────────────
+CREATE TABLE sla_leg (
+  id                 UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  shipment_id        UUID         NOT NULL,
+  leg                VARCHAR(24)  NOT NULL,                 -- SlaLegType
+  seq                INT          NOT NULL,
+  budget_minutes     INT          NOT NULL,
+  started_at         TIMESTAMPTZ,
+  deadline_at        TIMESTAMPTZ,
+  completed_at       TIMESTAMPTZ,
+  state              VARCHAR(16)  NOT NULL DEFAULT 'GREEN',
+  projected_end_at   TIMESTAMPTZ,
+  source_event       VARCHAR(64),
+  created_at         TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at         TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  CONSTRAINT uq_sla_leg UNIQUE (shipment_id, leg)
+);
+CREATE INDEX idx_sla_leg_shipment ON sla_leg(shipment_id);
+CREATE INDEX idx_sla_leg_open ON sla_leg(deadline_at) WHERE completed_at IS NULL;
+
+-- ── Append-only escalation raise log (no UPDATE/DELETE ever issued) ─────────
+CREATE TABLE sla_escalation (
+  id                   UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  shipment_id          UUID         NOT NULL,
+  shipment_ref         VARCHAR(64),
+  leg                  VARCHAR(24),
+  from_state           VARCHAR(16),
+  to_state             VARCHAR(16)  NOT NULL,               -- RED | BREACHED
+  level                VARCHAR(20)  NOT NULL,               -- SUPERVISOR|STATION_MANAGER|ADMIN
+  city                 VARCHAR(50),
+  reason_code          VARCHAR(48),
+  projected_finish_at  TIMESTAMPTZ,
+  created_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_sla_esc_shipment ON sla_escalation(shipment_id);
+CREATE INDEX idx_sla_esc_city ON sla_escalation(city, created_at);
+
+-- ── Append-only human action log against an escalation (ack/resolve/note) ──
+CREATE TABLE sla_action (
+  id             UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  escalation_id  UUID         NOT NULL REFERENCES sla_escalation(id),
+  shipment_id    UUID         NOT NULL,
+  action         VARCHAR(24)  NOT NULL,                     -- ACKNOWLEDGE | RESOLVE | NOTE
+  acted_by       VARCHAR(64)  NOT NULL,                     -- M1 user id
+  acted_by_role  VARCHAR(32),
+  notes          TEXT,
+  created_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_sla_action_escalation ON sla_action(escalation_id);

--- a/sla/src/test/java/com/oneday/sla/service/ProjectionCalculatorTest.java
+++ b/sla/src/test/java/com/oneday/sla/service/ProjectionCalculatorTest.java
@@ -1,0 +1,110 @@
+package com.oneday.sla.service;
+
+import com.oneday.common.domain.enums.SlaLegType;
+import com.oneday.common.domain.enums.SlaState;
+import com.oneday.sla.domain.SlaLeg;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The buffer-aware projection (M10-D-005). Budgets sum to 13.5h under a 16h target, so a leg can
+ * overrun its own budget and stay AMBER while the projection still clears the target; it only flips
+ * RED once the overrun eats the 2.5h internal cushion.
+ */
+class ProjectionCalculatorTest {
+
+    private final ProjectionCalculator calc = new ProjectionCalculator();
+
+    // INTERCITY budgets (minutes) from application.yml; Σ = 810 (13.5h).
+    private static final int[] BUDGETS = {180, 60, 120, 150, 90, 60, 150};
+    private static final SlaLegType[] LEGS = SlaLegType.values(); // 7, in order
+    private final Instant t0 = Instant.parse("2026-07-17T02:30:00Z"); // 08:00 IST
+    private final Instant target = t0.plus(Duration.ofHours(16));
+
+    private List<SlaLeg> freshPlan() {
+        List<SlaLeg> legs = new ArrayList<>();
+        for (int i = 0; i < LEGS.length; i++) {
+            SlaLeg l = new SlaLeg();
+            l.setLeg(LEGS[i]);
+            l.setSeq(i);
+            l.setBudgetMinutes(BUDGETS[i]);
+            legs.add(l);
+        }
+        // First mile live from booking.
+        legs.get(0).setStartedAt(t0);
+        legs.get(0).setDeadlineAt(t0.plus(Duration.ofMinutes(BUDGETS[0])));
+        return legs;
+    }
+
+    private Instant at(long minutes) {
+        return t0.plus(Duration.ofMinutes(minutes));
+    }
+
+    @Test
+    void onTrack_isGreen() {
+        List<SlaLeg> legs = freshPlan();
+        ProjectionCalculator.Projection p = calc.evaluate(legs, target, at(60));
+        assertThat(p.overall()).isEqualTo(SlaState.GREEN);
+        assertThat(p.projectedFinishAt()).isBeforeOrEqualTo(target);
+        assertThat(legs.get(0).getState()).isEqualTo(SlaState.GREEN);
+    }
+
+    @Test
+    void legOverBudget_butProjectionClearsTarget_isAmber() {
+        List<SlaLeg> legs = freshPlan();
+        // First mile 120m past its 180m budget, still open; projection stays under the 16h target.
+        ProjectionCalculator.Projection p = calc.evaluate(legs, target, at(300));
+        assertThat(legs.get(0).getState()).isEqualTo(SlaState.AMBER);
+        assertThat(p.overall()).isEqualTo(SlaState.AMBER);
+        assertThat(p.projectedFinishAt()).isBefore(target);
+    }
+
+    @Test
+    void overrunEatsTheCushion_isRed() {
+        List<SlaLeg> legs = freshPlan();
+        // First mile 220m past budget — projection now crosses the 16h target.
+        ProjectionCalculator.Projection p = calc.evaluate(legs, target, at(400));
+        assertThat(p.projectedFinishAt()).isAfter(target);
+        assertThat(legs.get(0).getState()).isEqualTo(SlaState.RED);
+        assertThat(p.overall()).isEqualTo(SlaState.RED);
+    }
+
+    @Test
+    void completedLateLeg_staysAmberInHistory() {
+        List<SlaLeg> legs = freshPlan();
+        // First mile completed 70m late; origin-hub now live and on time.
+        legs.get(0).setCompletedAt(at(250));
+        legs.get(1).setStartedAt(at(250));
+        legs.get(1).setDeadlineAt(at(250 + 60));
+        ProjectionCalculator.Projection p = calc.evaluate(legs, target, at(280));
+        assertThat(legs.get(0).getState()).isEqualTo(SlaState.AMBER);
+        assertThat(p.overall()).isEqualTo(SlaState.AMBER);
+    }
+
+    @Test
+    void completedOnTimeLeg_isGreenHistory() {
+        List<SlaLeg> legs = freshPlan();
+        legs.get(0).setCompletedAt(at(150)); // within 180 budget
+        legs.get(1).setStartedAt(at(150));
+        legs.get(1).setDeadlineAt(at(210));
+        ProjectionCalculator.Projection p = calc.evaluate(legs, target, at(180));
+        assertThat(legs.get(0).getState()).isEqualTo(SlaState.GREEN);
+        assertThat(p.overall()).isEqualTo(SlaState.GREEN);
+    }
+
+    @Test
+    void enrichmentEstimate_overridesBudget() {
+        List<SlaLeg> legs = freshPlan();
+        // A late signal on the open first mile: it will actually finish at t0+900, blowing the target.
+        legs.get(0).setProjectedEndAt(at(900));
+        ProjectionCalculator.Projection p = calc.evaluate(legs, target, at(60));
+        assertThat(p.projectedFinishAt()).isAfter(target);
+        assertThat(p.overall()).isEqualTo(SlaState.RED);
+    }
+}

--- a/sla/src/test/java/com/oneday/sla/service/SlaLegCatalogTest.java
+++ b/sla/src/test/java/com/oneday/sla/service/SlaLegCatalogTest.java
@@ -1,0 +1,57 @@
+package com.oneday.sla.service;
+
+import com.oneday.common.domain.enums.DeliveryType;
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.domain.enums.SlaLegType;
+import com.oneday.sla.config.SlaProperties;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SlaLegCatalogTest {
+
+    private SlaLegCatalog catalog() {
+        SlaProperties props = new SlaProperties();
+        Map<SlaLegType, Integer> legs = new EnumMap<>(SlaLegType.class);
+        legs.put(SlaLegType.FIRST_MILE, 180);
+        legs.put(SlaLegType.ORIGIN_HUB, 60);
+        props.setLegs(legs);
+        return new SlaLegCatalog(props);
+    }
+
+    @Test
+    void intercityPlanHasAllSevenLegs_sameCityCollapsesToThree() {
+        SlaLegCatalog c = catalog();
+        assertThat(c.plan(DeliveryType.INTERCITY)).hasSize(7)
+                .startsWith(SlaLegType.FIRST_MILE).endsWith(SlaLegType.LAST_MILE);
+        assertThat(c.plan(DeliveryType.SAME_CITY))
+                .containsExactly(SlaLegType.FIRST_MILE, SlaLegType.ORIGIN_HUB, SlaLegType.LAST_MILE);
+    }
+
+    @Test
+    void mapsStatesToTheirLiveLeg() {
+        SlaLegCatalog c = catalog();
+        assertThat(c.activeLeg(ShipmentState.BOOKED)).contains(SlaLegType.FIRST_MILE);
+        assertThat(c.activeLeg(ShipmentState.AT_ORIGIN_HUB)).contains(SlaLegType.ORIGIN_HUB);
+        assertThat(c.activeLeg(ShipmentState.DEPARTED)).contains(SlaLegType.AIR);
+        assertThat(c.activeLeg(ShipmentState.LANDED)).contains(SlaLegType.DEST_AIRPORT);
+        assertThat(c.activeLeg(ShipmentState.HANDED_TO_DROP_VAN)).contains(SlaLegType.LAST_MILE);
+        assertThat(c.activeLeg(ShipmentState.COLLECTED_FROM_HUB)).contains(SlaLegType.LAST_MILE);
+        assertThat(c.activeLeg(ShipmentState.DROPPED)).isEmpty();
+    }
+
+    @Test
+    void classifiesTerminalAndExceptionStates() {
+        SlaLegCatalog c = catalog();
+        assertThat(c.isTerminalSuccess(ShipmentState.DROPPED)).isTrue();
+        assertThat(c.isTerminalSuccess(ShipmentState.HUB_COLLECTED)).isTrue();
+        assertThat(c.isTerminalSuccess(ShipmentState.DELIVERY_FAILED)).isFalse();
+        assertThat(c.isException(ShipmentState.PICKUP_FAILED)).isTrue();
+        assertThat(c.isException(ShipmentState.RTO_IN_TRANSIT)).isTrue();
+        assertThat(c.isException(ShipmentState.DROPPED)).isFalse();
+        assertThat(c.budgetMinutes(SlaLegType.FIRST_MILE)).isEqualTo(180);
+    }
+}


### PR DESCRIPTION
## M10 — SLA Monitoring & Escalation

Builds M10 (previously a pom-only shell) into a complete, self-contained per-leg SLA engine: it consumes lifecycle events from every module, colours each leg **GREEN / AMBER / RED** with a **buffer-aware projection**, escalates at-risk parcels to the Station Manager / Admin **before** the customer promise is at risk, keeps an append-only audit, and serves a control-tower API.

Design: `docs/M10/M10-SLA-DESIGN.md` · Plan: `docs/M10/M10-IMPLEMENTATION-PLAN.md` · Decisions: `docs/DECISIONS.md` (M10-D-001…007).

### Locked decisions
- **M10-D-005 — buffer-aware projection.** AMBER = a leg overran its own budget; **RED = the projected end-to-end finish crosses the 16h internal target**. A slow leg that downstream slack absorbs stays AMBER → fewer, truer alerts.
- **M10-D-006 — clock start = order-placed.** Both the 16h internal target and 24h public promise anchor at `BOOKED`.
- **M10-D-007 — self-contained.** M10 owns its own tables and reads other modules **only via the event bus**; it emits escalation/breach events but changes no other module's logic. (The cross-module `slaDeadline` back-fill was considered and dropped.)

### How it works
1. `ShipmentCreated` opens the SLA + a per-`DeliveryType` leg plan; anchors set from booking.
2. `ShipmentStateChanged` is the **backbone** — completes the finishing leg and opens the next (idempotent, only-advance).
3. Parcel-keyed events **enrich** deadlines: `ParcelSortedForDelivery.slaDeadline` (last mile), `FlightReassigned.newCutoff` + `parcelIds` (airport), `LoopOverflow` (open leg).
4. Every change (and a 60s **sweeper** for silent overruns) runs the projection:
   `projected_finish = expected_end_of_current_leg + Σ(budget of downstream legs)`; RED if it exceeds the 16h target.
5. On RED → append-only `sla_escalation` (Station Manager) + `SLA_ESCALATION_RAISED` on `oneday.sla.events`; on breach → Admin + `SLA_BREACHED` (→ M11 reason code). Idempotent per `(shipment, leg, colour)`.
6. Control tower: `/api/v1/sla/*` — role-gated (STATION_MANAGER own-city / ADMIN all-city), pass-rate metric, ack/act (append-only `sla_action`, `sla:red:action`).

### Leg budgets (`sla.legs`)
FIRST_MILE 180 · ORIGIN_HUB 60 · ORIGIN_AIRPORT 120 · AIR 150 · DEST_AIRPORT 90 · DEST_HUB 60 · LAST_MILE 150 = **810m (13.5h)** — leaving a 2.5h cushion under the 16h target (the AMBER band); the 16h→24h gap is the customer-facing buffer.

### What's consumed / produced
- **Consumes:** `oneday.shipments.events` (backbone), `oneday.hub.events`, `oneday.cron.events`, `oneday.da.events`, `oneday.flight.events` (dormant until M9), `oneday.exceptions.events`.
- **Produces:** `oneday.sla.events` (`SLA_ESCALATION_RAISED`, `SLA_BREACHED`) + `NotificationEventType.SLA_ESCALATION`. All additive to `common`.

### Change surface
- **New (`sla/`):** Flyway `V10_1` (`sla_shipment`/`sla_leg` mutable; `sla_escalation`/`sla_action` append-only), entities/repos, `SlaLegCatalog`, `ProjectionCalculator`, `SlaEngine`, `SlaLifecycleService`, `SlaSweeper`, `EscalationService`, topology + 6 consumers, `SlaEventProducer`, dashboard controller/service/DTOs/Authz.
- **Additive (`common`):** `EventStreams.SLA_EVENTS`, enums `SlaState`/`SlaLegType`/`EscalationLevel`/`SlaEventType`, `events/sla/*`, `NotificationEventType.SLA_ESCALATION`.
- **Config (`app`):** `sla:` block in `application.yml`.
- **No changes to any other module's logic** (M10-D-007).

### Testing
- `mvn test -pl sla` → **9 green** (`ProjectionCalculatorTest` covers GREEN, AMBER-not-RED, cushion→RED, historical AMBER, enrichment override; `SlaLegCatalogTest`).
- `mvn install -pl common,sla,app -am` → full app assembles; no regressions (routing 59, hub 34 green).

### Honest v1 limits (documented)
- Van/flight/bag-level events with no parcel id (`VAN_RUNNING_LATE`, `FLIGHT_TIME_CHANGED`, `BAG_RESCHEDULED`) are logged, not attributed — enrichment uses parcel-keyed events only.
- No live plane position (M9 stub) → air leg uses scheduled times / budget.
- Grid alerts not consumed (payloads live in the grid module, not `common`).
- Web control-tower page (`oneday-web`) and the `slaDeadline` back-fill are follow-ons.


