### PR TITLE
Customer track map: live flight dot on the air leg

### DIFF
--- a/orders/src/main/java/com/oneday/orders/tracking/LocationResolver.java
+++ b/orders/src/main/java/com/oneday/orders/tracking/LocationResolver.java
@@ -7,6 +7,7 @@ import com.oneday.common.port.LiveVanPositionPort;
 import com.oneday.orders.config.TrackingProperties;
 import com.oneday.orders.domain.Address;
 import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.service.port.FlightTrackingPort;
 import com.oneday.orders.tracking.CityNodeCatalog.Coord;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Component;
@@ -20,7 +21,8 @@ import java.util.Optional;
  * and produce a coordinate. Resting states (with the customer, at a hub, at an airport) yield a static
  * pin; the with-a-DA and on-a-van states yield a live dot from {@link LiveDaPositionPort} /
  * {@link LiveVanPositionPort}, degrading to the nearest static node when the GPS fix is missing or
- * stale. The air leg has no live point in v1 — the UI draws the route arc instead.
+ * stale. The air leg yields an interpolated live dot from {@link FlightTrackingPort} while airborne,
+ * falling back to the route arc (no dot) before departure / after landing.
  *
  * <p>Ports are injected lazily ({@link ObjectProvider}) so the orders module (and any profile without
  * dispatch/routing on the classpath) resolves to static fallbacks rather than failing to wire.</p>
@@ -31,15 +33,18 @@ public class LocationResolver {
     private final CityNodeCatalog cities;
     private final ObjectProvider<LiveDaPositionPort> daPort;
     private final ObjectProvider<LiveVanPositionPort> vanPort;
+    private final ObjectProvider<FlightTrackingPort> flightPort;
     private final Duration staleAfter;
 
     LocationResolver(CityNodeCatalog cities,
                      ObjectProvider<LiveDaPositionPort> daPort,
                      ObjectProvider<LiveVanPositionPort> vanPort,
+                     ObjectProvider<FlightTrackingPort> flightPort,
                      TrackingProperties properties) {
         this.cities = cities;
         this.daPort = daPort;
         this.vanPort = vanPort;
+        this.flightPort = flightPort;
         this.staleAfter = Duration.ofSeconds(properties.getGpsStaleSeconds());
     }
 
@@ -51,7 +56,7 @@ public class LocationResolver {
             case DELIVERED -> staticAt(kind, deliveredCoord(s));
             case STATIONARY_HUB -> staticAt(kind, hubCoord(s));
             case STATIONARY_AIRPORT -> staticAt(kind, airportCoord(s));
-            case ON_FLIGHT -> new ResolvedLocation(kind, null, null, false, true, null, null);
+            case ON_FLIGHT -> onFlight(kind, s);
             case MOVING_DA -> moving(kind, s, movingDaFallback(s));
             case MOVING_VAN -> moving(kind, s, movingVanFallback(s));
         };
@@ -72,6 +77,18 @@ public class LocationResolver {
             case DEPARTED, RTO_IN_TRANSIT -> LocationKind.ON_FLIGHT;
             case DROPPED, HUB_COLLECTED, RTO_COMPLETED -> LocationKind.DELIVERED;
         };
+    }
+
+    // ── air leg ─────────────────────────────────────────────────────────────
+    // A live dot while airborne (M9 interpolates origin-hub → dest-hub on the flight's own clock).
+    // Empty before departure / after landing / when M9 is a no-op → the UI draws the route arc, no dot.
+    private ResolvedLocation onFlight(LocationKind kind, Shipment s) {
+        FlightTrackingPort port = flightPort.getIfAvailable();
+        Optional<FlightTrackingPort.LivePosition> pos =
+                port == null ? Optional.empty() : port.currentPosition(s.getId());
+        return pos
+                .map(p -> new ResolvedLocation(kind, p.lat(), p.lon(), true, true, p.asOf(), null))
+                .orElseGet(() -> new ResolvedLocation(kind, null, null, false, true, null, null));
     }
 
     // ── moving legs ─────────────────────────────────────────────────────────

--- a/orders/src/test/java/com/oneday/orders/tracking/LocationResolverTest.java
+++ b/orders/src/test/java/com/oneday/orders/tracking/LocationResolverTest.java
@@ -8,6 +8,7 @@ import com.oneday.orders.config.TrackingProperties;
 import com.oneday.orders.config.TrackingProperties.CityNode;
 import com.oneday.orders.domain.Address;
 import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.service.port.FlightTrackingPort;
 import com.oneday.orders.tracking.LocationResolver.ResolvedLocation;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,7 @@ class LocationResolverTest {
 
     private final LiveDaPositionPort daPort = mock(LiveDaPositionPort.class);
     private final LiveVanPositionPort vanPort = mock(LiveVanPositionPort.class);
+    private final FlightTrackingPort flightPort = mock(FlightTrackingPort.class);   // empty by default
 
     private LocationResolver resolver(boolean daAvailable, boolean vanAvailable) {
         TrackingProperties props = new TrackingProperties();
@@ -35,7 +37,7 @@ class LocationResolverTest {
         props.setCityNodes(Map.of("DEL", node(28.50, 77.15, 28.5562, 77.10)));
         CityNodeCatalog cities = new CityNodeCatalog(props);
         return new LocationResolver(cities, provider(daAvailable ? daPort : null),
-                provider(vanAvailable ? vanPort : null), props);
+                provider(vanAvailable ? vanPort : null), provider(flightPort), props);
     }
 
     @Test
@@ -63,12 +65,26 @@ class LocationResolverTest {
     }
 
     @Test
-    void departedIsOnFlightWithNoPoint() {
+    void departedWithNoFlightFixDrawsRouteOnly() {
+        // No M9 position (before departure / M9 no-op) → no dot, UI draws the route arc.
         ResolvedLocation r = resolver(true, true).resolve(shipment(ShipmentState.DEPARTED));
         assertThat(r.kind()).isEqualTo(LocationKind.ON_FLIGHT);
         assertThat(r.lat()).isNull();
         assertThat(r.moving()).isTrue();
         assertThat(r.live()).isFalse();
+    }
+
+    @Test
+    void departedWithFlightFixShowsMovingLiveDot() {
+        // M9 interpolates a position while airborne → a live, moving dot on the map.
+        when(flightPort.currentPosition(any())).thenReturn(Optional.of(
+                new FlightTrackingPort.LivePosition(22.9, 77.8, Instant.now(), "IN_TRANSIT")));
+        ResolvedLocation r = resolver(true, true).resolve(shipment(ShipmentState.DEPARTED));
+        assertThat(r.kind()).isEqualTo(LocationKind.ON_FLIGHT);
+        assertThat(r.lat()).isEqualTo(22.9);
+        assertThat(r.lon()).isEqualTo(77.8);
+        assertThat(r.live()).isTrue();
+        assertThat(r.moving()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## What & why
The customer track **map** polls `/track`, which returned **null coordinates for `ON_FLIGHT`** — so during the flight the map drew the route but **no moving plane**. M9's `FlightTrackingPortAdapter` already interpolates a live position (origin-hub → dest-hub on the flight's own clock) and `HubCoordinates` has HYD + DEL, but the adapter was only wired into the order-**detail** endpoint, not `/track`.

## Change
- `LocationResolver`: inject `FlightTrackingPort` (lazy `ObjectProvider`, like the DA/van ports). For `ON_FLIGHT`, return the interpolated **live, moving** dot when airborne; fall back to the route arc (no dot) before departure / after landing / when M9 is a no-op.

## Frontend
No functional change needed — `TrackMap.currentPoint` renders any non-null position and `glyphFor(ON_FLIGHT)` is the ✈️, so the dot now glides HYD→DEL. (Copy tweak is a separate oneday-web PR.)

## Verify
orders **64** green (incl. a new "airborne → live moving dot" test); app assembles. The dot appears once the bag is **sealed** (flight_instance booked) and the flight flips **DEPARTED** at its departure time — fast-forward the flight_instance times to test without waiting.

Independent of the hub-scan PR (#95).

🤖 Generated with [Claude Code](https://claude.com/claude-code)