### PR TITLE
Fix hub events dead-lettering (M7→M4): infer listener type + bind camelCase eventType

### DIFF
--- a/common/src/main/java/com/oneday/common/kafka/MessagingConfig.java
+++ b/common/src/main/java/com/oneday/common/kafka/MessagingConfig.java
@@ -1,7 +1,8 @@
 package com.oneday.common.kafka;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.amqp.support.converter.DefaultClassMapper;
+import org.springframework.amqp.support.converter.DefaultJackson2JavaTypeMapper;
+import org.springframework.amqp.support.converter.Jackson2JavaTypeMapper;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.annotation.Bean;
@@ -26,15 +27,19 @@ public class MessagingConfig {
     @Bean
     public MessageConverter jsonMessageConverter(ObjectMapper objectMapper) {
         Jackson2JsonMessageConverter converter = new Jackson2JsonMessageConverter(objectMapper);
-        // In-house monolith: every producer is our own code, so trust all packages for __TypeId__
-        // deserialization. NOTE: DefaultClassMapper does NOT do prefix/wildcard matching — a literal
-        // "com.oneday.*" matches no package (it only honours the exact "*" = trust-all token or exact
-        // package names), so it silently rejected every com.oneday event and broke ALL @RabbitListener
-        // consumers against a real broker. Use the trust-all token. Tighten to exact package names if
-        // an external/untrusted producer ever writes to a stream we consume.
-        DefaultClassMapper classMapper = new DefaultClassMapper();
-        classMapper.setTrustedPackages("*");
-        converter.setClassMapper(classMapper);
+        // Type resolution = INFERRED: deserialize each message to the TYPE THE LISTENER METHOD DECLARES
+        // (e.g. HubEvent), not the concrete class named in the producer's __TypeId__ header. Several M7
+        // events (StandAssignedEvent, BagCreatedEvent, …) publish their own concrete __TypeId__ but the
+        // orders.hub consumer binds the umbrella HubEvent — a header-driven ClassMapper deserialized to
+        // the concrete class and then failed "Cannot convert from [StandAssignedEvent] to [HubEvent]",
+        // dead-lettering every hub event and freezing shipments at AT_ORIGIN_HUB. Inference sidesteps the
+        // mismatch (the shared ObjectMapper ignores unknown fields, so the umbrella type absorbs any
+        // event's JSON). Still trust all packages for the header fallback (receiveAndConvert without a
+        // target type) — in-house monolith, every producer is ours.
+        DefaultJackson2JavaTypeMapper typeMapper = new DefaultJackson2JavaTypeMapper();
+        typeMapper.setTrustedPackages("*");
+        typeMapper.setTypePrecedence(Jackson2JavaTypeMapper.TypePrecedence.INFERRED);
+        converter.setJavaTypeMapper(typeMapper);
         return converter;
     }
 

--- a/common/src/main/java/com/oneday/common/kafka/events/HubEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/HubEvent.java
@@ -1,5 +1,6 @@
 package com.oneday.common.kafka.events;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.oneday.common.kafka.DomainEvent;
 import com.oneday.common.kafka.enums.HubEventType;
@@ -12,7 +13,11 @@ import java.util.UUID;
  * <p>Minimal consumption contract — see {@link DaEvent} for the tolerant-reader rationale.</p>
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record HubEvent(UUID shipmentId, HubEventType eventType) implements DomainEvent {
+public record HubEvent(UUID shipmentId,
+                       // M7's concrete events expose eventType() as an interface method, which Jackson
+                       // serializes camelCase ("eventType") even though record components are snake_case;
+                       // accept that key so the umbrella binds when a concrete event is inferred to HubEvent.
+                       @JsonAlias("eventType") HubEventType eventType) implements DomainEvent {
 
     @Override
     public String partitionKey() {

--- a/common/src/test/java/com/oneday/common/kafka/MessagingConfigTest.java
+++ b/common/src/test/java/com/oneday/common/kafka/MessagingConfigTest.java
@@ -1,0 +1,55 @@
+package com.oneday.common.kafka;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.oneday.common.kafka.enums.HubEventType;
+import com.oneday.common.kafka.events.HubEvent;
+import com.oneday.common.kafka.events.hub.StandAssignedEvent;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.support.converter.MessageConverter;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The M7→M4 seam regression: M7 publishes concrete event classes (their own __TypeId__), but the
+ * orders.hub consumer binds the umbrella {@link HubEvent}. A header-driven class mapper deserialized to
+ * the concrete class and failed "Cannot convert from [StandAssignedEvent] to [HubEvent]", dead-lettering
+ * every hub event. INFERRED type resolution must deserialize to the listener's declared type instead.
+ */
+class MessagingConfigTest {
+
+    private final MessageConverter converter = new MessagingConfig().jsonMessageConverter(mapper());
+
+    // Mirrors the app's Boot ObjectMapper: snake_case + tolerant of unknown fields.
+    private static ObjectMapper mapper() {
+        return new ObjectMapper()
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    @Test
+    void concreteHubEventDeserializesToUmbrellaHubEvent() throws Exception {
+        UUID shipmentId = UUID.randomUUID();
+        StandAssignedEvent concrete =
+                new StandAssignedEvent(shipmentId, UUID.randomUUID(), UUID.randomUUID(), "A-3", "DELHI", "OUTBOUND");
+
+        Message msg = converter.toMessage(concrete, new MessageProperties());
+        // The producer stamps the concrete class — this is exactly what tripped the old class mapper.
+        assertThat(msg.getMessageProperties().getHeader("__TypeId__").toString()).contains("StandAssignedEvent");
+
+        // The listener container sets the method's declared parameter type here before converting;
+        // with INFERRED precedence that type wins over the __TypeId__ header.
+        msg.getMessageProperties().setInferredArgumentType(HubEvent.class);
+        Object out = converter.fromMessage(msg);
+
+        assertThat(out).isInstanceOf(HubEvent.class);
+        HubEvent hub = (HubEvent) out;
+        assertThat(hub.eventType()).isEqualTo(HubEventType.STAND_ASSIGNED);
+        assertThat(hub.shipmentId()).isEqualTo(shipmentId);
+    }
+}


### PR DESCRIPTION
## The bug (why the parcel froze at AT_ORIGIN_HUB, air tracking blank)
M7 publishes each hub event as its **own concrete class** (`StandAssignedEvent`, `BagCreatedEvent`, …), stamping its own `__TypeId__`. The shared converter used a header-driven `DefaultClassMapper` → it deserialized to the concrete class, then failed because the `orders.hub` consumer binds the umbrella `HubEvent`:

```
Cannot convert from [StandAssignedEvent] -> [HubEvent]
Cannot convert from [BagCreatedEvent]    -> [HubEvent]
```

`StandAssignedEvent` drives `AT_ORIGIN_HUB → ORIGIN_HUB_PROCESSING`; `BagCreatedEvent` drives `→ IN_TAKEOFF_BAG`. Both dead-lettered → the shipment **froze at `AT_ORIGIN_HUB`**, and every later button/event failed as a consequence (`AT_ORIGIN_HUB → DISPATCHED_TO_AIRPORT/AT_AIRPORT/DEPARTED` all rejected in the logs).

**Why it slipped through:** it only breaks on the real broker (the `__TypeId__` header drives it). Unit tests invoke the consumer with a hand-built `HubEvent` object — no serialization — so nothing crossed the wire. This run is the first real M7→M4 end-to-end over RabbitMQ.

## The fix (two parts)
- **`MessagingConfig`** — replace `DefaultClassMapper` with `DefaultJackson2JavaTypeMapper` at **INFERRED** precedence: deserialize to the listener method's declared type (`HubEvent`), ignoring the producer's concrete `__TypeId__`. Still trusts `*` for the header fallback.
- **`HubEvent`** — the concrete events expose `eventType()` as an interface method, which Jackson serializes **camelCase `eventType`** even though record components are snake_case; the umbrella (snake) never bound it. `@JsonAlias("eventType")` accepts it. *(Verified empirically — the serialized wire really is `…,"stand_no":"A-3","eventType":"STAND_ASSIGNED"`.)*

## Proof
New `MessagingConfigTest` round-trips a concrete `StandAssignedEvent` (its own `__TypeId__`) → deserializes to `HubEvent` with `eventType=STAND_ASSIGNED` + `shipmentId` bound. common/orders/hub/airline/dispatch build green.

## Follow-up (pre-existing, not a live-run blocker)
`routing.hub` binds `#`, so with INFERRED it would now deserialize non-ParcelSorted events into `ParcelSortedForDeliveryEvent` instead of dead-lettering — tighten that binding to the `PARCEL_SORTED_FOR_DELIVERY` routing key. M6 isn't in the current HUB_RETURN flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)