### PR TITLE
Fix DEST_SORT_COMPLETE parcelId->shipmentId binding (last mile stuck at AT_DEST_HUB)

### DIFF
--- a/common/src/main/java/com/oneday/common/kafka/events/HubEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/HubEvent.java
@@ -13,7 +13,13 @@ import java.util.UUID;
  * <p>Minimal consumption contract — see {@link DaEvent} for the tolerant-reader rationale.</p>
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record HubEvent(UUID shipmentId,
+public record HubEvent(
+                       // Most M7 events key their parcel by "shipmentId", but the per-parcel
+                       // DestSortCompleteEvent names the same value "parcelId". Accept both so
+                       // DEST_SORT_COMPLETE binds a non-null id here — otherwise the consumer's
+                       // shipmentId==null guard silently drops it and the parcel never advances
+                       // AT_DEST_HUB → DEST_HUB_PROCESSING (and the whole last mile stalls).
+                       @JsonAlias({"parcelId", "parcel_id"}) UUID shipmentId,
                        // M7's concrete events expose eventType() as an interface method, which Jackson
                        // serializes camelCase ("eventType") even though record components are snake_case;
                        // accept that key so the umbrella binds when a concrete event is inferred to HubEvent.

--- a/common/src/test/java/com/oneday/common/kafka/MessagingConfigTest.java
+++ b/common/src/test/java/com/oneday/common/kafka/MessagingConfigTest.java
@@ -52,4 +52,23 @@ class MessagingConfigTest {
         assertThat(hub.eventType()).isEqualTo(HubEventType.STAND_ASSIGNED);
         assertThat(hub.shipmentId()).isEqualTo(shipmentId);
     }
+
+    /**
+     * DEST_SORT_COMPLETE ({@code DestSortCompleteEvent}) keys its parcel by {@code parcel_id}, not
+     * {@code shipment_id}. Without the alias on {@link HubEvent#shipmentId()} it bound to null, so the M4
+     * consumer's {@code shipmentId==null} guard silently dropped every dest-sort event and parcels froze
+     * at {@code AT_DEST_HUB}. This is the wire shape that event produces (java.time fields elided — the
+     * umbrella ignores them); the id must bind so the last mile can start.
+     */
+    @Test
+    void hubEventBindsParcelIdAliasToShipmentId() throws Exception {
+        UUID shipmentId = UUID.randomUUID();
+        String wire = "{\"parcel_id\":\"" + shipmentId + "\",\"eventType\":\"DEST_SORT_COMPLETE\","
+                + "\"city_id\":\"" + UUID.randomUUID() + "\",\"hub_id\":\"" + UUID.randomUUID() + "\"}";
+
+        HubEvent hub = mapper().readValue(wire, HubEvent.class);
+
+        assertThat(hub.shipmentId()).isEqualTo(shipmentId);   // was null before the @JsonAlias fix
+        assertThat(hub.eventType()).isEqualTo(HubEventType.DEST_SORT_COMPLETE);
+    }
 }


### PR DESCRIPTION
## Symptom
Parcel `1DD-HYD-20260812-00001` completed the whole physical last mile — shuttle collected from the airport, dock-scanned in at the DEL hub, sorted + sealed into a `DA_TERRITORY` delivery bag, **M5 assigned the DELIVERY task to yash.s1 (task `IN_PROGRESS`)**, and the DA collected + marked arrived — yet the shipment **state stayed frozen at `AT_DEST_HUB`**.

## Root cause
`AT_DEST_HUB → DEST_HUB_PROCESSING` is driven by the `DEST_SORT_COMPLETE` hub event. That event (`DestSortCompleteEvent`) keys its parcel by **`parcelId`** (serialized `parcel_id`), but M4's umbrella `HubEvent` reads **`shipmentId`**. With no alias, the event deserialized with `shipmentId = null`, so `HubEventsConsumer`'s guard `if (target == null || event.shipmentId() == null) return;` **silently dropped it**.

Because `HUB_DELIVERY_ASSIGNED`, `COLLECTED_FROM_HUB`, and `DROPPED` are only reachable **through** `DEST_HUB_PROCESSING`, every downstream delivery transition became illegal from `AT_DEST_HUB` and was rejected — the parcel froze even though dispatch and the DA did everything right.

This is a direct follow-on of the #98 M7→M4 mapping fix, which aliased `eventType` but not this field. `DEST_SORT_COMPLETE` is the **only** transition-driving hub event keyed by `parcelId`; `StandAssignedEvent` / `SameCityOutboundEvent` use `shipmentId` (which is why those bind).

## Fix
One line: `@JsonAlias({"parcelId", "parcel_id"})` on `HubEvent.shipmentId` — the same tolerant-reader pattern already used for `eventType`. Safe and targeted; the primary `shipmentId` name still wins for events that use it, and the producer field is untouched (M10 also consumes `DestSortCompleteEvent` by `parcelId`).

## Tests
`MessagingConfigTest.hubEventBindsParcelIdAliasToShipmentId` deserializes the event's wire shape and asserts `shipmentId` is now non-null (it was null before). `common` + `orders` suites green; reactor assembles.

## Note (separate from this PR)
The stuck parcel won't self-heal — the dropped event won't replay. Once this deploys, new parcels are fine; `1DD-HYD-20260812-00001` needs a one-off manual state advance to match reality (yash already has it `IN_PROGRESS`). Happy to prep the exact recovery statements once we confirm how far yash physically got.

🤖 Generated with [Claude Code](https://claude.com/claude-code)