### PR TITLE
M9 Bhagwati delta: prime rates + batching + AeroDataBox feeds + real AWB intake

### DIFF
--- a/airline/src/main/java/com/oneday/airline/api/AirlineAdminController.java
+++ b/airline/src/main/java/com/oneday/airline/api/AirlineAdminController.java
@@ -1,0 +1,39 @@
+package com.oneday.airline.api;
+
+import com.oneday.airline.schedule.AeroDataBoxScheduleIngestService;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Map;
+
+/**
+ * Ops triggers for M9. {@code /schedule/refresh} runs the AeroDataBox schedule ingest on demand (the
+ * "click a button" companion to the monthly cron). The ingest bean only exists when
+ * {@code airline.aerodatabox.enabled=true}, so this returns 409 when the feed is off rather than
+ * pretending to work. Auth is the app-level filter (same as the rest of {@code /airline}).
+ */
+@RestController
+@RequestMapping("/airline/admin")
+class AirlineAdminController {
+
+    private final ObjectProvider<AeroDataBoxScheduleIngestService> ingest;
+
+    AirlineAdminController(ObjectProvider<AeroDataBoxScheduleIngestService> ingest) {
+        this.ingest = ingest;
+    }
+
+    @PostMapping("/schedule/refresh")
+    Map<String, Object> refreshSchedule() {
+        AeroDataBoxScheduleIngestService service = ingest.getIfAvailable();
+        if (service == null) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "AeroDataBox schedule feed is disabled (airline.aerodatabox.enabled=false)");
+        }
+        int written = service.refresh();
+        return Map.of("status", "ok", "legsUpserted", written);
+    }
+}

--- a/airline/src/main/java/com/oneday/airline/api/AirlineController.java
+++ b/airline/src/main/java/com/oneday/airline/api/AirlineController.java
@@ -4,6 +4,7 @@ import com.oneday.airline.consolidator.ConsolidatorFlightRepository;
 import com.oneday.airline.domain.Awb;
 import com.oneday.airline.domain.AwbStatus;
 import com.oneday.airline.domain.FlightInstance;
+import com.oneday.airline.dto.AwbIntakeRequest;
 import com.oneday.airline.dto.AwbParcelResponse;
 import com.oneday.airline.dto.AwbResponse;
 import com.oneday.airline.dto.FlightScheduleResponse;
@@ -12,12 +13,15 @@ import com.oneday.airline.repository.AwbParcelRepository;
 import com.oneday.airline.repository.AwbRepository;
 import com.oneday.airline.repository.FlightInstanceRepository;
 import com.oneday.airline.service.AwbGroundService;
+import com.oneday.airline.service.AwbIntakeService;
 import com.oneday.airline.service.provider.FlightProviderPort;
+import jakarta.validation.Valid;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,6 +30,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -41,17 +46,20 @@ public class AirlineController {
     private final AwbRepository awbRepository;
     private final AwbParcelRepository awbParcelRepository;
     private final AwbGroundService awbGroundService;
+    private final AwbIntakeService awbIntakeService;
     private final FlightProviderPort flightProviderPort;
 
     AirlineController(ConsolidatorFlightRepository consolidatorFlightRepository,
                        FlightInstanceRepository flightInstanceRepository,
                        AwbRepository awbRepository, AwbParcelRepository awbParcelRepository,
-                       AwbGroundService awbGroundService, FlightProviderPort flightProviderPort) {
+                       AwbGroundService awbGroundService, AwbIntakeService awbIntakeService,
+                       FlightProviderPort flightProviderPort) {
         this.consolidatorFlightRepository = consolidatorFlightRepository;
         this.flightInstanceRepository = flightInstanceRepository;
         this.awbRepository = awbRepository;
         this.awbParcelRepository = awbParcelRepository;
         this.awbGroundService = awbGroundService;
+        this.awbIntakeService = awbIntakeService;
         this.flightProviderPort = flightProviderPort;
     }
 
@@ -110,11 +118,31 @@ public class AirlineController {
                 .toList();
     }
 
+    /**
+     * The real AWB Bhagwati hands us for a flight (admin entry now; a WhatsApp form later — see
+     * {@code WhatsAppAwbWebhookController}). Stamps it on every booked bag on that plane. 404 if the
+     * flight has no booked AWB yet.
+     */
+    @PostMapping("/flights/{flightNo}/{flightDate}/awb")
+    public Map<String, Object> assignAwb(@PathVariable String flightNo,
+                                         @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate flightDate,
+                                         @Valid @RequestBody AwbIntakeRequest request) {
+        int updated = awbIntakeService.assignRealAwb(flightNo, flightDate, request.awbNo());
+        if (updated == 0) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                    "No booked AWB for flight " + flightNo + " (" + flightDate + ")");
+        }
+        return Map.of("status", "ok", "flightNo", flightNo, "flightDate", flightDate.toString(),
+                "awbNo", request.awbNo(), "bagsUpdated", updated);
+    }
+
+    /** Bhagwati warehouse handoff: our goods have been physically handed to the consolidator's dock. */
     @PostMapping("/awb/{awbId}/handed-over")
     public AwbResponse handedOver(@PathVariable UUID awbId) {
         return toResponse(awbGroundService.handOver(awbId));
     }
 
+    /** Loaded onto the aircraft (consolidator confirmation). Both are timestamps for later reporting. */
     @PostMapping("/awb/{awbId}/loaded")
     public AwbResponse loaded(@PathVariable UUID awbId) {
         return toResponse(awbGroundService.markLoaded(awbId));

--- a/airline/src/main/java/com/oneday/airline/api/WhatsAppAwbWebhookController.java
+++ b/airline/src/main/java/com/oneday/airline/api/WhatsAppAwbWebhookController.java
@@ -1,0 +1,51 @@
+package com.oneday.airline.api;
+
+import com.oneday.airline.service.AwbIntakeService;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+/**
+ * <b>STUB — not yet wired to Meta.</b> The intended path for Bhagwati (non-tech) to return an AWB: they
+ * answer a WhatsApp Business "Flow" (a small form: flight number, date, AWB) and a BSP posts the parsed
+ * answer here, which stamps it via {@link AwbIntakeService} — the exact same effect as the admin entry
+ * on {@code AirlineController}.
+ *
+ * <p>Deferred before this is production-facing: Meta webhook signature verification (X-Hub-Signature-256),
+ * the Flow schema → field binding, and the verify/challenge handshake. Until then this door accepts a
+ * plain internal JSON body and should stay behind app-level auth — treat it as an internal test seam.</p>
+ */
+@RestController
+@RequestMapping("/airline/webhooks/whatsapp")
+class WhatsAppAwbWebhookController {
+
+    private final AwbIntakeService intake;
+
+    WhatsAppAwbWebhookController(AwbIntakeService intake) {
+        this.intake = intake;
+    }
+
+    @PostMapping("/awb")
+    Map<String, Object> onAwbSubmitted(@RequestBody WhatsAppAwbForm form) {
+        LocalDate date = LocalDate.parse(form.flightDate());
+        int updated = intake.assignRealAwb(form.flightNo(), date, form.awbNo());
+        if (updated == 0) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                    "No booked AWB for flight " + form.flightNo() + " (" + form.flightDate() + ")");
+        }
+        return Map.of("status", "ok", "bagsUpdated", updated);
+    }
+
+    /** The flattened answers a WhatsApp Flow submission would carry. */
+    record WhatsAppAwbForm(@NotBlank String flightNo,
+                           @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) String flightDate,
+                           @NotBlank String awbNo) {}
+}

--- a/airline/src/main/java/com/oneday/airline/batch/FlightStatusPollJob.java
+++ b/airline/src/main/java/com/oneday/airline/batch/FlightStatusPollJob.java
@@ -1,6 +1,7 @@
 package com.oneday.airline.batch;
 
 import com.oneday.airline.config.AirlineProperties;
+import com.oneday.airline.config.ClockConfig;
 import com.oneday.airline.domain.Awb;
 import com.oneday.airline.domain.AwbStatus;
 import com.oneday.airline.domain.FlightInstance;
@@ -21,24 +22,29 @@ import org.springframework.stereotype.Component;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Consumer;
 
 /**
- * The heartbeat behind live tracking and the reassignment engine (§8, §9), mirroring {@code
- * routing.NightlyRoutePlanJob}'s scheduled-job idiom. Every {@link AirlineProperties#getStatusPollDelayMs()}
- * (default 5 min), for every booked-but-not-landed flight:
+ * Two scheduled halves, split by cost and cadence (mirroring the user's "two crons" model):
+ *
  * <ul>
- *   <li>flips real DEPARTED/LANDED once the flight's own departure/arrival Instant has passed,
- *       notifying every parcel on it (the first real callers of {@link FlightEventProducer});</li>
- *   <li>asks the (simulated) vendor for its current word on the flight — a delay/cancellation past
- *       {@link AirlineProperties#getDelayReassignThresholdMinutes()} triggers a real reassignment; a
- *       milder delay is just an advisory time-changed notice.</li>
+ *   <li><b>Progress</b> — {@link #pollProgress()} runs frequently (every {@link
+ *       AirlineProperties#getStatusPollDelayMs()}, default 5 min) and only flips real DEPARTED/LANDED
+ *       once the flight's own departure/arrival Instant has passed, notifying every parcel on it. This
+ *       is <em>clock-based</em>: it never calls the flight-data vendor, so it costs nothing and keeps
+ *       live tracking fresh.</li>
+ *   <li><b>Disruption</b> — {@link #pollDisruptions()} runs once daily and, only for booked flights
+ *       departing <em>today or tomorrow</em>, asks the vendor for its current word (the only calls that
+ *       spend the vendor's paid units). A cancellation or a delay past {@link
+ *       AirlineProperties#getDelayReassignThresholdMinutes()} triggers a real reassignment; a milder
+ *       delay is just an advisory time-changed notice.</li>
  * </ul>
  */
 @Component
-class FlightStatusPollJob {
+public class FlightStatusPollJob {
 
     private static final Logger log = LoggerFactory.getLogger(FlightStatusPollJob.class);
 
@@ -65,28 +71,41 @@ class FlightStatusPollJob {
         this.clock = clock;
     }
 
+    /** Frequent, clock-only: advance DEPARTED/LANDED for every in-flight instance. No vendor calls. */
     @Scheduled(fixedDelayString = "${airline.status-poll-delay-ms:300000}")
-    public void run() {
+    public void pollProgress() {
         List<FlightInstance> instances = flightInstanceRepository.findByStatusIn(
                 List.of(FlightInstanceStatus.SCHEDULED, FlightInstanceStatus.DEPARTED));
         for (FlightInstance instance : instances) {
             try {
-                processInstance(instance);
+                advanceProgress(instance);
             } catch (Exception e) {
-                log.error("FlightStatusPollJob failed for flight {} ({})", instance.getFlightNo(),
-                        instance.getFlightDate(), e);
+                log.error("Progress poll failed for flight {} ({})", instance.getFlightNo(), instance.getFlightDate(), e);
             }
         }
     }
 
-    // Not @Transactional: called via self-invocation from run() in the same bean, where Spring's AOP
-    // proxy wouldn't apply anyway. Each repository save() is already atomic on its own (Spring Data
-    // JPA default); the one place multi-step atomicity matters (reassign) is a separate, correctly-
-    // proxied bean, and events are intentionally published best-effort after the DB write commits
-    // (matches RabbitEventPublisher's documented "never break an already-committed flow" rule).
-    void processInstance(FlightInstance instance) {
-        Instant now = clock.instant();
+    /** Daily, vendor-backed: check today/tomorrow flights for cancellation/delay and react (the paid calls). */
+    @Scheduled(cron = "${airline.disruption-poll-cron:0 0 6 * * *}", zone = "Asia/Kolkata")
+    public void pollDisruptions() {
+        LocalDate today = LocalDate.now(clock.withZone(ClockConfig.IST));
+        List<FlightInstance> instances = flightInstanceRepository.findByStatusInAndFlightDateIn(
+                List.of(FlightInstanceStatus.SCHEDULED), List.of(today, today.plusDays(1)));
+        for (FlightInstance instance : instances) {
+            try {
+                checkDisruption(instance);
+            } catch (Exception e) {
+                log.error("Disruption poll failed for flight {} ({})", instance.getFlightNo(), instance.getFlightDate(), e);
+            }
+        }
+    }
 
+    // Not @Transactional: each repository save() is atomic on its own; the one place multi-step atomicity
+    // matters (reassign) is a separate, correctly-proxied bean, and events publish best-effort after commit.
+
+    /** Clock-only progress: SCHEDULED→DEPARTED at departure, DEPARTED→LANDED at arrival. Never calls the vendor. */
+    void advanceProgress(FlightInstance instance) {
+        Instant now = clock.instant();
         if (instance.getStatus() == FlightInstanceStatus.SCHEDULED && !now.isBefore(instance.getDeparture())) {
             instance.setStatus(FlightInstanceStatus.DEPARTED);
             flightInstanceRepository.save(instance);
@@ -96,9 +115,14 @@ class FlightStatusPollJob {
             instance.setStatus(FlightInstanceStatus.LANDED);
             flightInstanceRepository.save(instance);
             notifyParcels(instance, flightEventProducer::emitLanded);
-            return;   // landed — nothing left to reassign
         }
+    }
 
+    /** Vendor-backed disruption handling for a still-scheduled flight (cancellation → reassign, delay → reassign/advisory). */
+    void checkDisruption(FlightInstance instance) {
+        if (instance.getStatus() != FlightInstanceStatus.SCHEDULED) {
+            return;   // only a not-yet-departed flight can be reassigned/retimed
+        }
         FlightProviderPort.FlightStatusResult status =
                 flightProviderPort.status(instance.getFlightNo(), instance.getFlightDate());
 

--- a/airline/src/main/java/com/oneday/airline/batch/FlightStatusPollJob.java
+++ b/airline/src/main/java/com/oneday/airline/batch/FlightStatusPollJob.java
@@ -1,7 +1,6 @@
 package com.oneday.airline.batch;
 
 import com.oneday.airline.config.AirlineProperties;
-import com.oneday.airline.config.ClockConfig;
 import com.oneday.airline.domain.Awb;
 import com.oneday.airline.domain.AwbStatus;
 import com.oneday.airline.domain.FlightInstance;
@@ -22,7 +21,6 @@ import org.springframework.stereotype.Component;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -36,9 +34,11 @@ import java.util.function.Consumer;
  *       once the flight's own departure/arrival Instant has passed, notifying every parcel on it. This
  *       is <em>clock-based</em>: it never calls the flight-data vendor, so it costs nothing and keeps
  *       live tracking fresh.</li>
- *   <li><b>Disruption</b> — {@link #pollDisruptions()} runs once daily and, only for booked flights
- *       departing <em>today or tomorrow</em>, asks the vendor for its current word (the only calls that
- *       spend the vendor's paid units). A cancellation or a delay past {@link
+ *   <li><b>Disruption</b> — {@link #pollImminent()} / {@link #pollUpcoming()} ask the vendor for its
+ *       current word (the only calls that spend paid units), on a <em>tiered</em> cadence keyed on
+ *       time-to-departure: flights in the last few hours before departure are swept every ~30 min so a
+ *       cancellation is caught while there's still time to rebook before cutoff; flights further out are
+ *       swept every ~3 h; far-out flights aren't polled at all. A cancellation or a delay past {@link
  *       AirlineProperties#getDelayReassignThresholdMinutes()} triggers a real reassignment; a milder
  *       delay is just an advisory time-changed notice.</li>
  * </ul>
@@ -85,12 +85,24 @@ public class FlightStatusPollJob {
         }
     }
 
-    /** Daily, vendor-backed: check today/tomorrow flights for cancellation/delay and react (the paid calls). */
-    @Scheduled(cron = "${airline.disruption-poll-cron:0 0 6 * * *}", zone = "Asia/Kolkata")
-    public void pollDisruptions() {
-        LocalDate today = LocalDate.now(clock.withZone(ClockConfig.IST));
-        List<FlightInstance> instances = flightInstanceRepository.findByStatusInAndFlightDateIn(
-                List.of(FlightInstanceStatus.SCHEDULED), List.of(today, today.plusDays(1)));
+    /** Imminent tier (paid): flights departing within the next few hours, swept every ~30 min. */
+    @Scheduled(cron = "${airline.disruption-imminent-cron:0 */30 * * * *}", zone = "Asia/Kolkata")
+    public void pollImminent() {
+        pollWindow(0, properties.getDisruptionImminentWindowHours());
+    }
+
+    /** Upcoming tier (paid): flights a bit further out, swept every ~3 h. Disjoint from the imminent window. */
+    @Scheduled(cron = "${airline.disruption-upcoming-cron:0 0 */3 * * *}", zone = "Asia/Kolkata")
+    public void pollUpcoming() {
+        pollWindow(properties.getDisruptionImminentWindowHours(), properties.getDisruptionUpcomingWindowHours());
+    }
+
+    /** Vendor-check every still-scheduled flight departing in [now+fromHours, now+toHours]. */
+    private void pollWindow(int fromHours, int toHours) {
+        Instant now = clock.instant();
+        List<FlightInstance> instances = flightInstanceRepository.findByStatusInAndDepartureBetween(
+                List.of(FlightInstanceStatus.SCHEDULED),
+                now.plus(Duration.ofHours(fromHours)), now.plus(Duration.ofHours(toHours)));
         for (FlightInstance instance : instances) {
             try {
                 checkDisruption(instance);

--- a/airline/src/main/java/com/oneday/airline/config/AeroDataBoxProperties.java
+++ b/airline/src/main/java/com/oneday/airline/config/AeroDataBoxProperties.java
@@ -1,0 +1,45 @@
+package com.oneday.airline.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * AeroDataBox integration config — the real flight-schedule + status feed behind {@code
+ * FlightProviderPort}, kept swappable and <b>off by default</b> (mirrors {@code RazorpayProperties.live}).
+ *
+ * <p>Nothing here is active until {@code enabled=true} AND an {@code apiKey} is supplied via env
+ * ({@code AIRLINE_AERODATABOX_ENABLED} / {@code AIRLINE_AERODATABOX_API_KEY}) — until then the app runs
+ * on the synthetic consolidator exactly as before. <b>Never commit the key.</b></p>
+ *
+ * <p>Cost model (see project docs): schedule ingest + the daily disruption poll are the only calls that
+ * spend AeroDataBox units; flight <em>selection</em> reads our own ingested {@code flight_leg} store and
+ * live position is interpolated, both zero-unit.</p>
+ */
+@Component
+@ConfigurationProperties(prefix = "airline.aerodatabox")
+@Data
+public class AeroDataBoxProperties {
+
+    /** Master switch. False → the synthetic consolidator provider stays primary; no HTTP calls are made. */
+    private boolean enabled = false;
+
+    /** RapidAPI (or direct) key. Env-only — never commit. */
+    private String apiKey = "";
+
+    /** Base URL of the AeroDataBox API. Default is the RapidAPI gateway. */
+    private String baseUrl = "https://aerodatabox.p.rapidapi.com";
+
+    /** RapidAPI host header value (ignored for a direct subscription with an empty value). */
+    private String rapidApiHost = "aerodatabox.p.rapidapi.com";
+
+    /** How many days of forward schedule the monthly ingest projects. Default ~3 months. */
+    private int scheduleHorizonDays = 90;
+
+    /**
+     * Block-time estimate (minutes) used to derive an arrival time from a FIDS departure row, since a
+     * departures query doesn't carry the arrival time. Corrected by the daily status poll's real
+     * estimated arrival. A single value is fine for the 5 metro lanes (all ~2h); refine per-lane later.
+     */
+    private int defaultBlockMinutes = 150;
+}

--- a/airline/src/main/java/com/oneday/airline/config/AeroDataBoxProperties.java
+++ b/airline/src/main/java/com/oneday/airline/config/AeroDataBoxProperties.java
@@ -33,8 +33,8 @@ public class AeroDataBoxProperties {
     /** RapidAPI host header value (ignored for a direct subscription with an empty value). */
     private String rapidApiHost = "aerodatabox.p.rapidapi.com";
 
-    /** How many days of forward schedule the monthly ingest projects. Default ~3 months. */
-    private int scheduleHorizonDays = 90;
+    /** How many days of forward schedule the monthly ingest projects. Default 1 month (less speculative booking). */
+    private int scheduleHorizonDays = 30;
 
     /**
      * Block-time estimate (minutes) used to derive an arrival time from a FIDS departure row, since a

--- a/airline/src/main/java/com/oneday/airline/config/AirlineProperties.java
+++ b/airline/src/main/java/com/oneday/airline/config/AirlineProperties.java
@@ -71,6 +71,19 @@ public class AirlineProperties {
      */
     private int delayReassignThresholdMinutes = 60;
 
+    /**
+     * Tiered disruption polling — poll frequency scales with proximity to departure so a cancellation
+     * is caught while there's still time to rebook before cutoff (correctness), while far-out flights
+     * cost nothing. The two windows are disjoint and each is swept at its own cadence:
+     * <ul>
+     *   <li>0 → {@code disruptionImminentWindowHours} before departure: swept every ~30 min;</li>
+     *   <li>that up to {@code disruptionUpcomingWindowHours}: swept every ~3 h;</li>
+     *   <li>beyond it: not polled — the schedule stands until the flight enters the upcoming window.</li>
+     * </ul>
+     */
+    private int disruptionImminentWindowHours = 6;
+    private int disruptionUpcomingWindowHours = 24;
+
     /** True if a flight departing at this IST time falls in the expensive prime window (§ prime-rate avoidance). */
     public boolean isPrime(LocalTime departure) {
         LocalTime start = LocalTime.of(primeWindowStartHour, 0);

--- a/airline/src/main/java/com/oneday/airline/config/AirlineProperties.java
+++ b/airline/src/main/java/com/oneday/airline/config/AirlineProperties.java
@@ -25,14 +25,27 @@ public class AirlineProperties {
      */
     private int gateCutoffLeadMinutes = 180;
 
-    /** A flight departing at/after this hour (IST) is in the discounted overnight window. */
-    private int overnightWindowStartHour = 22;
+    /**
+     * Start hour (IST, inclusive) of the <b>prime</b> air-cargo window — the expensive overnight rate
+     * the consolidator charges. A flight departing in {@code [primeWindowStartHour, primeWindowEndHour)}
+     * carries the {@link #primeSurchargeBps} surcharge, so cheapest-first selection avoids it unless it's
+     * the only flight that meets the promise. Default window 00:00–09:00.
+     */
+    private int primeWindowStartHour = 0;
 
-    /** A flight departing before this hour (IST) is still in the overnight window (wraps past midnight). */
-    private int overnightWindowEndHour = 6;
+    /** End hour (IST, exclusive) of the prime window. Default 09:00 (so 09:00–23:59 is the cheap rate). */
+    private int primeWindowEndHour = 9;
 
-    /** Discount applied to the overnight-window rate when comparing candidates (basis points off). */
-    private int overnightDiscountBps = 1000;
+    /** Surcharge applied to a prime-window flight's rate when comparing candidates (basis points on top). Default 35%. */
+    private int primeSurchargeBps = 3500;
+
+    /**
+     * The internal delivery-promise horizon (hours from a parcel being hub-ready) used as the flight
+     * cutoff for <b>leeway batching</b>: any flight arriving within this window is eligible, and among
+     * those the fullest (latest-departing) is preferred so parcels consolidate onto one AWB per plane.
+     * Default 16h.
+     */
+    private int slaHours = 16;
 
     /**
      * Typical bag weight (grams) used to rank candidate flights by cost during selection, before a
@@ -58,9 +71,10 @@ public class AirlineProperties {
      */
     private int delayReassignThresholdMinutes = 60;
 
-    public boolean isOvernight(LocalTime departure) {
-        LocalTime start = LocalTime.of(overnightWindowStartHour, 0);
-        LocalTime end = LocalTime.of(overnightWindowEndHour, 0);
+    /** True if a flight departing at this IST time falls in the expensive prime window (§ prime-rate avoidance). */
+    public boolean isPrime(LocalTime departure) {
+        LocalTime start = LocalTime.of(primeWindowStartHour, 0);
+        LocalTime end = LocalTime.of(primeWindowEndHour, 0);
         return start.isAfter(end)
                 ? !departure.isBefore(start) || departure.isBefore(end)   // window wraps midnight
                 : !departure.isBefore(start) && departure.isBefore(end);

--- a/airline/src/main/java/com/oneday/airline/consolidator/ConsolidatorLegRollForwardJob.java
+++ b/airline/src/main/java/com/oneday/airline/consolidator/ConsolidatorLegRollForwardJob.java
@@ -3,6 +3,7 @@ package com.oneday.airline.consolidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -21,6 +22,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @Profile("!prod")
+@ConditionalOnProperty(prefix = "airline.aerodatabox", name = "enabled", havingValue = "false", matchIfMissing = true)
 class ConsolidatorLegRollForwardJob {
 
     private static final Logger log = LoggerFactory.getLogger(ConsolidatorLegRollForwardJob.class);

--- a/airline/src/main/java/com/oneday/airline/dto/AwbIntakeRequest.java
+++ b/airline/src/main/java/com/oneday/airline/dto/AwbIntakeRequest.java
@@ -1,0 +1,7 @@
+package com.oneday.airline.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/** The real AWB number Bhagwati hands us for a flight (admin entry / WhatsApp form). */
+public record AwbIntakeRequest(@NotBlank String awbNo) {
+}

--- a/airline/src/main/java/com/oneday/airline/provider/aerodatabox/AeroDataBoxClient.java
+++ b/airline/src/main/java/com/oneday/airline/provider/aerodatabox/AeroDataBoxClient.java
@@ -1,0 +1,164 @@
+package com.oneday.airline.provider.aerodatabox;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneday.airline.config.AeroDataBoxProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Thin HTTP client for AeroDataBox — the real flight-schedule + status feed. Only instantiated when
+ * {@code airline.aerodatabox.enabled=true} (see {@link AeroDataBoxProperties}); otherwise absent and
+ * the synthetic consolidator provider stays primary.
+ *
+ * <p>The two parse methods are {@code static} and pure so they can be unit-tested against captured
+ * sample JSON without any network. <b>The exact field mapping must be validated against the live API
+ * when a key is first procured</b> — parsing is deliberately defensive (missing fields are skipped,
+ * never throw) so a schema surprise degrades to "fewer legs", not a crash.</p>
+ */
+@Component
+@ConditionalOnProperty(prefix = "airline.aerodatabox", name = "enabled", havingValue = "true")
+public class AeroDataBoxClient {
+
+    private static final Logger log = LoggerFactory.getLogger(AeroDataBoxClient.class);
+    private static final DateTimeFormatter FIDS_WINDOW = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final RestClient http;
+
+    public AeroDataBoxClient(AeroDataBoxProperties properties) {
+        RestClient.Builder b = RestClient.builder().baseUrl(properties.getBaseUrl());
+        if (!properties.getApiKey().isBlank()) {
+            b = b.defaultHeader("x-rapidapi-key", properties.getApiKey());
+        }
+        if (!properties.getRapidApiHost().isBlank()) {
+            b = b.defaultHeader("x-rapidapi-host", properties.getRapidApiHost());
+        }
+        this.http = b.build();
+    }
+
+    /** FIDS departures from {@code iata} within a ≤12h window (API limit). One row per scheduled departure. */
+    public List<DepartureRow> departures(String iata, LocalDateTime fromLocal, LocalDateTime toLocal) {
+        try {
+            String body = http.get()
+                    .uri("/flights/airports/iata/{iata}/{from}/{to}?direction=Departure&withLeg=true&withCancelled=false",
+                            iata, fromLocal.format(FIDS_WINDOW), toLocal.format(FIDS_WINDOW))
+                    .retrieve()
+                    .body(String.class);
+            return parseDepartures(MAPPER.readTree(body));
+        } catch (Exception e) {
+            log.error("AeroDataBox departures fetch failed for {} [{}..{}]: {}", iata, fromLocal, toLocal, e.getMessage());
+            return List.of();
+        }
+    }
+
+    /** Live status for one flight on a date — feeds the daily disruption poll. */
+    public Optional<StatusRow> flightStatus(String flightNo, LocalDate date) {
+        try {
+            String body = http.get()
+                    .uri("/flights/number/{number}/{date}", flightNo, date.toString())
+                    .retrieve()
+                    .body(String.class);
+            return parseStatus(MAPPER.readTree(body));
+        } catch (Exception e) {
+            log.error("AeroDataBox status fetch failed for {} ({}): {}", flightNo, date, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    // ── pure parsers (unit-tested) ────────────────────────────────────────────
+
+    static List<DepartureRow> parseDepartures(JsonNode root) {
+        JsonNode departures = root.path("departures");
+        if (!departures.isArray()) {
+            departures = root.isArray() ? root : MAPPER.createArrayNode();
+        }
+        List<DepartureRow> rows = new ArrayList<>();
+        for (JsonNode d : departures) {
+            String flightNo = normalizeFlightNo(text(d, "number"));
+            String destIata = text(d.path("movement").path("airport"), "iata");
+            LocalTime depTime = localTimeOf(d.path("movement").path("scheduledTime"));
+            if (flightNo != null && destIata != null && depTime != null) {
+                rows.add(new DepartureRow(flightNo, destIata, depTime));
+            }
+        }
+        return rows;
+    }
+
+    static Optional<StatusRow> parseStatus(JsonNode root) {
+        JsonNode leg = root.isArray() ? (root.isEmpty() ? null : root.get(0)) : root;
+        if (leg == null || leg.isMissingNode()) {
+            return Optional.empty();
+        }
+        String status = text(leg, "status");
+        Instant estDep = instantOf(leg.path("departure"));
+        Instant estArr = instantOf(leg.path("arrival"));
+        return Optional.of(new StatusRow(status == null ? "" : status, estDep, estArr));
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    /** "AI 806" / "ai806" → "AI806"; null-safe. */
+    private static String normalizeFlightNo(String raw) {
+        if (raw == null) return null;
+        String stripped = raw.replaceAll("\\s+", "").toUpperCase();
+        return stripped.isEmpty() ? null : stripped;
+    }
+
+    private static String text(JsonNode node, String field) {
+        JsonNode v = node.path(field);
+        return v.isValueNode() && !v.asText().isBlank() ? v.asText() : null;
+    }
+
+    /** Reads a {revisedTime|scheduledTime}.local time-of-day, tolerating "..HH:mm+05:30" or ISO forms. */
+    private static LocalTime localTimeOf(JsonNode scheduledTime) {
+        String local = text(scheduledTime, "local");
+        if (local == null) return null;
+        String normalized = local.trim().replace(' ', 'T');
+        try {
+            return OffsetDateTime.parse(normalized).toLocalTime();
+        } catch (Exception ignore) {
+            try {
+                return LocalDateTime.parse(normalized).toLocalTime();
+            } catch (Exception ignore2) {
+                return null;
+            }
+        }
+    }
+
+    /** Prefers a movement's revised (actual/estimated) UTC instant, falling back to scheduled. */
+    private static Instant instantOf(JsonNode movement) {
+        Instant revised = utcInstant(movement.path("revisedTime"));
+        return revised != null ? revised : utcInstant(movement.path("scheduledTime"));
+    }
+
+    private static Instant utcInstant(JsonNode time) {
+        String utc = time.path("utc").isValueNode() ? time.path("utc").asText() : null;
+        if (utc == null || utc.isBlank()) return null;
+        String normalized = utc.trim().replace(' ', 'T').replace("Z", "+00:00");
+        try {
+            return OffsetDateTime.parse(normalized).toInstant();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** A scheduled departure: flight number, destination airport, and local departure time-of-day. */
+    public record DepartureRow(String flightNo, String destIata, LocalTime departureLocal) {}
+
+    /** A flight's current word: raw status string plus best-known departure/arrival instants. */
+    public record StatusRow(String rawStatus, Instant estimatedDeparture, Instant estimatedArrival) {}
+}

--- a/airline/src/main/java/com/oneday/airline/repository/FlightInstanceRepository.java
+++ b/airline/src/main/java/com/oneday/airline/repository/FlightInstanceRepository.java
@@ -23,6 +23,9 @@ public interface FlightInstanceRepository extends JpaRepository<FlightInstance, 
     Optional<FlightInstance> findByFlightNoAndFlightDateForUpdate(
             @Param("flightNo") String flightNo, @Param("flightDate") LocalDate flightDate);
 
-    /** Scope for the status poll job (§13): flights not yet landed/cancelled. */
+    /** Scope for the frequent progress poll: flights not yet landed/cancelled. */
     List<FlightInstance> findByStatusIn(List<FlightInstanceStatus> statuses);
+
+    /** Scope for the daily disruption poll: not-yet-departed flights on the given dates (today/tomorrow). */
+    List<FlightInstance> findByStatusInAndFlightDateIn(List<FlightInstanceStatus> statuses, List<LocalDate> dates);
 }

--- a/airline/src/main/java/com/oneday/airline/repository/FlightInstanceRepository.java
+++ b/airline/src/main/java/com/oneday/airline/repository/FlightInstanceRepository.java
@@ -26,6 +26,7 @@ public interface FlightInstanceRepository extends JpaRepository<FlightInstance, 
     /** Scope for the frequent progress poll: flights not yet landed/cancelled. */
     List<FlightInstance> findByStatusIn(List<FlightInstanceStatus> statuses);
 
-    /** Scope for the daily disruption poll: not-yet-departed flights on the given dates (today/tomorrow). */
-    List<FlightInstance> findByStatusInAndFlightDateIn(List<FlightInstanceStatus> statuses, List<LocalDate> dates);
+    /** Scope for the tiered disruption poll: not-yet-departed flights departing inside a time-to-departure window. */
+    List<FlightInstance> findByStatusInAndDepartureBetween(
+            List<FlightInstanceStatus> statuses, java.time.Instant from, java.time.Instant to);
 }

--- a/airline/src/main/java/com/oneday/airline/schedule/AeroDataBoxScheduleIngestService.java
+++ b/airline/src/main/java/com/oneday/airline/schedule/AeroDataBoxScheduleIngestService.java
@@ -1,0 +1,121 @@
+package com.oneday.airline.schedule;
+
+import com.oneday.airline.config.AeroDataBoxProperties;
+import com.oneday.airline.config.AirlineProperties;
+import com.oneday.airline.config.ClockConfig;
+import com.oneday.airline.provider.aerodatabox.AeroDataBoxClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The "monthly cron" that fetches the forward flight schedule from AeroDataBox and populates our local
+ * {@code flight_leg} store, so flight <em>selection</em> always reads the DB (zero vendor units) — the
+ * schedule feed is the only place we spend AeroDataBox units besides the daily disruption poll.
+ *
+ * <p>Only active when {@code airline.aerodatabox.enabled=true}; otherwise the synthetic
+ * {@code ConsolidatorLegRollForwardJob} keeps the mock schedule fresh instead. Idempotent per
+ * {@code (flight_no, flight_date)} via upsert, so a re-run (or the admin trigger) never duplicates.
+ * Fixed lanes → the schedule is a stable repeating pattern, so an occasional refresh is enough; the
+ * daily disruption poll corrects same-day cancellations/retimes.</p>
+ */
+@Service
+@ConditionalOnProperty(prefix = "airline.aerodatabox", name = "enabled", havingValue = "true")
+public class AeroDataBoxScheduleIngestService {
+
+    private static final Logger log = LoggerFactory.getLogger(AeroDataBoxScheduleIngestService.class);
+    private static final int DEFAULT_CAPACITY_KG = 2000;
+
+    // Upsert into the same flight_leg store the read path uses; append/refresh, never lose history of a date.
+    private static final String UPSERT = """
+            INSERT INTO flight_leg (flight_no, flight_date, carrier, origin_hub, dest_hub,
+                                    departure_at, arrival_at, capacity_kg, status)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'SCHEDULED')
+            ON CONFLICT (flight_no, flight_date) DO UPDATE SET
+                carrier = EXCLUDED.carrier, origin_hub = EXCLUDED.origin_hub, dest_hub = EXCLUDED.dest_hub,
+                departure_at = EXCLUDED.departure_at, arrival_at = EXCLUDED.arrival_at,
+                capacity_kg = EXCLUDED.capacity_kg
+            """;
+
+    private final AeroDataBoxClient client;
+    private final AeroDataBoxProperties aeroProps;
+    private final AirlineProperties airlineProps;
+    private final JdbcTemplate consolidatorJdbcTemplate;
+
+    public AeroDataBoxScheduleIngestService(AeroDataBoxClient client, AeroDataBoxProperties aeroProps,
+                                            AirlineProperties airlineProps,
+                                            @Qualifier("consolidatorJdbcTemplate") JdbcTemplate consolidatorJdbcTemplate) {
+        this.client = client;
+        this.aeroProps = aeroProps;
+        this.airlineProps = airlineProps;
+        this.consolidatorJdbcTemplate = consolidatorJdbcTemplate;
+    }
+
+    /** Monthly refresh of the forward window (03:00 IST on the 1st). Admin can also trigger via the API. */
+    @Scheduled(cron = "${airline.schedule-ingest-cron:0 0 3 1 * *}", zone = "Asia/Kolkata")
+    public void scheduledRefresh() {
+        int n = refresh();
+        log.info("AeroDataBox schedule ingest (scheduled) upserted {} legs", n);
+    }
+
+    /** Fetch every serviceable lane's forward schedule and upsert into flight_leg. Returns rows written. */
+    public int refresh() {
+        Set<String> airports = airlineProps.getCities().keySet();   // the 5 grid cities' IATA hub codes
+        if (airports.isEmpty()) {
+            log.warn("AeroDataBox ingest: no airports configured (airline.cities empty) — nothing to do");
+            return 0;
+        }
+        int written = 0;
+        LocalDate today = LocalDate.now(ClockConfig.IST);
+        for (String origin : airports) {
+            for (int dayOffset = 0; dayOffset < aeroProps.getScheduleHorizonDays(); dayOffset++) {
+                LocalDate date = today.plusDays(dayOffset);
+                written += ingestAirportDay(origin, date, airports);
+            }
+        }
+        return written;
+    }
+
+    private int ingestAirportDay(String origin, LocalDate date, Set<String> serviceableAirports) {
+        int written = 0;
+        // FIDS windows are capped at 12h, so a day is two calls.
+        for (LocalTime windowStart : List.of(LocalTime.MIN, LocalTime.NOON)) {
+            LocalDateTime from = date.atTime(windowStart);
+            LocalDateTime to = from.plusHours(12);
+            for (AeroDataBoxClient.DepartureRow row : client.departures(origin, from, to)) {
+                // Keep only our own lanes (departures to another serviceable hub).
+                if (origin.equals(row.destIata()) || !serviceableAirports.contains(row.destIata())) {
+                    continue;
+                }
+                Instant departure = date.atTime(row.departureLocal()).atZone(ClockConfig.IST).toInstant();
+                Instant arrival = departure.plusSeconds(aeroProps.getDefaultBlockMinutes() * 60L);
+                consolidatorJdbcTemplate.update(UPSERT,
+                        row.flightNo(), date, carrierOf(row.flightNo()), origin, row.destIata(),
+                        Timestamp.from(departure), Timestamp.from(arrival), DEFAULT_CAPACITY_KG);
+                written++;
+            }
+        }
+        return written;
+    }
+
+    /** Leading letters of the flight number are the carrier code ("AI806" → "AI"). */
+    private static String carrierOf(String flightNo) {
+        int i = 0;
+        while (i < flightNo.length() && Character.isLetter(flightNo.charAt(i))) {
+            i++;
+        }
+        return i > 0 ? flightNo.substring(0, i) : "UNKNOWN";
+    }
+}

--- a/airline/src/main/java/com/oneday/airline/service/AwbIntakeService.java
+++ b/airline/src/main/java/com/oneday/airline/service/AwbIntakeService.java
@@ -1,0 +1,46 @@
+package com.oneday.airline.service;
+
+import com.oneday.airline.domain.Awb;
+import com.oneday.airline.domain.AwbStatus;
+import com.oneday.airline.repository.AwbRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Records the <b>real</b> air waybill number the freight consolidator (Bhagwati) hands us for a flight,
+ * replacing the local placeholder minted at booking. Bhagwati isn't tech-heavy — there's no booking API
+ * — so the AWB arrives out-of-band (admin entry now, a WhatsApp form later) and is stamped here.
+ *
+ * <p>One AWB covers the whole plane, so every BOOKED AWB row on that (flightNo, date) — one per sealed
+ * bag — is set to the same real number; that number then drives cargo-status lookups. Idempotent: a
+ * re-submit just re-writes the same value.</p>
+ */
+@Service
+public class AwbIntakeService {
+
+    private static final Logger log = LoggerFactory.getLogger(AwbIntakeService.class);
+
+    private final AwbRepository awbRepository;
+
+    public AwbIntakeService(AwbRepository awbRepository) {
+        this.awbRepository = awbRepository;
+    }
+
+    /** Stamp {@code awbNo} on every booked AWB for the flight. Returns how many rows were updated (0 → none booked). */
+    @Transactional
+    public int assignRealAwb(String flightNo, LocalDate flightDate, String awbNo) {
+        List<Awb> booked = awbRepository.findByFlightNoAndFlightDate(flightNo, flightDate).stream()
+                .filter(a -> a.getStatus() == AwbStatus.BOOKED)
+                .toList();
+        booked.forEach(a -> a.setAwbNo(awbNo));
+        awbRepository.saveAll(booked);
+        log.info("Stamped real AWB {} on {} booked bag(s) for flight {} ({})",
+                awbNo, booked.size(), flightNo, flightDate);
+        return booked.size();
+    }
+}

--- a/airline/src/main/java/com/oneday/airline/service/impl/AwbBookingServiceImpl.java
+++ b/airline/src/main/java/com/oneday/airline/service/impl/AwbBookingServiceImpl.java
@@ -76,8 +76,8 @@ class AwbBookingServiceImpl implements AwbBookingService {
 
         ConsolidatorLaneRate rateCard = consolidatorRateRepository
                 .findActiveRate(instance.getOriginHub(), instance.getDestHub());
-        boolean overnight = properties.isOvernight(instance.getDeparture().atZone(ClockConfig.IST).toLocalTime());
-        long costPaise = costEstimator.estimatePaise(rateCard, command.weightGrams(), overnight);
+        boolean prime = properties.isPrime(instance.getDeparture().atZone(ClockConfig.IST).toLocalTime());
+        long costPaise = costEstimator.estimatePaise(rateCard, command.weightGrams(), prime);
 
         Awb awb = new Awb();
         awb.setAwbNo(generateAwbNo(instance, command.bagId()));

--- a/airline/src/main/java/com/oneday/airline/service/impl/CostEstimator.java
+++ b/airline/src/main/java/com/oneday/airline/service/impl/CostEstimator.java
@@ -6,9 +6,10 @@ import org.springframework.stereotype.Component;
 
 /**
  * GCR-style slab cost math (§10): a per-kg rate that steps down as chargeable weight crosses a
- * break, plus a fixed terminal handling fee, floored at the lane's minimum charge. An overnight
- * flight's total gets the configured discount applied before the floor, so a cheapest-first pick
- * naturally prefers overnight when it's genuinely cheaper (§5).
+ * break, plus a fixed terminal handling fee, floored at the lane's minimum charge. A <b>prime</b>
+ * (overnight, 00:00–09:00) flight's total gets the configured surcharge added before the floor, so a
+ * cheapest-first pick naturally <em>avoids</em> the expensive prime window unless it's the only flight
+ * that meets the promise (§5).
  */
 @Component
 class CostEstimator {
@@ -19,12 +20,12 @@ class CostEstimator {
         this.properties = properties;
     }
 
-    long estimatePaise(ConsolidatorLaneRate rateCard, int weightGrams, boolean overnight) {
+    long estimatePaise(ConsolidatorLaneRate rateCard, int weightGrams, boolean prime) {
         double weightKg = weightGrams / 1000.0;
         long perKgPaise = ratePerKg(rateCard, weightKg);
         long total = Math.round(weightKg * perKgPaise) + rateCard.terminalHandlingPaise();
-        if (overnight) {
-            total -= total * properties.getOvernightDiscountBps() / 10_000;
+        if (prime) {
+            total += total * properties.getPrimeSurchargeBps() / 10_000;   // expensive prime-window rate
         }
         return Math.max(total, rateCard.minChargePaise());
     }

--- a/airline/src/main/java/com/oneday/airline/service/impl/FlightSelectionService.java
+++ b/airline/src/main/java/com/oneday/airline/service/impl/FlightSelectionService.java
@@ -11,15 +11,24 @@ import org.springframework.stereotype.Component;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
 
 /**
  * The shared brain behind both synchronous seams (hub's {@code FlightAssignmentPort}, routing's
- * {@code FlightCutoffPort}): pick the cheapest flight on a lane that still meets cutoff, preferring
- * a genuinely-discounted overnight slot, rolling to the next day if today's cutoffs have all passed
- * (§5). Read-only — it persists nothing; a {@code flight_instance} row is only created lazily when a
- * bag actually books (mirrors M7's lazy bag-open pattern).
+ * {@code FlightCutoffPort}): pick the cheapest flight on a lane that a parcel can catch and that still
+ * meets the delivery promise, rolling to the next day if today's cutoffs have all passed (§5).
+ *
+ * <p>Two objectives, in order: (1) <b>meet the {@code slaHours} promise</b> — only flights arriving
+ * within the parcel's SLA window are eligible; if none can (a very late booking), ship on the
+ * soonest-arriving catchable flight as best effort (M9 doc §11). (2) <b>Consolidate + avoid prime</b>
+ * — among eligible flights, pick the cheapest, breaking ties toward the <em>latest</em> departure so
+ * parcels accumulate onto the fullest flight (one AWB per plane); the prime-window surcharge makes the
+ * expensive 00:00–09:00 slot lose on cost unless it's the only option.</p>
+ *
+ * <p>Read-only — it persists nothing; a {@code flight_instance} row is only created lazily when a bag
+ * actually books (mirrors M7's lazy bag-open pattern).</p>
  */
 @Component
 public class FlightSelectionService {
@@ -40,12 +49,13 @@ public class FlightSelectionService {
         this.properties = properties;
     }
 
-    /** The cheapest flight from {@code originHub} to {@code destHub} that a parcel ready at {@code readyAt} can make. */
+    /** The best flight from {@code originHub} to {@code destHub} for a parcel ready at {@code readyAt}. */
     public Selection select(String originHub, String destHub, Instant readyAt) {
         ConsolidatorLaneRate rateCard = consolidatorRateRepository.findActiveRate(originHub, destHub);
 
         ZonedDateTime ready = readyAt.atZone(ClockConfig.IST);
         LocalDate date = ready.toLocalDate();
+        Instant slaDeadline = readyAt.plus(properties.getSlaHours(), ChronoUnit.HOURS);
 
         for (int daysAhead = 0; daysAhead < MAX_LOOKAHEAD_DAYS; daysAhead++) {
             LocalDate candidateDate = date.plusDays(daysAhead);
@@ -54,18 +64,30 @@ public class FlightSelectionService {
 
             // Day 0 must still be catchable (cutoff ahead of readyAt); later days are trivially catchable.
             boolean cutoffMustBeAhead = daysAhead == 0;
-            List<Priced> priced = candidates.stream()
+            List<Priced> catchable = candidates.stream()
                     .map(c -> price(c, candidateDate, rateCard))
                     .filter(p -> !cutoffMustBeAhead || !p.cutoff().isBefore(readyAt))
                     .toList();
 
-            if (!priced.isEmpty()) {
-                Priced best = priced.stream()
-                        .min(Comparator.comparingLong(Priced::costPaise).thenComparing(Priced::departure))
-                        .orElseThrow();
-                return new Selection(best.candidate().flightNo(), candidateDate, originHub, destHub,
-                        best.departure(), best.arrival(), best.cutoff(), best.candidate().capacityKg());
+            // First day with anything catchable decides it: a later day can only arrive even later, so it
+            // never beats this day on either the SLA or "soonest". Roll forward only when today is empty.
+            if (catchable.isEmpty()) {
+                continue;
             }
+
+            // (1) Prefer flights that meet the SLA promise; among them (2) cheapest, tie → latest departure
+            // (consolidation: fill one flight fuller). Prime-window flights are pricier so they lose on cost.
+            List<Priced> withinSla = catchable.stream()
+                    .filter(p -> !p.arrival().isAfter(slaDeadline))
+                    .toList();
+            Priced best = !withinSla.isEmpty()
+                    ? withinSla.stream()
+                        .min(Comparator.comparingLong(Priced::costPaise)
+                                .thenComparing(Priced::departure, Comparator.reverseOrder()))
+                        .orElseThrow()
+                    // No flight can meet the promise (very late booking): ship the soonest-arriving one.
+                    : catchable.stream().min(Comparator.comparing(Priced::arrival)).orElseThrow();
+            return toSelection(best, originHub, destHub);
         }
         throw new NoFlightAvailableException(originHub, destHub);
     }
@@ -77,13 +99,18 @@ public class FlightSelectionService {
             arrival = arrival.plusDays(1);   // overnight-spanning flight
         }
         Instant cutoff = departure.minusMinutes(properties.getGateCutoffLeadMinutes()).toInstant();
-        boolean overnight = properties.isOvernight(candidate.departureTime());
-        long costPaise = costEstimator.estimatePaise(rateCard, properties.getTypicalBagWeightGrams(), overnight);
-        return new Priced(candidate, departure.toInstant(), arrival.toInstant(), cutoff, costPaise);
+        boolean prime = properties.isPrime(candidate.departureTime());
+        long costPaise = costEstimator.estimatePaise(rateCard, properties.getTypicalBagWeightGrams(), prime);
+        return new Priced(candidate, date, departure.toInstant(), arrival.toInstant(), cutoff, costPaise);
     }
 
-    private record Priced(FlightProviderPort.FlightCandidate candidate, Instant departure, Instant arrival,
-                           Instant cutoff, long costPaise) {
+    private Selection toSelection(Priced p, String originHub, String destHub) {
+        return new Selection(p.candidate().flightNo(), p.flightDate(), originHub, destHub,
+                p.departure(), p.arrival(), p.cutoff(), p.candidate().capacityKg());
+    }
+
+    private record Priced(FlightProviderPort.FlightCandidate candidate, LocalDate flightDate, Instant departure,
+                           Instant arrival, Instant cutoff, long costPaise) {
     }
 
     public record Selection(String flightNo, LocalDate flightDate, String originHub, String destHub,

--- a/airline/src/main/java/com/oneday/airline/service/port/FlightTrackingPortAdapter.java
+++ b/airline/src/main/java/com/oneday/airline/service/port/FlightTrackingPortAdapter.java
@@ -4,6 +4,7 @@ import com.oneday.airline.config.HubCoordinates;
 import com.oneday.airline.domain.Awb;
 import com.oneday.airline.domain.AwbParcel;
 import com.oneday.airline.domain.FlightInstance;
+import com.oneday.airline.domain.FlightInstanceStatus;
 import com.oneday.airline.repository.AwbParcelRepository;
 import com.oneday.airline.repository.AwbRepository;
 import com.oneday.airline.repository.FlightInstanceRepository;
@@ -56,6 +57,11 @@ class FlightTrackingPortAdapter implements FlightTrackingPort {
         }
 
         FlightInstance fi = instance.get();
+        // Anchor the moving dot to the REAL airborne signal (the progress poll's DEPARTED flip), not the
+        // clock alone — a delayed-but-not-yet-departed flight stays SCHEDULED and shows no dot.
+        if (fi.getStatus() != FlightInstanceStatus.DEPARTED) {
+            return Optional.empty();
+        }
         Instant now = clock.instant();
         if (now.isBefore(fi.getDeparture()) || !now.isBefore(fi.getArrival())) {
             return Optional.empty();   // not airborne yet, or already landed

--- a/airline/src/main/java/com/oneday/airline/service/provider/AeroDataBoxFlightProviderAdapter.java
+++ b/airline/src/main/java/com/oneday/airline/service/provider/AeroDataBoxFlightProviderAdapter.java
@@ -1,0 +1,63 @@
+package com.oneday.airline.service.provider;
+
+import com.oneday.airline.config.ClockConfig;
+import com.oneday.airline.consolidator.ConsolidatorFlightRepository;
+import com.oneday.airline.provider.aerodatabox.AeroDataBoxClient;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * The real {@link FlightProviderPort} when {@code airline.aerodatabox.enabled=true} — becomes primary,
+ * replacing {@code ConsolidatorFlightProviderAdapter}. Deliberately asymmetric on cost:
+ *
+ * <ul>
+ *   <li>{@link #search} reads our own {@code flight_leg} store (populated by the monthly
+ *       {@code AeroDataBoxScheduleIngestService}), so flight selection at scan-in costs <b>zero</b>
+ *       vendor units;</li>
+ *   <li>{@link #status} is the one call that hits the live API — made only by the <b>daily</b>
+ *       disruption poll for today/tomorrow flights, bounding paid usage.</li>
+ * </ul>
+ */
+@Component
+@Primary
+@ConditionalOnProperty(prefix = "airline.aerodatabox", name = "enabled", havingValue = "true")
+class AeroDataBoxFlightProviderAdapter implements FlightProviderPort {
+
+    private final ConsolidatorFlightRepository flightLegStore;
+    private final AeroDataBoxClient client;
+
+    AeroDataBoxFlightProviderAdapter(ConsolidatorFlightRepository flightLegStore, AeroDataBoxClient client) {
+        this.flightLegStore = flightLegStore;
+        this.client = client;
+    }
+
+    @Override
+    public List<FlightCandidate> search(String originHub, String destHub, LocalDate date) {
+        return flightLegStore.findLegs(originHub, destHub, date).stream()
+                .map(leg -> new FlightCandidate(leg.flightNo(), leg.carrier(),
+                        leg.departureAt().atZone(ClockConfig.IST).toLocalTime(),
+                        leg.arrivalAt().atZone(ClockConfig.IST).toLocalTime(),
+                        leg.capacityKg()))
+                .toList();
+    }
+
+    @Override
+    public FlightStatusResult status(String flightNo, LocalDate flightDate) {
+        AeroDataBoxClient.StatusRow row = client.flightStatus(flightNo, flightDate).orElse(null);
+        if (row == null) {
+            return new FlightStatusResult(FlightRealWorldStatus.ON_TIME, null, null);
+        }
+        String s = row.rawStatus().toLowerCase();
+        if (s.contains("cancel")) {
+            return new FlightStatusResult(FlightRealWorldStatus.CANCELLED, row.estimatedDeparture(), row.estimatedArrival());
+        }
+        if (s.contains("delay") && row.estimatedDeparture() != null) {
+            return new FlightStatusResult(FlightRealWorldStatus.DELAYED, row.estimatedDeparture(), row.estimatedArrival());
+        }
+        return new FlightStatusResult(FlightRealWorldStatus.ON_TIME, row.estimatedDeparture(), row.estimatedArrival());
+    }
+}

--- a/airline/src/test/java/com/oneday/airline/batch/FlightStatusPollJobTest.java
+++ b/airline/src/test/java/com/oneday/airline/batch/FlightStatusPollJobTest.java
@@ -156,4 +156,26 @@ class FlightStatusPollJobTest {
         verify(flightEventProducer).emitTimeChanged(captor.capture());
         assertThat(captor.getValue().newDeparture()).isEqualTo(delayedDeparture);
     }
+
+    @Test
+    void pollImminent_sweepsTheNextFewHoursAndReactsToACancellation() {
+        FlightInstance fi = instance(FlightInstanceStatus.SCHEDULED);
+        Awb awb = bookedAwb();
+        Instant now = departure.minusSeconds(2 * 3600);   // 2h before departure → inside the imminent window
+        when(flightInstanceRepository.findByStatusInAndDepartureBetween(
+                eq(List.of(FlightInstanceStatus.SCHEDULED)), any(), any())).thenReturn(List.of(fi));
+        when(awbRepository.findByFlightNoAndFlightDate("ODDELBOM06", fi.getFlightDate())).thenReturn(List.of(awb));
+        when(flightProviderPort.status("ODDELBOM06", fi.getFlightDate())).thenReturn(
+                new FlightProviderPort.FlightStatusResult(FlightProviderPort.FlightRealWorldStatus.CANCELLED,
+                        departure, arrival));
+
+        job(now).pollImminent();
+
+        ArgumentCaptor<Instant> from = ArgumentCaptor.forClass(Instant.class);
+        ArgumentCaptor<Instant> to = ArgumentCaptor.forClass(Instant.class);
+        verify(flightInstanceRepository).findByStatusInAndDepartureBetween(any(), from.capture(), to.capture());
+        assertThat(from.getValue()).isEqualTo(now);                     // window starts now
+        assertThat(to.getValue()).isEqualTo(now.plusSeconds(6 * 3600)); // default 6h imminent window
+        verify(flightReassignmentService).reassign(awb, FlightReassignReason.CANCELLATION);
+    }
 }

--- a/airline/src/test/java/com/oneday/airline/batch/FlightStatusPollJobTest.java
+++ b/airline/src/test/java/com/oneday/airline/batch/FlightStatusPollJobTest.java
@@ -77,16 +77,14 @@ class FlightStatusPollJobTest {
         parcel.setParcelId(parcelId);
         when(awbRepository.findByFlightNoAndFlightDate("ODDELBOM06", fi.getFlightDate())).thenReturn(List.of(awb));
         when(awbParcelRepository.findByAwbId(any())).thenReturn(List.of(parcel));
-        when(flightProviderPort.status("ODDELBOM06", fi.getFlightDate())).thenReturn(
-                new FlightProviderPort.FlightStatusResult(FlightProviderPort.FlightRealWorldStatus.ON_TIME,
-                        departure, arrival));
 
-        job(departure.plusSeconds(60)).processInstance(fi);
+        job(departure.plusSeconds(60)).advanceProgress(fi);
 
         assertThat(fi.getStatus()).isEqualTo(FlightInstanceStatus.DEPARTED);
         verify(flightInstanceRepository).save(fi);
         verify(flightEventProducer).emitDeparted(parcelId);
         verify(flightEventProducer, never()).emitLanded(any());
+        verifyNoInteractions(flightProviderPort);   // progress is clock-only — never asks the vendor
     }
 
     @Test
@@ -99,7 +97,7 @@ class FlightStatusPollJobTest {
         when(awbRepository.findByFlightNoAndFlightDate("ODDELBOM06", fi.getFlightDate())).thenReturn(List.of(awb));
         when(awbParcelRepository.findByAwbId(any())).thenReturn(List.of(parcel));
 
-        job(arrival.plusSeconds(60)).processInstance(fi);
+        job(arrival.plusSeconds(60)).advanceProgress(fi);
 
         assertThat(fi.getStatus()).isEqualTo(FlightInstanceStatus.LANDED);
         verify(flightEventProducer).emitLanded(parcelId);
@@ -116,7 +114,7 @@ class FlightStatusPollJobTest {
                         departure, arrival));
 
         // Ready well before departure so the SCHEDULED→DEPARTED time-transition doesn't also fire.
-        job(departure.minusSeconds(3600)).processInstance(fi);
+        job(departure.minusSeconds(3600)).checkDisruption(fi);
 
         verify(flightReassignmentService).reassign(awb, FlightReassignReason.CANCELLATION);
         assertThat(fi.getStatus()).isEqualTo(FlightInstanceStatus.CANCELLED);
@@ -132,7 +130,7 @@ class FlightStatusPollJobTest {
                 new FlightProviderPort.FlightStatusResult(FlightProviderPort.FlightRealWorldStatus.DELAYED,
                         delayedDeparture, arrival.plusSeconds(90 * 60)));
 
-        job(departure.minusSeconds(3600)).processInstance(fi);
+        job(departure.minusSeconds(3600)).checkDisruption(fi);
 
         verify(flightReassignmentService).reassign(awb, FlightReassignReason.DELAY);
         verify(flightEventProducer, never()).emitTimeChanged(any());
@@ -147,7 +145,7 @@ class FlightStatusPollJobTest {
                 new FlightProviderPort.FlightStatusResult(FlightProviderPort.FlightRealWorldStatus.DELAYED,
                         delayedDeparture, delayedArrival));
 
-        job(departure.minusSeconds(3600)).processInstance(fi);
+        job(departure.minusSeconds(3600)).checkDisruption(fi);
 
         verifyNoInteractions(flightReassignmentService);
         assertThat(fi.getDeparture()).isEqualTo(delayedDeparture);

--- a/airline/src/test/java/com/oneday/airline/provider/aerodatabox/AeroDataBoxClientParserTest.java
+++ b/airline/src/test/java/com/oneday/airline/provider/aerodatabox/AeroDataBoxClientParserTest.java
@@ -1,0 +1,89 @@
+package com.oneday.airline.provider.aerodatabox;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneday.airline.provider.aerodatabox.AeroDataBoxClient.DepartureRow;
+import com.oneday.airline.provider.aerodatabox.AeroDataBoxClient.StatusRow;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Locks the AeroDataBox JSON parsing to its documented shape (validated live on key procurement).
+ * The parsers must be defensive: a missing field skips a row rather than throwing.
+ */
+class AeroDataBoxClientParserTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private com.fasterxml.jackson.databind.JsonNode json(String s) throws Exception {
+        return mapper.readTree(s);
+    }
+
+    @Test
+    void parsesDepartures_normalisingFlightNoAndReadingLocalTimeAndDest() throws Exception {
+        List<DepartureRow> rows = AeroDataBoxClient.parseDepartures(json("""
+            {
+              "departures": [
+                { "number": "AI 806",
+                  "movement": { "airport": { "iata": "BOM", "name": "Mumbai" },
+                                "scheduledTime": { "utc": "2026-08-11 00:30Z", "local": "2026-08-11 06:00+05:30" } } },
+                { "number": "6E 123",
+                  "movement": { "airport": { "iata": "BLR" },
+                                "scheduledTime": { "local": "2026-08-11 09:15+05:30" } } }
+              ]
+            }
+            """));
+
+        assertThat(rows).containsExactly(
+                new DepartureRow("AI806", "BOM", LocalTime.of(6, 0)),
+                new DepartureRow("6E123", "BLR", LocalTime.of(9, 15)));
+    }
+
+    @Test
+    void skipsDepartureRowsMissingRequiredFields() throws Exception {
+        List<DepartureRow> rows = AeroDataBoxClient.parseDepartures(json("""
+            { "departures": [
+                { "number": "AI806", "movement": { "airport": { "iata": "BOM" } } },
+                { "movement": { "airport": { "iata": "BOM" }, "scheduledTime": { "local": "2026-08-11 06:00+05:30" } } }
+            ] }
+            """));
+
+        assertThat(rows).isEmpty();   // first has no time, second has no flight number
+    }
+
+    @Test
+    void parsesStatus_preferringRevisedOverScheduledInstants() throws Exception {
+        Optional<StatusRow> row = AeroDataBoxClient.parseStatus(json("""
+            [ { "number": "AI806", "status": "Delayed",
+                "departure": { "scheduledTime": { "utc": "2026-08-11 00:30Z" }, "revisedTime": { "utc": "2026-08-11 01:15Z" } },
+                "arrival":   { "scheduledTime": { "utc": "2026-08-11 02:30Z" }, "revisedTime": { "utc": "2026-08-11 03:15Z" } } } ]
+            """));
+
+        assertThat(row).isPresent();
+        assertThat(row.get().rawStatus()).isEqualTo("Delayed");
+        assertThat(row.get().estimatedDeparture()).isEqualTo(Instant.parse("2026-08-11T01:15:00Z"));
+        assertThat(row.get().estimatedArrival()).isEqualTo(Instant.parse("2026-08-11T03:15:00Z"));
+    }
+
+    @Test
+    void statusFallsBackToScheduledWhenNoRevisedTime() throws Exception {
+        Optional<StatusRow> row = AeroDataBoxClient.parseStatus(json("""
+            [ { "status": "Expected",
+                "departure": { "scheduledTime": { "utc": "2026-08-11 00:30Z" } },
+                "arrival":   { "scheduledTime": { "utc": "2026-08-11 02:30Z" } } } ]
+            """));
+
+        assertThat(row).isPresent();
+        assertThat(row.get().estimatedDeparture()).isEqualTo(Instant.parse("2026-08-11T00:30:00Z"));
+    }
+
+    @Test
+    void emptyStatusArrayYieldsEmpty() throws Exception {
+        assertThat(AeroDataBoxClient.parseStatus(json("[]"))).isEmpty();
+    }
+}

--- a/airline/src/test/java/com/oneday/airline/service/AwbIntakeServiceTest.java
+++ b/airline/src/test/java/com/oneday/airline/service/AwbIntakeServiceTest.java
@@ -1,0 +1,52 @@
+package com.oneday.airline.service;
+
+import com.oneday.airline.domain.Awb;
+import com.oneday.airline.domain.AwbStatus;
+import com.oneday.airline.repository.AwbRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AwbIntakeServiceTest {
+
+    private final AwbRepository awbRepository = mock(AwbRepository.class);
+    private final AwbIntakeService service = new AwbIntakeService(awbRepository);
+    private final LocalDate date = LocalDate.of(2026, 7, 20);
+
+    private Awb awb(AwbStatus status) {
+        Awb a = new Awb();
+        a.setStatus(status);
+        a.setAwbNo("AWB-ODDELBOM06-2026-07-20-placeholder");
+        return a;
+    }
+
+    @Test
+    void stampsRealAwbOnEveryBookedBagButNotSupersededOnes() {
+        Awb booked1 = awb(AwbStatus.BOOKED);
+        Awb booked2 = awb(AwbStatus.BOOKED);
+        Awb superseded = awb(AwbStatus.SUPERSEDED);
+        when(awbRepository.findByFlightNoAndFlightDate("AI806", date))
+                .thenReturn(List.of(booked1, booked2, superseded));
+
+        int updated = service.assignRealAwb("AI806", date, "098-12345675");
+
+        assertThat(updated).isEqualTo(2);
+        assertThat(booked1.getAwbNo()).isEqualTo("098-12345675");
+        assertThat(booked2.getAwbNo()).isEqualTo("098-12345675");
+        assertThat(superseded.getAwbNo()).isEqualTo("AWB-ODDELBOM06-2026-07-20-placeholder");
+        verify(awbRepository).saveAll(List.of(booked1, booked2));
+    }
+
+    @Test
+    void returnsZeroWhenTheFlightHasNoBookedAwb() {
+        when(awbRepository.findByFlightNoAndFlightDate("AI806", date)).thenReturn(List.of());
+
+        assertThat(service.assignRealAwb("AI806", date, "098-12345675")).isZero();
+    }
+}

--- a/airline/src/test/java/com/oneday/airline/service/impl/CostEstimatorTest.java
+++ b/airline/src/test/java/com/oneday/airline/service/impl/CostEstimatorTest.java
@@ -43,12 +43,12 @@ class CostEstimatorTest {
     }
 
     @Test
-    void overnightFlight_getsTheConfiguredDiscountOffTheTotal() {
+    void primeFlight_getsTheConfiguredSurchargeOnTopOfTheTotal() {
         long dayCost = estimator.estimatePaise(rateCard(), 100_000, false);
-        long nightCost = estimator.estimatePaise(rateCard(), 100_000, true);
+        long primeCost = estimator.estimatePaise(rateCard(), 100_000, true);
 
-        // Default overnightDiscountBps = 1000 (10%).
-        assertThat(nightCost).isEqualTo(dayCost - dayCost / 10);
-        assertThat(nightCost).isLessThan(dayCost);
+        // Default primeSurchargeBps = 3500 (35%) — the expensive overnight window costs MORE.
+        assertThat(primeCost).isEqualTo(dayCost + dayCost * 35 / 100);
+        assertThat(primeCost).isGreaterThan(dayCost);
     }
 }

--- a/airline/src/test/java/com/oneday/airline/service/impl/FlightSelectionServiceTest.java
+++ b/airline/src/test/java/com/oneday/airline/service/impl/FlightSelectionServiceTest.java
@@ -47,10 +47,11 @@ class FlightSelectionServiceTest {
     }
 
     @Test
-    void picksTheCheapestCandidateWhoseCutoffIsStillAhead() {
+    void consolidatesOntoTheLatestFlightThatStillMeetsTheSla() {
         stubRateCard();
         LocalDate date = LocalDate.of(2026, 7, 20);
-        // Ready at 05:00 IST: both slots' cutoffs (departure - 3h) are still ahead.
+        // Ready 05:00 IST → SLA deadline 21:00. Both non-prime slots meet it at equal cost; the LATER
+        // one wins so parcels pile onto the fullest flight (one AWB per plane).
         var readyAt = ZonedDateTime.of(date, LocalTime.of(5, 0), ClockConfig.IST).toInstant();
         when(flightProviderPort.search("DEL", "BOM", date)).thenReturn(List.of(
                 new FlightProviderPort.FlightCandidate("ODDELBOM12", "SIM-CARRIER",
@@ -60,8 +61,7 @@ class FlightSelectionServiceTest {
 
         var selection = service().select("DEL", "BOM", readyAt);
 
-        // Same lane/rate card, no overnight discount on either → identical cost; earliest departure wins the tie.
-        assertThat(selection.flightNo()).isEqualTo("ODDELBOM12");
+        assertThat(selection.flightNo()).isEqualTo("ODDELBOM18");
         assertThat(selection.flightDate()).isEqualTo(date);
     }
 
@@ -83,19 +83,60 @@ class FlightSelectionServiceTest {
     }
 
     @Test
-    void prefersTheGenuinelyCheaperOvernightSlotWhenBothAreCatchable() {
+    void avoidsThePrimeWindowFlightWhenACheaperNonPrimeMeetsTheSla() {
         stubRateCard();
         LocalDate date = LocalDate.of(2026, 7, 20);
+        // Ready 02:00 IST → SLA deadline 18:00. The 06:00 slot is in the prime window (00:00–09:00, +35%);
+        // the 12:00 non-prime is cheaper, so it wins even though 06:00 is earlier and also catchable.
+        var readyAt = ZonedDateTime.of(date, LocalTime.of(2, 0), ClockConfig.IST).toInstant();
+        when(flightProviderPort.search("DEL", "BOM", date)).thenReturn(List.of(
+                new FlightProviderPort.FlightCandidate("ODDELBOM06", "SIM-CARRIER",
+                        LocalTime.of(6, 0), LocalTime.of(8, 0), 2000),    // prime, +35%
+                new FlightProviderPort.FlightCandidate("ODDELBOM12", "SIM-CARRIER",
+                        LocalTime.of(12, 0), LocalTime.of(14, 0), 2000)));
+
+        var selection = service().select("DEL", "BOM", readyAt);
+
+        assertThat(selection.flightNo()).isEqualTo("ODDELBOM12");
+    }
+
+    @Test
+    void takesThePrimeFlightWhenItIsTheOnlyOneMeetingTheSla() {
+        stubRateCard();
+        LocalDate today = LocalDate.of(2026, 7, 20);
+        LocalDate tomorrow = today.plusDays(1);
+        // Ready 23:00 → deadline 15:00 tomorrow; today's cutoffs all passed. Tomorrow a 06:00 prime flight
+        // arrives 08:00 (meets SLA) while a 22:00 non-prime arrives 00:00 the day after (misses it) — so the
+        // pricey prime slot is taken because it's the only one that keeps the promise (avoid-unless-only).
+        var readyAt = ZonedDateTime.of(today, LocalTime.of(23, 0), ClockConfig.IST).toInstant();
+        when(flightProviderPort.search("DEL", "BOM", today)).thenReturn(List.of());
+        when(flightProviderPort.search("DEL", "BOM", tomorrow)).thenReturn(List.of(
+                new FlightProviderPort.FlightCandidate("ODDELBOM06", "SIM-CARRIER",
+                        LocalTime.of(6, 0), LocalTime.of(8, 0), 2000),     // prime, meets SLA
+                new FlightProviderPort.FlightCandidate("ODDELBOM22", "SIM-CARRIER",
+                        LocalTime.of(22, 0), LocalTime.of(0, 0), 2000)));  // non-prime, arrives past deadline
+
+        var selection = service().select("DEL", "BOM", readyAt);
+
+        assertThat(selection.flightDate()).isEqualTo(tomorrow);
+        assertThat(selection.flightNo()).isEqualTo("ODDELBOM06");
+    }
+
+    @Test
+    void shipsTheSoonestFlightWhenNoFlightCanMeetTheSla() {
+        stubRateCard();
+        LocalDate date = LocalDate.of(2026, 7, 20);
+        // Ready 05:00 → deadline 21:00. The only catchable flight departs 22:00 and arrives 00:00 next day,
+        // past the SLA. It still ships (best effort, minimise lateness) rather than failing outright.
         var readyAt = ZonedDateTime.of(date, LocalTime.of(5, 0), ClockConfig.IST).toInstant();
         when(flightProviderPort.search("DEL", "BOM", date)).thenReturn(List.of(
-                new FlightProviderPort.FlightCandidate("ODDELBOM12", "SIM-CARRIER",
-                        LocalTime.of(12, 0), LocalTime.of(14, 0), 2000),
                 new FlightProviderPort.FlightCandidate("ODDELBOM22", "SIM-CARRIER",
-                        LocalTime.of(22, 0), LocalTime.of(0, 0), 2000)));   // overnight window (default 22:00-06:00)
+                        LocalTime.of(22, 0), LocalTime.of(0, 0), 2000)));
 
         var selection = service().select("DEL", "BOM", readyAt);
 
         assertThat(selection.flightNo()).isEqualTo("ODDELBOM22");
+        assertThat(selection.flightDate()).isEqualTo(date);
     }
 
     @Test

--- a/airline/src/test/java/com/oneday/airline/service/port/FlightTrackingPortAdapterTest.java
+++ b/airline/src/test/java/com/oneday/airline/service/port/FlightTrackingPortAdapterTest.java
@@ -92,6 +92,32 @@ class FlightTrackingPortAdapterTest {
     }
 
     @Test
+    void scheduledNotYetDeparted_returnsEmptyEvenInsideTheWindow() {
+        AwbParcel parcel = new AwbParcel();
+        parcel.setParcelId(shipmentId);
+        parcel.setAwbId(awbId);
+        when(awbParcelRepository.findFirstByParcelIdOrderByCreatedAtDesc(shipmentId)).thenReturn(Optional.of(parcel));
+        Awb awb = new Awb();
+        awb.setFlightNo("ODDELBOM06");
+        awb.setFlightDate(LocalDate.of(2026, 7, 20));
+        when(awbRepository.findById(awbId)).thenReturn(Optional.of(awb));
+        FlightInstance instance = new FlightInstance();
+        instance.setFlightNo("ODDELBOM06");
+        instance.setFlightDate(LocalDate.of(2026, 7, 20));
+        instance.setOriginHub("DEL");
+        instance.setDestHub("BOM");
+        instance.setDeparture(departure);
+        instance.setArrival(arrival);
+        instance.setStatus(FlightInstanceStatus.SCHEDULED);   // not yet flipped airborne
+        when(flightInstanceRepository.findByFlightNoAndFlightDate("ODDELBOM06", LocalDate.of(2026, 7, 20)))
+                .thenReturn(Optional.of(instance));
+
+        var result = adapter(departure.plusSeconds(3600)).currentPosition(shipmentId);
+
+        assertThat(result).isEmpty();   // clock says mid-window, but status isn't DEPARTED → no dot
+    }
+
+    @Test
     void noAwbParcelForShipment_returnsEmpty() {
         when(awbParcelRepository.findFirstByParcelIdOrderByCreatedAtDesc(shipmentId)).thenReturn(Optional.empty());
         var result = adapter(departure.plusSeconds(3600)).currentPosition(shipmentId);


### PR DESCRIPTION
## M9 (airline) targeted delta — the Bhagwati freight-consolidator model

The teammate's M9 already implemented ~80% of the consolidator model (FlightProviderPort, selection/reassignment engine, AWB model, interpolated tracking). This is the **targeted delta**, not a rewrite — three stacked commits, all defaulting to today's behaviour until a key is set.

**Vendor decision (locked with product):** AeroDataBox ($19/mo) for schedule + daily status; live map position stays **free interpolation** anchored to those status calls. Flight *selection*, position, and DEPARTED/LANDED all cost **0 units**; only the daily disruption check spends units. No scraping. Everything behind the existing ports — **synthetic default, real AeroDataBox behind an env key** (`airline.aerodatabox.enabled`), so nothing here is blocked on procuring a key.

### PR1 — prime-rate surcharge + leeway batching
- **00:00–09:00 is now the prime window with a +35% surcharge** (was an overnight *discount*). Cheapest-first selection therefore **avoids prime** unless it's the only flight meeting the promise.
- **Leeway batching:** among flights arriving within the 16h SLA, pick the cheapest, tie-break to the **latest departure** so parcels consolidate onto the fullest flight (one AWB/plane); ship the soonest flight best-effort if none meets SLA. Knobs: `airline.slaHours`, `primeSurchargeBps`, `primeWindow{Start,End}Hour`.

### PR2 — AeroDataBox schedule + daily disruption poll (env-gated)
- **Poll split into two crons:** `pollProgress()` (frequent, clock-based DEPARTED/LANDED, 0 units) and `pollDisruptions()` (**daily, today/tomorrow only** — the only paid calls) → existing reassignment.
- **AeroDataBoxClient** (RestClient, conditional) with pure, unit-tested JSON parsers (defensive; validated live on key procurement).
- **Monthly schedule ingest** → upserts the forward window into the local `flight_leg` store (selection reads the DB, 0 units) + admin trigger `POST /airline/admin/schedule/refresh`.
- **AeroDataBoxFlightProviderAdapter** (`@Primary` when enabled): search reads the store, status hits the API. Synthetic roll-forward gated off when the feed is enabled.

### PR3 — real AWB intake + status-anchored position
- **Real AWB from Bhagwati:** `POST /airline/flights/{flightNo}/{date}/awb` (admin) stamps the real waybill onto every booked bag on the plane, replacing the placeholder. **WhatsApp webhook stubbed** for later (Meta verification/Flow deferred).
- **Position anchored to the real DEPARTED flip** — the moving dot shows only while the flight is actually marked airborne, not on the clock alone.
- **Bhagwati warehouse handoff** mapped onto the existing `AwbGroundService` handed-over / loaded timestamps (M7 GHA console left dormant).

### Verify
Airline suite **42 green** (CostEstimator, FlightSelectionService, FlightStatusPollJob split, AeroDataBox parsers, AwbIntake, tracking status-gate); full app assembles. With no `AIRLINE_AERODATABOX_*` env, the app boots on the synthetic consolidator exactly as today (regression-safe). **No migration** (reuses `flight_leg`). **Never commit the AeroDataBox key.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7HAxotqFWPJirComsL33i