### PR TITLE
Shuttle collection: Axiom logging (by parcelId) + phase-3 run-card follow-ups

### DIFF
--- a/airline/src/main/java/com/oneday/airline/service/AirlineCustodyService.java
+++ b/airline/src/main/java/com/oneday/airline/service/AirlineCustodyService.java
@@ -57,8 +57,17 @@ public class AirlineCustodyService {
     private void stampDestCollected(UUID awbId) {
         awbRepository.findById(awbId).ifPresent(awb -> {
             if (awb.getDestCollectedAt() == null) {
-                awb.setDestCollectedAt(Instant.now());
+                Instant at = Instant.now();
+                awb.setDestCollectedAt(at);
                 awbRepository.save(awb);
+                AuditLog.event("awb.dest_collected")   // the "off the airport, on its way to the hub" fact
+                        .kv("awbId", awbId)
+                        .kv("awbNo", awb.getAwbNo())
+                        .kv("flightNo", awb.getFlightNo())
+                        .kv("destHub", awb.getDestHub())
+                        .kv("parcelCount", awb.getParcelCount())
+                        .kv("collectedAt", at)
+                        .log();
             }
         });
     }

--- a/docs/PHASE-3-HYD-DEL-RUN.md
+++ b/docs/PHASE-3-HYD-DEL-RUN.md
@@ -123,6 +123,10 @@ the **DEL shuttle agent (Ash)**. The airline console's "Dest shuttle-in" button 
 **Watch it live:** open the **track** page for the ref (business/customer). Milestones should advance
 **Landed → Out for delivery → Delivered**, with a moving dot on the airport→hub leg (if Ash pings) then on Yash.
 
+**Trace it in Axiom:** filter the logs by `parcelId` (or `shipmentRef`) to see the full custody trail in
+order — `shuttle.parcel_bound` (which agent carried it, in/out) · `awb.custody_scan` (DEST_SHUTTLE_IN) ·
+`awb.dest_collected` · `shipment.transition` for each state change.
+
 ---
 
 ## 6. If something stalls — quick triage

--- a/docs/PHASE-3-HYD-DEL-RUN.md
+++ b/docs/PHASE-3-HYD-DEL-RUN.md
@@ -24,12 +24,31 @@
 | **Drop** | Prasanna Apartment, Model Town, New Delhi 110033 (~28.7159, 77.1445) |
 | **DEL delivery mode** | **`HUB_RETURN`** ✅ (already set — delivery auto-assigns, no van needed) |
 
-**Done already** (steps 1–11 of the old chain, forced through ops-recovery where the M7 hub consumer was thin):
-`BOOKED → PICKUP_ASSIGNED → PICKED_UP → RETURNED_TO_HUB → AT_ORIGIN_HUB → ORIGIN_HUB_PROCESSING →
-IN_TAKEOFF_BAG → DISPATCHED_TO_AIRPORT → AT_AIRPORT → DEPARTED → LANDED`.
+### ✅ Already completed — the first mile + the flight (nothing for you to do here)
 
-**Left to do** (this card):
-`LANDED → DISPATCHED_TO_HUB → AT_DEST_HUB → DEST_HUB_PROCESSING → HUB_DELIVERY_ASSIGNED → COLLECTED_FROM_HUB → DROPPED`.
+This is why your card has **no pickup / hub / airport tasks** — they're all done. The parcel has already
+travelled the whole way from the Hyderabad sender to the Delhi airport:
+
+| ✅ | What happened | State reached |
+|---|---|---|
+| ✅ | Sender booked the parcel (HYD → DEL, prepaid) | `BOOKED` |
+| ✅ | Pickup auto-assigned to the HYD driver | `PICKUP_ASSIGNED` |
+| ✅ | HYD driver picked it up from the sender | `PICKED_UP` |
+| ✅ | Driver handed it to the Hyderabad hub | `RETURNED_TO_HUB` |
+| ✅ | Hub received + scanned it in | `AT_ORIGIN_HUB` |
+| ✅ | Hub sorted it into the flight bag | `ORIGIN_HUB_PROCESSING` → `IN_TAKEOFF_BAG` |
+| ✅ | Bag went to Hyderabad airport | `DISPATCHED_TO_AIRPORT` |
+| ✅ | Airline (GHA) took custody | `AT_AIRPORT` |
+| ✅ | Flight `6E6025` took off and **landed in Delhi** | `DEPARTED` → **`LANDED`** ← *you start here* |
+
+**👉 Your part — the Delhi last mile** (§5 below):
+
+| ⬜ | What you'll do | State it reaches |
+|---|---|---|
+| ⬜ | Shuttle agent collects it from Delhi airport | `DISPATCHED_TO_HUB` |
+| ⬜ | Delhi hub scans it in + sorts for delivery | `AT_DEST_HUB` → `DEST_HUB_PROCESSING` |
+| ⬜ | System assigns the delivery to Yash (auto) | `HUB_DELIVERY_ASSIGNED` |
+| ⬜ | Yash collects from hub + delivers to the door | `COLLECTED_FROM_HUB` → `DROPPED` ✅ |
 
 ---
 

--- a/shuttle/src/main/java/com/oneday/shuttle/service/ShuttleActionService.java
+++ b/shuttle/src/main/java/com/oneday/shuttle/service/ShuttleActionService.java
@@ -60,9 +60,16 @@ public class ShuttleActionService {
                 }
                 List<FlightBagService.BagParcelInfo> parcels = flightBagService.parcelsFor(bagId);
                 flightBagService.dispatch(bagId);   // throws if not SEALED / already dispatched
-                parcels.forEach(p -> legRepository.save(ShuttleLeg.builder()
-                        .parcelId(p.parcelId()).agentId(agentId)
-                        .direction(ShuttleDirection.OUTBOUND).bagId(bagId).build()));
+                parcels.forEach(p -> {
+                    legRepository.save(ShuttleLeg.builder()
+                            .parcelId(p.parcelId()).agentId(agentId)
+                            .direction(ShuttleDirection.OUTBOUND).bagId(bagId).build());
+                    // Per-parcel line so the whole leg is queryable by parcelId (who carried it, which way).
+                    AuditLog.event("shuttle.parcel_bound")
+                            .kv("parcelId", p.parcelId()).kv("shipmentRef", p.shipmentRef())
+                            .kv("agentId", agentId).kv("direction", "OUTBOUND")
+                            .kv("bagId", bagId).kv("flightNo", bag.getFlightNo()).log();
+                });
                 AuditLog.event("shuttle.out_to_airport")
                         .kv("agentId", agentId).kv("bagId", bagId)
                         .kv("flightNo", bag.getFlightNo()).kv("parcelCount", parcels.size()).log();
@@ -95,9 +102,15 @@ public class ShuttleActionService {
         if (scanned == 0) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No parcels on AWB " + awbId);
         }
-        parcelIds.forEach(pid -> legRepository.save(ShuttleLeg.builder()
-                .parcelId(pid).agentId(agentId)
-                .direction(ShuttleDirection.INBOUND).awbId(awbId).build()));
+        parcelIds.forEach(pid -> {
+            legRepository.save(ShuttleLeg.builder()
+                    .parcelId(pid).agentId(agentId)
+                    .direction(ShuttleDirection.INBOUND).awbId(awbId).build());
+            // Per-parcel line so the whole leg is queryable by parcelId (who carried it, which way).
+            AuditLog.event("shuttle.parcel_bound")
+                    .kv("parcelId", pid).kv("agentId", agentId)
+                    .kv("direction", "INBOUND").kv("awbId", awbId).log();
+        });
         AuditLog.event("shuttle.collect_from_airport")
                 .kv("agentId", agentId).kv("awbId", awbId).kv("parcelCount", scanned).log();
         return scanned;


### PR DESCRIPTION
Follow-ups to the already-merged **#102** (state-based shuttle queue). These two commits were pushed to the branch *after* #102 merged, so they never made it into `main` — this PR carries just them.

### 1. Axiom logging for the shuttle collection (queryable by `parcelId`)
The state-based collection flow was only partly observable — `awb.custody_scan` logged per parcel, but the new `dest_collected_at` stamp wasn't logged at all, and the shuttle summary lines carried only `awbId`/`bagId` (no `parcelId`).
- **`awb.dest_collected`** — new audit line on the stamp (`awbId`, `awbNo`, `flightNo`, `destHub`, `parcelCount`, `collectedAt`).
- **`shuttle.parcel_bound`** — per-parcel line on **both** legs (`parcelId` + `shipmentRef` where available + `agentId` + `direction` OUTBOUND/INBOUND + `bagId`/`awbId`).

Now filtering Axiom by `parcelId` shows the full custody trail in order:
`shuttle.parcel_bound` → `awb.custody_scan` → `awb.dest_collected` → `shipment.transition`.

### 2. Phase-3 run-card
- §1 now leads with a **✅ checklist of the completed first mile + flight** (BOOKED → LANDED) above the last-mile steps, so the field tester isn't confused by the missing pickup/hub/airport tasks.
- Adds a "Trace it in Axiom" note.

`airline` + `shuttle` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)