### PR TITLE
Phase-2 field-test: DA arrival logging + B2B rate card (backend)

### DIFF
--- a/dispatch/src/main/java/com/oneday/dispatch/api/DaDispatchController.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/api/DaDispatchController.java
@@ -107,6 +107,15 @@ public class DaDispatchController {
         return daTaskService.markEnRoute(daId, taskId);
     }
 
+    /** DA tapped "Mark arrived" at the pickup/delivery stop — stamps arrival time for dwell analysis. */
+    @PostMapping("/tasks/{taskId}/arrived")
+    public ResponseEntity<Void> arrivedAtStop(@PathVariable UUID daId, @PathVariable UUID taskId,
+                                              @AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireDaSelf(principal, daId);
+        daTaskService.markArrivedAtStop(daId, taskId);
+        return ResponseEntity.noContent().build();
+    }
+
     @PostMapping("/tasks/{taskId}/van-handoff")
     public DaTaskView vanHandoff(@PathVariable UUID daId, @PathVariable UUID taskId,
                                  @AuthenticationPrincipal AuthUserDetails principal,

--- a/dispatch/src/main/java/com/oneday/dispatch/domain/DispatchQueue.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/domain/DispatchQueue.java
@@ -87,6 +87,10 @@ public class DispatchQueue extends MutableBaseEntity {
     @Column(name = "started_at")
     private Instant startedAt;
 
+    // Set when the DA taps "Mark arrived" at the stop; arrived→picked_up/completed = dwell time.
+    @Column(name = "arrived_at")
+    private Instant arrivedAt;
+
     @Column(name = "completed_at")
     private Instant completedAt;
 

--- a/dispatch/src/main/java/com/oneday/dispatch/service/DaTaskService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/DaTaskService.java
@@ -22,6 +22,13 @@ public interface DaTaskService {
     DaTaskView markEnRoute(UUID daId, UUID taskId);
 
     /**
+     * Record the DA arriving at the stop (pickup or delivery). Stamps {@code arrived_at} once
+     * (idempotent — a resumed screen re-tap is a no-op) and writes an audit line; does not change
+     * task status. Best-effort from the app's side.
+     */
+    DaTaskView markArrivedAtStop(UUID daId, UUID taskId);
+
+    /**
      * VAN_MEETING city: PICKUP task IN_PROGRESS → COMPLETED at the cron van. Records the cron handoff
      * and emits VAN_HANDOFF_COMPLETED. {@code parcelScans} must be non-empty (full M8 scan-ledger
      * validation lands with barcode integration).

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
@@ -15,6 +15,7 @@ import com.oneday.dispatch.service.DaStatusService;
 import com.oneday.dispatch.service.DaTaskService;
 import com.oneday.dispatch.service.DaTaskView;
 import com.oneday.dispatch.service.model.DaQueue;
+import com.oneday.common.log.AuditLog;
 import com.oneday.common.port.ShipmentContactPort;
 import com.oneday.common.port.ShipmentContactPort.ShipmentContact;
 import com.oneday.common.port.ShipmentRefPort;
@@ -98,6 +99,27 @@ class DaTaskServiceImpl implements DaTaskService {
             task.setStatus(TaskStatus.IN_PROGRESS);
             task.setStartedAt(Instant.now());
             return save(task);
+        });
+    }
+
+    @Override
+    @Transactional
+    public DaTaskView markArrivedAtStop(UUID daId, UUID taskId) {
+        return daStatusService.withDaLock(daId, () -> {
+            DispatchQueue task = ownedTask(daId, taskId);
+            // Stamp once — a resumed screen re-tapping "Mark arrived" must not overwrite the first arrival.
+            if (task.getArrivedAt() == null) {
+                task.setArrivedAt(Instant.now());
+                DaTaskView view = save(task);
+                AuditLog.event("da.arrived_at_stop")
+                        .kv("taskId", taskId)
+                        .kv("shipmentId", task.getShipmentId())
+                        .kv("taskType", task.getTaskType())
+                        .kv("daId", daId)
+                        .log();
+                return view;
+            }
+            return DaTaskView.of(task);
         });
     }
 

--- a/dispatch/src/main/resources/db/migration/dispatch/V5_12__add_arrived_at.sql
+++ b/dispatch/src/main/resources/db/migration/dispatch/V5_12__add_arrived_at.sql
@@ -1,0 +1,3 @@
+-- DA "Mark arrived" timestamp: set when the DA taps arrived at a pickup/delivery stop.
+-- Nullable; the arrived→picked_up/completed gap measures dwell time at the customer.
+ALTER TABLE dispatch_queue ADD COLUMN arrived_at timestamptz;

--- a/orders/src/main/java/com/oneday/orders/dto/B2bAccountResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/B2bAccountResponse.java
@@ -19,5 +19,6 @@ public record B2bAccountResponse(
         long outstandingBalancePaise,
         long availableCreditPaise,
         short paymentTermsDays,
-        String rejectionReason
+        String rejectionReason,
+        UUID rateCardId
 ) {}

--- a/orders/src/main/java/com/oneday/orders/service/impl/B2bAccountServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/B2bAccountServiceImpl.java
@@ -43,6 +43,7 @@ class B2bAccountServiceImpl implements B2bAccountService {
                 a.getOutstandingBalancePaise(),
                 available,
                 a.getPaymentTermsDays(),
-                a.getRejectionReason());
+                a.getRejectionReason(),
+                a.getRateCardId());
     }
 }


### PR DESCRIPTION
## Phase-2 field-test fixes (backend)

Two of the six field-test fixes land in the backend.

### #1 — Log the DA "Mark arrived" tap
"Mark arrived" was UI-only, so we couldn't measure how long a DA spends at a stop.
- `V5_12__add_arrived_at.sql` adds `dispatch_queue.arrived_at` (nullable).
- `DaTaskService.markArrivedAtStop` stamps it **once** (idempotent — a resumed screen re-tap is a no-op), does not change task status, and writes an `AuditLog` line `da.arrived_at_stop` (IDs only, PII-safe).
- `POST /dispatch/da/{daId}/tasks/{taskId}/arrived` (204; DA-self or ADMIN).
- Dwell time = `arrived_at → picked_up/completed`, queryable in Axiom via `audit_event="da.arrived_at_stop"`.

### #2 — Expose the contracted B2B rate card
`B2bAccountResponse` (`GET /api/v1/b2b/accounts/mine`) now returns `rateCardId`, so the business portal can quote the account's **contracted** rate live before booking (paired with the web PR).

### Verification
`mvn clean install -pl dispatch,orders,app -am -DexcludedGroups=e2e` → **BUILD SUCCESS**, all module tests green.

### Rollout
Deploy this **before** relying on the business live price — the quote falls back to a non-contracted card without `rate_card_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7HAxotqFWPJirComsL33i