### PR TITLE
feat(orders): ops parcel-status summary endpoint

### DIFF
--- a/orders/src/main/java/com/oneday/orders/api/AdminOrdersController.java
+++ b/orders/src/main/java/com/oneday/orders/api/AdminOrdersController.java
@@ -3,7 +3,9 @@ package com.oneday.orders.api;
 import com.oneday.auth.security.AuthUserDetails;
 import com.oneday.orders.dto.CancellationResponse;
 import com.oneday.orders.dto.ShipmentPageResponse;
+import com.oneday.orders.dto.ShipmentSummaryStats;
 import com.oneday.orders.service.AdminOrderQueryService;
+import com.oneday.orders.service.AdminOrderSummaryService;
 import com.oneday.orders.service.CancellationService;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -33,11 +35,14 @@ class AdminOrdersController {
     private static final String STATION_MANAGER = "STATION_MANAGER";
 
     private final AdminOrderQueryService adminOrderQueryService;
+    private final AdminOrderSummaryService adminOrderSummaryService;
     private final CancellationService cancellationService;
 
     AdminOrdersController(AdminOrderQueryService adminOrderQueryService,
+                          AdminOrderSummaryService adminOrderSummaryService,
                           CancellationService cancellationService) {
         this.adminOrderQueryService = adminOrderQueryService;
+        this.adminOrderSummaryService = adminOrderSummaryService;
         this.cancellationService = cancellationService;
     }
 
@@ -49,17 +54,31 @@ class AdminOrdersController {
             @RequestParam(value = "size", defaultValue = "25") int size) {
         // ADMIN (always) + STATION_MANAGER; everyone else → 403.
         Authz.requireRole(principal, STATION_MANAGER);
+        return adminOrderQueryService.listShipments(state, cityScope(principal), page, size);
+    }
 
-        // Admin sees all cities (null scope). A station manager is restricted to their own city.
-        String cityScope = null;
-        if (STATION_MANAGER.equals(principal.getUser().getRole().getName())) {
-            cityScope = principal.getUser().getCityId();
-            if (cityScope == null || cityScope.isBlank()) {
-                throw new ResponseStatusException(HttpStatus.FORBIDDEN,
-                        "Station manager has no city assigned");
-            }
+    /**
+     * Aggregate parcel counts for the ops monitoring dashboard — per ops bucket and per raw state.
+     * Same visibility as {@link #listShipments}: ADMIN counts every city (null scope), a
+     * STATION_MANAGER counts only shipments touching their own city.
+     */
+    @GetMapping("/summary")
+    public ShipmentSummaryStats summary(@AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireRole(principal, STATION_MANAGER);
+        return adminOrderSummaryService.summary(cityScope(principal));
+    }
+
+    /** Null for ADMIN (all cities); the station manager's own city otherwise (403 if unassigned). */
+    private static String cityScope(AuthUserDetails principal) {
+        if (!STATION_MANAGER.equals(principal.getUser().getRole().getName())) {
+            return null;
         }
-        return adminOrderQueryService.listShipments(state, cityScope, page, size);
+        String cityScope = principal.getUser().getCityId();
+        if (cityScope == null || cityScope.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                    "Station manager has no city assigned");
+        }
+        return cityScope;
     }
 
     /**

--- a/orders/src/main/java/com/oneday/orders/dto/ShipmentSummaryStats.java
+++ b/orders/src/main/java/com/oneday/orders/dto/ShipmentSummaryStats.java
@@ -1,0 +1,18 @@
+package com.oneday.orders.dto;
+
+import java.util.Map;
+
+/**
+ * Aggregate parcel counts for the ops monitoring dashboard. Field names serialise to
+ * snake_case via the global Jackson config ({@code byState} → {@code by_state}); map keys
+ * pass through verbatim ({@code OpsBucket} / {@code ShipmentState} names).
+ *
+ * @param total   total shipments in scope
+ * @param buckets count per ops bucket ({@code OpsBucket} name → count); all five keys always present
+ * @param byState count per raw state ({@code ShipmentState} name → count); only non-zero states present
+ */
+public record ShipmentSummaryStats(
+        long total,
+        Map<String, Long> buckets,
+        Map<String, Long> byState) {
+}

--- a/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
@@ -63,4 +63,14 @@ public interface ShipmentRepository extends JpaRepository<Shipment, UUID> {
     Page<Shipment> findByCityInvolvedAndState(@Param("city") String city,
                                               @Param("state") ShipmentState state,
                                               Pageable pageable);
+
+    // Ops monitoring: one grouped count instead of N per-state list calls. Backed by
+    // idx_shipments_state / (origin_city|dest_city, state) — see V4_35.
+    @Query("SELECT s.state AS state, COUNT(s) AS count FROM Shipment s GROUP BY s.state")
+    List<StateCount> countByState();
+
+    // City-scoped variant — same origin-OR-dest rule as findByCityInvolved (station-manager scope).
+    @Query("SELECT s.state AS state, COUNT(s) AS count FROM Shipment s "
+            + "WHERE s.originCity = :city OR s.destCity = :city GROUP BY s.state")
+    List<StateCount> countByStateForCity(@Param("city") String city);
 }

--- a/orders/src/main/java/com/oneday/orders/repository/StateCount.java
+++ b/orders/src/main/java/com/oneday/orders/repository/StateCount.java
@@ -1,0 +1,13 @@
+package com.oneday.orders.repository;
+
+import com.oneday.common.domain.enums.ShipmentState;
+
+/**
+ * Spring Data projection for the grouped-count query — one row per {@link ShipmentState}
+ * with the number of shipments currently in it. Alias names in the JPQL ({@code AS state},
+ * {@code AS count}) must match these getters.
+ */
+public interface StateCount {
+    ShipmentState getState();
+    long getCount();
+}

--- a/orders/src/main/java/com/oneday/orders/service/AdminOrderSummaryService.java
+++ b/orders/src/main/java/com/oneday/orders/service/AdminOrderSummaryService.java
@@ -1,0 +1,19 @@
+package com.oneday.orders.service;
+
+import com.oneday.orders.dto.ShipmentSummaryStats;
+
+/**
+ * Aggregate parcel counts for the ops monitoring dashboard — one grouped query instead of the
+ * many per-state list calls the console used to fire. The read-only, count-only counterpart to
+ * {@link AdminOrderQueryService}.
+ */
+public interface AdminOrderSummaryService {
+
+    /**
+     * @param cityScope null → all cities (ADMIN oversight); otherwise restrict to shipments whose
+     *                  origin OR destination is this city (a station manager's own city), the same
+     *                  rule {@link AdminOrderQueryService#listShipments} uses.
+     * @return per-bucket and per-state counts plus the in-scope total
+     */
+    ShipmentSummaryStats summary(String cityScope);
+}

--- a/orders/src/main/java/com/oneday/orders/service/OpsBucket.java
+++ b/orders/src/main/java/com/oneday/orders/service/OpsBucket.java
@@ -1,0 +1,46 @@
+package com.oneday.orders.service;
+
+import com.oneday.common.domain.enums.ShipmentState;
+
+/**
+ * Ops-console grouping of the 30 {@link ShipmentState}s into the handful of buckets the
+ * operations team monitors day to day. Deliberately distinct from
+ * {@link CustomerVisibleStateMapper} (which is tuned for customers) — ops care about
+ * hub processing and per-leg detail that customers never see.
+ *
+ * <p>The mapping is an <b>exhaustive switch with no {@code default}</b>: adding a new
+ * {@code ShipmentState} fails compilation here until it is placed in a bucket, so a new
+ * state can never silently fall out of every count.
+ */
+public enum OpsBucket {
+
+    /** Booked, awaiting or in first-mile pickup (DA pickup or self-drop, up to the origin hub). */
+    BOOKED_PICKUP,
+
+    /** Between hubs — origin-hub processing, flight, and destination-hub processing. */
+    IN_TRANSIT,
+
+    /** Last mile — assigned/out for delivery, or ready for hub collect. */
+    OUT_FOR_DELIVERY,
+
+    /** Terminal success — delivered to door or collected from hub. */
+    DELIVERED,
+
+    /** Failed pickup/delivery, RTO in any phase, or cancelled — the queue that needs attention. */
+    EXCEPTIONS;
+
+    public static OpsBucket of(ShipmentState state) {
+        return switch (state) {
+            case BOOKED, PICKUP_ASSIGNED, PICKED_UP, HANDED_TO_PICKUP_VAN,
+                 AWAITING_SELF_DROP, RETURNED_TO_HUB -> BOOKED_PICKUP;
+            case AT_ORIGIN_HUB, ORIGIN_HUB_PROCESSING, IN_TAKEOFF_BAG, DISPATCHED_TO_AIRPORT,
+                 AT_AIRPORT, DEPARTED, LANDED, DISPATCHED_TO_HUB, AT_DEST_HUB,
+                 DEST_HUB_PROCESSING -> IN_TRANSIT;
+            case HANDED_TO_DROP_VAN, DROP_ASSIGNED, DROP_COLLECTED, HUB_DELIVERY_ASSIGNED,
+                 COLLECTED_FROM_HUB, AWAITING_HUB_COLLECT -> OUT_FOR_DELIVERY;
+            case DROPPED, HUB_COLLECTED -> DELIVERED;
+            case PICKUP_FAILED, DELIVERY_FAILED, RTO_INITIATED, RTO_IN_TRANSIT,
+                 RTO_COMPLETED, CANCELLED -> EXCEPTIONS;
+        };
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/AdminOrderSummaryServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/AdminOrderSummaryServiceImpl.java
@@ -1,0 +1,73 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.dto.ShipmentSummaryStats;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.repository.StateCount;
+import com.oneday.orders.service.AdminOrderSummaryService;
+import com.oneday.orders.service.OpsBucket;
+import org.springframework.stereotype.Service;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @see AdminOrderSummaryService
+ */
+@Service
+class AdminOrderSummaryServiceImpl implements AdminOrderSummaryService {
+
+    private static final long TTL_MILLIS = 30_000L;
+    private static final String ALL_CITIES_KEY = "__all__";
+
+    private final ShipmentRepository shipmentRepository;
+
+    // ponytail: 30s per-instance memo, keyed by city scope. Protects the (remote) DB from
+    // GROUP-BY on every ops poll; on one app node it's enough. Reach for a shared cache only if
+    // we scale out and cross-node staleness actually diverges.
+    private final Map<String, Cached> cache = new ConcurrentHashMap<>();
+
+    private record Cached(long at, ShipmentSummaryStats value) {}
+
+    AdminOrderSummaryServiceImpl(ShipmentRepository shipmentRepository) {
+        this.shipmentRepository = shipmentRepository;
+    }
+
+    @Override
+    public ShipmentSummaryStats summary(String cityScope) {
+        String key = (cityScope == null) ? ALL_CITIES_KEY : cityScope;
+        Cached hit = cache.get(key);
+        long now = System.currentTimeMillis();
+        if (hit != null && now - hit.at() < TTL_MILLIS) {
+            return hit.value();
+        }
+        ShipmentSummaryStats fresh = compute(cityScope);
+        cache.put(key, new Cached(now, fresh));
+        return fresh;
+    }
+
+    private ShipmentSummaryStats compute(String cityScope) {
+        List<StateCount> counts = (cityScope == null)
+                ? shipmentRepository.countByState()
+                : shipmentRepository.countByStateForCity(cityScope);
+
+        Map<OpsBucket, Long> buckets = new EnumMap<>(OpsBucket.class);
+        for (OpsBucket b : OpsBucket.values()) {
+            buckets.put(b, 0L);
+        }
+        Map<String, Long> byState = new LinkedHashMap<>();
+        long total = 0L;
+        for (StateCount c : counts) {
+            long n = c.getCount();
+            total += n;
+            byState.put(c.getState().name(), n);
+            buckets.merge(OpsBucket.of(c.getState()), n, Long::sum);
+        }
+
+        Map<String, Long> bucketsByName = new LinkedHashMap<>();
+        buckets.forEach((b, n) -> bucketsByName.put(b.name(), n));
+        return new ShipmentSummaryStats(total, bucketsByName, byState);
+    }
+}

--- a/orders/src/main/resources/db/migration/orders/V4_35__ops_summary_indexes.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_35__ops_summary_indexes.sql
@@ -1,0 +1,10 @@
+-- Ops monitoring dashboard: composite indexes backing the city-scoped summary query
+--   SELECT state, COUNT(*) FROM shipments WHERE origin_city = ? OR dest_city = ? GROUP BY state
+-- The all-cities variant (GROUP BY state, no filter) is already served by idx_shipments_state
+-- from V4_3; only these two (city, state) composites were missing. They let Postgres aggregate
+-- each arm of the OR with an index-only scan instead of touching the heap.
+--
+-- Plain (non-CONCURRENT) CREATE: Flyway runs each migration in a transaction, and
+-- CREATE INDEX CONCURRENTLY cannot run inside one. The brief lock at deploy is acceptable.
+CREATE INDEX IF NOT EXISTS idx_shipments_origin_city_state ON shipments (origin_city, state);
+CREATE INDEX IF NOT EXISTS idx_shipments_dest_city_state   ON shipments (dest_city, state);

--- a/orders/src/test/java/com/oneday/orders/service/impl/AdminOrderSummaryServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/AdminOrderSummaryServiceImplTest.java
@@ -1,0 +1,87 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.dto.ShipmentSummaryStats;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.repository.StateCount;
+import com.oneday.orders.service.OpsBucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminOrderSummaryServiceImplTest {
+
+    @Mock
+    ShipmentRepository shipmentRepository;
+
+    private record Count(ShipmentState state, long count) implements StateCount {
+        @Override public ShipmentState getState() { return state; }
+        @Override public long getCount() { return count; }
+    }
+
+    /** The exhaustive switch guarantees this at compile time; this asserts it at runtime too, so a
+     *  future refactor that reintroduces a default can't silently drop a state from every bucket. */
+    @Test
+    void everyStateMapsToABucket() {
+        for (ShipmentState s : ShipmentState.values()) {
+            assertThat(OpsBucket.of(s)).as("bucket for %s", s).isNotNull();
+        }
+    }
+
+    @Test
+    void bucketsAndByStateSumToTotal() {
+        when(shipmentRepository.countByState()).thenReturn(List.of(
+                new Count(ShipmentState.BOOKED, 5),              // BOOKED_PICKUP
+                new Count(ShipmentState.PICKED_UP, 3),           // BOOKED_PICKUP
+                new Count(ShipmentState.AT_AIRPORT, 7),          // IN_TRANSIT
+                new Count(ShipmentState.DROP_ASSIGNED, 2),       // OUT_FOR_DELIVERY
+                new Count(ShipmentState.DROPPED, 10),            // DELIVERED
+                new Count(ShipmentState.DELIVERY_FAILED, 4)));   // EXCEPTIONS
+
+        AdminOrderSummaryServiceImpl svc = new AdminOrderSummaryServiceImpl(shipmentRepository);
+        ShipmentSummaryStats stats = svc.summary(null);
+
+        assertThat(stats.total()).isEqualTo(31);
+        // All five buckets present; each equals the sum of its states.
+        assertThat(stats.buckets()).containsOnlyKeys(
+                "BOOKED_PICKUP", "IN_TRANSIT", "OUT_FOR_DELIVERY", "DELIVERED", "EXCEPTIONS");
+        assertThat(stats.buckets().get("BOOKED_PICKUP")).isEqualTo(8);
+        assertThat(stats.buckets().get("IN_TRANSIT")).isEqualTo(7);
+        assertThat(stats.buckets().get("OUT_FOR_DELIVERY")).isEqualTo(2);
+        assertThat(stats.buckets().get("DELIVERED")).isEqualTo(10);
+        assertThat(stats.buckets().get("EXCEPTIONS")).isEqualTo(4);
+        // Bucket totals and raw-state totals both reconcile to total.
+        assertThat(stats.buckets().values().stream().mapToLong(Long::longValue).sum()).isEqualTo(31);
+        assertThat(stats.byState().values().stream().mapToLong(Long::longValue).sum()).isEqualTo(31);
+    }
+
+    @Test
+    void secondCallWithinTtlIsServedFromCache() {
+        when(shipmentRepository.countByState()).thenReturn(List.of(new Count(ShipmentState.BOOKED, 1)));
+        AdminOrderSummaryServiceImpl svc = new AdminOrderSummaryServiceImpl(shipmentRepository);
+
+        svc.summary(null);
+        svc.summary(null);
+
+        verify(shipmentRepository, times(1)).countByState();
+    }
+
+    @Test
+    void cityScopeUsesTheCityScopedQuery() {
+        when(shipmentRepository.countByStateForCity("DEL"))
+                .thenReturn(List.of(new Count(ShipmentState.BOOKED, 2)));
+        AdminOrderSummaryServiceImpl svc = new AdminOrderSummaryServiceImpl(shipmentRepository);
+
+        assertThat(svc.summary("DEL").total()).isEqualTo(2);
+        verify(shipmentRepository, times(1)).countByStateForCity("DEL");
+    }
+}


### PR DESCRIPTION
## What
Adds `GET /api/v1/admin/shipments/summary` — per-ops-bucket and per-state parcel counts for the operations monitoring dashboard.

## Why
The station console faked its stat cards by firing ~8 `size=1` list calls per load just to read each `total_elements`. This replaces that with **one `GROUP BY state` query**.

## Changes
- **`OpsBucket`** — exhaustive switch collapsing the 30 `ShipmentState`s into 5 ops buckets (Booked/pickup · In transit · Out for delivery · Delivered · Exceptions). No `default`, so a newly added state won't compile until it's bucketed.
- **`ShipmentRepository.countByState` / `countByStateForCity`** — city-scoped variant uses the same origin-OR-dest rule as the list endpoint.
- **`AdminOrderSummaryService`** — 30s in-process cache (no new dependency; Caffeine isn't on the classpath).
- **`V4_35`** — `(origin_city, state)` / `(dest_city, state)` composite indexes (`idx_shipments_state` already existed from V4_3).
- Same **ADMIN / STATION_MANAGER** city scoping as `AdminOrdersController.list`.

## Testing
- `AdminOrderSummaryServiceImplTest` (4 tests) — bucket/total reconciliation, all-states-mapped guard, cache hit, city-scoped query. Green.
- Verified end-to-end against a local DB: `total 24` = `BOOKED_PICKUP 19` + `EXCEPTIONS 5`, matching `SELECT state, count(*)`.

Frontend consumer: Sidarthapati/oneday-web `feat/ops-monitoring-dashboard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)