### PR TITLE
Driver field-gaps (Phases 1–3): contact/COD, van stop coords, re-attempt + breakdown

### DIFF
--- a/common/src/main/java/com/oneday/common/port/ShipmentContactPort.java
+++ b/common/src/main/java/com/oneday/common/port/ShipmentContactPort.java
@@ -1,0 +1,33 @@
+package com.oneday.common.port;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Batch-resolve the field-facing contact + address details a DA needs on the ground: who to call and
+ * where to go for each end of a shipment, plus the COD amount to collect. Implemented in orders (M4);
+ * consumed in dispatch (M5) so the DA app can show a "Call" button + address block + "Collect ₹X"
+ * without importing the orders module. Batch (one {@code findAllById}) to avoid an N+1 over a DA's
+ * task list. Same cross-module pattern as {@link ShipmentRefPort} / {@link ShipmentLocationPort}.
+ */
+public interface ShipmentContactPort {
+
+    /** Contact bundle per shipment id; ids without a shipment are simply absent from the map. */
+    Map<UUID, ShipmentContact> contactsFor(Collection<UUID> shipmentIds);
+
+    /**
+     * Both ends of a shipment in one record — dispatch picks the sender end for a PICKUP task and the
+     * receiver end for a DELIVERY task. Address strings are pre-composed here so the boundary stays a
+     * plain String (no cross-module Address import). {@code codAmountPaise} is null unless COD.
+     */
+    record ShipmentContact(
+            String senderName,
+            String senderPhone,
+            String originAddress,
+            String receiverName,
+            String receiverPhone,
+            String destAddress,
+            Long codAmountPaise) {
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/api/DaDispatchController.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/api/DaDispatchController.java
@@ -133,6 +133,14 @@ public class DaDispatchController {
         return daTaskService.markFailed(daId, taskId, reason);
     }
 
+    /** DA-initiated re-attempt of a FAILED task: re-queue it at the end of the DA's list this shift. */
+    @PostMapping("/tasks/{taskId}/reattempt")
+    public DaTaskView reattempt(@PathVariable UUID daId, @PathVariable UUID taskId,
+                                @AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireDaSelf(principal, daId);
+        return daTaskService.reattempt(daId, taskId);
+    }
+
     @PostMapping("/tasks/{taskId}/drop-collected")
     public DaTaskView dropCollected(@PathVariable UUID daId, @PathVariable UUID taskId,
                                     @AuthenticationPrincipal AuthUserDetails principal) {

--- a/dispatch/src/main/java/com/oneday/dispatch/service/DaTaskService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/DaTaskService.java
@@ -38,6 +38,13 @@ public interface DaTaskService {
     /** Any active task → FAILED; emits PICKUP_FAILED or DROP_FAILED by task type. */
     DaTaskView markFailed(UUID daId, UUID taskId, String reason);
 
+    /**
+     * DA-initiated re-attempt: a FAILED task (e.g. "customer not home") → QUEUED, re-queued at the end
+     * of the DA's own list so it's retried after current work this shift. Clears the terminal
+     * timestamps and emits QUEUE_REORDERED. Only a FAILED task the DA owns is eligible (409 otherwise).
+     */
+    DaTaskView reattempt(UUID daId, UUID taskId);
+
     /** VAN_MEETING city: DELIVERY task QUEUED → IN_PROGRESS (collected from the van); emits DROP_COLLECTED. */
     DaTaskView markDropCollected(UUID daId, UUID taskId);
 

--- a/dispatch/src/main/java/com/oneday/dispatch/service/DaTaskView.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/DaTaskView.java
@@ -1,5 +1,6 @@
 package com.oneday.dispatch.service;
 
+import com.oneday.common.port.ShipmentContactPort.ShipmentContact;
 import com.oneday.dispatch.domain.DispatchQueue;
 import com.oneday.dispatch.domain.TaskStatus;
 import com.oneday.dispatch.domain.TaskType;
@@ -11,6 +12,11 @@ import java.util.UUID;
  * Read model returned to the DA app — the driver's task, including the stop's
  * coordinates ({@code taskLat}/{@code taskLon}, from {@code dispatch_queue}) so the
  * app can offer a free "Open in Maps" deeplink (geo:) with no maps-API cost.
+ *
+ * <p>{@code contactName}/{@code contactPhone}/{@code addressText}/{@code codAmountPaise} are the
+ * on-the-ground fields (Call button + address block + "Collect ₹X"), populated by {@code listTasks}
+ * from {@link ShipmentContact} — the sender end for a PICKUP, the receiver end for a DELIVERY. They
+ * are null on mutation responses (the app already holds them from listTasks), like {@code shipmentRef}.
  */
 public record DaTaskView(
         UUID taskId,
@@ -22,9 +28,13 @@ public record DaTaskView(
         Instant expectedEta,
         double taskLat,
         double taskLon,
-        String paymentMode) {
+        String paymentMode,
+        String contactName,
+        String contactPhone,
+        String addressText,
+        Long codAmountPaise) {
 
-    /** Mutation responses don't need the ref (the app already holds it from listTasks). */
+    /** Mutation responses don't need the ref/contact (the app already holds them from listTasks). */
     public static DaTaskView of(DispatchQueue row) {
         return of(row, null);
     }
@@ -32,6 +42,20 @@ public record DaTaskView(
     public static DaTaskView of(DispatchQueue row, String shipmentRef) {
         return new DaTaskView(row.getId(), row.getShipmentId(), shipmentRef, row.getTaskType(),
                 row.getStatus(), row.getQueuePosition(), row.getExpectedEta(),
-                row.getTaskLat(), row.getTaskLon(), row.getPaymentMode());
+                row.getTaskLat(), row.getTaskLon(), row.getPaymentMode(),
+                null, null, null, null);
+    }
+
+    /** List rows carry the field contact — sender end for a PICKUP, receiver end for a DELIVERY. */
+    public static DaTaskView of(DispatchQueue row, String shipmentRef, ShipmentContact c) {
+        boolean pickup = row.getTaskType() == TaskType.PICKUP;
+        String name = c == null ? null : pickup ? c.senderName() : c.receiverName();
+        String phone = c == null ? null : pickup ? c.senderPhone() : c.receiverPhone();
+        String addr = c == null ? null : pickup ? c.originAddress() : c.destAddress();
+        Long cod = c == null ? null : c.codAmountPaise();
+        return new DaTaskView(row.getId(), row.getShipmentId(), shipmentRef, row.getTaskType(),
+                row.getStatus(), row.getQueuePosition(), row.getExpectedEta(),
+                row.getTaskLat(), row.getTaskLon(), row.getPaymentMode(),
+                name, phone, addr, cod);
     }
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
@@ -162,6 +162,26 @@ class DaTaskServiceImpl implements DaTaskService {
 
     @Override
     @Transactional
+    public DaTaskView reattempt(UUID daId, UUID taskId) {
+        return daStatusService.withDaLock(daId, () -> {
+            DispatchQueue task = ownedTask(daId, taskId);
+            requireStatus(task, TaskStatus.FAILED);
+            // Re-queue at the end of the DA's own list so current work continues first, then this retry.
+            int endPos = queueRepository
+                    .findByDaIdAndOperatingDateOrderByQueuePosition(daId, task.getOperatingDate()).stream()
+                    .mapToInt(DispatchQueue::getQueuePosition).max().orElse(task.getQueuePosition());
+            task.setStatus(TaskStatus.QUEUED);
+            task.setQueuePosition(endPos + 1);
+            task.setStartedAt(null);
+            task.setCompletedAt(null);
+            DaTaskView view = save(task);
+            daEventProducer.emitQueueReordered(daId, task.getCityId());
+            return view;
+        });
+    }
+
+    @Override
+    @Transactional
     public DaTaskView markDropCollected(UUID daId, UUID taskId) {
         return collectDelivery(daId, taskId, task -> { /* van pickup from the loop — no extra scan */ });
     }

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
@@ -15,6 +15,8 @@ import com.oneday.dispatch.service.DaStatusService;
 import com.oneday.dispatch.service.DaTaskService;
 import com.oneday.dispatch.service.DaTaskView;
 import com.oneday.dispatch.service.model.DaQueue;
+import com.oneday.common.port.ShipmentContactPort;
+import com.oneday.common.port.ShipmentContactPort.ShipmentContact;
 import com.oneday.common.port.ShipmentRefPort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,6 +52,7 @@ class DaTaskServiceImpl implements DaTaskService {
     private final DispatchProperties props;
     private final HubScanSeamProducer hubScanSeamProducer;
     private final ShipmentRefPort shipmentRefPort;
+    private final ShipmentContactPort shipmentContactPort;
 
     DaTaskServiceImpl(DispatchQueueRepository queueRepository,
                       DaCronAssignmentRepository cronRepository,
@@ -57,7 +60,8 @@ class DaTaskServiceImpl implements DaTaskService {
                       DaEventProducer daEventProducer,
                       DispatchProperties props,
                       HubScanSeamProducer hubScanSeamProducer,
-                      ShipmentRefPort shipmentRefPort) {
+                      ShipmentRefPort shipmentRefPort,
+                      ShipmentContactPort shipmentContactPort) {
         this.queueRepository = queueRepository;
         this.cronRepository = cronRepository;
         this.daStatusService = daStatusService;
@@ -65,6 +69,7 @@ class DaTaskServiceImpl implements DaTaskService {
         this.props = props;
         this.hubScanSeamProducer = hubScanSeamProducer;
         this.shipmentRefPort = shipmentRefPort;
+        this.shipmentContactPort = shipmentContactPort;
     }
 
     @Override
@@ -72,8 +77,12 @@ class DaTaskServiceImpl implements DaTaskService {
     public List<DaTaskView> listTasks(UUID daId, LocalDate date) {
         LocalDate day = date != null ? date : LocalDate.now(ZoneId.of(props.getShift().getZone()));
         List<DispatchQueue> rows = queueRepository.findByDaIdAndOperatingDateOrderByQueuePosition(daId, day);
-        Map<UUID, String> refs = shipmentRefPort.refsFor(rows.stream().map(DispatchQueue::getShipmentId).toList());
-        return rows.stream().map(r -> DaTaskView.of(r, refs.get(r.getShipmentId()))).toList();
+        List<UUID> shipmentIds = rows.stream().map(DispatchQueue::getShipmentId).toList();
+        Map<UUID, String> refs = shipmentRefPort.refsFor(shipmentIds);
+        Map<UUID, ShipmentContact> contacts = shipmentContactPort.contactsFor(shipmentIds);
+        return rows.stream()
+                .map(r -> DaTaskView.of(r, refs.get(r.getShipmentId()), contacts.get(r.getShipmentId())))
+                .toList();
     }
 
     @Override

--- a/dispatch/src/test/java/com/oneday/dispatch/api/DaDispatchControllerTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/api/DaDispatchControllerTest.java
@@ -144,6 +144,7 @@ class DaDispatchControllerTest {
 
     private DaTaskView sampleView() {
         return new DaTaskView(taskId, UUID.randomUUID(), "1DD-BLR-20260716-00001", TaskType.PICKUP,
-                TaskStatus.IN_PROGRESS, 0, null, 12.9716, 77.5946, "PREPAID");
+                TaskStatus.IN_PROGRESS, 0, null, 12.9716, 77.5946, "PREPAID",
+                "Asha Rao", "+919000000001", "12, MG Road, Bengaluru, 560001", null);
     }
 }

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaTaskServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaTaskServiceImplTest.java
@@ -61,7 +61,7 @@ class DaTaskServiceImplTest {
         events = mock(DaEventProducer.class);
         scanSeam = mock(com.oneday.dispatch.events.HubScanSeamProducer.class);
         service = new DaTaskServiceImpl(queueRepo, cronRepo, daStatus, events, props, scanSeam,
-                ids -> java.util.Map.of());
+                ids -> java.util.Map.of(), ids -> java.util.Map.of());
     }
 
     @Test

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaTaskServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaTaskServiceImplTest.java
@@ -163,6 +163,29 @@ class DaTaskServiceImplTest {
     }
 
     @Test
+    void reattemptRequeuesAFailedTaskAtTheEndOfTheList() {
+        DispatchQueue existing = persist(TaskType.DELIVERY, TaskStatus.QUEUED); // queue pos 0
+        DispatchQueue failed = persist(TaskType.DELIVERY, TaskStatus.IN_PROGRESS);
+        service.markFailed(da, failed.getId(), "customer not home");
+
+        service.reattempt(da, failed.getId());
+
+        DispatchQueue reloaded = reload(failed);
+        assertThat(reloaded.getStatus()).isEqualTo(TaskStatus.QUEUED);
+        assertThat(reloaded.getQueuePosition()).isGreaterThan(existing.getQueuePosition());
+        assertThat(reloaded.getCompletedAt()).isNull();
+        verify(events).emitQueueReordered(eq(da), eq(city));
+    }
+
+    @Test
+    void reattemptRejectsATaskThatIsNotFailed() {
+        DispatchQueue task = persist(TaskType.DELIVERY, TaskStatus.QUEUED);
+        assertThatThrownBy(() -> service.reattempt(da, task.getId()))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("409");
+    }
+
+    @Test
     void hubCollectMovesDeliveryToInProgressAndEmitsScanSeam() {
         DispatchQueue task = persist(TaskType.DELIVERY, TaskStatus.QUEUED);
         service.recordHubCollect(da, task.getId());

--- a/orders/src/main/java/com/oneday/orders/service/impl/ShipmentContactAdapter.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/ShipmentContactAdapter.java
@@ -1,0 +1,73 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.enums.PaymentMode;
+import com.oneday.common.port.ShipmentContactPort;
+import com.oneday.orders.domain.Address;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.repository.ShipmentRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Orders-side implementation of {@link ShipmentContactPort}: batch-reads the sender/receiver contact +
+ * a human-readable address for each end so M5's DA task list can offer Call + an address block +
+ * "Collect ₹X". Address is composed here (the only side that knows {@link Address}).
+ */
+@Component
+class ShipmentContactAdapter implements ShipmentContactPort {
+
+    private final ShipmentRepository shipmentRepository;
+
+    ShipmentContactAdapter(ShipmentRepository shipmentRepository) {
+        this.shipmentRepository = shipmentRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<UUID, ShipmentContact> contactsFor(Collection<UUID> shipmentIds) {
+        if (shipmentIds == null || shipmentIds.isEmpty()) {
+            return Map.of();
+        }
+        return shipmentRepository.findAllById(shipmentIds).stream()
+                .collect(Collectors.toMap(Shipment::getId, ShipmentContactAdapter::toContact));
+    }
+
+    private static ShipmentContact toContact(Shipment s) {
+        Long cod = s.getPaymentMode() == PaymentMode.COD ? s.getCodAmountPaise() : null;
+        return new ShipmentContact(
+                s.getSenderName(), s.getSenderPhone(), compose(s.getOriginAddress()),
+                s.getReceiverName(), s.getReceiverPhone(), compose(s.getDestAddress()),
+                cod);
+    }
+
+    /**
+     * One readable line from an {@link Address}: prefer the granular house/street/locality trio, fall
+     * back to line1/line2, then landmark, city, pincode. Blanks dropped so the string never shows
+     * gaps like ", , ".
+     */
+    static String compose(Address a) {
+        if (a == null) {
+            return null;
+        }
+        boolean hasGranular = notBlank(a.getHouseFloor()) || notBlank(a.getBuildingStreet())
+                || notBlank(a.getAreaLocality());
+        Stream<String> street = hasGranular
+                ? Stream.of(a.getHouseFloor(), a.getBuildingStreet(), a.getAreaLocality())
+                : Stream.of(a.getLine1(), a.getLine2());
+        String joined = Stream.concat(street, Stream.of(a.getLandmark(), a.getCity(), a.getPincode()))
+                .filter(ShipmentContactAdapter::notBlank)
+                .map(String::trim)
+                .collect(Collectors.joining(", "));
+        return joined.isEmpty() ? null : joined;
+    }
+
+    private static boolean notBlank(String v) {
+        return v != null && !v.isBlank();
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/service/impl/ShipmentContactAdapterTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/ShipmentContactAdapterTest.java
@@ -1,0 +1,38 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.domain.Address;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ShipmentContactAdapterTest {
+
+    @Test
+    void prefersGranularTrioAndDropsBlanks() {
+        Address a = new Address();
+        a.setHouseFloor("12, 2nd Floor");
+        a.setBuildingStreet("");          // blank → dropped
+        a.setAreaLocality("Indiranagar");
+        a.setLandmark("near Metro");
+        a.setCity("Bengaluru");
+        a.setPincode("560038");
+        assertThat(ShipmentContactAdapter.compose(a))
+                .isEqualTo("12, 2nd Floor, Indiranagar, near Metro, Bengaluru, 560038");
+    }
+
+    @Test
+    void fallsBackToLine1Line2WhenGranularBlank() {
+        Address a = new Address();
+        a.setLine1("221B Baker Street");
+        a.setLine2("Marylebone");
+        a.setCity("Bengaluru");
+        a.setPincode("560001");
+        assertThat(ShipmentContactAdapter.compose(a))
+                .isEqualTo("221B Baker Street, Marylebone, Bengaluru, 560001");
+    }
+
+    @Test
+    void nullAddressComposesToNull() {
+        assertThat(ShipmentContactAdapter.compose(null)).isNull();
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/api/RecoveryController.java
+++ b/routing/src/main/java/com/oneday/routing/api/RecoveryController.java
@@ -1,10 +1,12 @@
 package com.oneday.routing.api;
 
+import com.oneday.routing.dto.BreakdownReportRequest;
 import com.oneday.routing.dto.RecoveryRequest;
 import com.oneday.routing.service.RecoveryService;
 import com.oneday.routing.service.model.RecoverySummary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -41,5 +43,14 @@ public class RecoveryController {
         log.info("Recovery requested for van {} → recovery van {} ({})", vanId, request.recoveryVanId(), date);
         return recoveryService.recoverVan(vanId, request.recoveryVanId(), request.cityId(), date,
                 request.lastLat(), request.lastLon());
+    }
+
+    /** Van driver reports their own breakdown — raises the alert; ops dispatches recovery via /recovery. */
+    @PostMapping("/vans/{vanId}/breakdown")
+    public ResponseEntity<Void> breakdown(@PathVariable UUID vanId, @RequestBody BreakdownReportRequest request) {
+        LocalDate date = request.dateOrToday(LocalDate.now(clock));
+        log.info("Breakdown reported by driver for van {} ({})", vanId, date);
+        recoveryService.reportBreakdown(vanId, request.cityId(), date, request.lat(), request.lon());
+        return ResponseEntity.accepted().build();
     }
 }

--- a/routing/src/main/java/com/oneday/routing/api/RoutePlanController.java
+++ b/routing/src/main/java/com/oneday/routing/api/RoutePlanController.java
@@ -11,6 +11,7 @@ import com.oneday.routing.dto.OverrideRequest;
 import com.oneday.routing.dto.RoutePlanResponse;
 import com.oneday.routing.dto.RoutePlanStopResponse;
 import com.oneday.routing.dto.ShuttleTimetableResponse;
+import com.oneday.routing.service.GridDataAdapter;
 import com.oneday.routing.service.RoutePlanLifecycleService;
 import com.oneday.routing.service.ShuttleScheduleService;
 import org.slf4j.Logger;
@@ -30,6 +31,7 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -46,15 +48,18 @@ public class RoutePlanController {
 
     private final RoutePlanLifecycleService lifecycleService;
     private final ShuttleScheduleService shuttleScheduleService;
+    private final GridDataAdapter gridDataAdapter;
     private final ObjectMapper objectMapper;
     private final Clock clock;
 
     RoutePlanController(RoutePlanLifecycleService lifecycleService,
                         ShuttleScheduleService shuttleScheduleService,
+                        GridDataAdapter gridDataAdapter,
                         ObjectMapper objectMapper,
                         Clock clock) {
         this.lifecycleService = lifecycleService;
         this.shuttleScheduleService = shuttleScheduleService;
+        this.gridDataAdapter = gridDataAdapter;
         this.objectMapper = objectMapper;
         this.clock = clock;
     }
@@ -81,8 +86,9 @@ public class RoutePlanController {
         RoutePlan plan = lifecycleService.activePlan(cityId, d)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
                         "No active route plan for cityId=" + cityId + " date=" + d));
+        Map<UUID, double[]> coords = gridDataAdapter.vertexCoords(cityId);
         return lifecycleService.stops(plan.getId(), vanId).stream()
-                .map(RoutePlanStopResponse::from)
+                .map(s -> RoutePlanStopResponse.from(s, coords))
                 .toList();
     }
 

--- a/routing/src/main/java/com/oneday/routing/dto/BreakdownReportRequest.java
+++ b/routing/src/main/java/com/oneday/routing/dto/BreakdownReportRequest.java
@@ -1,0 +1,17 @@
+package com.oneday.routing.dto;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * Body for {@code POST /routing/vans/{vanId}/breakdown} — the van driver reports their own van broke
+ * down. {@code cityId} scopes the alert; {@code lat}/{@code lon} are the van's current position (from
+ * the phone) so ops can find it. Raises a {@code VAN_BREAKDOWN} alert; ops then dispatches a recovery
+ * van via {@code /recovery}. No recovery van here — the driver can't pick one.
+ */
+public record BreakdownReportRequest(UUID cityId, LocalDate date, Double lat, Double lon) {
+
+    public LocalDate dateOrToday(LocalDate today) {
+        return date != null ? date : today;
+    }
+}

--- a/routing/src/main/java/com/oneday/routing/dto/RoutePlanStopResponse.java
+++ b/routing/src/main/java/com/oneday/routing/dto/RoutePlanStopResponse.java
@@ -3,9 +3,14 @@ package com.oneday.routing.dto;
 import com.oneday.routing.domain.RoutePlanStop;
 
 import java.time.LocalTime;
+import java.util.Map;
 import java.util.UUID;
 
-/** One ordered stop + ETAs ({@code GET /routing/plans/{cityId}/vans/{vanId}/stops}). */
+/**
+ * One ordered stop + ETAs ({@code GET /routing/plans/{cityId}/vans/{vanId}/stops}). {@code lat}/{@code
+ * lon} are the meeting-vertex coordinates (the plan stores only {@code hexVertexId}), joined to the
+ * grid server-side so the van app can deep-link navigation to each stop — null if unresolvable.
+ */
 public record RoutePlanStopResponse(
         UUID stopId,
         UUID vanId,
@@ -13,6 +18,8 @@ public record RoutePlanStopResponse(
         int stopSeq,
         String nodeKind,
         UUID hexVertexId,
+        Double lat,
+        Double lon,
         LocalTime plannedArrival,
         LocalTime plannedDeparture,
         int deliverQty,
@@ -20,10 +27,18 @@ public record RoutePlanStopResponse(
         int loadAfter) {
 
     public static RoutePlanStopResponse from(RoutePlanStop s) {
+        return from(s, Map.of());
+    }
+
+    public static RoutePlanStopResponse from(RoutePlanStop s, Map<UUID, double[]> coords) {
+        double[] ll = s.getHexVertexId() != null ? coords.get(s.getHexVertexId()) : null;
         return new RoutePlanStopResponse(
                 s.getId(), s.getVanId(), s.getLoopIndex(), s.getStopSeq(),
                 s.getNodeKind() != null ? s.getNodeKind().name() : null,
-                s.getHexVertexId(), s.getPlannedArrival(), s.getPlannedDeparture(),
+                s.getHexVertexId(),
+                ll != null ? ll[0] : null,
+                ll != null ? ll[1] : null,
+                s.getPlannedArrival(), s.getPlannedDeparture(),
                 s.getDeliverQty(), s.getCollectQty(), s.getLoadAfter());
     }
 }

--- a/routing/src/main/java/com/oneday/routing/service/RecoveryService.java
+++ b/routing/src/main/java/com/oneday/routing/service/RecoveryService.java
@@ -14,6 +14,10 @@ public interface RecoveryService {
     RecoverySummary recoverVan(UUID brokenVanId, UUID recoveryVanId, UUID cityId, LocalDate date,
                                double lastLat, double lastLon);
 
+    // Driver-initiated breakdown report: emit VAN_BREAKDOWN so ops/M11 are alerted and can dispatch a
+    // recovery van (via recoverVan). No manifest move here — the driver can't pick the recovery van.
+    void reportBreakdown(UUID vanId, UUID cityId, LocalDate date, Double lat, Double lon);
+
     // DA no-show at a stop: carry that DA's still-undelivered parcels to their next loop; collections
     // are deferred (the next pickup event re-binds them).
     int carryNoShow(UUID vanId, int loopIndex, LocalDate date, int stopSeq, UUID daId);

--- a/routing/src/main/java/com/oneday/routing/service/impl/RecoveryServiceImpl.java
+++ b/routing/src/main/java/com/oneday/routing/service/impl/RecoveryServiceImpl.java
@@ -80,6 +80,17 @@ class RecoveryServiceImpl implements RecoveryService {
 
     @Override
     @Transactional
+    public void reportBreakdown(UUID vanId, UUID cityId, LocalDate date, Double lat, Double lon) {
+        List<VanManifest> manifests = manifestRepository.findByVanIdAndValidDate(vanId, date);
+        UUID routePlanId = manifests.isEmpty() ? null : manifests.get(0).getRoutePlanId();
+        // No manifest move — ops picks a recovery van and calls recoverVan. This just raises the alert.
+        cronEventProducer.emitVanBreakdown(vanId, cityId, routePlanId,
+                lat != null ? lat : 0.0, lon != null ? lon : 0.0, Instant.now(clock));
+        log.info("Breakdown reported by driver for van {} ({}) at {},{}", vanId, date, lat, lon);
+    }
+
+    @Override
+    @Transactional
     public int carryNoShow(UUID vanId, int loopIndex, LocalDate date, int stopSeq, UUID daId) {
         VanManifest manifest = manifestRepository.findByVanIdAndLoopIndexAndValidDate(vanId, loopIndex, date)
                 .orElse(null);


### PR DESCRIPTION
Backend half of the driver field-readiness work. Companion app PR in `oneday-driver-app`.

All response additions are **nullable / additive** — deploy this before the app; older clients ignore the new fields.

## Phase 1 — DA contact + address + COD amount
- New cross-module port `ShipmentContactPort` (`common`) + `ShipmentContactAdapter` (`orders`): batch-resolves sender/receiver name + phone, a composed address string, and COD amount (mirrors `ShipmentRefPort`, no N+1).
- `DaTaskView` gains `contactName`/`contactPhone`/`addressText`/`codAmountPaise`; `listTasks` fills the **sender end for a PICKUP, receiver end for a DELIVERY**. Null on mutation responses. Still gated to the assigned DA.

## Phase 2 — Van stop coordinates
- `RoutePlanStopResponse` gains `lat`/`lon`, joined from the grid via `GridDataAdapter.vertexCoords` (one lookup per `/stops` call; null if unresolvable) so the app can navigate to each stop.

## Phase 3 — Re-attempt + breakdown
- `POST /dispatch/da/{daId}/tasks/{taskId}/reattempt` — a FAILED task the DA owns → QUEUED at the end of their list this shift; clears terminal timestamps, emits `QUEUE_REORDERED` (409 if not FAILED).
- `POST /routing/vans/{vanId}/breakdown` — driver raises a `VAN_BREAKDOWN` alert (reusing the existing event; payload is just the breakdown fact) with the van's position; ops dispatch recovery via the existing `/recovery`. No manifest move.

## Tests
dispatch **27** (incl. new re-attempt cases), routing **59**, `ShipmentContactAdapter.compose` **3**; full `mvn install` assembly **BUILD SUCCESS** (JDK 21).

## Not in this PR (flagged, not forgotten)
- **Routing-module auth** — no endpoint in `routing` authenticates today; enabling it is a dedicated workstream (auth dep + security config + van-ownership check). The app sends the Bearer token already.
- Re-attempt does not retract the already-emitted `*_FAILED` event — pilot affordance; a distinct "defer" model is the cleaner long-term shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)