### PR TITLE
Hub dock scan is the record of hub custody (not app buttons)

### DIFF
--- a/airline/src/main/java/com/oneday/airline/api/AirlineController.java
+++ b/airline/src/main/java/com/oneday/airline/api/AirlineController.java
@@ -140,13 +140,9 @@ public class AirlineController {
                 "awb_no", request.awbNo(), "bags_updated", updated);
     }
 
-    // ── Airport custody actions (gap G1): one AWB = one plane, so each fires the scan for every parcel ──
-    /** Handed to Bhagwati / dispatched from origin hub → every parcel advances to DISPATCHED_TO_AIRPORT. */
-    @PostMapping("/awb/{awbId}/dispatched-to-airport")
-    public Map<String, Object> dispatchedToAirport(@PathVariable UUID awbId) {
-        return custody(awbId, ScanEventType.HUB_ORIGIN_OUT);
-    }
-
+    // ── Airport custody actions: only the two genuinely air-side legs (no hub scanner exists there) live
+    // here, one AWB = one plane so each fires the scan for every parcel. Origin-out (bag leaving the hub)
+    // and dest-in (parcel arriving at the dest hub) are hub-dock scans now, not airline-console buttons.
     /** Accepted by the ground handler / into the cargo terminal → AT_AIRPORT. */
     @PostMapping("/awb/{awbId}/gha-accepted")
     public Map<String, Object> ghaAccepted(@PathVariable UUID awbId) {
@@ -157,12 +153,6 @@ public class AirlineController {
     @PostMapping("/awb/{awbId}/dest-shuttle-in")
     public Map<String, Object> destShuttleIn(@PathVariable UUID awbId) {
         return custody(awbId, ScanEventType.DEST_SHUTTLE_IN);
-    }
-
-    /** Received back at the destination hub → AT_DEST_HUB (dest sort + delivery assignment follow). */
-    @PostMapping("/awb/{awbId}/dest-received")
-    public Map<String, Object> destReceived(@PathVariable UUID awbId) {
-        return custody(awbId, ScanEventType.HUB_DEST_IN);
     }
 
     private Map<String, Object> custody(UUID awbId, ScanEventType type) {

--- a/dispatch/src/main/java/com/oneday/dispatch/events/HubScanSeamProducer.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/events/HubScanSeamProducer.java
@@ -27,11 +27,6 @@ public class HubScanSeamProducer {
         this.eventPublisher = eventPublisher;
     }
 
-    /** DA dropped a collected pickup at the origin hub → M4 (HANDED_TO_PICKUP_VAN → AT_ORIGIN_HUB). */
-    public void emitHubOriginIn(UUID shipmentId) {
-        emit(shipmentId, ScanEventType.HUB_ORIGIN_IN);
-    }
-
     /** DA collected a dest parcel from the hub for last-mile (ledger only — M4 ignores it). */
     public void emitHubDestOut(UUID shipmentId) {
         emit(shipmentId, ScanEventType.HUB_DEST_OUT);

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
@@ -140,13 +140,19 @@ class DaTaskServiceImpl implements DaTaskService {
     @Override
     @Transactional
     public DaTaskView recordHubHandoff(UUID daId, UUID taskId, List<String> parcelScans) {
-        // HUB_RETURN city (no van): the DA drops the collected pickups AT the hub. Same pickup-handoff
-        // lifecycle as the van path, but a neutral event (not VAN_HANDOFF_COMPLETED) + the origin-hub scan.
+        // HUB_RETURN city (no van): the DA drops the collected pickups AT the hub. This is a custody
+        // CLAIM (task done → RETURNED_TO_HUB, "handed to transport") — NOT the hub arrival. The hub
+        // operator's dock scan (M7 receive → HUB_ORIGIN_IN) is what advances the parcel to AT_ORIGIN_HUB,
+        // so a DA can't forge arrival by tapping a button.
         requireHubReturnCity(daId, taskId);
         return completePickupHandoff(daId, taskId, parcelScans, task -> {
             daEventProducer.emitHubReturnHandoffCompleted(daId, task.getCityId(), task.getShipmentId());
-            // M8-SEAM: the hub drop is the origin-hub inbound scan (advances to AT_ORIGIN_HUB → M7/M9).
-            hubScanSeamProducer.emitHubOriginIn(task.getShipmentId());
+            AuditLog.event("da.hub_handoff")
+                    .kv("daId", daId)
+                    .kv("taskId", taskId)
+                    .kv("shipmentId", task.getShipmentId())
+                    .kv("parcelScans", parcelScans.size())
+                    .log();
             log.debug("Hub handoff: task {} completed with {} scan(s)", taskId, parcelScans.size());
         });
     }

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaTaskServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaTaskServiceImplTest.java
@@ -36,6 +36,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /** Real-Postgres tests of the DA task-lifecycle transitions, guards, and (gated) event emission. */
@@ -155,9 +156,10 @@ class DaTaskServiceImplTest {
                 .atDate(today).atZone(zone).toInstant();
         assertThat(cron.getScheduledMeetingTime()).isEqualTo(expectedNext);
         assertThat(cron.getParcelCountHanded()).isEqualTo(1);
-        // Hub handoff emits the neutral (non-van) event + the origin-hub M8 seam.
+        // Hub handoff is a custody CLAIM only (→ RETURNED_TO_HUB). It must NOT drive the hub arrival —
+        // the origin-hub dock scan (M7 receive) owns AT_ORIGIN_HUB now, so nothing is emitted here.
         verify(events).emitHubReturnHandoffCompleted(eq(da), eq(city), eq(task.getShipmentId()));
-        verify(scanSeam).emitHubOriginIn(eq(task.getShipmentId()));
+        verifyNoInteractions(scanSeam);
     }
 
     @Test

--- a/hub/src/main/java/com/oneday/hub/domain/ArrivalMode.java
+++ b/hub/src/main/java/com/oneday/hub/domain/ArrivalMode.java
@@ -16,7 +16,10 @@ public enum ArrivalMode {
     /** Derive the arrival mode from the state the parcel is in when it hits the dock. */
     public static ArrivalMode fromState(ShipmentState state) {
         return switch (state) {
-            case HANDED_TO_PICKUP_VAN, AT_ORIGIN_HUB -> VAN;   // M6 may have already in-scanned it
+            // Origin dock arrival. HANDED_TO_PICKUP_VAN = VAN_MEETING; RETURNED_TO_HUB = HUB_RETURN
+            // (DA carried it, tapped handoff → RETURNED_TO_HUB, now the dock scan confirms arrival).
+            // AT_ORIGIN_HUB tolerates a re-scan (M6 may have already in-scanned it).
+            case HANDED_TO_PICKUP_VAN, RETURNED_TO_HUB, AT_ORIGIN_HUB -> VAN;
             case AWAITING_SELF_DROP -> SELF_DROP;
             case LANDED, DISPATCHED_TO_HUB, AT_DEST_HUB -> AIRPORT;
             default -> throw new UndeterminedArrivalException(state);

--- a/hub/src/main/java/com/oneday/hub/events/HubArrivalScanProducer.java
+++ b/hub/src/main/java/com/oneday/hub/events/HubArrivalScanProducer.java
@@ -1,0 +1,63 @@
+package com.oneday.hub.events;
+
+import com.oneday.common.kafka.EventPublisher;
+import com.oneday.common.kafka.EventStreams;
+import com.oneday.common.kafka.enums.ScanEventType;
+import com.oneday.common.kafka.events.ScanEvent;
+import com.oneday.common.log.AuditLog;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+/**
+ * The dock scan is the record of hub custody (M8-SEAM until barcode/M8 owns it). Every physical hub
+ * scan is emitted here on {@code oneday.scan.events} — the same exchange M8 uses — so M4's
+ * {@code ScanEventsConsumer} advances the parcel. Direction (origin-in vs dest-in) is decided by the
+ * caller from the parcel's prior M4 state, never by a console button. Every emit is best-effort: a
+ * publish failure is logged and swallowed so it can never block the dock operation.
+ */
+@Component
+public class HubArrivalScanProducer {
+
+    private static final Logger log = LoggerFactory.getLogger(HubArrivalScanProducer.class);
+
+    private final EventPublisher eventPublisher;
+
+    HubArrivalScanProducer(EventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    /** Hub arrival scan (origin-in / dest-in) — the parcel physically hit this dock. */
+    public void emitArrival(UUID shipmentId, String shipmentRef, UUID hubId, ScanEventType type, String direction) {
+        publish(shipmentId, type);
+        AuditLog.event("hub.arrival_scan")
+                .kv("shipmentRef", shipmentRef)
+                .kv("parcelId", shipmentId)
+                .kv("hubId", hubId)
+                .kv("direction", direction)
+                .kv("scanType", type.name())
+                .log();
+    }
+
+    /** Origin-out scan fired per parcel when a sealed flight bag is dispatched to the airport. */
+    public void emitOriginOut(UUID shipmentId, String shipmentRef, UUID bagId, String flightNo) {
+        publish(shipmentId, ScanEventType.HUB_ORIGIN_OUT);
+        AuditLog.event("hub.origin_out_scan")
+                .kv("shipmentRef", shipmentRef)
+                .kv("parcelId", shipmentId)
+                .kv("bagId", bagId)
+                .kv("flightNo", flightNo)
+                .log();
+    }
+
+    private void publish(UUID shipmentId, ScanEventType type) {
+        try {
+            eventPublisher.publish(EventStreams.SCAN_EVENTS, new ScanEvent(shipmentId, type));
+        } catch (Exception e) {   // never block a dock scan on a publish failure
+            log.warn("Hub scan {} for shipment {} failed to publish (non-blocking): {}",
+                    type, shipmentId, e.getMessage());
+        }
+    }
+}

--- a/hub/src/main/java/com/oneday/hub/service/impl/FlightBagServiceImpl.java
+++ b/hub/src/main/java/com/oneday/hub/service/impl/FlightBagServiceImpl.java
@@ -3,6 +3,7 @@ package com.oneday.hub.service.impl;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.oneday.hub.domain.*;
+import com.oneday.hub.events.HubArrivalScanProducer;
 import com.oneday.hub.events.HubEventProducer;
 import com.oneday.hub.repository.*;
 import com.oneday.hub.service.FlightBagService;
@@ -30,6 +31,7 @@ class FlightBagServiceImpl implements FlightBagService {
     private final ShipmentInfoPort shipmentInfoPort;
     private final BarcodePort barcodePort;
     private final HubEventProducer eventProducer;
+    private final HubArrivalScanProducer arrivalScanProducer;
     private final ObjectMapper objectMapper;
     private final Clock clock;
 
@@ -41,6 +43,7 @@ class FlightBagServiceImpl implements FlightBagService {
                    ShipmentInfoPort shipmentInfoPort,
                    BarcodePort barcodePort,
                    HubEventProducer eventProducer,
+                   HubArrivalScanProducer arrivalScanProducer,
                    ObjectMapper objectMapper,
                    Clock clock) {
         this.flightBagRepository = flightBagRepository;
@@ -51,6 +54,7 @@ class FlightBagServiceImpl implements FlightBagService {
         this.shipmentInfoPort = shipmentInfoPort;
         this.barcodePort = barcodePort;
         this.eventProducer = eventProducer;
+        this.arrivalScanProducer = arrivalScanProducer;
         this.objectMapper = objectMapper;
         this.clock = clock;
     }
@@ -206,6 +210,12 @@ class FlightBagServiceImpl implements FlightBagService {
                 .kv("flightDate", bag.getFlightDate())
                 .kv("parcelCount", bag.getParcelCount())
                 .log();
+
+        // The bag leaving the origin dock for the airport IS the origin-out scan for every parcel it
+        // holds (→ DISPATCHED_TO_AIRPORT). Driven off the sealed manifest here, not an airline button.
+        for (FlightBagService.BagParcelInfo p : parcelsFor(bagId)) {
+            arrivalScanProducer.emitOriginOut(p.parcelId(), p.shipmentRef(), bagId, bag.getFlightNo());
+        }
         return bag;
     }
 

--- a/hub/src/main/java/com/oneday/hub/service/impl/HubReceivingServiceImpl.java
+++ b/hub/src/main/java/com/oneday/hub/service/impl/HubReceivingServiceImpl.java
@@ -6,6 +6,7 @@ import com.oneday.hub.domain.DeliveryBagItem;
 import com.oneday.hub.domain.DeliveryBagItemStatus;
 import com.oneday.hub.domain.InboundReceipt;
 import com.oneday.hub.domain.SortDirection;
+import com.oneday.hub.events.HubArrivalScanProducer;
 import com.oneday.hub.events.HubEventProducer;
 import com.oneday.hub.repository.DeliveryBagItemRepository;
 import com.oneday.hub.repository.InboundReceiptRepository;
@@ -13,7 +14,9 @@ import com.oneday.hub.service.HubReceivingService;
 import com.oneday.hub.service.SortService;
 import com.oneday.hub.service.exception.ParcelNotFoundException;
 import com.oneday.hub.service.port.ShipmentInfoPort;
+import com.oneday.common.kafka.enums.ScanEventType;
 import com.oneday.common.log.AuditLog;
+import com.oneday.common.log.LogContext;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,6 +42,7 @@ class HubReceivingServiceImpl implements HubReceivingService {
     private final DeliveryBagItemRepository deliveryBagItemRepository;
     private final SortService sortService;
     private final HubEventProducer eventProducer;
+    private final HubArrivalScanProducer arrivalScanProducer;
     private final Clock clock;
 
     HubReceivingServiceImpl(ShipmentInfoPort shipmentInfoPort,
@@ -46,12 +50,14 @@ class HubReceivingServiceImpl implements HubReceivingService {
                             DeliveryBagItemRepository deliveryBagItemRepository,
                             SortService sortService,
                             HubEventProducer eventProducer,
+                            HubArrivalScanProducer arrivalScanProducer,
                             Clock clock) {
         this.shipmentInfoPort = shipmentInfoPort;
         this.inboundReceiptRepository = inboundReceiptRepository;
         this.deliveryBagItemRepository = deliveryBagItemRepository;
         this.sortService = sortService;
         this.eventProducer = eventProducer;
+        this.arrivalScanProducer = arrivalScanProducer;
         this.clock = clock;
     }
 
@@ -61,25 +67,35 @@ class HubReceivingServiceImpl implements HubReceivingService {
         ShipmentInfoPort.ParcelInfo parcel = shipmentInfoPort.lookup(shipmentRef)
                 .orElseThrow(() -> new ParcelNotFoundException(shipmentRef));
 
-        // The barcode never carries the arrival mode — we derive it from the leg the parcel just
-        // finished (its M4 state). VAN vs SELF_DROP vs AIRPORT map 1:1 to mutually-exclusive states.
-        ArrivalMode mode = ArrivalMode.fromState(parcel.state());
-        Instant now = clock.instant();
+        try (var ignored = LogContext.forShipment(parcel.shipmentId(), parcel.shipmentRef(), parcel.shipmentId())) {
+            // The barcode never carries the arrival mode — we derive it from the leg the parcel just
+            // finished (its M4 state). A not-yet-arrived parcel (e.g. still PICKED_UP — the DA hasn't
+            // tapped handoff, so it's not RETURNED_TO_HUB yet) throws UndeterminedArrivalException → 409.
+            ArrivalMode mode = ArrivalMode.fromState(parcel.state());
+            Instant now = clock.instant();
 
-        if (mode == ArrivalMode.AIRPORT) {
-            UUID receiptId = recordReceipt(parcel, hubId, mode, SortDirection.INBOUND).getId();
-            return inboundDispatch(receiptId, hubId, parcel, now);
-        }
+            if (mode == ArrivalMode.AIRPORT) {
+                UUID receiptId = recordReceipt(parcel, hubId, mode, SortDirection.INBOUND).getId();
+                // The dock scan IS the record of dest-hub arrival (→ AT_DEST_HUB) — not a console button.
+                arrivalScanProducer.emitArrival(parcel.shipmentId(), parcel.shipmentRef(), hubId,
+                        ScanEventType.HUB_DEST_IN, "INBOUND");
+                return inboundDispatch(receiptId, hubId, parcel, now);
+            }
 
-        // First-mile origin arrival (VAN / SELF_DROP).
-        UUID receiptId = recordReceipt(parcel, hubId, mode, SortDirection.OUTBOUND).getId();
-        if (isSameCity(parcel)) {
-            // §12 — origin hub IS the dest hub; collapse the air legs and sort straight for delivery.
-            eventProducer.emitSameCityOutbound(parcel.shipmentId(), hubId, hubId);
-            return inboundDispatch(receiptId, hubId, parcel, now);
+            // First-mile origin arrival (VAN_MEETING / HUB_RETURN / SELF_DROP).
+            UUID receiptId = recordReceipt(parcel, hubId, mode, SortDirection.OUTBOUND).getId();
+            // The dock scan IS the record of origin-hub arrival (→ AT_ORIGIN_HUB) — not the DA app button.
+            ScanEventType originScan = mode == ArrivalMode.SELF_DROP
+                    ? ScanEventType.SELF_DROP_ACCEPTED : ScanEventType.HUB_ORIGIN_IN;
+            arrivalScanProducer.emitArrival(parcel.shipmentId(), parcel.shipmentRef(), hubId, originScan, "OUTBOUND");
+            if (isSameCity(parcel)) {
+                // §12 — origin hub IS the dest hub; collapse the air legs and sort straight for delivery.
+                eventProducer.emitSameCityOutbound(parcel.shipmentId(), hubId, hubId);
+                return inboundDispatch(receiptId, hubId, parcel, now);
+            }
+            SortService.SortResult sort = sortService.resolveOutbound(hubId, parcel, now);
+            return new ReceiveResult(receiptId, parcel.shipmentId(), parcel.shipmentRef(), true, null, sort, null);
         }
-        SortService.SortResult sort = sortService.resolveOutbound(hubId, parcel, now);
-        return new ReceiveResult(receiptId, parcel.shipmentId(), parcel.shipmentRef(), true, null, sort, null);
     }
 
     /** Destination branch (§8.2): DA_DELIVERY → ladder + delivery bag + M6 feed; HUB_COLLECT → shelf. */

--- a/hub/src/test/java/com/oneday/hub/domain/ArrivalModeTest.java
+++ b/hub/src/test/java/com/oneday/hub/domain/ArrivalModeTest.java
@@ -1,0 +1,32 @@
+package com.oneday.hub.domain;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.hub.service.exception.UndeterminedArrivalException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ArrivalModeTest {
+
+    @Test
+    void originStatesMapToVan() {
+        assertThat(ArrivalMode.fromState(ShipmentState.HANDED_TO_PICKUP_VAN)).isEqualTo(ArrivalMode.VAN); // VAN_MEETING
+        assertThat(ArrivalMode.fromState(ShipmentState.RETURNED_TO_HUB)).isEqualTo(ArrivalMode.VAN);      // HUB_RETURN
+        assertThat(ArrivalMode.fromState(ShipmentState.AT_ORIGIN_HUB)).isEqualTo(ArrivalMode.VAN);        // re-scan
+    }
+
+    @Test
+    void selfDropAndAirportMap() {
+        assertThat(ArrivalMode.fromState(ShipmentState.AWAITING_SELF_DROP)).isEqualTo(ArrivalMode.SELF_DROP);
+        assertThat(ArrivalMode.fromState(ShipmentState.DISPATCHED_TO_HUB)).isEqualTo(ArrivalMode.AIRPORT);
+        assertThat(ArrivalMode.fromState(ShipmentState.AT_DEST_HUB)).isEqualTo(ArrivalMode.AIRPORT);
+    }
+
+    @Test
+    void notYetArrivedThrows() {
+        // Still in the DA's hands — not a dock-arrival state.
+        assertThatThrownBy(() -> ArrivalMode.fromState(ShipmentState.PICKED_UP))
+                .isInstanceOf(UndeterminedArrivalException.class);
+    }
+}

--- a/hub/src/test/java/com/oneday/hub/service/impl/FlightBagServiceImplTest.java
+++ b/hub/src/test/java/com/oneday/hub/service/impl/FlightBagServiceImplTest.java
@@ -41,13 +41,14 @@ class FlightBagServiceImplTest {
     @Mock ShipmentInfoPort shipmentInfoPort;
     @Mock BarcodePort barcodePort;
     @Mock HubEventProducer eventProducer;
+    @Mock com.oneday.hub.events.HubArrivalScanProducer arrivalScanProducer;
 
     private final Clock clock = Clock.fixed(Instant.parse("2026-06-27T10:00:00Z"), ZoneOffset.UTC);
 
     private FlightBagServiceImpl service() {
         return new FlightBagServiceImpl(flightBagRepository, flightBagItemRepository, bagManifestRepository,
                 standRepository, reassignmentAuditRepository, shipmentInfoPort, barcodePort,
-                eventProducer, new ObjectMapper(), clock);
+                eventProducer, arrivalScanProducer, new ObjectMapper(), clock);
     }
 
     private final UUID hubId = UUID.randomUUID();
@@ -205,16 +206,23 @@ class FlightBagServiceImplTest {
     }
 
     @Test
-    void dispatch_sealedBag_marksDispatched() {
+    void dispatch_sealedBag_marksDispatched_andEmitsOriginOutPerParcel() {
         UUID bagId = UUID.randomUUID();
         FlightBag bag = openBag(bagId);
         bag.setStatus(FlightBagStatus.SEALED);
         when(flightBagRepository.findById(bagId)).thenReturn(Optional.of(bag));
         when(flightBagRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        UUID parcelId = UUID.randomUUID();
+        FlightBagItem item = FlightBagItem.builder().bagId(bagId).parcelId(parcelId)
+                .shipmentRef("BLR-1").weightGrams(1500).status(FlightBagItemStatus.IN_BAG).build();
+        when(flightBagItemRepository.findByBagIdAndStatus(bagId, FlightBagItemStatus.IN_BAG))
+                .thenReturn(java.util.List.of(item));
 
         FlightBag dispatched = service().dispatch(bagId);
 
         assertThat(dispatched.getStatus()).isEqualTo(FlightBagStatus.DISPATCHED);
         assertThat(dispatched.getDispatchedAt()).isEqualTo(clock.instant());
+        // The bag leaving the dock IS the origin-out scan for each parcel (→ DISPATCHED_TO_AIRPORT).
+        verify(arrivalScanProducer).emitOriginOut(parcelId, "BLR-1", bagId, bag.getFlightNo());
     }
 }

--- a/hub/src/test/java/com/oneday/hub/service/impl/HubReceivingServiceImplTest.java
+++ b/hub/src/test/java/com/oneday/hub/service/impl/HubReceivingServiceImplTest.java
@@ -9,13 +9,16 @@ import com.oneday.hub.domain.DeliveryBagItem;
 import com.oneday.hub.domain.DeliveryBagItemStatus;
 import com.oneday.hub.domain.InboundReceipt;
 import com.oneday.hub.domain.SortDirection;
+import com.oneday.hub.events.HubArrivalScanProducer;
 import com.oneday.hub.events.HubEventProducer;
 import com.oneday.hub.repository.DeliveryBagItemRepository;
 import com.oneday.hub.repository.InboundReceiptRepository;
 import com.oneday.hub.service.HubReceivingService;
 import com.oneday.hub.service.SortService;
 import com.oneday.hub.service.exception.ParcelNotFoundException;
+import com.oneday.hub.service.exception.UndeterminedArrivalException;
 import com.oneday.hub.service.port.ShipmentInfoPort;
+import com.oneday.common.kafka.enums.ScanEventType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -42,12 +45,13 @@ class HubReceivingServiceImplTest {
     @Mock DeliveryBagItemRepository deliveryBagItemRepository;
     @Mock SortService sortService;
     @Mock HubEventProducer eventProducer;
+    @Mock HubArrivalScanProducer arrivalScanProducer;
 
     private final Clock clock = Clock.fixed(Instant.parse("2026-06-27T08:00:00Z"), ZoneOffset.UTC);
 
     private HubReceivingServiceImpl service() {
         return new HubReceivingServiceImpl(shipmentInfoPort, inboundReceiptRepository,
-                deliveryBagItemRepository, sortService, eventProducer, clock);
+                deliveryBagItemRepository, sortService, eventProducer, arrivalScanProducer, clock);
     }
 
     private final UUID hubId = UUID.randomUUID();
@@ -100,6 +104,46 @@ class HubReceivingServiceImplTest {
         assertThat(receipt.getValue().getArrivalMode()).isEqualTo(ArrivalMode.VAN);
         assertThat(receipt.getValue().getDirection()).isEqualTo(SortDirection.OUTBOUND);
         verify(eventProducer, never()).emitSameCityOutbound(any(), any(), any());
+        // The dock scan drives origin arrival (→ AT_ORIGIN_HUB), not the DA app button.
+        verify(arrivalScanProducer).emitArrival(parcel.shipmentId(), "BLR-1", hubId,
+                ScanEventType.HUB_ORIGIN_IN, "OUTBOUND");
+    }
+
+    @Test
+    void receive_hubReturnOrigin_recordsOutboundReceipt_andEmitsOriginIn() {
+        // HUB_RETURN: the DA carried it back, tapped handoff → RETURNED_TO_HUB. The dock scan confirms
+        // arrival (→ AT_ORIGIN_HUB) exactly like the VAN path.
+        ShipmentInfoPort.ParcelInfo parcel = new ShipmentInfoPort.ParcelInfo(UUID.randomUUID(), "BLR-1",
+                ShipmentState.RETURNED_TO_HUB, 1500, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                "DELHI", "MUMBAI", "400001", null, null);
+        when(shipmentInfoPort.lookup("BLR-1")).thenReturn(Optional.of(parcel));
+        stubReceiptSave();
+        SortService.SortResult sort = new SortService.SortResult(parcel.shipmentId(), "BLR-1", "MUMBAI",
+                UUID.randomUUID(), UUID.randomUUID(), "A-2", "ODMUMBAI12", null,
+                "DELHI", "MUMBAI", null, null);
+        when(sortService.resolveOutbound(eq(hubId), eq(parcel), any())).thenReturn(sort);
+
+        service().receive(hubId, "BLR-1");
+
+        ArgumentCaptor<InboundReceipt> receipt = ArgumentCaptor.forClass(InboundReceipt.class);
+        verify(inboundReceiptRepository).save(receipt.capture());
+        assertThat(receipt.getValue().getArrivalMode()).isEqualTo(ArrivalMode.VAN);
+        assertThat(receipt.getValue().getDirection()).isEqualTo(SortDirection.OUTBOUND);
+        verify(arrivalScanProducer).emitArrival(parcel.shipmentId(), "BLR-1", hubId,
+                ScanEventType.HUB_ORIGIN_IN, "OUTBOUND");
+    }
+
+    @Test
+    void receive_notYetHandedOff_throwsUndeterminedArrival() {
+        // Still PICKED_UP — the DA hasn't tapped handoff, so it's not a dock-arrival state yet.
+        ShipmentInfoPort.ParcelInfo parcel = new ShipmentInfoPort.ParcelInfo(UUID.randomUUID(), "BLR-1",
+                ShipmentState.PICKED_UP, 1500, DropType.DA_DELIVERY, DeliveryType.INTERCITY,
+                "DELHI", "MUMBAI", "400001", null, null);
+        when(shipmentInfoPort.lookup("BLR-1")).thenReturn(Optional.of(parcel));
+
+        assertThatThrownBy(() -> service().receive(hubId, "BLR-1"))
+                .isInstanceOf(UndeterminedArrivalException.class);
+        verifyNoInteractions(arrivalScanProducer);
     }
 
     @Test
@@ -119,6 +163,9 @@ class HubReceivingServiceImplTest {
         assertThat(receipt.getValue().getArrivalMode()).isEqualTo(ArrivalMode.AIRPORT);
         assertThat(receipt.getValue().getDirection()).isEqualTo(SortDirection.INBOUND);
         verify(deliveryBagItemRepository, never()).save(any());
+        // The dest-hub dock scan drives dest arrival (→ AT_DEST_HUB), not the airline console button.
+        verify(arrivalScanProducer).emitArrival(parcel.shipmentId(), "BLR-1", hubId,
+                ScanEventType.HUB_DEST_IN, "INBOUND");
     }
 
     @Test

--- a/orders/src/main/java/com/oneday/orders/events/ScanEventsConsumer.java
+++ b/orders/src/main/java/com/oneday/orders/events/ScanEventsConsumer.java
@@ -3,9 +3,11 @@ package com.oneday.orders.events;
 import com.oneday.common.domain.enums.ShipmentState;
 import com.oneday.common.kafka.enums.ScanEventType;
 import com.oneday.common.kafka.events.ScanEvent;
+import com.oneday.common.log.AuditLog;
 import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.service.ShipmentStateMachine;
 import com.oneday.orders.service.TransitionContext;
+import com.oneday.orders.service.exception.IllegalStateTransitionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
@@ -62,8 +64,37 @@ public class ScanEventsConsumer {
             log.debug("Scan event {} ignored for shipment {}", event.eventType(), event.shipmentId());
             return;
         }
-        stateMachine.transition(event.shipmentId(), target,
-                TransitionContext.fromKafka(SOURCE, String.valueOf(event.shipmentId())));
+        try {
+            stateMachine.transition(event.shipmentId(), target,
+                    TransitionContext.fromKafka(SOURCE, String.valueOf(event.shipmentId())));
+            AuditLog.event("scan.consumed")
+                    .kv("shipmentId", event.shipmentId())
+                    .kv("scanType", event.eventType().name())
+                    .kv("target", target)
+                    .log();
+        } catch (IllegalStateTransitionException e) {
+            if (e.getFromState() == target) {
+                // Idempotent re-scan: parcel already in the target state. Ack — don't retry/DLQ.
+                AuditLog.event("scan.skipped")
+                        .kv("shipmentId", event.shipmentId())
+                        .kv("scanType", event.eventType().name())
+                        .kv("target", target)
+                        .kv("reason", "already-in-target")
+                        .log();
+                return;
+            }
+            // Out-of-order (a racing predecessor event hasn't landed yet) or a genuine violation:
+            // rethrow so the listener retry re-delivers — the predecessor lands within the retry window,
+            // and a truly-invalid scan surfaces to the DLQ for investigation.
+            AuditLog.event("scan.skipped")
+                    .kv("shipmentId", event.shipmentId())
+                    .kv("scanType", event.eventType().name())
+                    .kv("from", e.getFromState())
+                    .kv("target", target)
+                    .kv("reason", "out-of-order-or-invalid")
+                    .log();
+            throw e;
+        }
     }
 
     private void applyLabel(ScanEvent event) {

--- a/orders/src/test/java/com/oneday/orders/events/ScanEventsConsumerTest.java
+++ b/orders/src/test/java/com/oneday/orders/events/ScanEventsConsumerTest.java
@@ -6,6 +6,7 @@ import com.oneday.common.kafka.events.ScanEvent;
 import com.oneday.orders.domain.Shipment;
 import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.service.ShipmentStateMachine;
+import com.oneday.orders.service.exception.IllegalStateTransitionException;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -82,5 +83,29 @@ class ScanEventsConsumerTest {
 
         verifyNoInteractions(stateMachine);
         verify(shipmentRepository, never()).save(any());
+    }
+
+    @Test
+    void duplicateScan_alreadyInTargetState_isSwallowed() {
+        // A re-scan: the parcel is already AT_DEST_HUB. The transition is illegal (from == to) but
+        // idempotent — ack, don't propagate to retry/DLQ.
+        UUID id = UUID.randomUUID();
+        doThrow(new IllegalStateTransitionException(ShipmentState.AT_DEST_HUB, ShipmentState.AT_DEST_HUB))
+                .when(stateMachine).transition(eq(id), eq(ShipmentState.AT_DEST_HUB), any());
+
+        consumer.onScanEvent(new ScanEvent(id, ScanEventType.HUB_DEST_IN)); // no throw
+    }
+
+    @Test
+    void outOfOrderScan_predecessorNotYetApplied_rethrowsForRetry() {
+        // Origin-out arrived before the bag-created event set IN_TAKEOFF_BAG. from != target → rethrow
+        // so the listener retry re-delivers once the predecessor lands.
+        UUID id = UUID.randomUUID();
+        doThrow(new IllegalStateTransitionException(ShipmentState.ORIGIN_HUB_PROCESSING, ShipmentState.DISPATCHED_TO_AIRPORT))
+                .when(stateMachine).transition(eq(id), eq(ShipmentState.DISPATCHED_TO_AIRPORT), any());
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() ->
+                        consumer.onScanEvent(new ScanEvent(id, ScanEventType.HUB_ORIGIN_OUT)))
+                .isInstanceOf(IllegalStateTransitionException.class);
     }
 }


### PR DESCRIPTION
## What & why

The physical **hub-dock scan** (M7 `receive`) is now the record of hub custody — a DA can no longer forge origin arrival by tapping "hand off to hub", and dest arrival is no longer a decoupled airline-console button. Direction (origin vs dest) is derived from the parcel's prior M4 state, which `receive()` already computes.

## Changes
- **ArrivalMode**: `RETURNED_TO_HUB` is an origin dock arrival (HUB_RETURN) → a DA-deposited parcel is a recognised VAN-branch arrival. Also closes the latent VAN_MEETING gap.
- **HubReceivingServiceImpl.receive()**: emits the arrival scan by derived mode (origin → `HUB_ORIGIN_IN`/`SELF_DROP_ACCEPTED` → AT_ORIGIN_HUB; dest → `HUB_DEST_IN` → AT_DEST_HUB) via new `HubArrivalScanProducer`. A still-`PICKED_UP` parcel 409s ("not yet handed off").
- **DaTaskServiceImpl.recordHubHandoff**: DA handoff is a custody **claim** only (→ `RETURNED_TO_HUB`, closes the task); no longer emits `HUB_ORIGIN_IN`.
- **FlightBagServiceImpl.dispatch**: emits `HUB_ORIGIN_OUT` per parcel from the sealed manifest (bag leaving the dock → DISPATCHED_TO_AIRPORT), replacing the airline "Dispatched to airport" button.
- **AirlineController**: drop `dispatched-to-airport` (#1) and `dest-received` (#4); keep the two air-side legs (`gha-accepted`, `dest-shuttle-in`).
- **ScanEventsConsumer**: idempotent guard — skip a true duplicate (`from==target`), rethrow out-of-order so the listener retry (3×/1s) self-heals the race between the arrival scan and the sort's processing event.

## Two-actor sequence (HUB_RETURN origin)
DA taps handoff → `RETURNED_TO_HUB` (claim). Hub operator dock scan → `AT_ORIGIN_HUB` (fact).

## Logging
Adds shipmentRef-correlated audit: `hub.arrival_scan`, `hub.origin_out_scan`, `da.hub_handoff`, `scan.consumed`/`scan.skipped`. State changes ride the existing `shipment.transition`.

## Impact on the live parcel — none
No migration, no state/guard change. Only *which console action* fires two later transitions changes (origin-out → hub bag-dispatch; dest-in → dock scan). The live parcel is already past origin-in.

## Tests
Hub 39, dispatch 79, airline 46, orders 63 green; app assembles. (Branched off fresh `main`; the uncommitted AeroDataBox retry/carrier work is a separate change and not included here.)

Pairs with oneday-web PR (airline console UI trim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)