### PR TITLE
Shuttle queue: state-based (landed & uncollected), not date-based

### DIFF
--- a/airline/src/main/java/com/oneday/airline/domain/Awb.java
+++ b/airline/src/main/java/com/oneday/airline/domain/Awb.java
@@ -71,4 +71,9 @@ public class Awb extends MutableBaseEntity {
 
     @Column(name = "loaded_at")
     private Instant loadedAt;
+
+    /** Destination custody: stamped when a shuttle agent collects the landed AWB from the airport
+     *  (DEST_SHUTTLE_IN). Null = still at the airport, so it stays on the shuttle inbound queue. */
+    @Column(name = "dest_collected_at")
+    private Instant destCollectedAt;
 }

--- a/airline/src/main/java/com/oneday/airline/repository/AwbRepository.java
+++ b/airline/src/main/java/com/oneday/airline/repository/AwbRepository.java
@@ -22,6 +22,11 @@ public interface AwbRepository extends JpaRepository<Awb, UUID> {
 
     List<Awb> findByOriginHubAndFlightDate(String originHub, LocalDate flightDate);
 
-    /** M12 shuttle inbound queue: AWBs arriving at a dest hub on a date (filtered to LANDED by the service). */
-    List<Awb> findByDestHubAndFlightDate(String destHub, LocalDate flightDate);
+    /**
+     * M12 shuttle inbound queue: live bookings to a dest hub that have <b>not yet been collected</b>
+     * from the airport ({@code dest_collected_at IS NULL}). Date-free on purpose — the service further
+     * filters to flights that have LANDED. Anything landed and uncollected shows up until it's brought
+     * in, whether it landed today or yesterday; a collected AWB drops off immediately.
+     */
+    List<Awb> findByDestHubAndStatusAndDestCollectedAtIsNull(String destHub, AwbStatus status);
 }

--- a/airline/src/main/java/com/oneday/airline/service/AirlineCustodyService.java
+++ b/airline/src/main/java/com/oneday/airline/service/AirlineCustodyService.java
@@ -3,12 +3,14 @@ package com.oneday.airline.service;
 import com.oneday.airline.domain.AwbParcel;
 import com.oneday.airline.events.CustodyScanProducer;
 import com.oneday.airline.repository.AwbParcelRepository;
+import com.oneday.airline.repository.AwbRepository;
 import com.oneday.common.kafka.enums.ScanEventType;
 import com.oneday.common.log.AuditLog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -23,10 +25,13 @@ public class AirlineCustodyService {
     private static final Logger log = LoggerFactory.getLogger(AirlineCustodyService.class);
 
     private final AwbParcelRepository awbParcelRepository;
+    private final AwbRepository awbRepository;
     private final CustodyScanProducer scanProducer;
 
-    public AirlineCustodyService(AwbParcelRepository awbParcelRepository, CustodyScanProducer scanProducer) {
+    public AirlineCustodyService(AwbParcelRepository awbParcelRepository, AwbRepository awbRepository,
+                                 CustodyScanProducer scanProducer) {
         this.awbParcelRepository = awbParcelRepository;
+        this.awbRepository = awbRepository;
         this.scanProducer = scanProducer;
     }
 
@@ -41,7 +46,20 @@ public class AirlineCustodyService {
                     .kv("scanType", type.name())
                     .log();
         });
+        if (type == ScanEventType.DEST_SHUTTLE_IN && !parcels.isEmpty()) {
+            stampDestCollected(awbId);   // the AWB is now off the airport → drops from the shuttle inbound queue
+        }
         log.info("Custody scan {} fired for {} parcel(s) on AWB {}", type, parcels.size(), awbId);
         return parcels.size();
+    }
+
+    /** Record that the AWB has been collected from the destination airport (idempotent — first stamp wins). */
+    private void stampDestCollected(UUID awbId) {
+        awbRepository.findById(awbId).ifPresent(awb -> {
+            if (awb.getDestCollectedAt() == null) {
+                awb.setDestCollectedAt(Instant.now());
+                awbRepository.save(awb);
+            }
+        });
     }
 }

--- a/airline/src/main/java/com/oneday/airline/service/ShuttleInboundQueryService.java
+++ b/airline/src/main/java/com/oneday/airline/service/ShuttleInboundQueryService.java
@@ -1,7 +1,7 @@
 package com.oneday.airline.service;
 
-import com.oneday.airline.domain.Awb;
 import com.oneday.airline.domain.AwbParcel;
+import com.oneday.airline.domain.AwbStatus;
 import com.oneday.airline.domain.FlightInstanceStatus;
 import com.oneday.airline.repository.AwbParcelRepository;
 import com.oneday.airline.repository.AwbRepository;
@@ -15,9 +15,11 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * Public read for the M12 shuttle inbound queue: the AWBs arriving at a destination hub on a date whose
- * flight has actually <b>LANDED</b> (per the M9 status poll). The shuttle module subtracts the ones it
- * has already collected. Dynamic by construction — a flight that lands mid-drive simply starts matching.
+ * Public read for the M12 shuttle inbound queue: every live booking to a destination hub whose flight
+ * has <b>LANDED</b> and which has <b>not yet been collected</b> from the airport (its
+ * {@code dest_collected_at} is null). No date filter — a bag that landed yesterday and still hasn't been
+ * brought to the hub must still be collected today. Dynamic by construction: a flight that lands
+ * mid-drive simply starts matching, and an AWB drops off the moment any agent collects it.
  */
 @Service
 public class ShuttleInboundQueryService {
@@ -43,8 +45,8 @@ public class ShuttleInboundQueryService {
     }
 
     @Transactional(readOnly = true)
-    public List<InboundAwb> landedInboundAwbs(String destHub, LocalDate date) {
-        return awbRepository.findByDestHubAndFlightDate(destHub, date).stream()
+    public List<InboundAwb> landedInboundAwbs(String destHub) {
+        return awbRepository.findByDestHubAndStatusAndDestCollectedAtIsNull(destHub, AwbStatus.BOOKED).stream()
                 .map(a -> flightInstanceRepository
                         .findByFlightNoAndFlightDate(a.getFlightNo(), a.getFlightDate())
                         .filter(fi -> fi.getStatus() == FlightInstanceStatus.LANDED)

--- a/airline/src/main/resources/db/migration/V9_12__awb_dest_collected_at.sql
+++ b/airline/src/main/resources/db/migration/V9_12__awb_dest_collected_at.sql
@@ -1,0 +1,7 @@
+-- M12 shuttle — the destination-side custody fact: when a shuttle agent collects a landed AWB from
+-- the airport (DEST_SHUTTLE_IN), stamp it here. This is what makes the shuttle inbound queue a STATE
+-- question ("landed and not yet brought to the hub") instead of a calendar one — the queue selects
+-- landed AWBs where dest_collected_at IS NULL, regardless of flight_date, and an AWB drops off the
+-- moment it's collected. Nullable until collected; the mirror of handed_over_at on the origin side.
+ALTER TABLE awb
+    ADD COLUMN dest_collected_at TIMESTAMPTZ;

--- a/airline/src/test/java/com/oneday/airline/service/AirlineCustodyServiceTest.java
+++ b/airline/src/test/java/com/oneday/airline/service/AirlineCustodyServiceTest.java
@@ -1,16 +1,21 @@
 package com.oneday.airline.service;
 
+import com.oneday.airline.domain.Awb;
 import com.oneday.airline.domain.AwbParcel;
 import com.oneday.airline.events.CustodyScanProducer;
 import com.oneday.airline.repository.AwbParcelRepository;
+import com.oneday.airline.repository.AwbRepository;
 import com.oneday.common.kafka.enums.ScanEventType;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -18,8 +23,10 @@ import static org.mockito.Mockito.when;
 class AirlineCustodyServiceTest {
 
     private final AwbParcelRepository awbParcelRepository = mock(AwbParcelRepository.class);
+    private final AwbRepository awbRepository = mock(AwbRepository.class);
     private final CustodyScanProducer scanProducer = mock(CustodyScanProducer.class);
-    private final AirlineCustodyService service = new AirlineCustodyService(awbParcelRepository, scanProducer);
+    private final AirlineCustodyService service =
+            new AirlineCustodyService(awbParcelRepository, awbRepository, scanProducer);
 
     private AwbParcel parcel(UUID parcelId) {
         AwbParcel p = new AwbParcel();
@@ -39,6 +46,8 @@ class AirlineCustodyServiceTest {
         assertThat(scanned).isEqualTo(2);
         verify(scanProducer).publish(p1, ScanEventType.HUB_ORIGIN_OUT);
         verify(scanProducer).publish(p2, ScanEventType.HUB_ORIGIN_OUT);
+        // Only DEST_SHUTTLE_IN stamps the AWB — an origin-out never touches dest custody.
+        verify(awbRepository, never()).save(any());
     }
 
     @Test
@@ -48,5 +57,44 @@ class AirlineCustodyServiceTest {
 
         assertThat(service.record(awbId, ScanEventType.HUB_DEST_IN)).isZero();
         verifyNoInteractions(scanProducer);
+    }
+
+    @Test
+    void destShuttleIn_stampsDestCollectedAt() {
+        UUID awbId = UUID.randomUUID();
+        Awb awb = new Awb();
+        when(awbParcelRepository.findByAwbId(awbId)).thenReturn(List.of(parcel(UUID.randomUUID())));
+        when(awbRepository.findById(awbId)).thenReturn(Optional.of(awb));
+
+        service.record(awbId, ScanEventType.DEST_SHUTTLE_IN);
+
+        assertThat(awb.getDestCollectedAt()).isNotNull();
+        verify(awbRepository).save(awb);
+    }
+
+    @Test
+    void destShuttleIn_isIdempotent_doesNotRestampAnAlreadyCollectedAwb() {
+        UUID awbId = UUID.randomUUID();
+        Awb awb = new Awb();
+        awb.setDestCollectedAt(java.time.Instant.parse("2026-08-12T20:00:00Z"));
+        when(awbParcelRepository.findByAwbId(awbId)).thenReturn(List.of(parcel(UUID.randomUUID())));
+        when(awbRepository.findById(awbId)).thenReturn(Optional.of(awb));
+
+        service.record(awbId, ScanEventType.DEST_SHUTTLE_IN);
+
+        assertThat(awb.getDestCollectedAt()).isEqualTo(java.time.Instant.parse("2026-08-12T20:00:00Z"));
+        verify(awbRepository, never()).save(any());
+    }
+
+    @Test
+    void destShuttleIn_unknownAwb_stampsNothing() {
+        UUID awbId = UUID.randomUUID();
+        when(awbParcelRepository.findByAwbId(awbId)).thenReturn(List.of());
+
+        service.record(awbId, ScanEventType.DEST_SHUTTLE_IN);
+
+        // No parcels → nothing scanned, and we never look up / stamp the AWB.
+        verify(awbRepository, never()).findById(any());
+        verify(awbRepository, never()).save(any());
     }
 }

--- a/docs/PHASE-3-HYD-DEL-RUN.md
+++ b/docs/PHASE-3-HYD-DEL-RUN.md
@@ -1,0 +1,144 @@
+# Phase 3 run-card — HYD → DEL — **RESUME: the last mile in Delhi**
+
+> One parcel, **Hyderabad → Delhi**. The first mile and the flight are **already done** (see §1). All that's
+> left is the **Delhi last mile**, run by **Yashvardhan**. This card is written so Yash can finish it on his
+> own, start to end. The only new thing since the first draft is the **Shuttle Agent** — §2 explains it in
+> two lines. Do §4 (pre-flight) first, then just follow §5 top to bottom.
+>
+> **IDs you'll need** (copy-paste):
+> - Parcel ref: `1DD-HYD-20260812-00001` · Flight: `6E6025` · AWB id: `c44073c8-2898-4bb2-bcf9-a28e43328d98`
+> - DEL shuttle agent (Ash) id: `eeceaa7e-07b2-48c8-8fef-a740312ff41e` · DEL fleet id: `f47ac10b-58cc-4372-a567-0e02b2c3d479`
+> - Backend: `https://one-day-delivery.onrender.com`
+
+---
+
+## 1. Where the parcel is RIGHT NOW — read this first
+
+| | Value |
+|---|---|
+| **Ref** | `1DD-HYD-20260812-00001` |
+| **State** | **`LANDED`** — the plane is down in Delhi; parcel is at the DEL airport, waiting to be collected |
+| **Lane** | HYD → DEL, INTERCITY, 900 g, PREPAID |
+| **AWB** | `312-80606072` · **AWB id** `c44073c8-2898-4bb2-bcf9-a28e43328d98` |
+| **Flight** | `6E6025`, flight_date **2026-08-12**, `flight_instance` status **LANDED** |
+| **Drop** | Prasanna Apartment, Model Town, New Delhi 110033 (~28.7159, 77.1445) |
+| **DEL delivery mode** | **`HUB_RETURN`** ✅ (already set — delivery auto-assigns, no van needed) |
+
+**Done already** (steps 1–11 of the old chain, forced through ops-recovery where the M7 hub consumer was thin):
+`BOOKED → PICKUP_ASSIGNED → PICKED_UP → RETURNED_TO_HUB → AT_ORIGIN_HUB → ORIGIN_HUB_PROCESSING →
+IN_TAKEOFF_BAG → DISPATCHED_TO_AIRPORT → AT_AIRPORT → DEPARTED → LANDED`.
+
+**Left to do** (this card):
+`LANDED → DISPATCHED_TO_HUB → AT_DEST_HUB → DEST_HUB_PROCESSING → HUB_DELIVERY_ASSIGNED → COLLECTED_FROM_HUB → DROPPED`.
+
+---
+
+## 2. What the Shuttle Agent is (the only new thing)
+
+A **shuttle agent** is the person who drives flight bags between a city's hub and its airport. Those two
+short legs used to be fake button-presses on the hub/airline consoles; now a real person does them in the
+**driver app**, and they show as a **live moving dot** on tracking. Same states as before — only *who taps*
+changed:
+
+| Leg | Old trigger | New trigger |
+|---|---|---|
+| Origin **hub → airport** (`… → DISPATCHED_TO_AIRPORT`) | Hub console "Dispatch to airport" | **Shuttle app → "Out to airport"** (HYD agent) |
+| Dest **airport → hub** (`LANDED → DISPATCHED_TO_HUB`) | Airline console "Dest shuttle-in" | **Shuttle app → "Collected from airport"** (DEL agent) |
+
+For **this parcel**, origin-out already happened, so **only the dest collect is a shuttle action** — done by
+the **DEL shuttle agent (Ash)**. The airline console's "Dest shuttle-in" button is **gone** (moved to the app).
+
+> ### The shuttle "From airport" list shows anything landed-and-not-yet-collected
+> Ash's list shows **every flight that has landed at Delhi airport and hasn't been brought to the hub yet** —
+> it does **not** matter what day the flight was. So our parcel (landed on the Aug-12 flight, never collected)
+> **shows up whenever Ash opens the app.** He taps **Collected from airport**, it disappears from the list,
+> and the parcel moves on. No SQL, no workarounds.
+>
+> *(This used to be broken — the list only showed "today's" flights, so an Aug-12 parcel vanished on Aug-13.
+> Fixed by `airline V9_12` + the state-based queries. **Pre-flight L0 below just checks that fix is live.**)*
+
+---
+
+## 3. Logins
+
+| Persona | Where | Login | Used for |
+|---|---|---|---|
+| **Shuttle agent — DEL (Ash)** | Godspeed **driver app**, needs the build with the shuttle persona | `ash.shuttle@oneday.in` / `godspeed2026` | **Collect from airport** (step S1) |
+| Shuttle agent — HYD (Agniva) | driver app | `agniva.shuttle@oneday.in` / `godspeed2026` | outbound leg — only for a *fresh* parcel (§6) |
+| Hub console — DEL | `godspeed-hub.vercel.app` | `admin@oneday.in` / `godspeed2026`, select **DEL** | **dock scan-in** (step S2) |
+| Delivery DA — DEL (Yash) | driver app | `yash.s1@oneday.test` (SHIFT_1) / `godspeed2026` | **deliver** (step S4) |
+| Admin / API | backend | `admin@oneday.in` / `godspeed2026` | OTP peek, curl fallbacks |
+| Backend base | `https://one-day-delivery.onrender.com` | — | API |
+
+- Both shuttle agents are **registered and verified** (Admin console → "Shuttle Agents"; role `SHUTTLE_AGENT`,
+  Ash=DEL, Agniva=HYD). First login shows a **"change password"** prompt — it does **not** block the token,
+  so Ash can just proceed (or set a new password once).
+- Yash wears **three hats** in this last mile: **shuttle agent (Ash)** to collect, **hub operator** to scan
+  in, **delivery DA (yash.s1)** to deliver. That's expected.
+
+---
+
+## 4. Pre-flight for the last mile — do these before you start
+
+| # | Check | How |
+|---|---|---|
+| **L0** | **Shuttle-queue state-fix deployed** (`airline V9_12` + state-based queries) | So the LANDED Aug-12 parcel shows in Ash's app regardless of date. Confirm after deploy: `GET $BASE/shuttle/eeceaa7e-07b2-48c8-8fef-a740312ff41e/queue` (as Ash) → the AWB appears under `inbound`. If `inbound` is empty, L0 isn't live yet. |
+| **L1** | **DEL delivery mode = `HUB_RETURN`** | ✅ already set. Confirm: `GET $BASE/routing/fleet/f47ac10b-58cc-4372-a567-0e02b2c3d479` → `"meeting_mode":"HUB_RETURN"`. |
+| **L2** | **DEL DA plan APPROVED + roster loaded for the run day** | Without an approved DEL territory plan + a loaded shift, `HUB_DELIVERY_ASSIGNED` never fires. Approve for the run day, then load: `POST $BASE/dispatch/admin/shift-load?date=<run-day>&shift=SHIFT_1`. (SHIFT_1 auto-loads 05:45 IST; force it if you start earlier.) |
+| **L3** | **`yash.s1` online in the driver app** | Log in as `yash.s1@oneday.test`, toggle **online** — needed for delivery auto-assign. |
+
+---
+
+## 5. The last mile — step by step (actor · action · state)
+
+| # | Log in as | What Yash does | Parcel moves to | How to confirm |
+|---|---|---|---|---|
+| **S1** | **`ash.shuttle`** in the **driver app** | The app opens on the shuttle screen. Under **"From airport"**, find flight `6E6025` and tap **Collected from airport**. (Keep the app open a minute so its GPS shows a live dot on tracking.) | `DISPATCHED_TO_HUB` | the flight disappears from Ash's list; tracking shows **"En route to delivery hub"** |
+| **S2** | **`admin@oneday.in`** on the **hub console** (`godspeed-hub.vercel.app`), pick **DEL** | Find the parcel, click **Receive**, then **scan it in** at the dock. It auto-sorts for delivery. | `AT_DEST_HUB → DEST_HUB_PROCESSING` | tracking shows **"At delivery hub"** |
+| **S3** | *(nothing — automatic)* | The system assigns the delivery to whoever is the online DEL driver (that's Yash). | `HUB_DELIVERY_ASSIGNED` | a **DROP task** pops up in Yash's driver app (S4 login) |
+| **S4** | **`yash.s1`** in the **driver app** (must be **online**) | Open the DROP task → **Collect from hub** → drive to Prasanna Apartment → **I've arrived** → **scan** → enter the **recipient OTP**. | `COLLECTED_FROM_HUB → DROPPED` ✅ | tracking shows **Delivered** 🎉 |
+
+- **Delivery has no cron/feasibility gate** (that's pickups only) — once assigned + online, Yash delivers immediately.
+- OTP peek if SMS isn't wired: `GET $BASE/internal/dev/shipments/1DD-HYD-20260812-00001/delivery-otp` (admin token, `!prod`).
+
+**Watch it live:** open the **track** page for the ref (business/customer). Milestones should advance
+**Landed → Out for delivery → Delivered**, with a moving dot on the airport→hub leg (if Ash pings) then on Yash.
+
+---
+
+## 6. If something stalls — quick triage
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| **Parcel not in Ash's "From airport" list** | L0 fix not deployed yet, **or** flight instance isn't `LANDED`, **or** it was already collected | confirm L0 is live; check `flight_instance` status = LANDED for `6E6025`; check the AWB isn't already stamped (`dest_collected_at`) |
+| Collect returns "already handled" | the other agent already collected it | check state: `GET $BASE/shipments/…` — if already `DISPATCHED_TO_HUB`, skip to S2 |
+| Dock scan 409 "not yet handed off" | parcel still `LANDED` | do S1 (collect) first |
+| **Delivery never assigns (S3)** | DEL DA plan not approved / shift not loaded / Yash offline | L2 + L3, then **re-scan** the parcel at the DEL hub |
+| Delivery OTP rejected | OTP wiring | peek endpoint above |
+
+---
+
+## 7. (Optional) Fresh full E2E — to exercise **both** shuttle legs
+
+The resume above only shows the **dest** shuttle leg (origin-out was already done for this parcel). To demo
+the **whole** shuttle feature end to end, book a **new** HYD → DEL parcel on the run day and add these two
+shuttle steps to the standard chain:
+
+- **HYD origin-out:** after the hub **seals** the flight bag, **Agniva (HYD shuttle agent)** opens "To airport",
+  (optionally multi-selects sealed bags), taps **Out to airport** → `DISPATCHED_TO_AIRPORT` + live dot.
+  If a bag is still OPEN, tap **Request seal** (badges the hub console) or wait for the auto-seal backstop.
+- **DEL dest-collect:** exactly step **S1** above.
+
+Everything between (GHA accepted on the airline console → auto DEPARTED/LANDED → DEL dock scan → HUB_RETURN
+delivery) is unchanged. Fast-forward the flight if you don't want to wait:
+```sql
+UPDATE flight_instance SET departure = now() + interval '2 min', arrival = now() + interval '4 min'
+ WHERE flight_no = '<FLIGHT_NO>' AND flight_date = CURRENT_DATE;
+```
+
+---
+
+**Bottom line for tomorrow:** the parcel is sitting at **LANDED** in Delhi with everything downstream green
+(DEL = HUB_RETURN, both shuttle agents registered and working, queue is now state-based). Once the **L0
+state-fix is deployed**, the parcel just shows in Ash's app — then it's four screen taps (S1→S4) to
+**DELIVERED**. No SQL, no curl.

--- a/hub/src/main/java/com/oneday/hub/repository/FlightBagRepository.java
+++ b/hub/src/main/java/com/oneday/hub/repository/FlightBagRepository.java
@@ -26,8 +26,12 @@ public interface FlightBagRepository extends JpaRepository<FlightBag, UUID> {
     /** Operator console: the day's flight bags at a hub (open = the live origin directory). */
     List<FlightBag> findByHubIdAndFlightDate(UUID hubId, LocalDate flightDate);
 
-    /** Shuttle outbound queue (M12): the day's bags leaving an origin hub, keyed by its string code. */
-    List<FlightBag> findByOriginHubAndFlightDate(String originHub, LocalDate flightDate);
+    /**
+     * Shuttle outbound queue (M12): bags at an origin hub still waiting to go to the airport — OPEN or
+     * SEALED, never DISPATCHED. State-based, not date-based: a bag sealed yesterday that never went out
+     * must still show today. Keyed by the hub's string code.
+     */
+    List<FlightBag> findByOriginHubAndStatusIn(String originHub, java.util.Collection<FlightBagStatus> statuses);
 
     /** The AutoSealJob backstop: still-OPEN bags whose cutoff has passed the seal buffer. */
     List<FlightBag> findByStatusAndBagCutoffBefore(FlightBagStatus status, java.time.Instant cutoffBefore);

--- a/hub/src/main/java/com/oneday/hub/service/FlightBagService.java
+++ b/hub/src/main/java/com/oneday/hub/service/FlightBagService.java
@@ -49,8 +49,8 @@ public interface FlightBagService {
     /** Operator console: the day's flight bags at a hub (the live origin directory). */
     java.util.List<FlightBag> bagsForDate(UUID hubId, LocalDate date);
 
-    /** Shuttle outbound queue (M12): the day's bags leaving an origin hub, keyed by its string code. */
-    java.util.List<FlightBag> bagsForOriginHub(String originHub, LocalDate date);
+    /** Shuttle outbound queue (M12): bags at an origin hub still waiting to go out (OPEN or SEALED). */
+    java.util.List<FlightBag> bagsForOriginHub(String originHub);
 
     /** M12: a shuttle agent asks the hub to seal this OPEN bag early (stamps seal_requested_at). */
     FlightBag requestSeal(UUID bagId);

--- a/hub/src/main/java/com/oneday/hub/service/impl/FlightBagServiceImpl.java
+++ b/hub/src/main/java/com/oneday/hub/service/impl/FlightBagServiceImpl.java
@@ -253,8 +253,9 @@ class FlightBagServiceImpl implements FlightBagService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<FlightBag> bagsForOriginHub(String originHub, java.time.LocalDate date) {
-        return flightBagRepository.findByOriginHubAndFlightDate(originHub, date);
+    public List<FlightBag> bagsForOriginHub(String originHub) {
+        return flightBagRepository.findByOriginHubAndStatusIn(originHub,
+                java.util.List.of(FlightBagStatus.OPEN, FlightBagStatus.SEALED));
     }
 
     @Override

--- a/shuttle/src/main/java/com/oneday/shuttle/api/ShuttleController.java
+++ b/shuttle/src/main/java/com/oneday/shuttle/api/ShuttleController.java
@@ -15,8 +15,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.Clock;
-import java.time.LocalDate;
 import java.util.Map;
 import java.util.UUID;
 
@@ -30,19 +28,17 @@ class ShuttleController {
 
     private final ShuttleQueueService queueService;
     private final ShuttleActionService actionService;
-    private final Clock clock;
 
-    ShuttleController(ShuttleQueueService queueService, ShuttleActionService actionService, Clock clock) {
+    ShuttleController(ShuttleQueueService queueService, ShuttleActionService actionService) {
         this.queueService = queueService;
         this.actionService = actionService;
-        this.clock = clock;
     }
 
     @GetMapping("/{agentId}/queue")
     public ShuttleQueueResponse queue(@AuthenticationPrincipal AuthUserDetails principal,
                                       @PathVariable UUID agentId) {
         ShuttleAuthz.requireAgent(principal, agentId);
-        return queueService.queue(ShuttleAuthz.city(principal), LocalDate.now(clock));
+        return queueService.queue(ShuttleAuthz.city(principal));
     }
 
     @PostMapping("/{agentId}/out-to-airport")

--- a/shuttle/src/main/java/com/oneday/shuttle/service/ShuttleQueueService.java
+++ b/shuttle/src/main/java/com/oneday/shuttle/service/ShuttleQueueService.java
@@ -15,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.Instant;
-import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
@@ -44,18 +43,20 @@ public class ShuttleQueueService {
     }
 
     @Transactional(readOnly = true)
-    public ShuttleQueueResponse queue(String cityCode, LocalDate date) {
+    public ShuttleQueueResponse queue(String cityCode) {
         Instant now = clock.instant();
         String hub = HubCode.of(cityCode);   // users.city_id ("delhi"/"DEL") → hub code ("DEL")
 
-        List<OutboundBag> outbound = flightBagService.bagsForOriginHub(hub, date).stream()
-                .filter(b -> b.getStatus() != FlightBagStatus.DISPATCHED)   // already gone
+        // Outbound = bags at this hub still waiting to go out (OPEN/SEALED); inbound = landed AWBs not
+        // yet collected. Both are STATE questions, never "today's" — anything still pending shows until
+        // it's handled, regardless of when the flight was.
+        List<OutboundBag> outbound = flightBagService.bagsForOriginHub(hub).stream()
                 .map(b -> toOutbound(b, now))
                 .sorted(Comparator.comparing(OutboundBag::leaveBy,
                         Comparator.nullsLast(Comparator.naturalOrder())))
                 .toList();
 
-        List<InboundFlight> inbound = inboundQuery.landedInboundAwbs(hub, date).stream()
+        List<InboundFlight> inbound = inboundQuery.landedInboundAwbs(hub).stream()
                 .filter(a -> !legRepository.existsByAwbIdAndDirection(a.awbId(), ShuttleDirection.INBOUND))
                 .map(a -> new InboundFlight(a.awbId(), a.flightNo(), a.flightDate(), a.awbNo(),
                         a.parcelCount(), a.landedAt()))

--- a/shuttle/src/test/java/com/oneday/shuttle/service/ShuttleQueueServiceTest.java
+++ b/shuttle/src/test/java/com/oneday/shuttle/service/ShuttleQueueServiceTest.java
@@ -43,18 +43,18 @@ class ShuttleQueueServiceTest {
     }
 
     @Test
-    void outbound_showsOpenAndSealed_excludesDispatched_flagsOverdue_sortedByLeaveBy() {
+    void outbound_flagsOverdue_sortedByLeaveBy() {
+        // bagsForOriginHub returns only pending bags (OPEN/SEALED) — DISPATCHED is filtered at the query.
         // SEALED, cutoff +120m → leaveBy = +120 − 75 = +45m (future, not overdue).
         FlightBag sealed = bag(FlightBagStatus.SEALED, NOW.plus(120, ChronoUnit.MINUTES));
         // OPEN, cutoff +60m → leaveBy = −15m (past → OVERDUE).
         FlightBag open = bag(FlightBagStatus.OPEN, NOW.plus(60, ChronoUnit.MINUTES));
-        FlightBag dispatched = bag(FlightBagStatus.DISPATCHED, NOW.plus(200, ChronoUnit.MINUTES));
-        when(flightBagService.bagsForOriginHub("HYD", DATE)).thenReturn(List.of(sealed, open, dispatched));
-        when(inboundQuery.landedInboundAwbs("HYD", DATE)).thenReturn(List.of());
+        when(flightBagService.bagsForOriginHub("HYD")).thenReturn(List.of(sealed, open));
+        when(inboundQuery.landedInboundAwbs("HYD")).thenReturn(List.of());
 
-        List<ShuttleQueueResponse.OutboundBag> out = service().queue("HYD", DATE).outbound();
+        List<ShuttleQueueResponse.OutboundBag> out = service().queue("HYD").outbound();
 
-        assertThat(out).hasSize(2);   // DISPATCHED excluded
+        assertThat(out).hasSize(2);
         assertThat(out.get(0).status()).isEqualTo("OVERDUE");   // earliest leaveBy first
         assertThat(out.get(1).status()).isEqualTo("SEALED");
     }
@@ -63,14 +63,14 @@ class ShuttleQueueServiceTest {
     void inbound_dropsAwbsAlreadyCollected() {
         UUID collected = UUID.randomUUID();
         UUID pending = UUID.randomUUID();
-        when(flightBagService.bagsForOriginHub(any(), any())).thenReturn(List.of());
-        when(inboundQuery.landedInboundAwbs("HYD", DATE)).thenReturn(List.of(
+        when(flightBagService.bagsForOriginHub(any())).thenReturn(List.of());
+        when(inboundQuery.landedInboundAwbs("HYD")).thenReturn(List.of(
                 new InboundAwb(collected, "6E6025", DATE, "098-1", 3, NOW),
                 new InboundAwb(pending, "AI806", DATE, "098-2", 2, NOW)));
         when(legRepository.existsByAwbIdAndDirection(collected, ShuttleDirection.INBOUND)).thenReturn(true);
         when(legRepository.existsByAwbIdAndDirection(eq(pending), any())).thenReturn(false);
 
-        List<ShuttleQueueResponse.InboundFlight> in = service().queue("HYD", DATE).inbound();
+        List<ShuttleQueueResponse.InboundFlight> in = service().queue("HYD").inbound();
 
         assertThat(in).singleElement().satisfies(f -> assertThat(f.awbId()).isEqualTo(pending));
     }


### PR DESCRIPTION
## Problem
The shuttle **inbound** queue filtered `awb.flight_date == today` and the **outbound** queue `flight_date == today`. So a flight bag that **landed yesterday and was never collected** silently disappeared from the agent's app the next day — stranding the parcel with no in-app way to bring it to the hub. (Hit live on the phase‑3 test parcel `1DD-HYD-20260812-00001`, `LANDED` on an Aug‑12 flight, invisible in the DEL agent's queue on Aug‑13.)

The queue should ask a **state** question — *"what's still pending at my airport/hub?"* — never a calendar one.

## Fix (prod‑ready, date‑free)
- **New authoritative destination‑custody fact `awb.dest_collected_at`** (`airline V9_12`), stamped inside `AirlineCustodyService.record()` whenever `DEST_SHUTTLE_IN` is recorded — so **every** collection path (shuttle app *and* the still‑live legacy airline endpoint) sets it. Idempotent, first stamp wins.
- **Inbound** = AWBs to the dest hub with `status = BOOKED`, flight `LANDED`, and `dest_collected_at IS NULL` (`findByDestHubAndStatusAndDestCollectedAtIsNull`). No date. Shows until collected, then drops for **every** agent.
- **Outbound** = bags at the origin hub with `status IN (OPEN, SEALED)` (`findByOriginHubAndStatusIn`). No date. Drops once `DISPATCHED`.
- `ShuttleController` / `ShuttleQueueService` drop the `LocalDate.now()` plumbing.

**Self‑cleaning on a mature DB:** because collection stamps the AWB, old delivered parcels never resurface — which a naive no‑date query *would*, since a flight's status stays `LANDED` forever.

## Effect on the stranded parcel
Once deployed, `1DD-HYD-20260812-00001` (LANDED, `dest_collected_at` NULL) simply appears in the DEL agent's "From airport" list again — **no SQL, no curl.**

## Tests
- `AirlineCustodyServiceTest` +3: stamps on `DEST_SHUTTLE_IN`, idempotent (no re‑stamp), unknown‑AWB stamps nothing.
- `ShuttleQueueServiceTest` updated to the no‑date contract.
- Whole reactor assembles (15/15); `hub` / `airline` / `shuttle` suites green.

## Docs
Updates `docs/PHASE-3-HYD-DEL-RUN.md` — removes the temporary SQL/curl workaround, adds pre‑flight **L0 = deploy this fix**, and rewrites the last‑mile steps in plain language for the field tester.

🤖 Generated with [Claude Code](https://claude.com/claude-code)