### PR TITLE
Phase-2 field-test: fix live-track flip + hub-handoff 500 (backend)

### DIFF
--- a/dispatch/src/main/java/com/oneday/dispatch/adapter/LiveDaPositionAdapter.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/adapter/LiveDaPositionAdapter.java
@@ -2,9 +2,9 @@ package com.oneday.dispatch.adapter;
 
 import com.oneday.common.port.LiveDaPositionPort;
 import com.oneday.common.port.LivePosition;
-import com.oneday.dispatch.domain.DaStatus;
+import com.oneday.dispatch.domain.DaGpsPing;
 import com.oneday.dispatch.domain.DispatchQueue;
-import com.oneday.dispatch.repository.DaStatusRepository;
+import com.oneday.dispatch.repository.DaGpsPingRepository;
 import com.oneday.dispatch.repository.DispatchQueueRepository;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,19 +15,20 @@ import java.util.UUID;
 
 /**
  * M5-side implementation of {@link LiveDaPositionPort}: resolves the shipment to its currently
- * assigned DA ({@code dispatch_queue}) and reads that DA's last GPS fix from {@code da_status}.
- * Empty when no DA is actively carrying the parcel or no GPS has been reported yet — the tracker
- * then falls back to a static node.
+ * assigned DA ({@code dispatch_queue}) and reads that DA's most recent {@code da_gps_ping}. The ping
+ * trail is written on every heartbeat (unconditionally), unlike the {@code da_status} snapshot which
+ * only updates while the DA is loaded in the in-memory roster — so this stays live even for a DA that
+ * fell out of memory (restart/eviction). Empty when no DA is carrying the parcel or no GPS yet.
  */
 @Component
 class LiveDaPositionAdapter implements LiveDaPositionPort {
 
     private final DispatchQueueRepository queueRepository;
-    private final DaStatusRepository daStatusRepository;
+    private final DaGpsPingRepository gpsPingRepository;
 
-    LiveDaPositionAdapter(DispatchQueueRepository queueRepository, DaStatusRepository daStatusRepository) {
+    LiveDaPositionAdapter(DispatchQueueRepository queueRepository, DaGpsPingRepository gpsPingRepository) {
         this.queueRepository = queueRepository;
-        this.daStatusRepository = daStatusRepository;
+        this.gpsPingRepository = gpsPingRepository;
     }
 
     @Override
@@ -38,13 +39,9 @@ class LiveDaPositionAdapter implements LiveDaPositionPort {
             return Optional.empty();
         }
         UUID daId = active.get(0).getDaId();
-        return daStatusRepository.findByDaId(daId)
-                .filter(LiveDaPositionAdapter::hasFix)
-                .map(s -> new LivePosition(
-                        s.getLastGpsLat(), s.getLastGpsLon(), s.getLastHeartbeat(), null, daId));
-    }
-
-    private static boolean hasFix(DaStatus s) {
-        return s.getLastGpsLat() != null && s.getLastGpsLon() != null;
+        DaGpsPing fix = gpsPingRepository.findTopByDaIdOrderByRecordedAtDesc(daId);
+        return fix == null
+                ? Optional.empty()
+                : Optional.of(new LivePosition(fix.getLat(), fix.getLon(), fix.getRecordedAt(), null, daId));
     }
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/api/DaDispatchController.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/api/DaDispatchController.java
@@ -1,8 +1,6 @@
 package com.oneday.dispatch.api;
 
 import com.oneday.auth.security.AuthUserDetails;
-import com.oneday.common.domain.MeetingMode;
-import com.oneday.common.port.CityMeetingModePort;
 import com.oneday.dispatch.dto.request.DropCompletedRequest;
 import com.oneday.dispatch.dto.request.GpsPingRequest;
 import com.oneday.dispatch.dto.request.HubHandoffRequest;
@@ -16,7 +14,6 @@ import com.oneday.dispatch.service.GpsFixView;
 import com.oneday.dispatch.service.OtpVerificationService;
 import jakarta.validation.Valid;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,7 +23,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -46,15 +42,12 @@ public class DaDispatchController {
     private final DaStatusService daStatusService;
     private final DaTaskService daTaskService;
     private final OtpVerificationService otpVerificationService;
-    private final CityMeetingModePort meetingModePort;
 
     public DaDispatchController(DaStatusService daStatusService, DaTaskService daTaskService,
-                               OtpVerificationService otpVerificationService,
-                               CityMeetingModePort meetingModePort) {
+                               OtpVerificationService otpVerificationService) {
         this.daStatusService = daStatusService;
         this.daTaskService = daTaskService;
         this.otpVerificationService = otpVerificationService;
-        this.meetingModePort = meetingModePort;
     }
 
     /** The DA's task queue for the day (the app's home list). Each item carries taskLat/taskLon for Open-in-Maps. */
@@ -129,7 +122,6 @@ public class DaDispatchController {
                                  @AuthenticationPrincipal AuthUserDetails principal,
                                  @RequestBody HubHandoffRequest request) {
         Authz.requireDaSelf(principal, daId);
-        requireHubReturnCity(daId);
         return daTaskService.recordHubHandoff(daId, taskId, request.parcelScans());
     }
 
@@ -161,7 +153,6 @@ public class DaDispatchController {
     public DaTaskView hubCollect(@PathVariable UUID daId, @PathVariable UUID taskId,
                                  @AuthenticationPrincipal AuthUserDetails principal) {
         Authz.requireDaSelf(principal, daId);
-        requireHubReturnCity(daId);
         return daTaskService.recordHubCollect(daId, taskId);
     }
 
@@ -191,16 +182,4 @@ public class DaDispatchController {
         return ResponseEntity.noContent().build();
     }
 
-    /**
-     * Cheap edge guard: the hub-handoff / hub-collect endpoints are only valid in a HUB_RETURN city.
-     * The DA's city (from their live status) resolves the mode; a VAN_MEETING city → 409 so a misrouted
-     * client can't emit hub events where a van rendezvous is expected. The service itself stays mode-agnostic.
-     */
-    private void requireHubReturnCity(UUID daId) {
-        UUID cityId = daStatusService.getLiveStatus(daId).getCityId();
-        if (meetingModePort.modeFor(cityId) != MeetingMode.HUB_RETURN) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT,
-                    "Hub handoff/collect is only valid in a HUB_RETURN city");
-        }
-    }
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/repository/DaGpsPingRepository.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/repository/DaGpsPingRepository.java
@@ -17,6 +17,10 @@ public interface DaGpsPingRepository extends JpaRepository<DaGpsPing, UUID> {
     List<DaGpsPing> findByDaIdAndRecordedAtBetweenOrderByRecordedAtAsc(
             UUID daId, Instant from, Instant to);
 
+    /** The DA's most recent fix — the live-tracking source of truth (written on every ping, unlike the
+     *  da_status snapshot which only updates while the DA is loaded in memory). */
+    DaGpsPing findTopByDaIdOrderByRecordedAtDesc(UUID daId);
+
     /** Bulk-delete trail rows older than {@code cutoff} (retention purge). Returns rows removed. */
     @Modifying
     @Transactional

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
@@ -15,7 +15,9 @@ import com.oneday.dispatch.service.DaStatusService;
 import com.oneday.dispatch.service.DaTaskService;
 import com.oneday.dispatch.service.DaTaskView;
 import com.oneday.dispatch.service.model.DaQueue;
+import com.oneday.common.domain.MeetingMode;
 import com.oneday.common.log.AuditLog;
+import com.oneday.common.port.CityMeetingModePort;
 import com.oneday.common.port.ShipmentContactPort;
 import com.oneday.common.port.ShipmentContactPort.ShipmentContact;
 import com.oneday.common.port.ShipmentRefPort;
@@ -55,6 +57,7 @@ class DaTaskServiceImpl implements DaTaskService {
     private final ShipmentRefPort shipmentRefPort;
     private final ShipmentContactPort shipmentContactPort;
     private final QueueReorderService queueReorderService;
+    private final CityMeetingModePort meetingModePort;
 
     DaTaskServiceImpl(DispatchQueueRepository queueRepository,
                       DaCronAssignmentRepository cronRepository,
@@ -64,7 +67,8 @@ class DaTaskServiceImpl implements DaTaskService {
                       HubScanSeamProducer hubScanSeamProducer,
                       ShipmentRefPort shipmentRefPort,
                       ShipmentContactPort shipmentContactPort,
-                      QueueReorderService queueReorderService) {
+                      QueueReorderService queueReorderService,
+                      CityMeetingModePort meetingModePort) {
         this.queueRepository = queueRepository;
         this.cronRepository = cronRepository;
         this.daStatusService = daStatusService;
@@ -74,6 +78,7 @@ class DaTaskServiceImpl implements DaTaskService {
         this.queueReorderService = queueReorderService;
         this.shipmentRefPort = shipmentRefPort;
         this.shipmentContactPort = shipmentContactPort;
+        this.meetingModePort = meetingModePort;
     }
 
     @Override
@@ -137,6 +142,7 @@ class DaTaskServiceImpl implements DaTaskService {
     public DaTaskView recordHubHandoff(UUID daId, UUID taskId, List<String> parcelScans) {
         // HUB_RETURN city (no van): the DA drops the collected pickups AT the hub. Same pickup-handoff
         // lifecycle as the van path, but a neutral event (not VAN_HANDOFF_COMPLETED) + the origin-hub scan.
+        requireHubReturnCity(daId, taskId);
         return completePickupHandoff(daId, taskId, parcelScans, task -> {
             daEventProducer.emitHubReturnHandoffCompleted(daId, task.getCityId(), task.getShipmentId());
             // M8-SEAM: the hub drop is the origin-hub inbound scan (advances to AT_ORIGIN_HUB → M7/M9).
@@ -217,6 +223,7 @@ class DaTaskServiceImpl implements DaTaskService {
     @Transactional
     public DaTaskView recordHubCollect(UUID daId, UUID taskId) {
         // HUB_RETURN city (no van): the DA collects the delivery FROM the hub for last-mile.
+        requireHubReturnCity(daId, taskId);
         return collectDelivery(daId, taskId, task ->
                 // M8-SEAM: hub-dest custody scan (ledger only — the DA's later DROP_* events drive state).
                 hubScanSeamProducer.emitHubDestOut(task.getShipmentId()));
@@ -325,6 +332,19 @@ class DaTaskServiceImpl implements DaTaskService {
         if (q != null && q.getCron() != null) {
             q.getCron().setScheduledMeetingTime(nextMeeting);
             q.getCron().setStatus(CronAssignmentStatus.SCHEDULED);
+        }
+    }
+
+    /**
+     * The hub-handoff / hub-collect ops are only valid in a HUB_RETURN city. Resolve the mode from the
+     * TASK's city (authoritative, always present) — not the in-memory DA live status, which can be null
+     * after a restart and previously NPE'd here (→ 500). A non-HUB_RETURN city → 409.
+     */
+    private void requireHubReturnCity(UUID daId, UUID taskId) {
+        DispatchQueue task = ownedTask(daId, taskId);
+        if (meetingModePort.modeFor(task.getCityId()) != MeetingMode.HUB_RETURN) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Hub handoff/collect is only valid in a HUB_RETURN city");
         }
     }
 

--- a/dispatch/src/test/java/com/oneday/dispatch/api/DaDispatchControllerTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/api/DaDispatchControllerTest.java
@@ -1,12 +1,9 @@
 package com.oneday.dispatch.api;
 
 import com.oneday.auth.security.AuthUserDetails;
-import com.oneday.common.domain.MeetingMode;
-import com.oneday.common.port.CityMeetingModePort;
 import com.oneday.dispatch.dto.request.GpsPingRequest;
 import com.oneday.dispatch.dto.request.HubHandoffRequest;
 import com.oneday.dispatch.dto.request.OtpVerifyRequest;
-import com.oneday.dispatch.service.model.DaLiveStatus;
 import com.oneday.dispatch.service.DaStatusService;
 import com.oneday.dispatch.service.DaTaskService;
 import com.oneday.dispatch.service.DaTaskView;
@@ -36,11 +33,9 @@ class DaDispatchControllerTest {
     private DaStatusService daStatusService;
     private DaTaskService daTaskService;
     private OtpVerificationService otpVerificationService;
-    private CityMeetingModePort meetingModePort;
     private DaDispatchController controller;
 
     private final UUID da = UUID.randomUUID();
-    private final UUID city = UUID.randomUUID();
     private final UUID taskId = UUID.randomUUID();
 
     @BeforeEach
@@ -48,8 +43,7 @@ class DaDispatchControllerTest {
         daStatusService = mock(DaStatusService.class);
         daTaskService = mock(DaTaskService.class);
         otpVerificationService = mock(OtpVerificationService.class);
-        meetingModePort = mock(CityMeetingModePort.class);
-        controller = new DaDispatchController(daStatusService, daTaskService, otpVerificationService, meetingModePort);
+        controller = new DaDispatchController(daStatusService, daTaskService, otpVerificationService);
         when(daTaskService.markEnRoute(any(), any())).thenReturn(sampleView());
     }
 
@@ -102,37 +96,19 @@ class DaDispatchControllerTest {
         verify(otpVerificationService).resendOtp(da, taskId);
     }
 
+    // The HUB_RETURN-vs-VAN_MEETING guard now lives in DaTaskService (resolved from the task's city),
+    // so the controller just delegates; mode enforcement is covered by DaTaskServiceImplTest.
     @Test
-    void hubHandoffDelegatesWhenCityIsHubReturn() {
-        stubCityMode(MeetingMode.HUB_RETURN);
+    void hubHandoffDelegates() {
         controller.hubHandoff(da, taskId, principal(da, "DELIVERY_ASSOCIATE"),
                 new HubHandoffRequest(java.util.List.of("P-1"), null));
         verify(daTaskService).recordHubHandoff(da, taskId, java.util.List.of("P-1"));
     }
 
     @Test
-    void hubHandoffRejectedWithConflictInVanCity() {
-        stubCityMode(MeetingMode.VAN_MEETING);
-        assertThatThrownBy(() -> controller.hubHandoff(da, taskId, principal(da, "DELIVERY_ASSOCIATE"),
-                new HubHandoffRequest(java.util.List.of("P-1"), null)))
-                .isInstanceOf(ResponseStatusException.class)
-                .hasMessageContaining("409");
-        verify(daTaskService, org.mockito.Mockito.never()).recordHubHandoff(any(), any(), any());
-    }
-
-    @Test
-    void hubCollectDelegatesWhenCityIsHubReturn() {
-        stubCityMode(MeetingMode.HUB_RETURN);
+    void hubCollectDelegates() {
         controller.hubCollect(da, taskId, principal(da, "DELIVERY_ASSOCIATE"));
         verify(daTaskService).recordHubCollect(da, taskId);
-    }
-
-    /** Wire the DA's live status → city → meeting mode (flat, to avoid nested stubbing). */
-    private void stubCityMode(MeetingMode mode) {
-        DaLiveStatus status = mock(DaLiveStatus.class);
-        when(status.getCityId()).thenReturn(city);
-        when(daStatusService.getLiveStatus(da)).thenReturn(status);
-        when(meetingModePort.modeFor(city)).thenReturn(mode);
     }
 
     private AuthUserDetails principal(UUID userId, String role) {

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaTaskServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaTaskServiceImplTest.java
@@ -27,11 +27,16 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.UUID;
 
+import com.oneday.common.domain.MeetingMode;
+import com.oneday.common.port.CityMeetingModePort;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /** Real-Postgres tests of the DA task-lifecycle transitions, guards, and (gated) event emission. */
 @Tag("e2e")
@@ -51,6 +56,7 @@ class DaTaskServiceImplTest {
 
     private DaEventProducer events;
     private com.oneday.dispatch.events.HubScanSeamProducer scanSeam;
+    private CityMeetingModePort meetingModePort;
     private DaTaskService service;
 
     @BeforeEach
@@ -61,8 +67,11 @@ class DaTaskServiceImplTest {
         events = mock(DaEventProducer.class);
         scanSeam = mock(com.oneday.dispatch.events.HubScanSeamProducer.class);
         QueueReorderService reorder = mock(QueueReorderService.class);
+        meetingModePort = mock(CityMeetingModePort.class);
+        // This test's city is a HUB_RETURN city (hub-handoff/collect paths exercised below).
+        when(meetingModePort.modeFor(any())).thenReturn(MeetingMode.HUB_RETURN);
         service = new DaTaskServiceImpl(queueRepo, cronRepo, daStatus, events, props, scanSeam,
-                ids -> java.util.Map.of(), ids -> java.util.Map.of(), reorder);
+                ids -> java.util.Map.of(), ids -> java.util.Map.of(), reorder, meetingModePort);
     }
 
     @Test
@@ -161,6 +170,16 @@ class DaTaskServiceImplTest {
 
         DaCronAssignment cron = cronRepo.findByDaIdAndOperatingDate(da, today).orElseThrow();
         assertThat(cron.getStatus()).isEqualTo(CronAssignmentStatus.COMPLETED);
+    }
+
+    @Test
+    void hubHandoffRejectedWithConflictInVanCity() {
+        // The mode guard now resolves from the task's city (not the in-memory live status).
+        when(meetingModePort.modeFor(any())).thenReturn(MeetingMode.VAN_MEETING);
+        DispatchQueue task = persist(TaskType.PICKUP, TaskStatus.IN_PROGRESS);
+        assertThatThrownBy(() -> service.recordHubHandoff(da, task.getId(), java.util.List.of("P-1")))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("409");
     }
 
     @Test

--- a/orders/src/main/java/com/oneday/orders/tracking/LocationResolver.java
+++ b/orders/src/main/java/com/oneday/orders/tracking/LocationResolver.java
@@ -77,11 +77,14 @@ public class LocationResolver {
     // ── moving legs ─────────────────────────────────────────────────────────
     private ResolvedLocation moving(LocationKind kind, Shipment s, Optional<Coord> fallback) {
         Optional<LivePosition> fix = livePosition(kind, s.getId());
-        if (fix.isPresent() && isFresh(fix.get().lastSeenAt())) {
+        if (fix.isPresent()) {
+            // A fix exists — plot the DA/van's real position. If it's gone stale, keep it as an idle
+            // (non-live) dot at that last-known spot rather than teleporting to the pickup/dest pin.
             LivePosition p = fix.get();
-            return new ResolvedLocation(kind, p.lat(), p.lon(), true, true, p.lastSeenAt(), p.minutesLate());
+            boolean fresh = isFresh(p.lastSeenAt());
+            return new ResolvedLocation(kind, p.lat(), p.lon(), fresh, true, p.lastSeenAt(), p.minutesLate());
         }
-        // No fresh fix — show the nearest static node, not a stale dot.
+        // No fix ever reported — show the nearest static node.
         Coord c = fallback.orElse(null);
         return new ResolvedLocation(kind, latOf(c), lonOf(c), false, false, null, null);
     }

--- a/orders/src/test/java/com/oneday/orders/tracking/LocationResolverTest.java
+++ b/orders/src/test/java/com/oneday/orders/tracking/LocationResolverTest.java
@@ -90,14 +90,16 @@ class LocationResolverTest {
     }
 
     @Test
-    void pickedUpWithStaleDaFixFallsBackToOrigin() {
+    void pickedUpWithStaleDaFixHoldsLastKnownPositionAsIdle() {
+        // A stale fix keeps the DA's last-known coordinate as an idle (non-live) dot — it must NOT
+        // teleport back to the pickup/origin pin (that caused the hub↔pickup flip in the field test).
         when(daPort.forShipment(any())).thenReturn(Optional.of(
                 new LivePosition(28.61, 77.21, Instant.now().minus(30, ChronoUnit.MINUTES), null, null)));
         ResolvedLocation r = resolver(true, true).resolve(shipment(ShipmentState.PICKED_UP));
         assertThat(r.kind()).isEqualTo(LocationKind.MOVING_DA);
-        assertThat(r.live()).isFalse();
-        assertThat(r.moving()).isFalse();
-        assertThat(r.lat()).isEqualTo(28.60);   // origin address fallback
+        assertThat(r.live()).isFalse();     // stale → idle styling
+        assertThat(r.moving()).isTrue();    // still a DA-carried leg
+        assertThat(r.lat()).isEqualTo(28.61);   // last-known DA position, not the origin fallback
     }
 
     @Test


### PR DESCRIPTION
## Phase-2 field-test — live-track flip + hub-handoff 500 (backend)

Both bugs trace to one root cause: a DA dropping out of the server's **in-memory roster**
(`DaStatusServiceImpl.liveStatus`) after a restart, which several paths dereferenced. Confirmed against
the staging DB and the Render stacktrace.

### Tracking flip (hub ↔ pickup)
The phone was pinging fine (`da_gps_ping`: 570 rows, ~30–50s apart, all at the hub), but `updateGps` only
refreshes the `da_status` snapshot **while the DA is in memory** — so it froze, `LiveDaPositionAdapter`
served a 22-min-stale fix, and `LocationResolver` fell back to the **pickup pin** (still `MOVING_DA` → the
bike icon teleported to California Burrito).
- `LiveDaPositionAdapter.forShipment` now reads the DA's **latest `da_gps_ping`** (written on every ping,
  unconditionally) via `findTopByDaIdOrderByRecordedAtDesc` — always current, roster-independent.
- Defensively, `LocationResolver.moving()` now **holds the last-known position** as an idle (non-live) dot
  when a fix is stale, instead of teleporting to the origin/dest pin.

### Hub-handoff HTTP 500
`DaDispatchController.requireHubReturnCity` did `getLiveStatus(daId).getCityId()` → **NPE** when the DA
isn't in memory. The HUB_RETURN guard now lives in `DaTaskService`, resolved from the **task's stable
`city_id`**; the controller helper is removed. Same 409 for a VAN city.

### Tests
`LocationResolverTest` updated to the last-known-idle contract; `DaDispatchControllerTest` simplified
(guard moved); `DaTaskServiceImplTest` gains the `meetingModePort` mock + a VAN→409 case.
`mvn install -pl dispatch,orders,app -am -DexcludedGroups=e2e` → **BUILD SUCCESS**.

_No migrations, no config changes._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7HAxotqFWPJirComsL33i