### PR TITLE
M7: place parcel INTO flight bag on outbound sort (+ live parcel list)

### DIFF
--- a/hub/src/main/java/com/oneday/hub/api/HubBagController.java
+++ b/hub/src/main/java/com/oneday/hub/api/HubBagController.java
@@ -99,6 +99,12 @@ public class HubBagController {
         return ManifestResponse.from(flightBagService.currentManifest(bagId));
     }
 
+    /** The parcels currently in the bag (IN_BAG) — powers the console's per-bag parcel list, live before sealing. */
+    @GetMapping("/{bagId}/parcels")
+    public List<FlightBagService.BagParcelInfo> parcels(@PathVariable UUID hubId, @PathVariable UUID bagId) {
+        return flightBagService.parcelsFor(bagId);
+    }
+
     /** One query per request, not per bag — every bag list/lookup here is scoped to a single hub. */
     private Map<UUID, String> standNoMap(UUID hubId) {
         return standRepository.findByHubIdOrderByZoneAscStandNoAsc(hubId).stream()

--- a/hub/src/main/java/com/oneday/hub/service/impl/SortServiceImpl.java
+++ b/hub/src/main/java/com/oneday/hub/service/impl/SortServiceImpl.java
@@ -11,6 +11,7 @@ import com.oneday.hub.repository.StandRepository;
 import com.oneday.hub.service.FlightBagService;
 import com.oneday.hub.service.DeliveryBagService;
 import com.oneday.hub.service.SortService;
+import com.oneday.hub.service.exception.DuplicateBagItemException;
 import com.oneday.hub.service.exception.StandNotFoundException;
 import com.oneday.hub.service.exception.UnresolvedDestinationException;
 import com.oneday.hub.service.port.DeliveryRoutePort;
@@ -71,6 +72,15 @@ class SortServiceImpl implements SortService {
         FlightBag bag = flightBagService.openBag(new FlightBagService.OpenBagCommand(
                 hubId, hubId, flight.flightNo(), flight.flightDate(),
                 parcel.originCity(), destHub, flight.bagCutoff()));
+
+        // Place the parcel INTO the bag — the actual point of the sort. Without this the bag opens but
+        // stays empty (parcel_count 0). Idempotent: a re-scan of an already-bagged parcel is a no-op,
+        // never a duplicate error — mirrors the inbound path, which adds to its delivery bag here too.
+        try {
+            flightBagService.addParcel(bag.getId(), parcel.shipmentRef());
+        } catch (DuplicateBagItemException alreadyBagged) {
+            // Parcel already sits in a bag (re-scan / reprocess) — nothing to add.
+        }
 
         Stand stand = standRepository.findById(bag.getCurrentStandId())
                 .orElseThrow(() -> new StandNotFoundException(bag.getCurrentStandId()));

--- a/hub/src/test/java/com/oneday/hub/service/impl/SortServiceImplTest.java
+++ b/hub/src/test/java/com/oneday/hub/service/impl/SortServiceImplTest.java
@@ -85,6 +85,8 @@ class SortServiceImplTest {
         verify(flightBagService).openBag(cmd.capture());
         assertThat(cmd.getValue().destHub()).isEqualTo("CHENNAI");
         assertThat(cmd.getValue().flightNo()).isEqualTo("ODCHENNAI12");
+        // The parcel is actually placed INTO the bag — the whole point of the sort (not just bag-open).
+        verify(flightBagService).addParcel(bagId, parcel.shipmentRef());
         verify(eventProducer).emitStandAssigned(parcel.shipmentId(), hubId, hubId, "A-3", "CHENNAI", SortDirection.OUTBOUND);
     }
 


### PR DESCRIPTION
## Problem
On first-mile scan-in, `SortServiceImpl.resolveOutbound` assigned the flight and **opened** its bag but never called `addParcel` — so the bag opened (stand allocated) yet the parcel stayed out of it (`parcel_count = 0`). Seen live today on `1DD-HYD-20260812-00001`: bag `6E6025` OPEN but PARCELS 0, blocking seal/manifest without a manual "Add a parcel".

The inbound/delivery path (`resolveInbound`) already adds to its delivery bag — this makes outbound symmetric.

## Changes
- `resolveOutbound` now places the parcel in the opened bag, **idempotently** (a re-scan is a no-op, not a `DuplicateBagItemException`).
- New `GET /hub/{hubId}/bags/{bagId}/parcels` returns the live IN_BAG parcels (works before sealing) so the console can list a bag's contents.
- `SortServiceImplTest` asserts the parcel is bagged.

Hub suite **34 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)