### PR TITLE
Fix HUB_RETURN delivery OTP + intercity post-hub doc

### DIFF
--- a/docs/PHASE-2A-HUB-RETURN-RUN.md
+++ b/docs/PHASE-2A-HUB-RETURN-RUN.md
@@ -1,0 +1,122 @@
+# Phase 2a — HUB_RETURN live run (Hyderabad)
+
+> Ready-to-run card for the field test. Verified 2026-08-09 against staging (backend `ce3c026`).
+
+## Credentials & URLs
+| What | Value |
+|---|---|
+| Driver app (Agniva = DA) | `agniva.da@oneday.test` / `2DGykZBwunW5` |
+| Business portal (booking) | `b2b.demo@oneday.test` / `godspeed2026` |
+| Hub console | **godspeed-hub.vercel.app** → `admin@oneday.in` / `godspeed2026` → select hub **HYD — Hyderabad** |
+| Admin (API / OTP peek) | `admin@oneday.in` / `godspeed2026` |
+| Backend | `https://one-day-delivery.onrender.com` |
+| Pickup | California Burrito, Rajpurohit Tower, Nanakramguda (~17.4155, 78.3428) |
+| Hub | Vajra Jasmine County, Financial District (~17.41397, 78.34436) — ~1 km from pickup |
+
+## Verified ready
+- Backend live (`ce3c026`): OTP peek + startup roster-load deployed.
+- Agniva is in the roster for the pickup/hub hex (OFFLINE now → IDLE on login).
+- Hyderabad = **HUB_RETURN**; pickup + hub both serviceable (same hex).
+- B2B booking works; hub scan-gun autofocus deployed.
+
+## The run — in order
+- **0. Agniva online FIRST.** Log into the driver app, leave it open so GPS pings → flips **OFFLINE→IDLE (assignable)**. *If offline, the pickup defers `NO_DA_AVAILABLE`.*
+- **1. Book.** Business portal → intercity **HYD → DEL**, pickup pin at California Burrito. Ensure wallet has balance. → `BOOKED`.
+- **2. Auto-assign.** M5 assigns pickup to Agniva → **PICKUP task** appears. → `PICKUP_ASSIGNED` (OTP minted).
+- **3. Label.** Shipment → label page → print Code128 → tape to the box → place box at the pickup point.
+- **4. Pickup.** Agniva: **En route** (`IN_PROGRESS`, GPS) → drive → **Mark arrived** → **camera-scan** the label.
+- **5. OTP.** Fetch on the hub laptop, read to Agniva → **Confirm pickup** → `PICKED_UP`:
+  ```bash
+  BASE=https://one-day-delivery.onrender.com
+  TOK=$(curl -s -X POST $BASE/auth/login -H "Content-Type: application/json" \
+    -d '{"email":"admin@oneday.in","password":"godspeed2026"}' \
+    | python3 -c "import sys,json;print(json.load(sys.stdin)['token'])")
+  curl -s -H "Authorization: Bearer $TOK" "$BASE/internal/dev/shipments/<SHIPMENT_REF>/pickup-otp"
+  ```
+- **6. Carry to hub.** Agniva drives to Vajra Jasmine County → **"Hand off at hub"** → `RETURNED_TO_HUB` → `AT_ORIGIN_HUB`.
+- **7. Hub scan-in (finish).** Hub console → **Receive** → click "Scan one parcel" → **scan with the gun** → parcel sorts into the **DEL flight bag** (verify on **Bags** page: bag + stand). → `ORIGIN_HUB_PROCESSING`. **← Phase-2a done.**
+
+## Throughout
+Watch the customer **track** page for the ref: Agniva's live dot follows his GPS; milestones advance **Booked → Picked up → At hub**.
+
+## State chain
+`BOOKED → PICKUP_ASSIGNED → PICKED_UP → RETURNED_TO_HUB → AT_ORIGIN_HUB → ORIGIN_HUB_PROCESSING (flight bag)`
+
+> **Intercity?** Everything *after* the origin hub (flight bag → airport → flight → dest hub → delivery)
+> is in [`PHASE-2B-INTERCITY-POST-HUB.md`](./PHASE-2B-INTERCITY-POST-HUB.md).
+
+## If something stalls
+- No task after booking → confirm Agniva is **online/IDLE** and it's within SHIFT_2 (14:00–22:00 IST). Re-load roster: `POST /dispatch/admin/shift-load?shift=SHIFT_2` (admin token).
+- OTP 404 → the pickup isn't `PICKUP_ASSIGNED` yet.
+- Hub receive error → confirm the shipment reached `AT_ORIGIN_HUB` (hub-handoff done) and hub **HYD** is selected.
+
+---
+
+# Phase 2b — same-city HUB_RETURN delivery (#00002, HYD → HYD)
+
+A same-city parcel **collapses the air legs** — no flight, no dest hub hop. After the pickup + hub drop
+it's sorted straight into a **destination territory (delivery) bag** at a stand, then a delivery DA
+collects it **from the hub** and runs the last mile. First mile (steps 0–7 above) is identical; this
+section is the **delivery half**.
+
+## Full state chain (same-city, HUB_RETURN)
+`BOOKED → PICKUP_ASSIGNED → PICKED_UP → RETURNED_TO_HUB → AT_ORIGIN_HUB → ORIGIN_HUB_PROCESSING →`
+`IN_TAKEOFF_BAG → HANDED_TO_DROP_VAN → HUB_DELIVERY_ASSIGNED → COLLECTED_FROM_HUB → DROPPED`
+
+## Done so far for #00002
+Pickup → hub drop → **received + sorted at the hub → delivery territory bag + stand assigned**
+(≈ `ORIGIN_HUB_PROCESSING`). The parcel is physically at the hub, staged for its territory.
+
+## Next steps to see it delivered
+- **A. Dispatch the same-city bag (hub console).** Seal / close the same-city **delivery bag** on the hub
+  console. This emits `SAMECITY_OUTBOUND` → **`HANDED_TO_DROP_VAN`** — the exact state M5 listens on to
+  create a delivery task. *(If the console has no "seal/dispatch same-city bag" action wired, tell me and
+  I'll nudge it via API — the goal is to reach `HANDED_TO_DROP_VAN`.)*
+- **B. Auto-assign delivery.** M5 (`HANDED_TO_DROP_VAN` + `DA_DELIVERY` → `assignDelivery`) assigns the
+  parcel to the DA covering the dest territory (Agniva) → a **DELIVERY task** appears in the driver app →
+  **`HUB_DELIVERY_ASSIGNED`**. *Agniva must be online/IDLE — same roster rule as pickup; re-load with
+  `POST /dispatch/admin/shift-load?shift=SHIFT_2` if the task doesn't show.*
+- **C. Collect from hub.** Driver app → open the DELIVERY task → **"Collect from hub"** (the HUB_RETURN
+  RECEIVE step) → records hub-collect → **`COLLECTED_FROM_HUB`** (+ hub-dest custody scan).
+- **D. Deliver.** **En route** (GPS) → drive to the recipient → **Mark arrived** → **scan the parcel**.
+- **E. Confirm → delivered.** Recipient OTP → **`DROPPED`** (+ COD if any). End-to-end done.
+
+## Step E (recipient OTP) — FIXED (was a blocker)
+The last-mile **delivery OTP now works** for HUB_RETURN. The OTP is minted the moment the parcel goes out
+for delivery (`COLLECTED_FROM_HUB`), and the verify/resend endpoint accepts both `DROP_COLLECTED` and
+`COLLECTED_FROM_HUB`. Peek the code on the hub laptop, read it to the DA, and the in-app OTP step drives
+`COLLECTED_FROM_HUB → DROPPED`:
+```bash
+curl -s -H "Authorization: Bearer $TOK" "$BASE/internal/dev/shipments/<SHIPMENT_REF>/delivery-otp"
+```
+*(TTL is 30 min; if it lapses on a long drive, the DA taps "Resend OTP" and re-peek.)*
+
+**To still see `DROPPED` (Delivered) today — workaround, no app change:** after step C (task is
+IN_PROGRESS / `COLLECTED_FROM_HUB`), complete it via the dispatch API — this bypasses the OTP screen and
+drives the shipment to delivered:
+```bash
+BASE=https://one-day-delivery.onrender.com
+TOK=$(curl -s -X POST $BASE/auth/login -H "Content-Type: application/json" \
+  -d '{"email":"admin@oneday.in","password":"godspeed2026"}' \
+  | python3 -c "import sys,json;print(json.load(sys.stdin)['token'])")
+# Agniva's DA id = a0bd9ada-b181-4618-83c9-335a550836a4 ; use the DELIVERY task id from GET /dispatch/da/{daId}/tasks
+curl -s -X POST -H "Authorization: Bearer $TOK" -H "Content-Type: application/json" \
+  "$BASE/dispatch/da/<DA_ID>/tasks/<DELIVERY_TASK_ID>/drop-completed" \
+  -d '{"cod_collected": false}'
+```
+→ `DROP_COMPLETED` → **`DROPPED`**; the track page shows **Delivered**.
+
+**Shipped** (backend Part A): the delivery OTP is minted on out-for-delivery, verify/resend accept
+`COLLECTED_FROM_HUB`, and the dev peek above mirrors the pickup OTP. The `drop-completed` call above
+remains a valid manual fallback if you ever want to bypass the OTP screen.
+
+## Watch
+Business/customer **track** for `1DD-HYD-20260809-00002`: milestones advance **At hub → Out for delivery →
+Delivered**; Agniva's live dot follows his GPS on the delivery leg (needs backend PR #88 deployed so the
+dot reads the live ping trail instead of flipping to the pickup).
+
+## Delivery-side stalls
+- No DELIVERY task after step A → parcel didn't reach `HANDED_TO_DROP_VAN` (bag not dispatched), or Agniva
+  isn't online/IDLE, or the dest hex isn't in his territory.
+- Hub-collect 409 → the parcel isn't `HUB_DELIVERY_ASSIGNED` yet (step B not done), or HYD isn't HUB_RETURN.
+- Recipient-OTP "wrong code" → the known blocker above; use the `drop-completed` workaround.

--- a/docs/PHASE-2B-INTERCITY-POST-HUB.md
+++ b/docs/PHASE-2B-INTERCITY-POST-HUB.md
@@ -1,0 +1,128 @@
+# Phase 2b — Intercity post-hub flow (origin hub → flight → dest hub → delivery)
+
+> Companion to [`PHASE-2A-HUB-RETURN-RUN.md`](./PHASE-2A-HUB-RETURN-RUN.md). Phase 2a proved the
+> **first mile → origin hub** (pickup → hub scan-in → flight bag). This card covers everything **after
+> the origin hub** for a true **intercity** parcel (e.g. HYD → DEL): the air legs and the destination
+> last mile. It documents the intended chain, what's actually wired today, the seams that still need a
+> hand (G1–G5), and the **manual M8 scan-API calls** that force an intercity run end-to-end right now.
+
+## How intercity differs from the same-city (#00002) run
+
+A same-city parcel **collapses the air legs** — no flight, straight from origin-hub sort into a delivery
+bag. An intercity parcel runs the **full chain**: origin-hub sort → takeoff bag → **airport → flight →
+destination airport** → destination-hub sort → last mile. The origin half (steps 0–7 in Phase 2a) is
+**identical**; this card is the **post-hub half**.
+
+## Full intercity state chain & what drives each hop
+
+| # | State | Driver | Event → M4 consumer | Wired? |
+|---|-------|--------|---------------------|--------|
+| — | `AT_ORIGIN_HUB` | M8 scan / M5 seam | `HUB_ORIGIN_IN` → `ScanEventsConsumer` | ✅ (Phase 2a) |
+| 1 | `ORIGIN_HUB_PROCESSING` | M7 hub | `STAND_ASSIGNED` (per-parcel) → `HubEventsConsumer` | ✅ |
+| 2 | `IN_TAKEOFF_BAG` | M7 hub | `BAG_CREATED` → `HubEventsConsumer` | ⚠️ **G2** (no shipmentId) |
+| 3 | `DISPATCHED_TO_AIRPORT` | M8 scan | `HUB_ORIGIN_OUT` → `ScanEventsConsumer` | ⚠️ **G1** (no emitter) |
+| 4 | `AT_AIRPORT` | M8 scan | `GHA_ACCEPTANCE` → `ScanEventsConsumer` | ⚠️ **G1** (no emitter) |
+| 5 | `DEPARTED` | **M9 flight** | `DEPARTED` → `FlightEventsConsumer` | ✅ (poll job, clock-based) |
+| 6 | `LANDED` | **M9 flight** | `LANDED` → `FlightEventsConsumer` | ✅ (poll job, clock-based) |
+| 7 | `DISPATCHED_TO_HUB` | M8 scan | `DEST_SHUTTLE_IN` → `ScanEventsConsumer` | ⚠️ **G1** (no emitter) |
+| 8 | `AT_DEST_HUB` | M8 scan | `HUB_DEST_IN` → `ScanEventsConsumer` | ⚠️ **G1** (no emitter) |
+| 9 | `DEST_HUB_PROCESSING` | M7 hub | `DEST_SORT_COMPLETE` (per-parcel) → `HubEventsConsumer` | ✅ |
+| 10 | **delivery assignment** | M7 → M5 | `HANDED_TO_DROP_VAN` (VAN) / `DROP_ASSIGNED` (both) | ⚠️ **G4** (intercity path) |
+| 11 | `DROPPED` | M5 + delivery OTP | `DROP_COLLECTED`/`COLLECTED_FROM_HUB` → OTP verify | ✅ (**G5 fixed** — Part A) |
+
+Full sequence (INTERCITY, VAN_MEETING dest):
+`… AT_ORIGIN_HUB → ORIGIN_HUB_PROCESSING → IN_TAKEOFF_BAG → DISPATCHED_TO_AIRPORT → AT_AIRPORT →`
+`DEPARTED → LANDED → DISPATCHED_TO_HUB → AT_DEST_HUB → DEST_HUB_PROCESSING → HANDED_TO_DROP_VAN →`
+`DROP_ASSIGNED → DROP_COLLECTED → DROPPED`
+
+For a **HUB_RETURN** destination city the tail is `DEST_HUB_PROCESSING → HUB_DELIVERY_ASSIGNED →
+COLLECTED_FROM_HUB → DROPPED` (same as the same-city delivery half).
+
+## What's confirmed wired
+
+- **M9 auto-flips `DEPARTED`/`LANDED`** — `FlightStatusPollJob` (@5 min) flips a booked flight the moment
+  its departure/arrival instant passes and notifies every parcel on the AWB. **Clock-based, zero vendor
+  calls.**
+- **M7 per-parcel hub milestones** — `STAND_ASSIGNED → ORIGIN_HUB_PROCESSING` and
+  `DEST_SORT_COMPLETE → DEST_HUB_PROCESSING`.
+- **All three M4 consumers are live** — `HubEventsConsumer`, `ScanEventsConsumer`, `FlightEventsConsumer`.
+- **Live flight position** — `FlightTrackingPortAdapter` interpolates a straight-line dot between the two
+  airports over the scheduled flight time (free, no ADS-B vendor).
+
+## The gaps to close (or work around) before a clean intercity E2E
+
+- **G1 — the four intercity custody scans have no automated emitter.** `HUB_ORIGIN_OUT`, `GHA_ACCEPTANCE`,
+  `DEST_SHUTTLE_IN`, `HUB_DEST_IN` are consumed by `ScanEventsConsumer` but **nothing produces them** —
+  they only exist as a physical scan-gun hitting `POST /api/v1/scan`. In the **Bhagwati** model the
+  airport-side actor (GHA) is the non-tech freight consolidator, so `GHA_ACCEPTANCE` / `HUB_ORIGIN_OUT`
+  won't be scanned by them. **Workaround today: POST them manually** (commands below). **Fix:** the M9
+  delta reframes these — origin-hub-out + warehouse handoff become the M9 `AwbGroundService` timestamps;
+  `GHA_ACCEPTANCE` is retired (Bhagwati owns the airport). Until then they stay manual.
+- **G2 — `IN_TAKEOFF_BAG` carries no per-parcel id.** `HubEventsConsumer` maps `BAG_CREATED →
+  IN_TAKEOFF_BAG` but `BAG_CREATED` is bag-level (null `shipmentId`) so it's skipped — the parcel never
+  actually enters `IN_TAKEOFF_BAG`, and `HUB_ORIGIN_OUT → DISPATCHED_TO_AIRPORT` becomes an illegal jump
+  from `ORIGIN_HUB_PROCESSING`. Needs a **per-parcel "sorted into flight bag"** seam (or post a per-parcel
+  scan). Verify against `TransitionRegistry` before the run.
+- **G3 — the parcel must be bound to a flight instance for `DEPARTED`/`LANDED` to fire.** `FlightStatusPollJob`
+  only notifies parcels on a **booked AWB** whose `flight_instance` exists. Confirm the M7 bag-seal →
+  M9 `HubEventConsumer.onBagSealed` → `AwbBookingService.book` chain actually ran for the test bag (check
+  `GET /airline/awb/by-bag/{bagId}` returns a BOOKED AWB with a flight instance).
+- **G4 — intercity HUB_RETURN delivery assignment.** Same-city reaches the delivery DA via
+  `SAMECITY_OUTBOUND → HANDED_TO_DROP_VAN → assignDelivery`. For an **intercity HUB_RETURN destination**
+  the parcel sits at `DEST_HUB_PROCESSING`; confirm M5 assigns a delivery DA on that path (else it stalls
+  after the dest-hub sort). VAN_MEETING dest uses the (deprecated) `DROP_VAN_HANDOFF` / M6 loop.
+- **G5 — delivery OTP.** ✅ **Fixed in Part A**: the OTP is minted when the parcel goes out for delivery
+  (`DROP_COLLECTED`/`COLLECTED_FROM_HUB`), the verify/resend gate accepts both, and there's a dev peek at
+  `GET /internal/dev/shipments/{ref}/delivery-otp`.
+
+## Force an intercity run today — manual M8 scan-API fallback
+
+`POST /api/v1/scan` records a lifecycle scan and fans a `ScanEvent` to M4 (the same door a hub scan-gun
+uses). Use it to supply the four G1 scans (and, if G2 bites, a per-parcel takeoff scan) at each physical
+checkpoint. Admin token as in Phase 2a:
+
+```bash
+BASE=https://one-day-delivery.onrender.com
+TOK=$(curl -s -X POST $BASE/auth/login -H "Content-Type: application/json" \
+  -d '{"email":"admin@oneday.in","password":"godspeed2026"}' \
+  | python3 -c "import sys,json;print(json.load(sys.stdin)['token'])")
+
+# helper: post one scan for a shipment (SHIP_ID = the shipment UUID, not the ref)
+scan() {  # usage: scan <SCAN_TYPE>
+  curl -s -o /dev/null -w "%{http_code}\n" -X POST "$BASE/api/v1/scan" \
+    -H "Authorization: Bearer $TOK" -H "Content-Type: application/json" \
+    -d "{\"shipmentId\":\"$SHIP_ID\",\"scanType\":\"$1\",\"locationType\":\"HUB\",\"actorId\":\"$SHIP_ID\"}"
+}
+
+SHIP_ID=<shipment-uuid>
+scan HUB_ORIGIN_OUT     # → DISPATCHED_TO_AIRPORT
+scan GHA_ACCEPTANCE     # → AT_AIRPORT   (then M9 auto-flips DEPARTED → LANDED on the flight clock)
+scan DEST_SHUTTLE_IN    # → DISPATCHED_TO_HUB   (after LANDED)
+scan HUB_DEST_IN        # → AT_DEST_HUB   (then M7 DEST_SORT_COMPLETE → DEST_HUB_PROCESSING)
+```
+
+Between `AT_AIRPORT` and `DEST_SHUTTLE_IN`, leave a gap for `FlightStatusPollJob` to flip `DEPARTED`
+then `LANDED` (it fires on the booked flight's scheduled departure/arrival instant; a demo/near-term
+flight lands quickly). Check progress on the customer **track** page or
+`GET /api/v1/shipments/mine/{ref}/track`.
+
+## Where the M9 delta takes this next (Bhagwati model)
+
+The intercity air legs above are the exact thing the **M9 targeted delta** makes real (see
+`~/.claude/plans/cozy-forging-mccarthy.md` / project CLAUDE.md):
+- **`GHA_ACCEPTANCE` retired; Bhagwati warehouse handoff** captured as `AwbGroundService.handOver` /
+  `markLoaded` timestamps — the airport-side scans (G1) stop being our job.
+- **Real schedule + daily status via AeroDataBox** (env-gated) replace the synthetic consolidator legs;
+  cancellations/delays drive the existing `FlightReassignmentService`.
+- **Real AWB number** entered by admin (later WhatsApp) replaces the synthetic `AWB-…`.
+- **Prime-rate avoidance** (00:00–09:00 = +35%) + **leeway batching** shape which flight the bag books.
+
+## Delivery-side stalls
+- Stuck at `ORIGIN_HUB_PROCESSING` → G2: `IN_TAKEOFF_BAG` never applied; post a per-parcel takeoff scan or
+  confirm the per-parcel seam.
+- Never `DEPARTED` → G3: no booked AWB/flight instance for the bag (`GET /airline/awb/by-bag/{bagId}`).
+- Stuck at `DEST_HUB_PROCESSING` → G4: no delivery DA assigned on the intercity path; check M5 or push via
+  the dispatch API (as in Phase 2a step B).
+- Recipient-OTP "wrong code" → should be fixed (G5, Part A); if still failing, peek
+  `GET /internal/dev/shipments/{ref}/delivery-otp` and confirm the parcel is `DROP_COLLECTED` /
+  `COLLECTED_FROM_HUB`.

--- a/orders/src/main/java/com/oneday/orders/api/DeliveryOtpController.java
+++ b/orders/src/main/java/com/oneday/orders/api/DeliveryOtpController.java
@@ -25,7 +25,9 @@ import java.util.Map;
 /**
  * Internal endpoints for last-mile <em>delivery</em> OTP verification — drop-side mirror of
  * {@link PickupOtpController}. Called by the DA mobile app at the recipient's door. The delivery OTP
- * gates {@code DROP_COLLECTED → DROPPED} (the verification step left open as OD-8).
+ * gates the final hop to {@code DROPPED} from whichever "out for delivery" state the parcel is in:
+ * {@code DROP_COLLECTED} (VAN_MEETING city — received off the drop van) or {@code COLLECTED_FROM_HUB}
+ * (HUB_RETURN city — collected from the destination hub). Both are valid predecessors of {@code DROPPED}.
  */
 @RestController
 @RequestMapping("/internal/v1/shipments")
@@ -44,15 +46,15 @@ public class DeliveryOtpController {
     }
 
     /**
-     * DA submits the OTP read out by the recipient. On success the shipment transitions
-     * {@code DROP_COLLECTED → DROPPED}.
+     * DA submits the OTP read out by the recipient. On success the shipment transitions to
+     * {@code DROPPED} from its "out for delivery" state ({@code DROP_COLLECTED} or {@code COLLECTED_FROM_HUB}).
      *
      * <pre>
      * POST /internal/v1/shipments/{ref}/delivery-otp/verify
      * Body: { "otp": "4821" }
      *
      * 204 No Content          — OTP correct; state transitioned to DROPPED
-     * 409 Conflict            — shipment is not in DROP_COLLECTED state
+     * 409 Conflict            — shipment is not out for delivery (DROP_COLLECTED / COLLECTED_FROM_HUB)
      * 422 Unprocessable Entity — OTP wrong / expired / already used
      * 404 Not Found           — shipment ref does not exist
      * </pre>
@@ -66,10 +68,7 @@ public class DeliveryOtpController {
         String daUserId = Authz.requireUserId(principal);
         Shipment shipment = resolveShipment(ref);
 
-        if (shipment.getState() != ShipmentState.DROP_COLLECTED) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT,
-                    "Shipment is not in DROP_COLLECTED state");
-        }
+        requireOutForDelivery(shipment);
 
         try {
             deliveryOtpService.verify(shipment.getId(), request.getOtp());
@@ -90,7 +89,7 @@ public class DeliveryOtpController {
      * <pre>
      * POST /internal/v1/shipments/{ref}/delivery-otp/resend
      * 200 OK  — { "otp": "3902" }
-     * 409 Conflict          — shipment is not in DROP_COLLECTED state
+     * 409 Conflict          — shipment is not out for delivery (DROP_COLLECTED / COLLECTED_FROM_HUB)
      * 429 Too Many Requests — resend limit reached
      * 404 Not Found         — shipment ref does not exist
      * </pre>
@@ -102,10 +101,7 @@ public class DeliveryOtpController {
         Authz.requireRole(principal, "DELIVERY_ASSOCIATE");
         Shipment shipment = resolveShipment(ref);
 
-        if (shipment.getState() != ShipmentState.DROP_COLLECTED) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT,
-                    "Shipment is not in DROP_COLLECTED state");
-        }
+        requireOutForDelivery(shipment);
 
         try {
             String newOtp = deliveryOtpService.resend(shipment.getId());
@@ -121,5 +117,18 @@ public class DeliveryOtpController {
         return shipmentRepository.findByShipmentRef(ref)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
                         "Shipment not found: " + ref));
+    }
+
+    /**
+     * The delivery OTP is only meaningful once the parcel is "out for delivery": received off the drop
+     * van ({@code DROP_COLLECTED}) in a VAN_MEETING city, or collected from the destination hub
+     * ({@code COLLECTED_FROM_HUB}) in a HUB_RETURN city. Both transition to {@code DROPPED} on verify.
+     */
+    private void requireOutForDelivery(Shipment shipment) {
+        ShipmentState state = shipment.getState();
+        if (state != ShipmentState.DROP_COLLECTED && state != ShipmentState.COLLECTED_FROM_HUB) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Shipment is not out for delivery (DROP_COLLECTED / COLLECTED_FROM_HUB)");
+        }
     }
 }

--- a/orders/src/main/java/com/oneday/orders/api/DevOtpController.java
+++ b/orders/src/main/java/com/oneday/orders/api/DevOtpController.java
@@ -41,5 +41,19 @@ class DevOtpController {
         return new PickupOtpPeek(ref, otp);
     }
 
+    @GetMapping("/shipments/{ref}/delivery-otp")
+    public DeliveryOtpPeek peekDelivery(@PathVariable String ref) {
+        Shipment shipment = shipments.findByShipmentRef(ref)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Shipment not found: " + ref));
+        String otp = registry.getDelivery(shipment.getId());
+        if (otp == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                    "No delivery OTP yet for " + ref + " — the parcel must be out for delivery first");
+        }
+        return new DeliveryOtpPeek(ref, otp);
+    }
+
     record PickupOtpPeek(String shipmentRef, String otp) {}
+
+    record DeliveryOtpPeek(String shipmentRef, String otp) {}
 }

--- a/orders/src/main/java/com/oneday/orders/config/DeliveryOtpProperties.java
+++ b/orders/src/main/java/com/oneday/orders/config/DeliveryOtpProperties.java
@@ -20,9 +20,13 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 public class DeliveryOtpProperties {
 
-    /** How long a generated delivery OTP is valid. Default: 10 minutes. */
+    /**
+     * How long a generated delivery OTP is valid. Default: 30 minutes — longer than the pickup OTP
+     * because the last-mile drive from the drop van / destination hub to the recipient's door is
+     * longer than a pickup verification. {@code resend} mints a fresh code if it still lapses.
+     */
     @Positive
-    private int ttlMinutes = 10;
+    private int ttlMinutes = 30;
 
     /** Maximum number of resend attempts before the endpoint returns 429. Default: 3. */
     @Positive

--- a/orders/src/main/java/com/oneday/orders/events/DaEventsConsumer.java
+++ b/orders/src/main/java/com/oneday/orders/events/DaEventsConsumer.java
@@ -4,6 +4,7 @@ import com.oneday.common.domain.MeetingMode;
 import com.oneday.common.domain.enums.ShipmentState;
 import com.oneday.common.kafka.events.DaLifecycleEvent;
 import com.oneday.common.port.CityMeetingModePort;
+import com.oneday.orders.service.DeliveryOtpService;
 import com.oneday.orders.service.PickupOtpService;
 import com.oneday.orders.service.ShipmentStateMachine;
 import com.oneday.orders.service.TransitionContext;
@@ -26,6 +27,11 @@ import org.springframework.stereotype.Component;
  * via the notification service — until that service exists (separate {@code oneday.notifications.events}
  * fan-out) the OTP is logged at DEBUG only. Generation runs <em>after</em> the transition commits,
  * so the shipment is firmly in {@code PICKUP_ASSIGNED} before an OTP is minted.</p>
+ *
+ * <p><b>Delivery-OTP side-effect:</b> symmetrically, when a shipment becomes "out for delivery" — the DA
+ * receives it off the drop van ({@code DROP_COLLECTED}) or collects it from the destination hub
+ * ({@code COLLECTED_FROM_HUB}) — a fresh delivery OTP is minted for the recipient. This is the moment
+ * closest to the door, so the OTP's TTL comfortably covers the last-mile drive.</p>
  */
 @Component
 public class DaEventsConsumer {
@@ -35,12 +41,14 @@ public class DaEventsConsumer {
 
     private final ShipmentStateMachine stateMachine;
     private final PickupOtpService pickupOtpService;
+    private final DeliveryOtpService deliveryOtpService;
     private final CityMeetingModePort meetingModePort;
 
     DaEventsConsumer(ShipmentStateMachine stateMachine, PickupOtpService pickupOtpService,
-                     CityMeetingModePort meetingModePort) {
+                     DeliveryOtpService deliveryOtpService, CityMeetingModePort meetingModePort) {
         this.stateMachine = stateMachine;
         this.pickupOtpService = pickupOtpService;
+        this.deliveryOtpService = deliveryOtpService;
         this.meetingModePort = meetingModePort;
     }
 
@@ -87,6 +95,8 @@ public class DaEventsConsumer {
 
         if (target == ShipmentState.PICKUP_ASSIGNED) {
             generatePickupOtp(event);   // only on a real BOOKED→PICKUP_ASSIGNED, never a redelivery
+        } else if (target == ShipmentState.DROP_COLLECTED || target == ShipmentState.COLLECTED_FROM_HUB) {
+            generateDeliveryOtp(event);   // parcel is out for delivery — mint the recipient's OTP
         }
     }
 
@@ -99,6 +109,19 @@ public class DaEventsConsumer {
                     event.shipmentId(), otp);
         } catch (RuntimeException e) {
             log.error("Failed to generate pickup OTP for shipment {}: {}",
+                    event.shipmentId(), e.getMessage());
+        }
+    }
+
+    /** Mint a delivery OTP for the recipient. Best-effort: a failure here never undoes the transition. */
+    private void generateDeliveryOtp(DaLifecycleEvent event) {
+        try {
+            String otp = deliveryOtpService.generate(event.shipmentId());
+            // TODO: dispatch to recipient via the notification service (oneday.notifications.events).
+            log.debug("Generated delivery OTP for shipment {} (cleartext suppressed in prod): {}",
+                    event.shipmentId(), otp);
+        } catch (RuntimeException e) {
+            log.error("Failed to generate delivery OTP for shipment {}: {}",
                     event.shipmentId(), e.getMessage());
         }
     }

--- a/orders/src/main/java/com/oneday/orders/service/DevOtpRegistry.java
+++ b/orders/src/main/java/com/oneday/orders/service/DevOtpRegistry.java
@@ -6,23 +6,36 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * In-memory store of the last cleartext pickup OTP per shipment.
+ * In-memory store of the last cleartext pickup <em>and</em> delivery OTP per shipment.
  *
- * <p>Pickup OTPs are BCrypt-hashed (cleartext is never persisted). This captures the cleartext at
- * generation time so the shipment owner can read it in the business portal
- * ({@code /api/v1/shipments/mine/{ref}/pickup-otp}) and read it to the pickup associate — no SMS.
- * It's a cache, not a store: a restart empties it, and "Regenerate" mints a fresh code.</p>
+ * <p>OTPs are BCrypt-hashed (cleartext is never persisted). This captures the cleartext at
+ * generation time so the shipment owner / a field tester can read it in the business portal
+ * ({@code /api/v1/shipments/mine/{ref}/pickup-otp}) or the dev peek
+ * ({@code /internal/dev/shipments/{ref}/delivery-otp}) and read it to the associate — no SMS.
+ * It's a cache, not a store: a restart empties it, and a resend/regenerate mints a fresh code.</p>
+ *
+ * <p>Pickup and delivery codes are kept in <b>separate</b> maps so they never collide on the same
+ * {@code shipmentId} (one shipment has both, at different points in its life).</p>
  */
 @Component
 public class DevOtpRegistry {
 
-    private final ConcurrentHashMap<UUID, String> latest = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, String> latestPickup = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, String> latestDelivery = new ConcurrentHashMap<>();
 
     public void put(UUID shipmentId, String otp) {
-        latest.put(shipmentId, otp);
+        latestPickup.put(shipmentId, otp);
     }
 
     public String get(UUID shipmentId) {
-        return latest.get(shipmentId);
+        return latestPickup.get(shipmentId);
+    }
+
+    public void putDelivery(UUID shipmentId, String otp) {
+        latestDelivery.put(shipmentId, otp);
+    }
+
+    public String getDelivery(UUID shipmentId) {
+        return latestDelivery.get(shipmentId);
     }
 }

--- a/orders/src/main/java/com/oneday/orders/service/impl/DeliveryOtpServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/DeliveryOtpServiceImpl.java
@@ -6,8 +6,10 @@ import com.oneday.orders.domain.Shipment;
 import com.oneday.orders.repository.DeliveryOtpRepository;
 import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.service.DeliveryOtpService;
+import com.oneday.orders.service.DevOtpRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,13 +36,17 @@ class DeliveryOtpServiceImpl implements DeliveryOtpService {
     private final DeliveryOtpRepository otpRepository;
     private final ShipmentRepository shipmentRepository;
     private final DeliveryOtpProperties properties;
+    // Absent in prod (the bean is @Profile("!prod")) — the dev peek is a field-test aid only.
+    private final ObjectProvider<DevOtpRegistry> devOtpRegistry;
 
     DeliveryOtpServiceImpl(DeliveryOtpRepository otpRepository,
                            ShipmentRepository shipmentRepository,
-                           DeliveryOtpProperties properties) {
+                           DeliveryOtpProperties properties,
+                           ObjectProvider<DevOtpRegistry> devOtpRegistry) {
         this.otpRepository      = otpRepository;
         this.shipmentRepository = shipmentRepository;
         this.properties         = properties;
+        this.devOtpRegistry     = devOtpRegistry;
     }
 
     @Override
@@ -61,6 +67,7 @@ class DeliveryOtpServiceImpl implements DeliveryOtpService {
         record.setUsed(false);
         otpRepository.save(record);
 
+        devOtpRegistry.ifAvailable(r -> r.putDelivery(shipmentId, otp));   // no-op in prod (bean absent)
         log.debug("Delivery OTP generated for shipmentId={}", shipmentId);
         return otp;
     }
@@ -113,6 +120,7 @@ class DeliveryOtpServiceImpl implements DeliveryOtpService {
         record.setUsed(false);
         otpRepository.save(record);
 
+        devOtpRegistry.ifAvailable(r -> r.putDelivery(shipmentId, otp));   // no-op in prod (bean absent)
         log.debug("Delivery OTP resent (attempt {}/{}) for shipmentId={}",
                 newResendCount, properties.getMaxResendCount(), shipmentId);
         return otp;

--- a/orders/src/test/java/com/oneday/orders/events/DaEventsConsumerTest.java
+++ b/orders/src/test/java/com/oneday/orders/events/DaEventsConsumerTest.java
@@ -1,8 +1,11 @@
 package com.oneday.orders.events;
 
+import com.oneday.common.domain.MeetingMode;
 import com.oneday.common.domain.enums.ShipmentState;
 import com.oneday.common.kafka.enums.DaEventType;
 import com.oneday.common.kafka.events.DaLifecycleEvent;
+import com.oneday.common.port.CityMeetingModePort;
+import com.oneday.orders.service.DeliveryOtpService;
 import com.oneday.orders.service.PickupOtpService;
 import com.oneday.orders.service.ShipmentStateMachine;
 import com.oneday.orders.service.exception.IllegalStateTransitionException;
@@ -15,27 +18,56 @@ import static org.mockito.Mockito.*;
 
 /**
  * The idempotency guard that keeps M5's event-driven assignment (PICKUP_ASSIGNED / DROP_ASSIGNED) from
- * dead-lettering when the demo has already fast-forwarded the shipment past the target state.
+ * dead-lettering when the demo has already fast-forwarded the shipment past the target state, plus the
+ * pickup/delivery OTP side-effects minted on real transitions.
  */
 class DaEventsConsumerTest {
 
     private final ShipmentStateMachine stateMachine = mock(ShipmentStateMachine.class);
-    private final PickupOtpService otp = mock(PickupOtpService.class);
-    private final com.oneday.common.port.CityMeetingModePort meetingMode =
-            mock(com.oneday.common.port.CityMeetingModePort.class);
-    private final DaEventsConsumer consumer = new DaEventsConsumer(stateMachine, otp, meetingMode);
+    private final PickupOtpService pickupOtp = mock(PickupOtpService.class);
+    private final DeliveryOtpService deliveryOtp = mock(DeliveryOtpService.class);
+    private final CityMeetingModePort meetingMode = mock(CityMeetingModePort.class);
+    private final DaEventsConsumer consumer =
+            new DaEventsConsumer(stateMachine, pickupOtp, deliveryOtp, meetingMode);
+
+    private DaLifecycleEvent event(DaEventType type, UUID shipmentId, UUID cityId) {
+        return new DaLifecycleEvent(UUID.randomUUID(), type, "1.0", Instant.now(),
+                shipmentId, "REF", UUID.randomUUID(), cityId, null, null, null, null, null);
+    }
 
     private DaLifecycleEvent pickupAssigned(UUID shipmentId) {
-        return new DaLifecycleEvent(UUID.randomUUID(), DaEventType.PICKUP_ASSIGNED, "1.0", Instant.now(),
-                shipmentId, "REF", UUID.randomUUID(), UUID.randomUUID(), null, null, null, null, null);
+        return event(DaEventType.PICKUP_ASSIGNED, shipmentId, UUID.randomUUID());
     }
 
     @Test
-    void assignedEvent_transitionsAndMintsOtp() {
+    void assignedEvent_transitionsAndMintsPickupOtp() {
         UUID id = UUID.randomUUID();
         consumer.onDaEvent(pickupAssigned(id));
         verify(stateMachine).transition(eq(id), eq(ShipmentState.PICKUP_ASSIGNED), any());
-        verify(otp).generate(id);   // OTP minted only on a real transition
+        verify(pickupOtp).generate(id);         // pickup OTP minted only on a real transition
+        verify(deliveryOtp, never()).generate(any());
+    }
+
+    @Test
+    void dropCollectedVanCity_transitionsAndMintsDeliveryOtp() {
+        UUID id = UUID.randomUUID();
+        UUID cityId = UUID.randomUUID();
+        when(meetingMode.modeFor(cityId)).thenReturn(MeetingMode.VAN_MEETING);
+        consumer.onDaEvent(event(DaEventType.DROP_COLLECTED, id, cityId));
+        verify(stateMachine).transition(eq(id), eq(ShipmentState.DROP_COLLECTED), any());
+        verify(deliveryOtp).generate(id);       // out for delivery → recipient OTP minted
+        verify(pickupOtp, never()).generate(any());
+    }
+
+    @Test
+    void collectedFromHubReturnCity_transitionsAndMintsDeliveryOtp() {
+        UUID id = UUID.randomUUID();
+        UUID cityId = UUID.randomUUID();
+        when(meetingMode.modeFor(cityId)).thenReturn(MeetingMode.HUB_RETURN);
+        consumer.onDaEvent(event(DaEventType.DROP_COLLECTED, id, cityId));
+        verify(stateMachine).transition(eq(id), eq(ShipmentState.COLLECTED_FROM_HUB), any());
+        verify(deliveryOtp).generate(id);       // HUB_RETURN out for delivery → recipient OTP minted
+        verify(pickupOtp, never()).generate(any());
     }
 
     @Test
@@ -45,7 +77,8 @@ class DaEventsConsumerTest {
                 .when(stateMachine).transition(eq(id), eq(ShipmentState.PICKUP_ASSIGNED), any());
         // must NOT rethrow (rethrow → RabbitMQ retry → DLQ), and must NOT double-mint the OTP
         consumer.onDaEvent(pickupAssigned(id));
-        verify(otp, never()).generate(any());
+        verify(pickupOtp, never()).generate(any());
+        verify(deliveryOtp, never()).generate(any());
     }
 
     @Test
@@ -55,6 +88,7 @@ class DaEventsConsumerTest {
         doThrow(new jakarta.persistence.EntityNotFoundException("Shipment not found: " + id))
                 .when(stateMachine).transition(eq(id), eq(ShipmentState.PICKUP_ASSIGNED), any());
         consumer.onDaEvent(pickupAssigned(id));   // must not throw → no retry/DLQ
-        verify(otp, never()).generate(any());
+        verify(pickupOtp, never()).generate(any());
+        verify(deliveryOtp, never()).generate(any());
     }
 }


### PR DESCRIPTION
## What this changes if merged

Fixes the **HUB_RETURN last-mile delivery OTP**, which was never wired — closing the live same-city **#00002** delivery blocker — and adds the intercity post-hub run-card.

### Delivery OTP (backend, `orders`)
- **It's now generated.** `DaEventsConsumer` mints the recipient OTP the moment the parcel goes *out for delivery* (`DROP_COLLECTED` for VAN cities, `COLLECTED_FROM_HUB` for HUB_RETURN) — the point closest to the door, so the TTL covers the drive. Covers VAN + HUB_RETURN, same-city + intercity.
- **The gate accepts HUB_RETURN.** `DeliveryOtpController` verify/resend previously required `DROP_COLLECTED` only, so a HUB_RETURN parcel (`COLLECTED_FROM_HUB`) always got *"Wrong or expired OTP."* Now both out-for-delivery states are accepted; success drives `→ DROPPED`.
- **Field-test peek.** Cleartext is captured in `DevOtpRegistry` (separate delivery slot) and readable at `GET /internal/dev/shipments/{ref}/delivery-otp` (`!prod` only), mirroring the pickup peek.
- **TTL 10 → 30 min** — the last-mile drive is longer than a pickup verification; `resend` refreshes if it still lapses.

No driver-app change (it already calls verify → drop-completed). **No migration.**

### Docs
- `docs/PHASE-2B-INTERCITY-POST-HUB.md` — intended intercity state chain, per-hop drivers, gap analysis **G1–G5** (G5 = this OTP fix), and copy-paste M8 scan-API commands to force an intercity run today.
- `docs/PHASE-2A-HUB-RETURN-RUN.md` — the delivery-OTP blocker section marked fixed.

### Verify
`DaEventsConsumerTest` covers van + hub-return mint (5/5 green); full app assembles. After deploy: parcel out for delivery → peek `/delivery-otp` → DA enters code → `DROPPED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7HAxotqFWPJirComsL33i