### PR TITLE
B2B enters dispatch/SLA + cron-aware queue reorder for all DAs

### DIFF
--- a/dispatch/src/main/java/com/oneday/dispatch/batch/QueueReorderJob.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/batch/QueueReorderJob.java
@@ -10,8 +10,10 @@ import java.time.ZoneId;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Periodic re-score so aging keeps promoting stale tasks even when no new order arrives. No-op outside
- * shift hours (no DAs loaded). Reorder itself skips cron DAs.
+ * Slow safety tick: reorder normally runs on queue-changing events (insert / drop / task completion);
+ * this periodic re-score exists only for the time-based effects no event triggers — the ≥ aging-
+ * saturation starvation promotion and cron-slack shrinking as the cutoff nears. No-op outside shift
+ * hours (no DAs loaded). Runs for cron DAs too (reorder keeps the cron cutoff feasible).
  */
 @Component
 public class QueueReorderJob {
@@ -26,7 +28,7 @@ public class QueueReorderJob {
         this.queueReorderService = queueReorderService;
     }
 
-    @Scheduled(fixedDelayString = "${dispatch.reorder.tick-seconds:180}", timeUnit = TimeUnit.SECONDS)
+    @Scheduled(fixedDelayString = "${dispatch.reorder.tick-seconds:300}", timeUnit = TimeUnit.SECONDS)
     public void tick() {
         LocalDate today = LocalDate.now(IST);
         for (var daId : daStatusService.loadedDaIds()) {

--- a/dispatch/src/main/java/com/oneday/dispatch/config/DispatchProperties.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/config/DispatchProperties.java
@@ -4,7 +4,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Every tunable threshold in M5 lives here — there are NO hardcoded literals anywhere else in the
@@ -165,6 +167,14 @@ public class DispatchProperties {
          */
         private double breakerFallbackMultiplier = 1.2;
 
+        /**
+         * Per-city overrides of the haversine travel estimate, keyed by the dispatch city id (as a
+         * string). Any unset field on an override, or a city with no entry, falls back to the global
+         * defaults above — so an empty map means "use the global values everywhere" (no behaviour
+         * change). Lets dense/irregular cities carry a higher road factor or lower speed.
+         */
+        private Map<String, CityTravel> cities = new HashMap<>();
+
         public double getRoadFactor() { return roadFactor; }
         public void setRoadFactor(double roadFactor) { this.roadFactor = roadFactor; }
         public double getAvgSpeedKmph() { return avgSpeedKmph; }
@@ -172,6 +182,37 @@ public class DispatchProperties {
         public double getBreakerFallbackMultiplier() { return breakerFallbackMultiplier; }
         public void setBreakerFallbackMultiplier(double breakerFallbackMultiplier) {
             this.breakerFallbackMultiplier = breakerFallbackMultiplier;
+        }
+        public Map<String, CityTravel> getCities() { return cities; }
+        public void setCities(Map<String, CityTravel> cities) { this.cities = cities; }
+
+        // ── Per-city resolvers (null cityId or no override → global default) ──
+        public double roadFactor(String cityId) {
+            CityTravel c = cityId == null ? null : cities.get(cityId);
+            return c != null && c.roadFactor != null ? c.roadFactor : roadFactor;
+        }
+        public double avgSpeedKmph(String cityId) {
+            CityTravel c = cityId == null ? null : cities.get(cityId);
+            return c != null && c.avgSpeedKmph != null ? c.avgSpeedKmph : avgSpeedKmph;
+        }
+        public double breakerFallbackMultiplier(String cityId) {
+            CityTravel c = cityId == null ? null : cities.get(cityId);
+            return c != null && c.breakerFallbackMultiplier != null
+                    ? c.breakerFallbackMultiplier : breakerFallbackMultiplier;
+        }
+
+        /** Optional per-city travel override; any null field inherits the global {@link Travel} default. */
+        public static class CityTravel {
+            private Double roadFactor;
+            private Double avgSpeedKmph;
+            private Double breakerFallbackMultiplier;
+
+            public Double getRoadFactor() { return roadFactor; }
+            public void setRoadFactor(Double roadFactor) { this.roadFactor = roadFactor; }
+            public Double getAvgSpeedKmph() { return avgSpeedKmph; }
+            public void setAvgSpeedKmph(Double avgSpeedKmph) { this.avgSpeedKmph = avgSpeedKmph; }
+            public Double getBreakerFallbackMultiplier() { return breakerFallbackMultiplier; }
+            public void setBreakerFallbackMultiplier(Double v) { this.breakerFallbackMultiplier = v; }
         }
     }
 
@@ -211,8 +252,14 @@ public class DispatchProperties {
         private double maxDistanceKm = 15.0;
         /** Wait (min) at which aging saturates — past this an isolated task outranks near-but-fresh ones. */
         private int ageSaturationMinutes = 120;
-        /** Periodic re-score cadence so aging keeps promoting stale tasks with no new inserts. */
-        private int tickSeconds = 180;
+        /** Slow safety-tick cadence: re-scores aging + cron slack when no insert/drop/complete event fires. */
+        private int tickSeconds = 300;
+        /**
+         * Slack (min) a cron DA must still have at the van-meeting cutoff for a task to count as
+         * pre-cron feasible during reorder. Tasks that would leave less than this are demoted to the
+         * "after van meeting" tail so the cron is never cut fine.
+         */
+        private int cronSafetyMarginMinutes = 10;
 
         public boolean isEnabled() { return enabled; }
         public void setEnabled(boolean v) { this.enabled = v; }
@@ -226,6 +273,8 @@ public class DispatchProperties {
         public void setAgeSaturationMinutes(int v) { this.ageSaturationMinutes = v; }
         public int getTickSeconds() { return tickSeconds; }
         public void setTickSeconds(int v) { this.tickSeconds = v; }
+        public int getCronSafetyMarginMinutes() { return cronSafetyMarginMinutes; }
+        public void setCronSafetyMarginMinutes(int v) { this.cronSafetyMarginMinutes = v; }
     }
 
     public static class Pickup {

--- a/dispatch/src/main/java/com/oneday/dispatch/domain/DispatchQueue.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/domain/DispatchQueue.java
@@ -67,6 +67,12 @@ public class DispatchQueue extends MutableBaseEntity {
     @Column(name = "cron_safe", nullable = false, updatable = false)
     private boolean cronSafe;
 
+    // Cron-aware reorder: true when this task can't be reached before the cron/van-meeting cutoff, so it
+    // is parked at the queue tail ("after van meeting") and excluded from pre-cron feasibility. Mutable —
+    // it flips as the DA moves, tasks arrive/complete, and the cutoff nears; auto-clears once reachable.
+    @Column(name = "beyond_cron", nullable = false)
+    private boolean beyondCron;
+
     @Column(name = "assigned_at", nullable = false, updatable = false)
     private Instant assignedAt;
 

--- a/dispatch/src/main/java/com/oneday/dispatch/service/CronFeasibilityService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/CronFeasibilityService.java
@@ -1,5 +1,10 @@
 package com.oneday.dispatch.service;
 
+import com.oneday.dispatch.service.model.LatLon;
+
+import java.time.Instant;
+import java.util.List;
+
 /**
  * The algorithmic heart of M5: given a DA's current position, queued stops, and cron meeting, decide
  * whether an incoming task can be inserted without the DA missing the van rendezvous — the
@@ -12,4 +17,14 @@ package com.oneday.dispatch.service;
 public interface CronFeasibilityService {
 
     FeasibilityResult checkFeasibility(FeasibilityRequest request);
+
+    /**
+     * Slack (seconds) the DA has left at the cron vertex after visiting {@code orderedStops} in the
+     * given order, starting from {@code current}/{@code currentTime}. Positive = arrives with margin;
+     * negative = would miss the meeting. Used by the reorder to build the largest priority-ordered
+     * prefix that still makes the cron (haversine estimate — no OSRM per reorder). {@code cityId}
+     * selects the per-city travel estimate (null → global).
+     */
+    long cronSlackSeconds(LatLon current, Instant currentTime, List<FeasibilityStop> orderedStops,
+                          LatLon cronVertex, Instant meetingTime, String cityId);
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/service/FeasibilityRequest.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/FeasibilityRequest.java
@@ -27,7 +27,8 @@ public record FeasibilityRequest(
         List<FeasibilityStop> existingQueue,
         FeasibilityStop newTask,
         LatLon cronVertex,
-        Instant scheduledMeetingTime) {
+        Instant scheduledMeetingTime,
+        String cityId) {
 
     public FeasibilityRequest {
         Objects.requireNonNull(currentPosition, "currentPosition");
@@ -36,5 +37,6 @@ public record FeasibilityRequest(
         Objects.requireNonNull(cronVertex, "cronVertex");
         Objects.requireNonNull(scheduledMeetingTime, "scheduledMeetingTime");
         existingQueue = existingQueue == null ? List.of() : List.copyOf(existingQueue);
+        // cityId is optional — null selects the global travel estimate (per-city overrides fall back to it).
     }
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/CronFeasibilityServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/CronFeasibilityServiceImpl.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.OptionalLong;
@@ -43,7 +44,9 @@ class CronFeasibilityServiceImpl implements CronFeasibilityService {
     @Override
     public FeasibilityResult checkFeasibility(FeasibilityRequest req) {
         DispatchProperties.Travel travel = props.getTravel();
-        double fastFactor = travel.getRoadFactor();
+        String cityId = req.cityId();
+        double fastFactor = travel.roadFactor(cityId);
+        double avgSpeed = travel.avgSpeedKmph(cityId);
         long confirmThresholdSeconds = props.getOsrm().getConfirmThresholdMinutes() * 60L;
 
         // Seconds available between "now" (or the IN_PROGRESS task's expected completion) and the cutoff.
@@ -55,7 +58,7 @@ class CronFeasibilityServiceImpl implements CronFeasibilityService {
 
         // Service time is constant across insertion positions, so it never affects which slot is cheapest.
         long fixedService = totalServiceSeconds(req) + req.newTask().serviceSeconds();
-        long baseTravelFast = routeTravelSeconds(nodes, fastFactor);
+        long baseTravelFast = routeTravelSeconds(nodes, fastFactor, avgSpeed);
 
         // Cheapest insertion == earliest cron arrival (the only k-dependent term is extra travel),
         // so the single cheapest slot is also the most likely to be feasible — find it once.
@@ -63,7 +66,7 @@ class CronFeasibilityServiceImpl implements CronFeasibilityService {
         long bestExtra = Long.MAX_VALUE;
         for (int k = 0; k <= n; k++) {
             long extra = extraTravelSeconds(nodes.get(k), nodes.get(k + 1),
-                    req.newTask().location(), fastFactor);
+                    req.newTask().location(), fastFactor, avgSpeed);
             if (extra < bestExtra) {
                 bestExtra = extra;
                 bestK = k;
@@ -88,13 +91,35 @@ class CronFeasibilityServiceImpl implements CronFeasibilityService {
         }
 
         // OSRM unavailable (breaker open) → conservative haversine so we never optimistically accept.
-        double consFactor = fastFactor * travel.getBreakerFallbackMultiplier();
-        long baseTravelCons = routeTravelSeconds(nodes, consFactor);
+        double consFactor = fastFactor * travel.breakerFallbackMultiplier(cityId);
+        long baseTravelCons = routeTravelSeconds(nodes, consFactor, avgSpeed);
         long extraCons = extraTravelSeconds(nodes.get(bestK), nodes.get(bestK + 1),
-                req.newTask().location(), consFactor);
+                req.newTask().location(), consFactor, avgSpeed);
         long arrivalCons = baseTravelCons + extraCons + fixedService;
         log.debug("OSRM unavailable; conservative arrival {}s vs slack {}s", arrivalCons, slackSeconds);
         return result(arrivalCons <= slackSeconds, bestK, slackSeconds - arrivalCons, extraCons, false);
+    }
+
+    @Override
+    public long cronSlackSeconds(LatLon current, Instant currentTime, List<FeasibilityStop> orderedStops,
+                                 LatLon cronVertex, Instant meetingTime, String cityId) {
+        DispatchProperties.Travel travel = props.getTravel();
+        double factor = travel.roadFactor(cityId);
+        double avgSpeed = travel.avgSpeedKmph(cityId);
+
+        // Route: current → each ordered stop (in the given order) → cron vertex.
+        List<LatLon> nodes = new ArrayList<>(orderedStops.size() + 2);
+        nodes.add(current);
+        long service = 0;
+        for (FeasibilityStop stop : orderedStops) {
+            nodes.add(stop.location());
+            service += stop.serviceSeconds();
+        }
+        nodes.add(cronVertex);
+
+        long arrival = routeTravelSeconds(nodes, factor, avgSpeed) + service;
+        long available = Duration.between(currentTime, meetingTime).getSeconds();
+        return available - arrival;
     }
 
     private static List<LatLon> routeNodes(FeasibilityRequest req) {
@@ -116,25 +141,25 @@ class CronFeasibilityServiceImpl implements CronFeasibilityService {
     }
 
     /** Sum of leg travel times along the node list, in seconds. */
-    private long routeTravelSeconds(List<LatLon> nodes, double factor) {
+    private long routeTravelSeconds(List<LatLon> nodes, double factor, double avgSpeedKmph) {
         long total = 0;
         for (int i = 0; i < nodes.size() - 1; i++) {
-            total += travelSeconds(nodes.get(i), nodes.get(i + 1), factor);
+            total += travelSeconds(nodes.get(i), nodes.get(i + 1), factor, avgSpeedKmph);
         }
         return total;
     }
 
     /** Added travel from splicing {@code via} between {@code left} and {@code right}. */
-    private long extraTravelSeconds(LatLon left, LatLon right, LatLon via, double factor) {
-        return travelSeconds(left, via, factor)
-                + travelSeconds(via, right, factor)
-                - travelSeconds(left, right, factor);
+    private long extraTravelSeconds(LatLon left, LatLon right, LatLon via, double factor, double avgSpeedKmph) {
+        return travelSeconds(left, via, factor, avgSpeedKmph)
+                + travelSeconds(via, right, factor, avgSpeedKmph)
+                - travelSeconds(left, right, factor, avgSpeedKmph);
     }
 
     /** Haversine distance scaled to road seconds: km × roadFactor ÷ km/h × 3600 (hours → seconds). */
-    private long travelSeconds(LatLon from, LatLon to, double factor) {
+    private long travelSeconds(LatLon from, LatLon to, double factor, double avgSpeedKmph) {
         double km = GeoDistance.km(from.lat(), from.lon(), to.lat(), to.lon());
-        return Math.round((km * factor / props.getTravel().getAvgSpeedKmph()) * 3600);
+        return Math.round((km * factor / avgSpeedKmph) * 3600);
     }
 
     private static List<LatLon> insert(List<LatLon> nodes, int index, LatLon point) {

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/CronMeetings.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/CronMeetings.java
@@ -1,0 +1,32 @@
+package com.oneday.dispatch.service.impl;
+
+import com.oneday.dispatch.domain.DaCronAssignment;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Comparator;
+
+/** Shared cron-meeting helpers used by both assignment (insertion) and reorder. */
+final class CronMeetings {
+
+    private CronMeetings() {}
+
+    /**
+     * The DA's next reachable van meeting: the earliest of the cron's {@code meetingTimes} strictly
+     * after {@code now}. M6 emits the whole day's loop meetings but v1 pins
+     * {@code scheduled_meeting_time} to the morning slot and never rolls it forward — so measuring
+     * slack against a meeting that already passed would mark every task infeasible mid-day. Computing
+     * the next future meeting keeps the gate honest at any hour; falls back to the persisted primary
+     * when the list is empty or the day is genuinely over (→ correctly infeasible).
+     */
+    static Instant activeMeetingTime(DaCronAssignment cron, Instant now, ZoneId zone) {
+        return cron.getMeetingTimes().stream()
+                .map(LocalTime::parse)
+                .map(t -> LocalDateTime.of(cron.getOperatingDate(), t).atZone(zone).toInstant())
+                .filter(i -> i.isAfter(now))
+                .min(Comparator.naturalOrder())
+                .orElse(cron.getScheduledMeetingTime());
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
@@ -53,6 +53,7 @@ class DaTaskServiceImpl implements DaTaskService {
     private final HubScanSeamProducer hubScanSeamProducer;
     private final ShipmentRefPort shipmentRefPort;
     private final ShipmentContactPort shipmentContactPort;
+    private final QueueReorderService queueReorderService;
 
     DaTaskServiceImpl(DispatchQueueRepository queueRepository,
                       DaCronAssignmentRepository cronRepository,
@@ -61,13 +62,15 @@ class DaTaskServiceImpl implements DaTaskService {
                       DispatchProperties props,
                       HubScanSeamProducer hubScanSeamProducer,
                       ShipmentRefPort shipmentRefPort,
-                      ShipmentContactPort shipmentContactPort) {
+                      ShipmentContactPort shipmentContactPort,
+                      QueueReorderService queueReorderService) {
         this.queueRepository = queueRepository;
         this.cronRepository = cronRepository;
         this.daStatusService = daStatusService;
         this.daEventProducer = daEventProducer;
         this.props = props;
         this.hubScanSeamProducer = hubScanSeamProducer;
+        this.queueReorderService = queueReorderService;
         this.shipmentRefPort = shipmentRefPort;
         this.shipmentContactPort = shipmentContactPort;
     }
@@ -138,6 +141,8 @@ class DaTaskServiceImpl implements DaTaskService {
             DaTaskView view = save(task);
             recordCronHandoff(daId, task.getOperatingDate(), parcelScans.size());
             onComplete.accept(task);
+            // Head removed → re-rank the remaining tail against the new head (cron-aware).
+            queueReorderService.reorder(daId, task.getOperatingDate());
             return view;
         });
     }
@@ -228,6 +233,8 @@ class DaTaskServiceImpl implements DaTaskService {
             if (codCollected) {
                 daEventProducer.emitCodCollected(daId, task.getCityId(), task.getShipmentId());
             }
+            // Head removed → re-rank the remaining tail against the new head (cron-aware).
+            queueReorderService.reorder(daId, task.getOperatingDate());
             return view;
         });
     }

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DispatchServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DispatchServiceImpl.java
@@ -161,6 +161,8 @@ class DispatchServiceImpl implements DispatchService {
             queueRepository.save(row);
             resequence(daId, date);
             rebuildMemQueue(daId, date);
+            // A drop changes the queue — re-score the remaining tail (cron-aware).
+            queueReorderService.reorder(daId, date);
             return null;
         });
         // Queue order changed → notify downstream (gated; no-op until the producer flag is on).
@@ -272,11 +274,10 @@ class DispatchServiceImpl implements DispatchService {
         queueRepository.saveAll(activeRows);
         queueRepository.save(newRow(daId, req, tileId, date, absolutePosition, crossTerritory, cronActive));
         rebuildMemQueue(daId, date);
-        // Re-score the QUEUED tail by distance + aging (no-op for cron DAs — cron order is the hard
-        // constraint). Runs under the DA lock already held by assign(...).
-        if (!cronActive) {
-            queueReorderService.reorder(daId, date);
-        }
+        // Re-score the QUEUED tail by distance + aging for every DA. For cron DAs the reorder keeps the
+        // cron cutoff feasible (tasks that don't fit are parked beyond_cron), so it is safe to run here.
+        // Runs under the DA lock already held by assign(...).
+        queueReorderService.reorder(daId, date);
 
         // Push the assignment to M4 (event-driven) — this fires exactly once per NEW task (the
         // idempotency short-circuit returns before here), so M4 transitions BOOKED→PICKUP_ASSIGNED /
@@ -419,13 +420,18 @@ class DispatchServiceImpl implements DispatchService {
             current = new LatLon(live.getLat(), live.getLon());
             currentTime = Instant.now();
         }
+        // Only tasks committed *before* the cron count against pre-cron slack. Tasks already parked
+        // "after van meeting" (beyond_cron) by the reorder are excluded, so a new task isn't wrongly
+        // rejected by load the DA won't actually do before the cron.
         List<FeasibilityStop> existing = queued.stream()
+                .filter(r -> !r.isBeyondCron())
                 .map(r -> new FeasibilityStop(new LatLon(r.getTaskLat(), r.getTaskLon()), serviceSeconds))
                 .toList();
         FeasibilityStop newTask = new FeasibilityStop(new LatLon(req.lat(), req.lon()), serviceSeconds);
         LatLon cronVertex = new LatLon(cron.getMeetingLat(), cron.getMeetingLon());
         return new FeasibilityRequest(current, currentTime, existing, newTask, cronVertex,
-                activeMeetingTime(cron, currentTime));
+                activeMeetingTime(cron, currentTime),
+                req.cityId() != null ? req.cityId().toString() : null);
     }
 
     /**
@@ -438,13 +444,7 @@ class DispatchServiceImpl implements DispatchService {
      * genuinely over (→ correctly infeasible).
      */
     private Instant activeMeetingTime(DaCronAssignment cron, Instant now) {
-        ZoneId zone = ZoneId.of(props.getShift().getZone());
-        return cron.getMeetingTimes().stream()
-                .map(LocalTime::parse)
-                .map(t -> LocalDateTime.of(cron.getOperatingDate(), t).atZone(zone).toInstant())
-                .filter(i -> i.isAfter(now))
-                .min(Comparator.naturalOrder())
-                .orElse(cron.getScheduledMeetingTime());
+        return CronMeetings.activeMeetingTime(cron, now, ZoneId.of(props.getShift().getZone()));
     }
 
     private DispatchQueue newRow(UUID daId, Request req, UUID tileId, LocalDate date,

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/QueueReorderService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/QueueReorderService.java
@@ -8,8 +8,11 @@ import com.oneday.dispatch.domain.TaskStatus;
 import com.oneday.dispatch.events.DaEventProducer;
 import com.oneday.dispatch.repository.DaCronAssignmentRepository;
 import com.oneday.dispatch.repository.DispatchQueueRepository;
+import com.oneday.dispatch.service.CronFeasibilityService;
 import com.oneday.dispatch.service.DaStatusService;
+import com.oneday.dispatch.service.FeasibilityStop;
 import com.oneday.dispatch.service.model.DaLiveStatus;
+import com.oneday.dispatch.service.model.LatLon;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -17,7 +20,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
@@ -28,9 +33,13 @@ import java.util.UUID;
  * {@code ageSaturationMinutes} — it outranks near-but-fresh tasks. The IN_PROGRESS prefix (what the DA
  * is doing / heading to) is never moved.
  *
- * <p><b>v1 scope:</b> only DAs <em>without</em> an active cron are reordered. For cron DAs the
- * cron-meeting deadline is a hard constraint and the assign path already places tasks by cheapest
- * (distance-aware) insertion; free-form reordering there is deferred to v2.</p>
+ * <p><b>Cron-aware:</b> for a DA with an active cron/van-meeting, the priority order is applied only
+ * as far as it stays cron-feasible — the largest priority-ordered prefix the DA can still finish and
+ * reach the cron vertex by cutoff (with a {@code cronSafetyMarginMinutes} buffer). Tasks that don't
+ * fit are kept on the DA but demoted to the tail and flagged {@code beyond_cron} ("after van
+ * meeting"); {@code buildFeasibility} excludes them from pre-cron slack, and they auto-promote once
+ * reachable again (after the meeting / against the next loop). As the cutoff nears the feasible
+ * prefix shrinks to empty — so the cron effectively gets 100% priority near the deadline.</p>
  */
 @Service
 public class QueueReorderService {
@@ -41,17 +50,20 @@ public class QueueReorderService {
     private final DaCronAssignmentRepository cronRepository;
     private final DaStatusService daStatusService;
     private final DaEventProducer daEventProducer;
+    private final CronFeasibilityService feasibilityService;
     private final DispatchProperties props;
 
     QueueReorderService(DispatchQueueRepository queueRepository,
                         DaCronAssignmentRepository cronRepository,
                         DaStatusService daStatusService,
                         DaEventProducer daEventProducer,
+                        CronFeasibilityService feasibilityService,
                         DispatchProperties props) {
         this.queueRepository = queueRepository;
         this.cronRepository = cronRepository;
         this.daStatusService = daStatusService;
         this.daEventProducer = daEventProducer;
+        this.feasibilityService = feasibilityService;
         this.props = props;
     }
 
@@ -61,13 +73,8 @@ public class QueueReorderService {
         if (!props.getReorder().isEnabled()) {
             return;
         }
-        // Cron DAs keep the cron-safe insertion order (v1).
-        DaCronAssignment cron = cronRepository.findByDaIdAndOperatingDate(daId, date).orElse(null);
-        if (cronActive(cron)) {
-            return;
-        }
 
-        List<DispatchQueue> active = new java.util.ArrayList<>(queueRepository
+        List<DispatchQueue> active = new ArrayList<>(queueRepository
                 .findByDaIdAndOperatingDateAndStatusIn(daId, date, List.of(TaskStatus.QUEUED, TaskStatus.IN_PROGRESS)));
         active.sort(Comparator.comparingInt(DispatchQueue::getQueuePosition));
 
@@ -75,28 +82,91 @@ public class QueueReorderService {
                 .filter(q -> q.getStatus() == TaskStatus.IN_PROGRESS).toList();
         List<DispatchQueue> queued = active.stream()
                 .filter(q -> q.getStatus() == TaskStatus.QUEUED).toList();
-        if (queued.size() <= 1) {
-            return;   // nothing to reorder
+        if (queued.isEmpty()) {
+            return;
         }
 
-        double[] anchor = anchor(inProgress, daId);
+        // Where the DA is / will be next, and when — the reference point for both scoring and cron feasibility.
+        double[] anchorLoc;
+        Instant anchorTime;
+        if (!inProgress.isEmpty()) {
+            DispatchQueue head = inProgress.stream()
+                    .max(Comparator.comparing(r -> r.getExpectedEta() != null ? r.getExpectedEta() : Instant.now()))
+                    .orElseThrow();
+            anchorLoc = new double[] {head.getTaskLat(), head.getTaskLon()};
+            anchorTime = head.getExpectedEta() != null ? head.getExpectedEta() : Instant.now();
+        } else {
+            DaLiveStatus live = daStatusService.getLiveStatus(daId);
+            anchorLoc = (live != null && live.getLat() != null && live.getLon() != null)
+                    ? new double[] {live.getLat(), live.getLon()} : null;
+            anchorTime = Instant.now();
+        }
+
         Instant now = Instant.now();
-        List<DispatchQueue> reordered = queued.stream()
-                .sorted(Comparator.comparingDouble((DispatchQueue q) -> priority(q, anchor, now)).reversed())
+        List<DispatchQueue> byPriority = queued.stream()
+                .sorted(Comparator.comparingDouble((DispatchQueue q) -> priority(q, anchorLoc, now)).reversed())
                 .toList();
 
-        if (sameOrder(queued, reordered)) {
-            return;   // already optimal — no churn
+        DaCronAssignment cron = cronRepository.findByDaIdAndOperatingDate(daId, date).orElse(null);
+        // Cron-constrain only when we know where the DA is (no anchor → can't assess feasibility, reorder freely).
+        boolean cronActive = cronActive(cron) && anchorLoc != null;
+
+        // Desired result: ordered tasks + whether each is parked beyond the cron. Computed without
+        // mutating the entities, so the no-churn check below is accurate.
+        List<Desired> desired = cronActive
+                ? cronConstrained(byPriority, anchorLoc, anchorTime, cron, now)
+                : byPriority.stream().map(q -> new Desired(q, false)).toList();
+
+        if (unchanged(queued, desired)) {
+            return;
         }
 
         int pos = inProgress.size();
-        for (DispatchQueue q : reordered) {
-            q.setQueuePosition(pos++);
+        for (Desired d : desired) {
+            d.task().setQueuePosition(pos++);
+            d.task().setBeyondCron(d.beyondCron());
         }
-        queueRepository.saveAll(reordered);
+        List<DispatchQueue> toSave = desired.stream().map(Desired::task).toList();
+        queueRepository.saveAll(toSave);
         QueueMirror.rebuild(daStatusService, queueRepository, daId, date);
         daEventProducer.emitQueueReordered(daId, queued.get(0).getCityId());
-        log.debug("Reordered {} queued tasks for DA {}", queued.size(), daId);
+        long beyond = desired.stream().filter(Desired::beyondCron).count();
+        log.debug("Reordered {} queued tasks for DA {} ({} beyond-cron)", queued.size(), daId, beyond);
+    }
+
+    /**
+     * Greedy cron-feasible prefix: take tasks in priority order, keeping each only while the whole
+     * accepted sequence still reaches the cron vertex with at least the safety margin to spare. Tasks
+     * that would cut it too fine are demoted (beyond-cron), in priority order among themselves.
+     */
+    private List<Desired> cronConstrained(List<DispatchQueue> byPriority, double[] anchorLoc,
+                                          Instant anchorTime, DaCronAssignment cron, Instant now) {
+        LatLon current = new LatLon(anchorLoc[0], anchorLoc[1]);
+        LatLon cronVertex = new LatLon(cron.getMeetingLat(), cron.getMeetingLon());
+        Instant meetingTime = CronMeetings.activeMeetingTime(cron, now, ZoneId.of(props.getShift().getZone()));
+        long marginSec = props.getReorder().getCronSafetyMarginMinutes() * 60L;
+        long serviceSec = props.getService().getDefaultMinutes() * 60L;
+        String cityId = cron.getCityId() != null ? cron.getCityId().toString() : null;
+
+        List<DispatchQueue> accepted = new ArrayList<>();
+        List<Desired> beyond = new ArrayList<>();
+        for (DispatchQueue q : byPriority) {
+            List<FeasibilityStop> trial = new ArrayList<>(accepted.size() + 1);
+            for (DispatchQueue a : accepted) {
+                trial.add(new FeasibilityStop(new LatLon(a.getTaskLat(), a.getTaskLon()), serviceSec));
+            }
+            trial.add(new FeasibilityStop(new LatLon(q.getTaskLat(), q.getTaskLon()), serviceSec));
+            long slack = feasibilityService.cronSlackSeconds(current, anchorTime, trial, cronVertex, meetingTime, cityId);
+            if (slack >= marginSec) {
+                accepted.add(q);
+            } else {
+                beyond.add(new Desired(q, true));
+            }
+        }
+        List<Desired> result = new ArrayList<>(byPriority.size());
+        accepted.forEach(q -> result.add(new Desired(q, false)));
+        result.addAll(beyond);
+        return result;
     }
 
     /**
@@ -123,22 +193,12 @@ public class QueueReorderService {
         return cfg.getDistanceWeight() * dScore + cfg.getAgeWeight() * aScore;
     }
 
-    /** Where the DA is heading: its in-progress stop, else its last GPS, else none. */
-    private double[] anchor(List<DispatchQueue> inProgress, UUID daId) {
-        if (!inProgress.isEmpty()) {
-            DispatchQueue head = inProgress.get(inProgress.size() - 1);
-            return new double[] {head.getTaskLat(), head.getTaskLon()};
-        }
-        DaLiveStatus live = daStatusService.getLiveStatus(daId);
-        if (live != null && live.getLat() != null && live.getLon() != null) {
-            return new double[] {live.getLat(), live.getLon()};
-        }
-        return null;
-    }
-
-    private static boolean sameOrder(List<DispatchQueue> a, List<DispatchQueue> b) {
-        for (int i = 0; i < a.size(); i++) {
-            if (!a.get(i).getShipmentId().equals(b.get(i).getShipmentId())) {
+    /** True when the desired order + beyond-cron flags already match the current queued rows. */
+    private static boolean unchanged(List<DispatchQueue> current, List<Desired> desired) {
+        for (int i = 0; i < current.size(); i++) {
+            DispatchQueue cur = current.get(i);
+            Desired des = desired.get(i);
+            if (!cur.getShipmentId().equals(des.task().getShipmentId()) || cur.isBeyondCron() != des.beyondCron()) {
                 return false;
             }
         }
@@ -151,4 +211,7 @@ public class QueueReorderService {
                 && cron.getStatus() != CronAssignmentStatus.CANCELLED
                 && cron.getStatus() != CronAssignmentStatus.MISSED;
     }
+
+    /** A queued task's target place in the reordered tail. */
+    private record Desired(DispatchQueue task, boolean beyondCron) {}
 }

--- a/dispatch/src/main/resources/db/migration/dispatch/V5_10__add_beyond_cron.sql
+++ b/dispatch/src/main/resources/db/migration/dispatch/V5_10__add_beyond_cron.sql
@@ -1,0 +1,4 @@
+-- Cron-aware reorder: marks a QUEUED task the DA can't reach before its cron/van-meeting cutoff.
+-- Such a task is kept on the same DA but demoted to the tail ("after van meeting") and excluded from
+-- pre-cron feasibility; it auto-promotes once reachable again. Mutable (unlike insertion-time cron_safe).
+ALTER TABLE dispatch_queue ADD COLUMN beyond_cron BOOLEAN NOT NULL DEFAULT false;

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/CronFeasibilityServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/CronFeasibilityServiceImplTest.java
@@ -152,7 +152,7 @@ class CronFeasibilityServiceImplTest {
         // The DA is already 4 km out with only 1008 s of slack; reaching the cron 20 km out (≈3226 s)
         // busts it. Anchoring at the in-progress position is what makes this infeasible.
         FeasibilityRequest fromInProgress = new FeasibilityRequest(
-                north(4), BASE, List.of(), task(4), north(20), BASE.plusSeconds(1008));
+                north(4), BASE, List.of(), task(4), north(20), BASE.plusSeconds(1008), null);
 
         FeasibilityResult r = service.checkFeasibility(fromInProgress);
 
@@ -201,6 +201,6 @@ class CronFeasibilityServiceImplTest {
     private static FeasibilityRequest req(LatLon current, List<FeasibilityStop> existing,
                                           FeasibilityStop newTask, LatLon cron, long slackSeconds) {
         return new FeasibilityRequest(current, BASE, existing, newTask, cron,
-                BASE.plusSeconds(slackSeconds));
+                BASE.plusSeconds(slackSeconds), null);
     }
 }

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaTaskServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaTaskServiceImplTest.java
@@ -60,8 +60,9 @@ class DaTaskServiceImplTest {
         daStatus.initShift(da, city, today, "MORNING", null);
         events = mock(DaEventProducer.class);
         scanSeam = mock(com.oneday.dispatch.events.HubScanSeamProducer.class);
+        QueueReorderService reorder = mock(QueueReorderService.class);
         service = new DaTaskServiceImpl(queueRepo, cronRepo, daStatus, events, props, scanSeam,
-                ids -> java.util.Map.of(), ids -> java.util.Map.of());
+                ids -> java.util.Map.of(), ids -> java.util.Map.of(), reorder);
     }
 
     @Test

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/QueueReorderServiceTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/QueueReorderServiceTest.java
@@ -1,6 +1,8 @@
 package com.oneday.dispatch.service.impl;
 
 import com.oneday.dispatch.config.DispatchProperties;
+import com.oneday.dispatch.domain.CronAssignmentStatus;
+import com.oneday.dispatch.domain.DaCronAssignment;
 import com.oneday.dispatch.domain.DaStatusEnum;
 import com.oneday.dispatch.domain.DispatchQueue;
 import com.oneday.dispatch.domain.TaskStatus;
@@ -8,7 +10,9 @@ import com.oneday.dispatch.domain.TaskType;
 import com.oneday.dispatch.events.DaEventProducer;
 import com.oneday.dispatch.repository.DaCronAssignmentRepository;
 import com.oneday.dispatch.repository.DispatchQueueRepository;
+import com.oneday.dispatch.service.CronFeasibilityService;
 import com.oneday.dispatch.service.DaStatusService;
+import com.oneday.dispatch.service.FeasibilityStop;
 import com.oneday.dispatch.service.model.DaLiveStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,6 +37,7 @@ class QueueReorderServiceTest {
     private DaCronAssignmentRepository cronRepo;
     private DaStatusService daStatus;
     private DaEventProducer events;
+    private CronFeasibilityService feasibility;
     private QueueReorderService service;
 
     private final UUID daId = UUID.randomUUID();
@@ -45,12 +50,15 @@ class QueueReorderServiceTest {
         cronRepo = mock(DaCronAssignmentRepository.class);
         daStatus = mock(DaStatusService.class);
         events = mock(DaEventProducer.class);
-        service = new QueueReorderService(queueRepo, cronRepo, daStatus, events, new DispatchProperties());
-        when(cronRepo.findByDaIdAndOperatingDate(daId, date)).thenReturn(Optional.empty()); // no cron
+        feasibility = mock(CronFeasibilityService.class);
+        service = new QueueReorderService(queueRepo, cronRepo, daStatus, events, feasibility, new DispatchProperties());
+        when(cronRepo.findByDaIdAndOperatingDate(daId, date)).thenReturn(Optional.empty()); // no cron by default
         // Anchor at (0,0) — the DA's GPS (no in-progress task).
         when(daStatus.getLiveStatus(daId))
                 .thenReturn(new DaLiveStatus(daId, city, 0.0, 0.0, null, DaStatusEnum.IDLE, "SHIFT_1"));
     }
+
+    // ── non-cron reorder ─────────────────────────────────────────────────────
 
     @Test
     void agedFarTaskOvertakesFreshNearTask() {
@@ -80,6 +88,74 @@ class QueueReorderServiceTest {
         assertThat(head.getQueuePosition()).isEqualTo(0);      // pinned
         assertThat(farOld.getQueuePosition()).isEqualTo(1);    // reordered tail starts after the head
         assertThat(nearFresh.getQueuePosition()).isEqualTo(2);
+    }
+
+    // ── cron-aware reorder ───────────────────────────────────────────────────
+
+    @Test
+    void cronRiskyTaskIsDemotedBeyondCron() {
+        // Two queued tasks under a cron. The near/high-priority one fits before the cron; adding the
+        // far one busts it → the far one is kept but parked "after van meeting".
+        DispatchQueue near = queued(0, 0.01, 0.01, Instant.now());
+        DispatchQueue far = queued(1, 0.3, 0.3, Instant.now());
+        when(queueRepo.findByDaIdAndOperatingDateAndStatusIn(eq(daId), eq(date), any()))
+                .thenReturn(List.of(near, far));
+        withCron();
+        // Accepting one stop is feasible; accepting two would miss the cron.
+        when(feasibility.cronSlackSeconds(any(), any(), any(), any(), any(), any()))
+                .thenAnswer(inv -> ((List<FeasibilityStop>) inv.getArgument(2)).size() == 1 ? 100_000L : -1L);
+
+        service.reorder(daId, date);
+
+        assertThat(near.getQueuePosition()).isEqualTo(0);
+        assertThat(near.isBeyondCron()).isFalse();
+        assertThat(far.getQueuePosition()).isEqualTo(1);
+        assertThat(far.isBeyondCron()).isTrue();               // demoted, kept on the DA
+        verify(events).emitQueueReordered(daId, city);
+    }
+
+    @Test
+    void whenNothingFitsAllTasksAreBeyondCron() {
+        // Near the cutoff no queued task fits → all beyond-cron, so the DA's next move is the cron itself.
+        DispatchQueue a = queued(0, 0.01, 0.01, Instant.now());
+        DispatchQueue b = queued(1, 0.3, 0.3, Instant.now());
+        when(queueRepo.findByDaIdAndOperatingDateAndStatusIn(eq(daId), eq(date), any()))
+                .thenReturn(List.of(a, b));
+        withCron();
+        when(feasibility.cronSlackSeconds(any(), any(), any(), any(), any(), any())).thenReturn(-1L);
+
+        service.reorder(daId, date);
+
+        assertThat(a.isBeyondCron()).isTrue();
+        assertThat(b.isBeyondCron()).isTrue();
+    }
+
+    @Test
+    void beyondCronTaskPromotesWhenReachableAgain() {
+        // A task parked beyond the cron becomes feasible again (e.g. after the meeting rolls forward).
+        DispatchQueue parked = queued(0, 0.01, 0.01, Instant.now());
+        parked.setBeyondCron(true);
+        when(queueRepo.findByDaIdAndOperatingDateAndStatusIn(eq(daId), eq(date), any()))
+                .thenReturn(List.of(parked));
+        withCron();
+        when(feasibility.cronSlackSeconds(any(), any(), any(), any(), any(), any())).thenReturn(100_000L);
+
+        service.reorder(daId, date);
+
+        assertThat(parked.isBeyondCron()).isFalse();           // promoted back into the pre-cron queue
+        verify(events).emitQueueReordered(daId, city);
+    }
+
+    private void withCron() {
+        DaCronAssignment cron = new DaCronAssignment();
+        cron.setDaId(daId);
+        cron.setCityId(city);
+        cron.setOperatingDate(date);
+        cron.setMeetingLat(1.0);
+        cron.setMeetingLon(1.0);
+        cron.setScheduledMeetingTime(Instant.now().plus(2, ChronoUnit.HOURS));
+        cron.setStatus(CronAssignmentStatus.SCHEDULED);
+        when(cronRepo.findByDaIdAndOperatingDate(daId, date)).thenReturn(Optional.of(cron));
     }
 
     private DispatchQueue queued(int pos, double lat, double lon, Instant assignedAt) {

--- a/orders/src/main/java/com/oneday/orders/events/ShipmentBooked.java
+++ b/orders/src/main/java/com/oneday/orders/events/ShipmentBooked.java
@@ -3,8 +3,9 @@ package com.oneday.orders.events;
 import com.oneday.orders.domain.Shipment;
 
 /**
- * In-process (NOT Kafka) Spring {@code ApplicationEvent}, published by
- * {@code BookingServiceImpl} after a shipment is persisted in {@code BOOKED} state.
+ * In-process (NOT Kafka) Spring {@code ApplicationEvent}, published by the booking services
+ * ({@code BookingServiceImpl} for B2C, {@code B2bBookingServiceImpl} for B2B) after a shipment is
+ * persisted in {@code BOOKED} state.
  *
  * <p>{@link ShipmentEventProducer} maps it to the outbound Kafka {@code ShipmentCreatedEvent}
  * after the booking transaction commits (AFTER_COMMIT).</p>

--- a/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
@@ -35,9 +35,11 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
+import com.oneday.orders.events.ShipmentBooked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -64,6 +66,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
     private final CustomerVisibleStateMapper stateMapper;
     private final WalletService walletService;
     private final TransactionTemplate tx;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     private final CircuitBreaker serviceabilityCb;
     private final CircuitBreaker pricingCb;
@@ -84,6 +87,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
                           CustomerVisibleStateMapper stateMapper,
                           WalletService walletService,
                           TransactionTemplate transactionTemplate,
+                          ApplicationEventPublisher applicationEventPublisher,
                           CircuitBreakerRegistry circuitBreakerRegistry,
                           TimeLimiterRegistry timeLimiterRegistry,
                           @Qualifier("resilienceScheduler") ScheduledExecutorService resilienceScheduler) {
@@ -98,6 +102,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
         this.stateMapper          = stateMapper;
         this.walletService        = walletService;
         this.tx                   = transactionTemplate;
+        this.applicationEventPublisher = applicationEventPublisher;
         this.serviceabilityCb     = circuitBreakerRegistry.circuitBreaker("serviceability");
         this.pricingCb            = circuitBreakerRegistry.circuitBreaker("pricing");
         this.serviceabilityTl     = timeLimiterRegistry.timeLimiter("serviceability");
@@ -300,6 +305,11 @@ class B2bBookingServiceImpl implements B2bBookingService {
             log.warn("ETA fetch failed for B2B shipment {}; booking proceeds without ETA: {}",
                     shipment.getId(), e.getMessage());
         }
+
+        // ── Emit CREATED — in-process; ShipmentEventProducer publishes AFTER_COMMIT, so a rolled-back
+        //    booking never produces a phantom event. This is what starts the B2B lifecycle: M5 pickup
+        //    assignment, M10 SLA, and (via delivery) COD collection — same as the B2C path. ──────────
+        applicationEventPublisher.publishEvent(new ShipmentBooked(shipment));
 
         // ── 6. Build response (payment = null for B2B) ─────────────────────────
         BookingResponse.PricingDetails pricing = new BookingResponse.PricingDetails();

--- a/orders/src/test/java/com/oneday/orders/service/impl/B2bBookingServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/B2bBookingServiceImplTest.java
@@ -66,6 +66,7 @@ class B2bBookingServiceImplTest {
     @Mock private ShipmentStateHistoryRepository historyRepository;
     @Mock private com.oneday.orders.repository.CodCollectionRepository codCollectionRepository;
     @Mock private com.oneday.orders.service.WalletService walletService;
+    @Mock private org.springframework.context.ApplicationEventPublisher applicationEventPublisher;
 
     private static final AbstractPlatformTransactionManager NO_OP_TX =
             new AbstractPlatformTransactionManager() {
@@ -94,6 +95,7 @@ class B2bBookingServiceImplTest {
                 b2bAccountRepository, serviceabilityPort, pricingPort, etaPort,
                 shipmentRefService, shipmentRepository, historyRepository,
                 codCollectionRepository, stateMapper, walletService, new TransactionTemplate(NO_OP_TX),
+                applicationEventPublisher,
                 CircuitBreakerRegistry.ofDefaults(),
                 TimeLimiterRegistry.ofDefaults(),
                 scheduler);
@@ -145,6 +147,13 @@ class B2bBookingServiceImplTest {
         assertThat(resp.getPayment()).isNull();
         assertThat(resp.getEtaPromised()).isNotNull();
         assertThat(resp.getSlaCommitmentMinutes()).isEqualTo(1440);
+
+        // CREATED is emitted so M5 (pickup), M10 (SLA) and COD collection actually run for B2B —
+        // this is the fix that starts the B2B lifecycle (previously only the B2C path published it).
+        ArgumentCaptor<com.oneday.orders.events.ShipmentBooked> bookedCaptor =
+                ArgumentCaptor.forClass(com.oneday.orders.events.ShipmentBooked.class);
+        verify(applicationEventPublisher).publishEvent(bookedCaptor.capture());
+        assertThat(bookedCaptor.getValue().shipment().getShipmentRef()).isEqualTo(SHIPMENT_REF);
     }
 
     // ── account not found ──────────────────────────────────────────────────


### PR DESCRIPTION
Two follow-ups from the staging E2E of the Phase-2 dispatch features (#84).

## Part 1 — B2B publishes `ShipmentCreated`

During E2E a B2B order got its `scheduled_pickup_*` columns but no dispatch hold and no SLA row. Root cause: only the B2C `BookingServiceImpl` published the in-process `ShipmentBooked` (→ `ShipmentCreatedEvent` AFTER_COMMIT); `B2bBookingServiceImpl.persistB2b` never did — and every B2B path (portal, dev-API, cart/bulk via `CartServiceImpl → b2bBookingService.book`) funnels through it.

- `B2bBookingServiceImpl` injects `ApplicationEventPublisher` and publishes `ShipmentBooked` at the end of `persistB2b` (inside the tx → AFTER_COMMIT, same guarantee as B2C).
- No producer/consumer/schema change: the CREATED event already maps `b2bAccountId`/`scheduledPickup*`/tiles/coords; the dispatch consumer is null-safe on `paymentMode`.
- **Unblocks the whole B2B lifecycle** — M5 pickup assignment, M10 SLA, and COD collection (`CodCollectionListener` fires on `DROPPED`/`HUB_COLLECTED`) were all inert while B2B shipments sat at `BOOKED`.
- Test: `B2bBookingServiceImplTest` asserts the event fires.

## Part 2 — cron-aware queue reorder (all DAs)

Reorder previously skipped cron DAs. It now runs for every DA, constrained so the cron/van-meeting cutoff is never jeopardised.

- `dispatch_queue.beyond_cron` (`V5_10`, mutable): a task the DA can't reach before the cutoff — kept on the DA but demoted to the tail ("after van meeting").
- `CronFeasibilityService.cronSlackSeconds(...)`: whole-sequence slack (haversine, no per-tick OSRM). OSRM stays only at the insertion cron gate.
- `QueueReorderService` builds the largest priority-ordered prefix that still makes the cron with a `cronSafetyMarginMinutes` (=10) buffer; the rest go `beyond_cron` and auto-promote once reachable again (`activeMeetingTime` rolls to the next loop). As the cutoff nears the feasible prefix shrinks to empty → the cron gets 100% priority.
- `buildFeasibility` excludes `beyond_cron` rows from pre-cron slack. Reorder now runs for cron DAs (removed the `!cronActive` guard), on drop (`cancelTask`), and on head-completion (`DaTaskServiceImpl`); `QueueReorderJob` tick 180→300s (a safety net — insert/drop/complete events are the primary trigger).
- Anchor = head task location (in-progress, else GPS), not live GPS mid-task.
- Travel estimate is city-tunable: `DispatchProperties.Travel.cities` resolvers threaded via a nullable `FeasibilityRequest.cityId` (empty map = global defaults, zero behaviour change). `activeMeetingTime` extracted to `CronMeetings`.
- Tests: `QueueReorderServiceTest` (cron demote / all-beyond-cron / promote-back), `CronFeasibilityServiceImplTest` updated.

## Verification
- `mvn install -DexcludedGroups=e2e` → BUILD SUCCESS.

## Out of scope (flagged)
- Driver-app "after van meeting" surfacing of `beyond_cron` (frontend).
- Per-city travel keys are the dispatch city id (UUID) with a global fallback; can move to city-code keys later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)