### PR TITLE
AeroDataBox status: pick the instance departing on the queried date

### DIFF
--- a/airline/src/main/java/com/oneday/airline/provider/aerodatabox/AeroDataBoxClient.java
+++ b/airline/src/main/java/com/oneday/airline/provider/aerodatabox/AeroDataBoxClient.java
@@ -100,7 +100,7 @@ public class AeroDataBoxClient {
                     .uri("/flights/number/{number}/{date}", flightNo, date.toString())
                     .retrieve()
                     .body(String.class);
-            return parseStatus(MAPPER.readTree(body));
+            return parseStatus(MAPPER.readTree(body), date);
         } catch (Exception e) {
             log.error("AeroDataBox status fetch failed for {} ({}): {}", flightNo, date, e.getMessage());
             return Optional.empty();
@@ -131,15 +131,43 @@ public class AeroDataBoxClient {
         return rows;
     }
 
-    static Optional<StatusRow> parseStatus(JsonNode root) {
-        JsonNode leg = root.isArray() ? (root.isEmpty() ? null : root.get(0)) : root;
-        if (leg == null || leg.isMissingNode()) {
+    static Optional<StatusRow> parseStatus(JsonNode root, LocalDate queryDate) {
+        List<JsonNode> legs = new ArrayList<>();
+        if (root.isArray()) {
+            root.forEach(legs::add);
+        } else if (root != null && !root.isMissingNode()) {
+            legs.add(root);
+        }
+        if (legs.isEmpty()) {
             return Optional.empty();
         }
+        // A flight number that straddles midnight returns MULTIPLE instances for one date: the one that
+        // ARRIVED that morning (departed the prior evening) and the one DEPARTING that evening.
+        // AeroDataBox's date query matches either endpoint (dateLocalRole=Both), so we must pick the
+        // instance whose SCHEDULED DEPARTURE local date == the queried date — otherwise a red-eye reads
+        // as its already-arrived prior-day instance. Fall back to the first row if none carry a local date.
+        JsonNode leg = legs.stream()
+                .filter(l -> queryDate.equals(scheduledDepartureLocalDate(l)))
+                .findFirst()
+                .orElse(legs.get(0));
         String status = text(leg, "status");
         Instant estDep = instantOf(leg.path("departure"));
         Instant estArr = instantOf(leg.path("arrival"));
         return Optional.of(new StatusRow(status == null ? "" : status, estDep, estArr));
+    }
+
+    /** The flight's scheduled departure date in the departure airport's local time — AeroDataBox's own
+     *  query key — or null if absent. Disambiguates midnight-straddling instances of one flight number. */
+    private static LocalDate scheduledDepartureLocalDate(JsonNode leg) {
+        JsonNode local = leg.path("departure").path("scheduledTime").path("local");
+        if (!local.isValueNode() || local.asText().length() < 10) {
+            return null;
+        }
+        try {
+            return LocalDate.parse(local.asText().substring(0, 10));
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────

--- a/airline/src/test/java/com/oneday/airline/provider/aerodatabox/AeroDataBoxClientParserTest.java
+++ b/airline/src/test/java/com/oneday/airline/provider/aerodatabox/AeroDataBoxClientParserTest.java
@@ -65,7 +65,7 @@ class AeroDataBoxClientParserTest {
             [ { "number": "AI806", "status": "Delayed",
                 "departure": { "scheduledTime": { "utc": "2026-08-11 00:30Z" }, "revisedTime": { "utc": "2026-08-11 01:15Z" } },
                 "arrival":   { "scheduledTime": { "utc": "2026-08-11 02:30Z" }, "revisedTime": { "utc": "2026-08-11 03:15Z" } } } ]
-            """));
+            """), LocalDate.of(2026, 8, 11));
 
         assertThat(row).isPresent();
         assertThat(row.get().rawStatus()).isEqualTo("Delayed");
@@ -79,14 +79,41 @@ class AeroDataBoxClientParserTest {
             [ { "status": "Expected",
                 "departure": { "scheduledTime": { "utc": "2026-08-11 00:30Z" } },
                 "arrival":   { "scheduledTime": { "utc": "2026-08-11 02:30Z" } } } ]
-            """));
+            """), LocalDate.of(2026, 8, 11));
 
         assertThat(row).isPresent();
         assertThat(row.get().estimatedDeparture()).isEqualTo(Instant.parse("2026-08-11T00:30:00Z"));
     }
 
     @Test
+    void picksTheInstanceDepartingOnTheQueriedDate_forMidnightStraddlingFlight() throws Exception {
+        // Captured live: 6E6025 on 2026-08-12 returns BOTH the instance that arrived that morning
+        // (departed 2026-08-11 23:50 IST) and the one departing that evening (2026-08-12 23:50 IST).
+        // We must pick the latter — the one whose scheduled DEPARTURE local date is the queried date.
+        String twoInstances = """
+            [ { "number": "6E 6025", "status": "Arrived",
+                "departure": { "scheduledTime": { "utc": "2026-08-11 18:20Z", "local": "2026-08-11 23:50+05:30" } },
+                "arrival":   { "scheduledTime": { "utc": "2026-08-11 20:20Z", "local": "2026-08-12 01:50+05:30" } } },
+              { "number": "6E 6025", "status": "Expected",
+                "departure": { "scheduledTime": { "utc": "2026-08-12 18:20Z", "local": "2026-08-12 23:50+05:30" } },
+                "arrival":   { "scheduledTime": { "utc": "2026-08-12 20:14Z", "local": "2026-08-13 01:44+05:30" } } } ]
+            """;
+
+        Optional<StatusRow> row = AeroDataBoxClient.parseStatus(json(twoInstances), LocalDate.of(2026, 8, 12));
+
+        assertThat(row).isPresent();
+        assertThat(row.get().rawStatus()).isEqualTo("Expected");   // tonight's instance, not the arrived one
+        assertThat(row.get().estimatedDeparture()).isEqualTo(Instant.parse("2026-08-12T18:20:00Z"));
+        assertThat(row.get().estimatedArrival()).isEqualTo(Instant.parse("2026-08-12T20:14:00Z"));
+
+        // And querying the prior date selects the earlier (arrived) instance — symmetry.
+        Optional<StatusRow> prior = AeroDataBoxClient.parseStatus(json(twoInstances), LocalDate.of(2026, 8, 11));
+        assertThat(prior).isPresent();
+        assertThat(prior.get().rawStatus()).isEqualTo("Arrived");
+    }
+
+    @Test
     void emptyStatusArrayYieldsEmpty() throws Exception {
-        assertThat(AeroDataBoxClient.parseStatus(json("[]"))).isEmpty();
+        assertThat(AeroDataBoxClient.parseStatus(json("[]"), LocalDate.of(2026, 8, 12))).isEmpty();
     }
 }


### PR DESCRIPTION
## The bug
For a flight number that **straddles midnight** (6E6025 departs 23:50 IST), AeroDataBox returns **two instances** for one date — verified live:

| status | dep (HYD) | arr (DEL) |
|---|---|---|
| Arrived | 2026-08-11 23:50 IST | 2026-08-12 01:50 IST |
| **Expected** | **2026-08-12 23:50 IST** | **2026-08-13 01:44 IST** |

…because the date query (`dateLocalRole=Both`) matches either the departure **or** arrival date. `parseStatus` took `root.get(0)` — the **first** row, i.e. the already-**arrived** prior-day instance. So `/status` reported a red-eye's ~24h-stale yesterday times, which mislead the disruption poll and the status card.

**AeroDataBox is correct; our selection was wrong.**

## The fix
`parseStatus(root, queryDate)` now picks the instance whose **scheduled departure local date == the queried date** (the departure airport's local date is AeroDataBox's own query key), falling back to the first row when no local date is present. Deterministic and unit-tested against the **real captured 6E6025 payload** (asserts it picks the "Expected" evening instance; querying the prior date picks the "Arrived" one).

- No behaviour change for single-instance flights.
- airline suite green; `AeroDataBoxClientParserTest` **6/6** (incl. the new midnight-straddling test).

Off clean `main` — deploys the corrected status feed. Does not touch the run's `flight_instance` (already correct) or the clock-based DEPARTED/LANDED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)