### PR TITLE
Courier contact on customer tracking (backend)

### DIFF
--- a/auth/src/main/java/com/oneday/auth/repository/DaProfileRepository.java
+++ b/auth/src/main/java/com/oneday/auth/repository/DaProfileRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
@@ -52,6 +53,27 @@ public interface DaProfileRepository extends JpaRepository<DaProfile, UUID> {
     List<DaSummary> findDaSummaries(@Param("cityId") String cityId,
                                     @Param("shift") String shift,
                                     @Param("active") Boolean active);
+
+    /**
+     * Field contact (name + phone) for a set of DA ids — the reciprocal of the customer contact the DA
+     * app already gets. Keyed by {@code users.id} (= the {@code da_id} carried on a dispatch task).
+     */
+    @Query(value = """
+            SELECT u.id AS daId,
+                   (p.first_name || ' ' || p.last_name) AS name,
+                   u.phone AS phone
+              FROM da_profile p
+              JOIN users u ON u.id = p.user_id
+             WHERE u.id IN (:daIds)
+            """, nativeQuery = true)
+    List<DaContactRow> findContactsByDaIds(@Param("daIds") Collection<UUID> daIds);
+
+    /** Native projection for the DA field contact. */
+    interface DaContactRow {
+        UUID getDaId();
+        String getName();
+        String getPhone();
+    }
 
     /** Native projection for the admin list. */
     interface DaSummary {

--- a/auth/src/main/java/com/oneday/auth/service/impl/DaDirectoryPortAdapter.java
+++ b/auth/src/main/java/com/oneday/auth/service/impl/DaDirectoryPortAdapter.java
@@ -6,8 +6,11 @@ import com.oneday.common.port.DaDirectoryPort;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /** The single {@link DaDirectoryPort} implementation — the real DA roster read from auth. */
 @Component
@@ -22,5 +25,16 @@ class DaDirectoryPortAdapter implements DaDirectoryPort {
     @Override
     public List<UUID> availableDaIds(String cityId, LocalDate date, Shift shift) {
         return daProfileRepository.findAvailableDaIds(cityId, shift.name(), date);
+    }
+
+    @Override
+    public Map<UUID, DaContact> contactsFor(Collection<UUID> daIds) {
+        if (daIds.isEmpty()) {
+            return Map.of();
+        }
+        return daProfileRepository.findContactsByDaIds(daIds).stream()
+                .collect(Collectors.toMap(
+                        DaProfileRepository.DaContactRow::getDaId,
+                        row -> new DaContact(row.getName(), row.getPhone())));
     }
 }

--- a/common/src/main/java/com/oneday/common/port/CourierOnShipmentPort.java
+++ b/common/src/main/java/com/oneday/common/port/CourierOnShipmentPort.java
@@ -1,0 +1,22 @@
+package com.oneday.common.port;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * The DA currently on a shipment's first-mile pickup or last-mile delivery — who to call and which leg
+ * they're on. Implemented in M5 (dispatch) over the active {@code dispatch_queue} task + the auth DA
+ * directory; consumed by the M4 tracking read path so the customer sees the assigned DA exactly while a
+ * live DA is on the parcel (same signal as {@link LiveDaPositionPort}). The reciprocal of
+ * {@link ShipmentContactPort}, which hands the DA the customer's contact. Both sides depend only on
+ * {@code common}, so M4 never imports dispatch internals.
+ */
+public interface CourierOnShipmentPort {
+
+    /** The DA on this shipment's active pickup/delivery task, or empty if none is currently assigned. */
+    Optional<Courier> forShipment(UUID shipmentId);
+
+    record Courier(String name, String phone, Role role) {}
+
+    enum Role { PICKUP, DELIVERY }
+}

--- a/common/src/main/java/com/oneday/common/port/DaDirectoryPort.java
+++ b/common/src/main/java/com/oneday/common/port/DaDirectoryPort.java
@@ -3,7 +3,9 @@ package com.oneday.common.port;
 import com.oneday.common.domain.Shift;
 
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -21,4 +23,13 @@ import java.util.UUID;
 public interface DaDirectoryPort {
 
     List<UUID> availableDaIds(String cityId, LocalDate date, Shift shift);
+
+    /**
+     * Name + phone for each DA id — the field contact a customer needs to reach the DA on their
+     * shipment (the reciprocal of {@link ShipmentContactPort}, which hands the DA the customer's).
+     * Batch to avoid an N+1; ids without a DA are simply absent from the map.
+     */
+    Map<UUID, DaContact> contactsFor(Collection<UUID> daIds);
+
+    record DaContact(String name, String phone) {}
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/adapter/CourierOnShipmentAdapter.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/adapter/CourierOnShipmentAdapter.java
@@ -1,0 +1,50 @@
+package com.oneday.dispatch.adapter;
+
+import com.oneday.common.port.CourierOnShipmentPort;
+import com.oneday.common.port.DaDirectoryPort;
+import com.oneday.common.port.DaDirectoryPort.DaContact;
+import com.oneday.dispatch.domain.DispatchQueue;
+import com.oneday.dispatch.domain.TaskType;
+import com.oneday.dispatch.repository.DispatchQueueRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * M5-side implementation of {@link CourierOnShipmentPort}: resolves the shipment to its currently
+ * assigned DA ({@code dispatch_queue}, the same lookup as {@link LiveDaPositionAdapter}) and reads that
+ * DA's field contact from the auth DA directory. Empty when no DA is on the parcel — so the customer
+ * sees the courier in exactly the pickup/last-mile states the live DA dot appears.
+ */
+@Component
+class CourierOnShipmentAdapter implements CourierOnShipmentPort {
+
+    private final DispatchQueueRepository queueRepository;
+    private final DaDirectoryPort daDirectoryPort;
+
+    CourierOnShipmentAdapter(DispatchQueueRepository queueRepository, DaDirectoryPort daDirectoryPort) {
+        this.queueRepository = queueRepository;
+        this.daDirectoryPort = daDirectoryPort;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<Courier> forShipment(UUID shipmentId) {
+        List<DispatchQueue> active = queueRepository.findActiveByShipmentId(shipmentId);
+        if (active.isEmpty()) {
+            return Optional.empty();
+        }
+        DispatchQueue task = active.get(0);   // newest active assignment — the DA carrying the parcel now
+        Map<UUID, DaContact> contacts = daDirectoryPort.contactsFor(List.of(task.getDaId()));
+        DaContact c = contacts.get(task.getDaId());
+        if (c == null) {
+            return Optional.empty();
+        }
+        Role role = task.getTaskType() == TaskType.PICKUP ? Role.PICKUP : Role.DELIVERY;
+        return Optional.of(new Courier(c.name(), c.phone(), role));
+    }
+}

--- a/dispatch/src/test/java/com/oneday/dispatch/adapter/CourierOnShipmentAdapterTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/adapter/CourierOnShipmentAdapterTest.java
@@ -1,0 +1,78 @@
+package com.oneday.dispatch.adapter;
+
+import com.oneday.common.port.CourierOnShipmentPort.Courier;
+import com.oneday.common.port.CourierOnShipmentPort.Role;
+import com.oneday.common.port.DaDirectoryPort;
+import com.oneday.common.port.DaDirectoryPort.DaContact;
+import com.oneday.dispatch.domain.DispatchQueue;
+import com.oneday.dispatch.domain.TaskType;
+import com.oneday.dispatch.repository.DispatchQueueRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CourierOnShipmentAdapterTest {
+
+    @Mock DispatchQueueRepository queueRepository;
+    @Mock DaDirectoryPort daDirectoryPort;
+
+    private final UUID shipmentId = UUID.randomUUID();
+    private final UUID daId = UUID.randomUUID();
+
+    private CourierOnShipmentAdapter adapter() {
+        return new CourierOnShipmentAdapter(queueRepository, daDirectoryPort);
+    }
+
+    private DispatchQueue task(TaskType type) {
+        DispatchQueue q = new DispatchQueue();
+        q.setDaId(daId);
+        q.setShipmentId(shipmentId);
+        q.setTaskType(type);
+        return q;
+    }
+
+    @Test
+    void activePickupTask_returnsTheDaContactAndPickupRole() {
+        when(queueRepository.findActiveByShipmentId(shipmentId)).thenReturn(List.of(task(TaskType.PICKUP)));
+        when(daDirectoryPort.contactsFor(List.of(daId)))
+                .thenReturn(Map.of(daId, new DaContact("Ravi Kumar", "+919876543210")));
+
+        Optional<Courier> courier = adapter().forShipment(shipmentId);
+
+        assertThat(courier).contains(new Courier("Ravi Kumar", "+919876543210", Role.PICKUP));
+    }
+
+    @Test
+    void deliveryTask_carriesTheDeliveryRole() {
+        when(queueRepository.findActiveByShipmentId(shipmentId)).thenReturn(List.of(task(TaskType.DELIVERY)));
+        when(daDirectoryPort.contactsFor(List.of(daId)))
+                .thenReturn(Map.of(daId, new DaContact("Asha S", "+919000000000")));
+
+        assertThat(adapter().forShipment(shipmentId)).map(Courier::role).contains(Role.DELIVERY);
+    }
+
+    @Test
+    void noActiveTask_isEmpty() {
+        when(queueRepository.findActiveByShipmentId(shipmentId)).thenReturn(List.of());
+
+        assertThat(adapter().forShipment(shipmentId)).isEmpty();
+    }
+
+    @Test
+    void activeTaskButDirectoryHasNoContact_isEmpty() {
+        when(queueRepository.findActiveByShipmentId(shipmentId)).thenReturn(List.of(task(TaskType.PICKUP)));
+        when(daDirectoryPort.contactsFor(List.of(daId))).thenReturn(Map.of());
+
+        assertThat(adapter().forShipment(shipmentId)).isEmpty();
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/dto/ShipmentTrackResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/ShipmentTrackResponse.java
@@ -18,7 +18,15 @@ public record ShipmentTrackResponse(
         Location location,
         Route route,
         List<Milestone> milestones,
-        Eta eta) {
+        Eta eta,
+        Courier courier) {
+
+    /**
+     * The DA on the ground during the pickup and last-mile legs — name + phone so the customer can reach
+     * them, and a display role. Null whenever no DA is currently on the parcel. Only populated for the
+     * authenticated owner's view, never the public share link.
+     */
+    public record Courier(String name, String phone, String role) {}
 
     /**
      * The current position. {@code lat}/{@code lon} are null for the air leg (draw the arc) or when no

--- a/orders/src/main/java/com/oneday/orders/service/impl/TrackingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/TrackingServiceImpl.java
@@ -1,6 +1,7 @@
 package com.oneday.orders.service.impl;
 
 import com.oneday.common.domain.enums.DeliveryType;
+import com.oneday.common.port.CourierOnShipmentPort;
 import com.oneday.orders.domain.Address;
 import com.oneday.orders.domain.Shipment;
 import com.oneday.orders.dto.ShipmentTrackResponse;
@@ -16,6 +17,7 @@ import com.oneday.orders.tracking.CityNodeCatalog.Coord;
 import com.oneday.orders.tracking.LocationResolver;
 import com.oneday.orders.tracking.LocationResolver.ResolvedLocation;
 import com.oneday.orders.tracking.MilestoneBuilder;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,19 +39,22 @@ class TrackingServiceImpl implements TrackingService {
     private final LocationResolver locationResolver;
     private final MilestoneBuilder milestoneBuilder;
     private final CityNodeCatalog cities;
+    private final ObjectProvider<CourierOnShipmentPort> courierPort;
 
     TrackingServiceImpl(ShipmentRepository shipmentRepository,
                         com.oneday.orders.repository.B2bAccountRepository b2bAccountRepository,
                         CustomerVisibleStateMapper stateMapper,
                         LocationResolver locationResolver,
                         MilestoneBuilder milestoneBuilder,
-                        CityNodeCatalog cities) {
+                        CityNodeCatalog cities,
+                        ObjectProvider<CourierOnShipmentPort> courierPort) {
         this.shipmentRepository = shipmentRepository;
         this.b2bAccountRepository = b2bAccountRepository;
         this.stateMapper = stateMapper;
         this.locationResolver = locationResolver;
         this.milestoneBuilder = milestoneBuilder;
         this.cities = cities;
+        this.courierPort = courierPort;
     }
 
     @Override
@@ -61,7 +66,7 @@ class TrackingServiceImpl implements TrackingService {
         }
         return shipmentRepository.findByShipmentRef(shipmentRef)
                 .filter(s -> id.equals(s.getBookedByUserId()))   // ownership scope: not yours → not found
-                .map(this::toResponse);
+                .map(s -> toResponse(s, courierFor(s)));
     }
 
     @Override
@@ -80,7 +85,12 @@ class TrackingServiceImpl implements TrackingService {
         });
     }
 
+    /** Public/share view — no courier contact (the share link is not the authenticated owner). */
     private ShipmentTrackResponse toResponse(Shipment s) {
+        return toResponse(s, null);
+    }
+
+    private ShipmentTrackResponse toResponse(Shipment s, ShipmentTrackResponse.Courier courier) {
         String stateLabel = stateMapper.labelFor(s.getState());
         ResolvedLocation r = locationResolver.resolve(s);
         Location location = new Location(
@@ -92,7 +102,19 @@ class TrackingServiceImpl implements TrackingService {
 
         return new ShipmentTrackResponse(
                 s.getShipmentRef(), s.getState(), stateLabel, location, route(s), milestones,
-                new Eta(s.getEtaPromised(), s.getEtaUpdated()));
+                new Eta(s.getEtaPromised(), s.getEtaUpdated()), courier);
+    }
+
+    /** The DA on the parcel now (pickup or last-mile), or null. Port is optional — absent until M5 is wired. */
+    private ShipmentTrackResponse.Courier courierFor(Shipment s) {
+        CourierOnShipmentPort port = courierPort.getIfAvailable();
+        if (port == null) {
+            return null;
+        }
+        return port.forShipment(s.getId())
+                .map(c -> new ShipmentTrackResponse.Courier(c.name(), c.phone(),
+                        c.role() == CourierOnShipmentPort.Role.PICKUP ? "Pickup agent" : "Delivery agent"))
+                .orElse(null);
     }
 
     private Route route(Shipment s) {


### PR DESCRIPTION
Task 3 (backend) — give the customer the DA's contact, mirroring the DA app.

**Before:** the DA app saw the customer's name/phone (`ShipmentContactPort`), but the customer never saw the DA's.

**After:** the tracking read path returns a `courier` (name, phone, role) whenever a DA is on the parcel — pickup or last-mile, the same signal as the live-DA map dot.

- **common** — `DaDirectoryPort.contactsFor(daIds)`; new `CourierOnShipmentPort`.
- **auth** — DA contact join (`da_profile` + `users`; `da_id` = `users.id`).
- **dispatch** — `CourierOnShipmentAdapter`: active `dispatch_queue` task → `da_id` → contact.
- **orders** — `courier` on the track response.

**Privacy:** only on the authenticated owner's `/mine/{ref}/track`, never the public share link. Test: `CourierOnShipmentAdapterTest`. Frontend: oneday-web **#15**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)