### PR TITLE
Platform-wide structured logging + queryable audit trail (Axiom)

### DIFF
--- a/app/src/main/java/com/oneday/app/log/RequestIdFilter.java
+++ b/app/src/main/java/com/oneday/app/log/RequestIdFilter.java
@@ -1,0 +1,47 @@
+package com.oneday.app.log;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Puts a {@code requestId} into the MDC for the life of each HTTP request (propagating an inbound
+ * {@code X-Request-Id} header, or minting one), and echoes it back on the response. Lets REST-triggered
+ * flows — booking, cancellation, OTP — correlate their log lines even before a shipment id exists.
+ * Runs early (before {@code IdempotencyFilter}) so downstream logging is tagged.
+ *
+ * <p>Lives in {@code app} rather than {@code common} because the servlet API / spring-web is only on
+ * the assembled web app's classpath.</p>
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RequestIdFilter extends OncePerRequestFilter {
+
+    private static final String HEADER = "X-Request-Id";
+    private static final String MDC_KEY = "requestId";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String requestId = request.getHeader(HEADER);
+        if (requestId == null || requestId.isBlank()) {
+            requestId = UUID.randomUUID().toString();
+        }
+        MDC.put(MDC_KEY, requestId);
+        response.setHeader(HEADER, requestId);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove(MDC_KEY);
+        }
+    }
+}

--- a/app/src/main/resources/logback-spring.xml
+++ b/app/src/main/resources/logback-spring.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Logging config for the assembled app.
+
+  - Local dev (no staging/prod profile): human-readable console, with the correlation MDC keys
+    (requestId / shipmentRef / shipmentId / parcelId) appended so a developer can see them.
+  - staging / prod: one JSON object per line via LogstashEncoder — MDC keys become top-level JSON
+    fields, so a log platform (Axiom) can query shipmentRef="1DD-…" / audit_event="…" directly.
+    Emitted to stdout; Render captures stdout and a log drain forwards it to Axiom (no app↔Axiom
+    coupling, so logging never blocks the request path and the platform can be swapped freely).
+
+  The dedicated `com.oneday.audit` logger carries the business-seam audit lines (shipment.booked,
+  shipment.transition, scan.recorded, event.published/consumed, …); it stays at INFO in every profile.
+-->
+<configuration>
+
+    <springProperty scope="context" name="appName" source="spring.application.name" defaultValue="oneday-api"/>
+
+    <!-- Plain console for local dev. %X{key} renders the MDC correlation keys. -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} [req=%X{requestId:-} ref=%X{shipmentRef:-} sid=%X{shipmentId:-} pid=%X{parcelId:-}] - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- One JSON line per event for staging/prod. MDC + StructuredArguments become JSON fields. -->
+    <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp/>
+                <version/>
+                <logLevel/>
+                <loggerName/>
+                <threadName/>
+                <message/>
+                <mdc/>                <!-- requestId, shipmentId, shipmentRef, parcelId, … -->
+                <arguments/>          <!-- StructuredArguments.kv(...) from AuditLog -->
+                <stackTrace/>
+                <pattern>
+                    <pattern>{"service":"${appName}"}</pattern>
+                </pattern>
+            </providers>
+        </encoder>
+    </appender>
+
+    <!-- Default (local dev) → plain console. -->
+    <springProfile name="!staging &amp; !prod">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <!-- staging / prod → JSON to stdout for the Axiom drain. -->
+    <springProfile name="staging | prod">
+        <root level="INFO">
+            <appender-ref ref="JSON"/>
+        </root>
+    </springProfile>
+
+    <!-- Business audit trail — always on, regardless of profile. -->
+    <logger name="com.oneday.audit" level="INFO"/>
+    <logger name="com.oneday" level="INFO"/>
+
+</configuration>

--- a/barcode/src/main/java/com/oneday/barcode/service/ScanLedgerServiceImpl.java
+++ b/barcode/src/main/java/com/oneday/barcode/service/ScanLedgerServiceImpl.java
@@ -3,6 +3,7 @@ package com.oneday.barcode.service;
 import com.oneday.barcode.domain.ScanLedgerEntry;
 import com.oneday.barcode.events.ScanRecorded;
 import com.oneday.barcode.repository.ScanLedgerRepository;
+import com.oneday.common.log.AuditLog;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,6 +43,15 @@ class ScanLedgerServiceImpl implements ScanLedgerService {
                 .scannedAt(cmd.scannedAt())
                 .clientScanId(cmd.clientScanId())
                 .build());
+
+        AuditLog.event("scan.recorded")
+                .kv("shipmentId", entry.getShipmentId())
+                .kv("parcelId", entry.getParcelId())
+                .kv("scanType", entry.getScanType())
+                .kv("locationType", entry.getLocationType())
+                .kv("locationId", entry.getLocationId())
+                .kv("actorId", entry.getActorId())
+                .log();
 
         // In-process signal; the outbound ScanEvent is published only AFTER this tx commits.
         events.publishEvent(new ScanRecorded(

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -28,6 +28,20 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-amqp</artifactId>
         </dependency>
+        <!-- @Aspect support for the RabbitListener MDC/audit advice (brings aspectjweaver;
+             Spring Boot auto-enables AspectJ auto-proxying when it's on the classpath). -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+        <!-- Structured JSON logging: the encoder (used by app/logback-spring.xml) AND the
+             StructuredArguments API used by AuditLog. Not managed by the Boot BOM, so pin here;
+             7.4 targets Logback 1.4.x (Spring Boot 3.2). -->
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>7.4</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/common/src/main/java/com/oneday/common/kafka/RabbitEventPublisher.java
+++ b/common/src/main/java/com/oneday/common/kafka/RabbitEventPublisher.java
@@ -1,5 +1,7 @@
 package com.oneday.common.kafka;
 
+import com.oneday.common.log.AuditLog;
+import com.oneday.common.log.CorrelationKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -28,6 +30,17 @@ public class RabbitEventPublisher implements EventPublisher {
             // exchange = stream; routing key = event type; payload converted to JSON by the
             // shared Jackson2JsonMessageConverter (MessagingConfig).
             rabbitTemplate.convertAndSend(stream, event.eventTypeName(), event);
+
+            // Audit the emit — the counterpart to event.consumed (RabbitConsumerMdcAspect); together
+            // they make the otherwise-invisible RabbitMQ hop queryable by shipment/parcel.
+            CorrelationKeys keys = CorrelationKeys.from(event);
+            AuditLog.event("event.published")
+                    .kv("stream", stream)
+                    .kv("eventType", event.eventTypeName())
+                    .kv("shipmentId", keys.shipmentId())
+                    .kv("shipmentRef", keys.shipmentRef())
+                    .kv("parcelId", keys.parcelId())
+                    .log();
         } catch (Exception e) {
             log.warn("Rabbit publish failed — exchange={} type={} key={}: {}",
                     stream, event.eventTypeName(), event.partitionKey(), e.getMessage());

--- a/common/src/main/java/com/oneday/common/log/AuditLog.java
+++ b/common/src/main/java/com/oneday/common/log/AuditLog.java
@@ -1,0 +1,66 @@
+package com.oneday.common.log;
+
+import net.logstash.logback.argument.StructuredArgument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static net.logstash.logback.argument.StructuredArguments.keyValue;
+
+/**
+ * One-line audit trail for the important business activities of a shipment/parcel. Every call
+ * writes a single structured line to the dedicated {@code com.oneday.audit} logger: the event
+ * name plus typed key/value fields. Under the JSON encoder (staging/prod) those fields become
+ * top-level JSON keys, so a log platform (Axiom) can query {@code audit_event="shipment.transition"}
+ * or {@code shipmentRef="1DD-…"} directly; under the plain console (local dev) they render as
+ * {@code key=value} appended to the message.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * AuditLog.event("shipment.transition")
+ *         .kv("from", from).kv("to", target)
+ *         .kv("shipmentRef", ref).kv("triggeredBy", actor)
+ *         .log();
+ * }</pre></p>
+ *
+ * <p><b>PII discipline:</b> log IDs, states, actor/location ids, timestamps only — never customer
+ * name / phone / address / OTP.</p>
+ */
+public final class AuditLog {
+
+    /** Dedicated logger name so audit lines can be routed/filtered independently. */
+    private static final Logger log = LoggerFactory.getLogger("com.oneday.audit");
+
+    private AuditLog() {
+    }
+
+    /** Begin an audit line for {@code eventName} (e.g. {@code "shipment.booked"}). */
+    public static Builder event(String eventName) {
+        return new Builder(eventName);
+    }
+
+    public static final class Builder {
+        private final String eventName;
+        private final List<StructuredArgument> args = new ArrayList<>();
+
+        private Builder(String eventName) {
+            this.eventName = eventName;
+            this.args.add(keyValue("audit_event", eventName));
+        }
+
+        /** Add a structured field. Null values are skipped so absent ids don't clutter the line. */
+        public Builder kv(String key, Object value) {
+            if (value != null) {
+                args.add(keyValue(key, value));
+            }
+            return this;
+        }
+
+        /** Emit the audit line at INFO. */
+        public void log() {
+            log.info(eventName, args.toArray());
+        }
+    }
+}

--- a/common/src/main/java/com/oneday/common/log/CorrelationKeys.java
+++ b/common/src/main/java/com/oneday/common/log/CorrelationKeys.java
@@ -1,0 +1,63 @@
+package com.oneday.common.log;
+
+import com.oneday.common.kafka.DomainEvent;
+import com.oneday.common.kafka.events.BaseShipmentEvent;
+import com.oneday.common.kafka.events.DaLifecycleEvent;
+import com.oneday.common.kafka.events.ExceptionsEvent;
+import com.oneday.common.kafka.events.FlightEvent;
+import com.oneday.common.kafka.events.HubEvent;
+import com.oneday.common.kafka.events.ScanEvent;
+
+/**
+ * Pulls the correlation identifiers off any bus payload so the same extraction is used on both the
+ * publish and consume seams. Handles the shipment-bearing event types explicitly (to get
+ * {@code shipmentRef}/{@code parcelId} where they exist) and falls back to {@link DomainEvent#partitionKey()}
+ * for everything else.
+ *
+ * <p>Prefer this central extractor over a per-event marker interface: all bus-facing payloads live
+ * in {@code common}, so one switch keeps the mapping in a single place and needs no edits to the
+ * event classes.</p>
+ */
+public record CorrelationKeys(String shipmentId, String shipmentRef, String parcelId) {
+
+    private static final CorrelationKeys EMPTY = new CorrelationKeys(null, null, null);
+
+    public static CorrelationKeys from(Object payload) {
+        if (payload == null) {
+            return EMPTY;
+        }
+        if (payload instanceof BaseShipmentEvent e) {
+            return new CorrelationKeys(str(e.getShipmentId()), e.getShipmentRef(), null);
+        }
+        if (payload instanceof DaLifecycleEvent e) {
+            return new CorrelationKeys(str(e.shipmentId()), e.shipmentRef(), str(e.parcelId()));
+        }
+        if (payload instanceof ScanEvent e) {
+            return new CorrelationKeys(str(e.shipmentId()), null, e.parcelId());
+        }
+        if (payload instanceof HubEvent e) {
+            return new CorrelationKeys(str(e.shipmentId()), null, null);
+        }
+        if (payload instanceof FlightEvent e) {
+            return new CorrelationKeys(str(e.shipmentId()), null, null);
+        }
+        if (payload instanceof ExceptionsEvent e) {
+            return new CorrelationKeys(str(e.shipmentId()), null, null);
+        }
+        if (payload instanceof DomainEvent e) {
+            // Hub/cron/sla payload families etc. — partitionKey is the shipmentId for shipment-scoped
+            // events; for the few actor/route-scoped ones it is the best available correlation key.
+            return new CorrelationKeys(e.partitionKey(), null, null);
+        }
+        return EMPTY;
+    }
+
+    /** True when at least one identifier was found. */
+    public boolean isEmpty() {
+        return shipmentId == null && shipmentRef == null && parcelId == null;
+    }
+
+    private static String str(Object o) {
+        return o == null ? null : o.toString();
+    }
+}

--- a/common/src/main/java/com/oneday/common/log/LogContext.java
+++ b/common/src/main/java/com/oneday/common/log/LogContext.java
@@ -1,0 +1,60 @@
+package com.oneday.common.log;
+
+import org.slf4j.MDC;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Scoped MDC helper. Puts correlation keys ({@code shipmentId}/{@code shipmentRef}/{@code parcelId}/…)
+ * into the SLF4J {@link MDC} for the duration of a try-with-resources block, so every log line
+ * emitted inside — including the scattered {@code log.info(...)} calls in the services this unit of
+ * work touches — carries those fields (rendered by the JSON encoder / the MDC pattern). Cleared on
+ * {@link #close()} so values never leak to the next task on a pooled thread.
+ *
+ * <pre>{@code
+ * try (var ignored = LogContext.forShipment(shipmentId, shipmentRef, parcelId)) {
+ *     ...  // all logs here are tagged
+ * }
+ * }</pre>
+ *
+ * <p>Generalises the ad-hoc {@code MDC.put/remove} block that used to live in
+ * {@code DispatchServiceImpl.tracked(...)}.</p>
+ */
+public final class LogContext implements AutoCloseable {
+
+    private final List<String> keys = new ArrayList<>(4);
+
+    private LogContext() {
+    }
+
+    public static LogContext of() {
+        return new LogContext();
+    }
+
+    /** Convenience for the common shipment/parcel correlation triple. Null parts are skipped. */
+    public static LogContext forShipment(Object shipmentId, String shipmentRef, Object parcelId) {
+        return of()
+                .put("shipmentId", str(shipmentId))
+                .put("shipmentRef", shipmentRef)
+                .put("parcelId", str(parcelId));
+    }
+
+    /** Put a key into the MDC (no-op if {@code value} is null); remembered for cleanup. */
+    public LogContext put(String key, String value) {
+        if (value != null) {
+            MDC.put(key, value);
+            keys.add(key);
+        }
+        return this;
+    }
+
+    @Override
+    public void close() {
+        keys.forEach(MDC::remove);
+    }
+
+    private static String str(Object o) {
+        return o == null ? null : o.toString();
+    }
+}

--- a/common/src/main/java/com/oneday/common/log/RabbitConsumerMdcAspect.java
+++ b/common/src/main/java/com/oneday/common/log/RabbitConsumerMdcAspect.java
@@ -1,0 +1,59 @@
+package com.oneday.common.log;
+
+import com.oneday.common.kafka.DomainEvent;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+/**
+ * Wraps every {@code @RabbitListener} method so a consumed message is (a) recorded as a self-contained
+ * {@code event.consumed} audit line and (b) run with the shipment/parcel ids in the MDC, tagging the
+ * consumer's own {@code log.*} calls with the same correlation keys.
+ *
+ * <p>This is the counterpart to the {@code event.published} line in {@code RabbitEventPublisher}: together
+ * they make the RabbitMQ hop — otherwise invisible once a message is consumed — queryable end-to-end by
+ * {@code shipmentId} / {@code shipmentRef} / {@code parcelId}.</p>
+ *
+ * <p>Implemented as AOP around the listener bean method (not a container-factory advice) so it composes
+ * with Boot's retry/DLQ advice chain instead of replacing it, and gets the already-deserialized payload.</p>
+ */
+@Aspect
+@Component
+public class RabbitConsumerMdcAspect {
+
+    @Around("@annotation(org.springframework.amqp.rabbit.annotation.RabbitListener)")
+    public Object aroundListener(ProceedingJoinPoint pjp) throws Throwable {
+        Object payload = firstEventArg(pjp.getArgs());
+        CorrelationKeys keys = CorrelationKeys.from(payload);
+
+        MethodSignature sig = (MethodSignature) pjp.getSignature();
+        String consumer = sig.getDeclaringType().getSimpleName() + "#" + sig.getName();
+        String eventType = payload instanceof DomainEvent de ? de.eventTypeName() : null;
+
+        try (var ignored = LogContext.forShipment(keys.shipmentId(), keys.shipmentRef(), keys.parcelId())) {
+            AuditLog.event("event.consumed")
+                    .kv("consumer", consumer)
+                    .kv("eventType", eventType)
+                    .kv("shipmentId", keys.shipmentId())
+                    .kv("shipmentRef", keys.shipmentRef())
+                    .kv("parcelId", keys.parcelId())
+                    .log();
+            return pjp.proceed();
+        }
+    }
+
+    /** The message payload is the first argument that is a {@link DomainEvent}; else the first arg. */
+    private static Object firstEventArg(Object[] args) {
+        if (args == null || args.length == 0) {
+            return null;
+        }
+        for (Object a : args) {
+            if (a instanceof DomainEvent) {
+                return a;
+            }
+        }
+        return args[0];
+    }
+}

--- a/common/src/test/java/com/oneday/common/log/CorrelationKeysTest.java
+++ b/common/src/test/java/com/oneday/common/log/CorrelationKeysTest.java
@@ -1,0 +1,89 @@
+package com.oneday.common.log;
+
+import com.oneday.common.kafka.DomainEvent;
+import com.oneday.common.kafka.enums.DaEventType;
+import com.oneday.common.kafka.enums.HubEventType;
+import com.oneday.common.kafka.enums.ScanEventType;
+import com.oneday.common.kafka.events.DaLifecycleEvent;
+import com.oneday.common.kafka.events.HubEvent;
+import com.oneday.common.kafka.events.ScanEvent;
+import com.oneday.common.kafka.events.ShipmentCreatedEvent;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CorrelationKeysTest {
+
+    @Test
+    void shipmentEvent_extractsIdAndRef() {
+        UUID sid = UUID.randomUUID();
+        ShipmentCreatedEvent e = new ShipmentCreatedEvent();
+        e.setShipmentId(sid);
+        e.setShipmentRef("1DD-BLR-20260530-00042");
+
+        CorrelationKeys k = CorrelationKeys.from(e);
+
+        assertThat(k.shipmentId()).isEqualTo(sid.toString());
+        assertThat(k.shipmentRef()).isEqualTo("1DD-BLR-20260530-00042");
+        assertThat(k.parcelId()).isNull();
+        assertThat(k.isEmpty()).isFalse();
+    }
+
+    @Test
+    void scanEvent_extractsIdAndParcel() {
+        UUID sid = UUID.randomUUID();
+        ScanEvent e = new ScanEvent(sid, ScanEventType.LABEL_GENERATED, "1DD-DEL-260530-000123", Instant.now());
+
+        CorrelationKeys k = CorrelationKeys.from(e);
+
+        assertThat(k.shipmentId()).isEqualTo(sid.toString());
+        assertThat(k.parcelId()).isEqualTo("1DD-DEL-260530-000123");
+        assertThat(k.shipmentRef()).isNull();
+    }
+
+    @Test
+    void daLifecycleEvent_extractsAllThree() {
+        UUID sid = UUID.randomUUID();
+        UUID pid = UUID.randomUUID();
+        DaLifecycleEvent e = new DaLifecycleEvent(UUID.randomUUID(), DaEventType.PICKUP_COMPLETED, "1.0",
+                Instant.now(), sid, "1DD-DEL-20260530-00007", UUID.randomUUID(), UUID.randomUUID(),
+                null, null, null, pid, LocalDate.now());
+
+        CorrelationKeys k = CorrelationKeys.from(e);
+
+        assertThat(k.shipmentId()).isEqualTo(sid.toString());
+        assertThat(k.shipmentRef()).isEqualTo("1DD-DEL-20260530-00007");
+        assertThat(k.parcelId()).isEqualTo(pid.toString());
+    }
+
+    @Test
+    void hubEvent_extractsShipmentIdOnly() {
+        UUID sid = UUID.randomUUID();
+        CorrelationKeys k = CorrelationKeys.from(new HubEvent(sid, HubEventType.STAND_ASSIGNED));
+
+        assertThat(k.shipmentId()).isEqualTo(sid.toString());
+        assertThat(k.shipmentRef()).isNull();
+        assertThat(k.parcelId()).isNull();
+    }
+
+    @Test
+    void unknownDomainEvent_fallsBackToPartitionKey() {
+        DomainEvent generic = new DomainEvent() {
+            @Override public String partitionKey() { return "TILE-9"; }
+            @Override public String eventTypeName() { return "SOMETHING"; }
+        };
+
+        CorrelationKeys k = CorrelationKeys.from(generic);
+
+        assertThat(k.shipmentId()).isEqualTo("TILE-9");
+    }
+
+    @Test
+    void nullPayload_isEmpty() {
+        assertThat(CorrelationKeys.from(null).isEmpty()).isTrue();
+    }
+}

--- a/common/src/test/java/com/oneday/common/log/RabbitConsumerMdcAspectTest.java
+++ b/common/src/test/java/com/oneday/common/log/RabbitConsumerMdcAspectTest.java
@@ -1,0 +1,98 @@
+package com.oneday.common.log;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.oneday.common.kafka.enums.ScanEventType;
+import com.oneday.common.kafka.events.ScanEvent;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RabbitConsumerMdcAspectTest {
+
+    private final RabbitConsumerMdcAspect aspect = new RabbitConsumerMdcAspect();
+    private Logger auditLogger;
+    private ListAppender<ILoggingEvent> appender;
+
+    @BeforeEach
+    void setUp() {
+        auditLogger = (Logger) LoggerFactory.getLogger("com.oneday.audit");
+        appender = new ListAppender<>();
+        appender.start();
+        auditLogger.addAppender(appender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        auditLogger.detachAppender(appender);
+        MDC.clear();
+    }
+
+    @Test
+    void setsMdcDuringInvocationAndClearsAfter() throws Throwable {
+        UUID sid = UUID.randomUUID();
+        ScanEvent payload = new ScanEvent(sid, ScanEventType.LABEL_GENERATED, "1DD-DEL-260530-000001", Instant.now());
+
+        ProceedingJoinPoint pjp = mock(ProceedingJoinPoint.class);
+        MethodSignature sig = mock(MethodSignature.class);
+        when(pjp.getArgs()).thenReturn(new Object[]{payload});
+        when(pjp.getSignature()).thenReturn(sig);
+        when(sig.getDeclaringType()).thenReturn(Object.class);
+        when(sig.getName()).thenReturn("onScanEvent");
+        String[] mdcInside = new String[3];
+        when(pjp.proceed()).thenAnswer(inv -> {
+            mdcInside[0] = MDC.get("shipmentId");
+            mdcInside[1] = MDC.get("parcelId");
+            mdcInside[2] = MDC.get("shipmentRef");
+            return null;
+        });
+
+        aspect.aroundListener(pjp);
+
+        // MDC populated for the duration of the listener…
+        assertThat(mdcInside[0]).isEqualTo(sid.toString());
+        assertThat(mdcInside[1]).isEqualTo("1DD-DEL-260530-000001");
+        assertThat(mdcInside[2]).isNull();
+        // …and cleared afterwards so it doesn't leak to the next task on this thread.
+        assertThat(MDC.get("shipmentId")).isNull();
+        assertThat(MDC.get("parcelId")).isNull();
+    }
+
+    @Test
+    void emitsEventConsumedAuditLine() throws Throwable {
+        UUID sid = UUID.randomUUID();
+        ScanEvent payload = new ScanEvent(sid, ScanEventType.LABEL_GENERATED);
+
+        ProceedingJoinPoint pjp = mock(ProceedingJoinPoint.class);
+        MethodSignature sig = mock(MethodSignature.class);
+        when(pjp.getArgs()).thenReturn(new Object[]{payload});
+        when(pjp.getSignature()).thenReturn(sig);
+        when(sig.getDeclaringType()).thenReturn(Object.class);
+        when(sig.getName()).thenReturn("onScanEvent");
+        when(pjp.proceed()).thenReturn(null);
+
+        aspect.aroundListener(pjp);
+
+        assertThat(appender.list).hasSize(1);
+        ILoggingEvent line = appender.list.get(0);
+        assertThat(line.getLevel()).isEqualTo(Level.INFO);
+        assertThat(line.getMessage()).isEqualTo("event.consumed");
+        // The correlation ids ride as structured arguments (→ JSON fields under the encoder),
+        // not as message placeholders — so assert on the argument array.
+        assertThat(java.util.Arrays.stream(line.getArgumentArray()).map(Object::toString))
+                .anyMatch(s -> s.contains("shipmentId") && s.contains(sid.toString()));
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DispatchServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DispatchServiceImpl.java
@@ -1,5 +1,7 @@
 package com.oneday.dispatch.service.impl;
 
+import com.oneday.common.log.AuditLog;
+import com.oneday.common.log.LogContext;
 import com.oneday.dispatch.config.DispatchProperties;
 import com.oneday.dispatch.domain.AssignmentDecision;
 import com.oneday.dispatch.domain.CronAssignmentStatus;
@@ -32,7 +34,6 @@ import com.oneday.grid.service.GridService;
 import com.oneday.grid.service.IntradayLoadScoreService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -118,17 +119,19 @@ class DispatchServiceImpl implements DispatchService {
                 () -> assign(new Request(shipmentId, cityId, TaskType.DELIVERY, lat, lon, destTileId, null), true));
     }
 
-    /** Wrap an assignment in MDC (shipment/city correlation) + record its outcome metric. */
+    /** Wrap an assignment in MDC (shipment/city correlation) + record its outcome (metric + audit line). */
     private AssignmentResult tracked(UUID shipmentId, UUID cityId, java.util.function.Supplier<AssignmentResult> work) {
-        MDC.put("shipment_id", String.valueOf(shipmentId));
-        MDC.put("city_id", String.valueOf(cityId));
-        try {
+        try (var ignored = LogContext.of()
+                .put("shipmentId", String.valueOf(shipmentId))
+                .put("cityId", String.valueOf(cityId))) {
             AssignmentResult result = work.get();
             metrics.assignment(result.outcome(), cityId);
+            AuditLog.event("da.assignment")
+                    .kv("shipmentId", shipmentId)
+                    .kv("cityId", cityId)
+                    .kv("outcome", result.outcome())
+                    .log();
             return result;
-        } finally {
-            MDC.remove("shipment_id");
-            MDC.remove("city_id");
         }
     }
 

--- a/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
@@ -3,6 +3,7 @@ package com.oneday.orders.service.impl;
 import com.oneday.common.domain.PickupSlots;
 import com.oneday.common.domain.enums.CustomerType;
 import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.log.AuditLog;
 import com.oneday.orders.service.BookingService;
 import com.oneday.common.port.EtaPort;
 import com.oneday.common.port.PricingPort;
@@ -309,6 +310,18 @@ class B2bBookingServiceImpl implements B2bBookingService {
         // ── Emit CREATED — in-process; ShipmentEventProducer publishes AFTER_COMMIT, so a rolled-back
         //    booking never produces a phantom event. This is what starts the B2B lifecycle: M5 pickup
         //    assignment, M10 SLA, and (via delivery) COD collection — same as the B2C path. ──────────
+        AuditLog.event("shipment.booked")
+                .kv("shipmentId", shipment.getId())
+                .kv("shipmentRef", shipment.getShipmentRef())
+                .kv("customerType", CustomerType.B2B)
+                .kv("b2bAccountId", req.getB2bAccountId())
+                .kv("lane", shipment.getOriginCity() + "->" + shipment.getDestCity())
+                .kv("deliveryType", serviceability.deliveryType())
+                .kv("chargeableWeightGrams", chargeableWeightGrams)
+                .kv("totalPricePaise", quote.totalPricePaise())
+                .kv("fundingSource", funding)
+                .log();
+
         applicationEventPublisher.publishEvent(new ShipmentBooked(shipment));
 
         // ── 6. Build response (payment = null for B2B) ─────────────────────────

--- a/orders/src/main/java/com/oneday/orders/service/impl/BookingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/BookingServiceImpl.java
@@ -4,6 +4,7 @@ import com.oneday.common.domain.PickupSlots;
 import com.oneday.common.domain.enums.CustomerType;
 import com.oneday.common.domain.enums.PaymentMode;
 import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.log.AuditLog;
 import com.oneday.common.port.EtaPort;
 import com.oneday.common.port.PricingPort;
 import com.oneday.common.port.ServiceabilityPort;
@@ -333,6 +334,17 @@ class BookingServiceImpl implements BookingService {
             log.warn("ETA fetch failed for shipment {}; booking proceeds without ETA: {}",
                     shipment.getId(), e.getMessage());
         }
+
+        AuditLog.event("shipment.booked")
+                .kv("shipmentId", shipment.getId())
+                .kv("shipmentRef", shipment.getShipmentRef())
+                .kv("customerType", customerType)
+                .kv("lane", shipment.getOriginCity() + "->" + shipment.getDestCity())
+                .kv("deliveryType", serviceability.deliveryType())
+                .kv("chargeableWeightGrams", chargeableWeightGrams)
+                .kv("totalPricePaise", quote.totalPricePaise())
+                .kv("paymentMode", req.getPaymentMode())
+                .log();
 
         // ── Emit CREATED — in-process; ShipmentEventProducer publishes to Kafka AFTER_COMMIT,
         //    so a rolled-back booking never produces a phantom CREATED event. ──────────────

--- a/orders/src/main/java/com/oneday/orders/service/impl/CancellationServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/CancellationServiceImpl.java
@@ -3,6 +3,7 @@ package com.oneday.orders.service.impl;
 import com.oneday.common.domain.enums.CustomerType;
 import com.oneday.common.domain.enums.PaymentMode;
 import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.log.AuditLog;
 import com.oneday.orders.domain.B2bAccount;
 import com.oneday.orders.domain.PaymentTransaction;
 import com.oneday.orders.domain.Shipment;
@@ -157,6 +158,15 @@ class CancellationServiceImpl implements CancellationService {
         events.publishEvent(new ShipmentCancelled(
                 shipment.getId(), shipmentRef, cancelledAtState, reason,
                 refundInitiated, refundAmountPaise, Instant.now()));
+
+        AuditLog.event("shipment.cancelled")
+                .kv("shipmentId", shipment.getId())
+                .kv("shipmentRef", shipmentRef)
+                .kv("cancelledAtState", cancelledAtState)
+                .kv("lane", isB2b ? "B2B" : "B2C")
+                .kv("refundInitiated", refundInitiated)
+                .kv("refundAmountPaise", refundAmountPaise)
+                .log();
 
         log.info("Cancelled shipment {} at state {} (refundInitiated={})",
                 shipmentRef, cancelledAtState, refundInitiated);

--- a/orders/src/main/java/com/oneday/orders/service/impl/ShipmentStateMachineImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/ShipmentStateMachineImpl.java
@@ -4,6 +4,7 @@ import com.oneday.common.domain.enums.DeliveryType;
 import com.oneday.common.domain.enums.DropType;
 import com.oneday.common.domain.enums.PickupType;
 import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.log.AuditLog;
 import com.oneday.orders.domain.Shipment;
 import com.oneday.orders.domain.ShipmentStateHistory;
 import com.oneday.orders.repository.ShipmentRepository;
@@ -60,6 +61,15 @@ class ShipmentStateMachineImpl implements ShipmentStateMachine {
         // and flushes the UPDATE automatically when the transaction commits.
 
         historyRepo.save(ShipmentStateHistory.of(shipmentId, current, target, ctx));
+
+        AuditLog.event("shipment.transition")
+                .kv("shipmentId", shipmentId)
+                .kv("shipmentRef", shipment.getShipmentRef())
+                .kv("from", current)
+                .kv("to", target)
+                .kv("triggeredBy", ctx.getTriggeredBy())
+                .kv("source", ctx.getTriggerSource())
+                .log();
 
         // In-process announcement — ShipmentEventProducer turns this into the outbound Kafka
         // STATE_CHANGED event after this transaction commits (AFTER_COMMIT). The state machine


### PR DESCRIPTION
## What

Adds centralized, **queryable-by-parcel** activity logging. For any `shipmentId` / `shipmentRef` (`1DD-BLR-…`) / `parcelId`, you can search the log platform (Axiom) and see the shipment's whole journey across every module — including the RabbitMQ hops, which were invisible once a message was consumed.

## How

- **`common/log`**: `AuditLog` (fluent → dedicated `com.oneday.audit` logger via logstash `StructuredArguments`), `LogContext` (AutoCloseable MDC), `CorrelationKeys` (central id extractor off any `DomainEvent`), `RabbitConsumerMdcAspect` (`@Aspect` around every `@RabbitListener` → sets MDC + emits `event.consumed`). An AOP aspect was chosen over a container-factory advice so it composes with Boot's retry/DLQ advice chain instead of replacing it.
- **Publish seam**: `RabbitEventPublisher.publish` emits `event.published`, so every `*EventProducer` (DA/hub/flight/SLA/cron) is auto-covered — no per-producer edits.
- **Business-seam audit lines**: `shipment.transition` (state machine), `scan.recorded` (also covers label generation), `shipment.booked` (B2C + B2B), `shipment.cancelled`, `da.assignment` (refactored `DispatchServiceImpl`'s old unrendered MDC block onto `LogContext`).
- **`app`**: `logback-spring.xml` — plain console + MDC for local dev; **JSON to stdout under `staging`/`prod`** for the Axiom drain. `RequestIdFilter` correlates HTTP flows.
- **`common/pom`**: `spring-boot-starter-aop` + `logstash-logback-encoder:7.4`.

## Destination

**Axiom** (free 500 GB/mo, 30-day retention — well above our <15 GB/mo). App emits JSON to stdout; a Render Log Stream → Axiom **Secure Syslog** endpoint forwards it (no app↔Axiom coupling). Splunk was rejected as an enterprise SIEM at ~100× the cost for this scale.

## PII

Audit lines carry ids / states / actor-ids / timestamps only — never name / phone / address / OTP.

## Testing

- Full `mvn clean install` compiles across all modules.
- `common` (13, incl. new `CorrelationKeysTest` + `RabbitConsumerMdcAspectTest`) and `barcode` (13) tests pass.
- **Booted clean against the dev DB with `SPRING_PROFILES_ACTIVE=staging`** — JSON logging confirmed live (well-formed JSON lines with `service`, `@timestamp`, `level`, `logger_name`), and the AOP aspect proxies all `@RabbitListener` consumer beans without breaking the context.
- Note: `dispatch`/`orders` `@AutoConfigureTestDatabase(replace=NONE)` integration tests fail on a pre-existing dirty local Postgres (`V5_9 … scheduled_pickup already exists`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
