### PR TITLE
fix(dispatch): exempt GPS telemetry from idempotency filter

### DIFF
--- a/orders/src/main/java/com/oneday/orders/config/IdempotencyProperties.java
+++ b/orders/src/main/java/com/oneday/orders/config/IdempotencyProperties.java
@@ -49,7 +49,10 @@ public class IdempotencyProperties {
      * Ant-style URL patterns that are exempt from idempotency enforcement even though they
      * match {@link #applyToPathPattern}. Use for simple resource CRUD that doesn't need
      * replay protection (e.g. saved-address and cart-item management); booking, payment,
-     * and cart checkout deliberately stay enforced.
+     * and cart checkout deliberately stay enforced. GPS telemetry heartbeats are exempt too:
+     * they're fire-and-forget, overwrite a single live-status row, and fire every ~12s — an
+     * idempotency key would be meaningless and would flood the key store. Without this the
+     * shuttle/van apps' pings 400 with IDEMPOTENCY_KEY_REQUIRED and are silently dropped.
      */
     @NotNull
     private List<String> exemptPathPatterns = List.of(
@@ -57,7 +60,9 @@ public class IdempotencyProperties {
             "/api/v1/addresses",
             "/api/v1/cart/items/**",
             "/api/v1/cart/items",
-            "/api/v1/bulk/**"
+            "/api/v1/bulk/**",
+            "/api/v1/shuttle/*/telemetry",
+            "/api/v1/van/*/telemetry"
     );
 
     public Duration getTtl() {

--- a/orders/src/test/java/com/oneday/orders/config/IdempotencyPropertiesTest.java
+++ b/orders/src/test/java/com/oneday/orders/config/IdempotencyPropertiesTest.java
@@ -1,0 +1,36 @@
+package com.oneday.orders.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.util.AntPathMatcher;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Guards the exempt-path list against a class of silent bug: GPS telemetry heartbeats sit under
+ * {@code /api/v1/**} (so the idempotency filter matches them) but must be exempt — the shuttle/van
+ * apps fire-and-forget them every ~12s with no Idempotency-Key, and without the exemption every
+ * ping is rejected 400 IDEMPOTENCY_KEY_REQUIRED and silently dropped.
+ */
+class IdempotencyPropertiesTest {
+
+    private final AntPathMatcher matcher = new AntPathMatcher();
+    private final IdempotencyProperties props = new IdempotencyProperties();
+
+    private boolean isExempt(String uri) {
+        return props.getExemptPathPatterns().stream().anyMatch(p -> matcher.match(p, uri));
+    }
+
+    @Test
+    void telemetryHeartbeatsAreExempt() {
+        assertTrue(isExempt("/api/v1/shuttle/eeceaa7e-07b2-48c8-8fef-a740312ff41e/telemetry"),
+                "shuttle telemetry must be exempt or every GPS ping 400s");
+        assertTrue(isExempt("/api/v1/van/123e4567-e89b-12d3-a456-426614174000/telemetry"),
+                "van telemetry must be exempt or every GPS ping 400s");
+    }
+
+    @Test
+    void bookingStaysEnforced() {
+        assertFalse(isExempt("/api/v1/b2c/shipments"), "booking must keep idempotency enforcement");
+    }
+}


### PR DESCRIPTION
## Before vs After
| | Before | After |
|---|---|---|
| Shuttle/van GPS ping (keyless) | `400 IDEMPOTENCY_KEY_REQUIRED` | `200 {"status":"ok"}` |
| `shuttle_live_status` | Never written — 0 rows | Row written & updated each ping |
| Live position on tracking map | Never appears | Live moving dot |
| Booking / payment POSTs | Idempotency enforced | Idempotency enforced (unchanged) |

## Problem
Shuttle telemetry is served at `/api/v1/shuttle/{id}/telemetry`, which matches the idempotency filter's `/api/v1/**` guard. That filter requires an `Idempotency-Key` header on every POST. The agent app fires GPS pings fire-and-forget every ~12s with **no** key (like all its POSTs — the others work only because they're under `/dispatch/…`, outside the guard). So every ping was rejected `400 IDEMPOTENCY_KEY_REQUIRED` before reaching the controller, and the app swallowed the error → **zero pings ever stored**.

Verified against staging: keyless POST → 400; same POST **with** a key → 200 and the row appeared.

## Fix
Exempt the telemetry paths from the filter (one file):
```
/api/v1/shuttle/*/telemetry
/api/v1/van/*/telemetry      # same latent bug on the van app
```
A GPS heartbeat overwrites a single live-status row — an idempotency key is meaningless for it and would flood the key store. **No client change needed**: the app's existing keyless POST now passes.

## Scope & testing
- `orders/.../config/IdempotencyProperties.java` (+ `IdempotencyPropertiesTest`).
- New test asserts telemetry is exempt and booking stays enforced — **2/2 green**.
- Booking/payment idempotency behaviour unchanged.

## Deploy note
`oneday-api-staging` has `autoDeploy: false` — this needs a manual Render deploy to take effect on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)