### PR TITLE
fix(security): server-side wallet recharge amount + IDOR guard on GET /users/{id}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ docs/SID-PROGRESS.md
 # Playwright MCP browser artifacts (local testing)
 .playwright-mcp/
 graphify-out/
+
+# Strix pentest run artifacts (may contain creds/logs)
+strix_runs/

--- a/auth/src/main/java/com/oneday/auth/api/UserController.java
+++ b/auth/src/main/java/com/oneday/auth/api/UserController.java
@@ -100,6 +100,7 @@ public class UserController {
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'CALL_CENTER_AGENT') or #id == authentication.principal.userId")
     public ResponseEntity<UserResponse> getUser(@PathVariable UUID id) {
         return ResponseEntity.ok(userService.getUser(id));
     }

--- a/docs/prod-readiness/STRIX-PENTEST-PLAN.md
+++ b/docs/prod-readiness/STRIX-PENTEST-PLAN.md
@@ -1,0 +1,165 @@
+# Strix AI Pentest — Plan & Cost Estimate
+
+**Status:** Tooling installed 2026-08-20; blocked only on an Anthropic API key.
+**Scope:** Local-only (never the shared staging DB). **Owner:** Sid.
+
+---
+
+## 1. Why & what
+
+Before the Sept 1 pilot we want an automated adversarial pass over the backend API + code to
+surface security gaps the prod-readiness batch didn't cover. **Strix**
+([github.com/usestrix/strix](https://github.com/usestrix/strix), Apache-2.0) is an autonomous
+AI pentest agent: it runs the app in a Docker sandbox, behaves like a real attacker, and
+**actively validates/exploits** findings (OWASP Top 10 — broken access control/IDOR, injection,
+auth/session, business-logic, API security, SSRF, misconfig), then writes a report.
+
+**Tool choice: open-source CLI, not the $29/mo Platform Pro plan.** OSS is free (you pay only
+model tokens), keeps the API key on our machine (nothing routes through the vendor), and is enough
+for a one-off self-assessment. Platform Pro's extras (autofix PRs, scheduled scans, Jira/Slack) +
+per-test billing only pay off for ongoing use.
+
+**Can it run "in Claude Code only"?** Partly. Strix is its own CLI + Docker agent, not a Claude Code
+plugin. We drive it from the terminal here, but it needs its own **pay-as-you-go Anthropic API key**
+(console.anthropic.com) — the Claude Code subscription can't be reused, and Strix's token spend is
+billed separately.
+
+---
+
+## 2. 💰 Cost estimate & guardrails (read this first)
+
+Strix is an autonomous agent that **loops**, so cost = model token spend, and it can run away.
+
+**Real-world data points (Claude Sonnet via Anthropic API):**
+| Source | Run | Tokens | Cost |
+|---|---|---|---|
+| Protego hands-on review | one **quick** scan, ~10 min | ~5.7M input | **~$17** (enough to trip auto-suspension) |
+| 18-model benchmark | Sonnet run | — | ~$20 (API) / $55.90 (reseller) |
+| Community rule of thumb | — | — | "quick scans single digits, deep scans tens of dollars" |
+
+⚠️ **Strix defaults to `deep` scan mode** — the most expensive. Left uncapped, a deep run on this
+multi-module Java repo could plausibly be **$30–60+**, and a runaway loop more.
+
+The `--max-budget` cap is **not a hard kill** — as it's approached, Strix sends graduated wrap-up
+warnings to all agents so they write out findings. A capped run = **bounded-but-coherent report,
+never wasted work.** So the cap = "define your ceiling," set to the most you're willing to spend, not
+artificially low.
+
+### The controls we use
+
+1. **`--max-budget <USD>` — a hard dollar ceiling per run.** The single most important control.
+2. **Scan mode `-m {quick,standard,deep}`** — override the `deep` default per phase to match value/risk.
+3. **Phase gates** — read each report before spending on the next; stop early if you've seen enough.
+4. **Interactive TUI (default)** — live spend is visible; Ctrl-C if it thrashes.
+5. **A spend limit on the Anthropic key itself** (console) — belt-and-suspenders backstop. Dedicated
+   key, not a shared one; **rotate/revoke after the exercise.**
+
+### Final budgeted plan — 3-phase ladder (chosen: thorough, ~$100 ceiling)
+
+Ordering is cheap→expensive and safe→risky. Source scanning has **zero blast radius** (pure
+analysis); the live phase mutates data so it runs **local-only, mock payments**.
+
+| Phase | Scope | Mode | `--max-budget` | Expected | Blast radius |
+|---|---|---|---|---|---|
+| **1 — Recon** | repo source | `quick` | **$10** | ~$4–8 | none |
+| **2 — Deep source audit** | repo source | `deep` | **$30** | ~$18–30 | none |
+| **3 — Live API** | `localhost:8080` | `deep` | **$50** | ~$30–50 | local DB only |
+| **Total** | | | **$90 hard ceiling** | **~$50–75 actual** | |
+
+**Rationale:** Phase 1 doubles as the smoke test (proves key/sandbox/report work) + catches quick
+wins before risking more. Phase 2 spends deep where it's **safest and highest signal-per-dollar** —
+static reasoning over auth/HMAC/IDOR code. Phase 3 goes deep on the running app for the runtime
+authz/IDOR/auth-bypass bugs static can't see, capped at $50 because live exploit loops are the most
+expensive and the only phase that writes data. Gate after each phase.
+
+---
+
+## 3. Setup status
+
+| Prereq | Status |
+|---|---|
+| `strix` CLI | ✅ v1.5.3 at `~/.strix/bin/strix` (on PATH via `~/.zshrc`) |
+| Sandbox image | ✅ `ghcr.io/usestrix/strix-sandbox:1.3.0` (5.83 GB) pulled |
+| Docker Desktop | ✅ installed, daemon up (29.4.3) |
+| JDK 21 / local Postgres | ✅ ready (`localhost:5432` up) |
+| Mock payments | ✅ `RAZORPAY_LIVE` unset → mock gateway (no real charges) |
+| Anthropic API key | ✅ in gitignored `.env` (`STRIX_LLM` + `LLM_API_KEY`) — **rotate/revoke after the exercise** |
+
+Config lives in gitignored `.env` (sourced before each run): `STRIX_LLM=anthropic/claude-sonnet-4-6`
++ `LLM_API_KEY=sk-ant-…`. ⚠️ The key was shared over chat — set a console spend limit on it and
+**revoke it once the assessment is done.**
+
+---
+
+## 4. Run commands
+
+Auth model: one stateless chain, `JwtAuthenticationFilter` in every profile — real creds required.
+Demo logins: `admin@oneday.in` (ADMIN) / `b2b.demo@oneday.test` (B2B), pw `godspeed2026`.
+
+Each phase: `set -a; source .env; set +a` then `export PATH=/Users/sidarthapati/.strix/bin:$PATH`.
+Run **interactive** (default TUI) to watch live spend. **Gate:** `strix view` the report and decide
+before starting the next phase.
+
+### Phase 1 — Recon: source scan, `quick`, cap $10
+```bash
+strix -m quick --max-budget 10 --scope-mode full \
+  --target /Users/sidarthapati/Desktop/Projects/one_day_delivery \
+  --instruction "Spring Boot 3 multi-module monolith (com.oneday.{module}). Focus: broken access
+  control / IDOR across orders controllers (B2C /api/v1/b2c/shipments, B2B /api/v1/b2b/shipments +
+  /accounts, tracking /api/v1/shipments, COD /api/v1/cod, admin /api/v1/admin/**); the Authz
+  role/owner gates; JWT + X-Api-Key handling in auth/JwtAuthenticationFilter/SecurityConfig; Razorpay
+  HMAC verification and /api/v1/payments + /wallet; idempotency filter; the WhatsApp AWB webhook;
+  SQL/injection; committed secrets. Skip test code and docs."
+```
+
+### Phase 2 — Deep source audit: source scan, `deep`, cap $30
+```bash
+strix -m deep --max-budget 30 --scope-mode full \
+  --target /Users/sidarthapati/Desktop/Projects/one_day_delivery \
+  --instruction "<same focus as Phase 1 — exhaustive static review of authz/IDOR/HMAC/injection/secrets>"
+```
+
+### Phase 3 — Live API: `localhost:8080`, `deep`, cap $50 (never the shared staging DB)
+```bash
+# Terminal A — boot locally (mock payments; own local Postgres)
+export JAVA_HOME=/opt/homebrew/opt/openjdk@21
+mvn spring-boot:run -pl app            # -> http://localhost:8080  (wait for health UP)
+
+# Terminal B
+strix -m deep --max-budget 50 --target http://localhost:8080 \
+  --instruction "Authenticated intercity-delivery API. Auth via POST /auth/login (admin@oneday.in /
+  godspeed2026 = ADMIN; b2b.demo@oneday.test / godspeed2026 = B2B), then Bearer JWT; B2B also X-Api-Key.
+  Probe broken access control / IDOR across lanes: /api/v1/b2c/shipments, /api/v1/b2b/shipments +
+  /api/v1/b2b/accounts, /api/v1/shipments, /api/v1/cod, admin /api/v1/admin/** and
+  /api/v1/pricing/admin/cards; OTP /internal/v1/shipments + /internal/dev peek; payments
+  /api/v1/payments(+/mock), /api/v1/wallet; public /auth/*, POST /api/sales/leads, GET /api/v1/track/**,
+  /airline/webhooks/whatsapp, /actuator/health/**. No destructive DoS / load flooding."
+```
+
+> ⚠️ **Do not** point Strix at `https://one-day-delivery.onrender.com` or any Vercel console — Strix
+> exploits and mutates data on whatever it targets, and staging shares the team DB.
+
+### Read the report
+```bash
+strix view              # opens latest run; results saved under ./strix_runs/<run-name>
+```
+
+Useful flags: `--max-turns N` (per-agent turn cap, default 500), `-n` (headless), `--resume <run>`,
+`--scope-mode diff --diff-base origin/main` (CI: changed files only).
+
+---
+
+## 5. Triage → change register
+
+AI pentesters over-report. For each finding: confirm against the cited code, keep the real ones,
+discard hallucinations, then fold confirmed items into `docs/CHANGE-REQUESTS.md` /
+`docs/prod-readiness/PROD-READINESS-NOW.md` for follow-up fixes.
+
+### Pre-findings already surfaced (worth a manual look regardless)
+- **Mock endpoints live on the internet-facing staging host** (`staging` profile ≠ `prod`):
+  `/api/v1/payments/mock`, `/api/v1/wallet/mock`, `/internal/dev` (OTP peek), self-drop demo. Prod
+  profile's `MockGuard` would block these; staging doesn't.
+- **Rate limiting off + wildcard `*.vercel.app` CORS** on staging.
+- **CSRF disabled on `/**`** (fine for a stateless bearer API — confirm no cookie-auth path exists).
+- Root `.env` holds a live `VERCEL_TOKEN`, but `.env` is gitignored **and never committed** — no git
+  exposure, so rotation is optional hygiene, not urgent.

--- a/docs/prod-readiness/STRIX-VIEWER-GUIDE.md
+++ b/docs/prod-readiness/STRIX-VIEWER-GUIDE.md
@@ -1,0 +1,82 @@
+# Strix — where runs live & how to view them
+
+Quick reference for finding past Strix pentest runs and opening them in the web viewer.
+(Full plan + cost model: `docs/prod-readiness/STRIX-PENTEST-PLAN.md`.)
+
+---
+
+## Where runs are stored
+
+Every run is written to **`strix_runs/<run-name>/`**, relative to the directory Strix was launched
+from. We launch from the repo root, so runs live at:
+
+```
+/Users/sidarthapati/Desktop/Projects/one_day_delivery/strix_runs/
+```
+
+This folder is **gitignored** (run logs can contain creds), so it stays local to this machine.
+
+**List all runs:**
+```bash
+ls -1 strix_runs/
+# e.g. one-day-delivery_88d1
+```
+
+**What's inside each `strix_runs/<run>/`:**
+| File | What it is |
+|---|---|
+| `penetration_test_report.md` | The human-readable report (exec summary, findings, recommendations) |
+| `vulnerabilities/vuln-000N.md` | One detailed markdown file per finding (PoC, code locations, fix) |
+| `findings.sarif` | SARIF — import into IDEs / code-scanning tools |
+| `vulnerabilities.csv` / `.json` | Machine-readable finding lists |
+| `strix.log` | Full agent activity log |
+| `run.json`, `.state/` | Run metadata + agent state (used by the viewer) |
+
+> You don't need the viewer to read results — just open the `.md` files directly
+> (`open strix_runs/<run>/penetration_test_report.md`).
+
+---
+
+## Opening a run in the web viewer
+
+The viewer binary is at `~/.strix/bin/strix`, so first put it on PATH:
+```bash
+export PATH=~/.strix/bin:$PATH
+```
+
+**Open a specific run** (from the repo root so it finds `strix_runs/`):
+```bash
+strix view one-day-delivery_88d1            # a random free port, auto-opens browser
+strix view one-day-delivery_88d1 --port 7331    # fixed port
+strix view                                   # most recent run
+strix view <run> --port 7331 --no-open       # serve only, don't auto-open (we use this when Claude launches it)
+```
+
+### ⚠️ The important gotcha — use the tokenized URL
+
+When it starts, the viewer **prints a URL with a `?token=…`** — open **that** one:
+```
+Serving one-day-delivery_88d1 (finished) at:
+  http://127.0.0.1:7331/?token=XXXXXXXXXXXXXXXX
+```
+
+- The **bare** `http://localhost:7331` drops you on a **"Verify your email to browse all runs"** page.
+  That is just Strix's lead-capture gate on the *browse-all-history* feature — **ignore it.**
+- The **`?token=…`** link authorizes your browser and opens the run **directly, no email needed.**
+- If you launched with `--no-open`, the token URL is only in the terminal output — copy it from there.
+
+**Security:** that token link lets whoever opens it browse history and even steer a *live* scan.
+It's localhost-only, so just **don't share it**. A new token is minted each time you start the viewer.
+
+**Stop the viewer:** `Ctrl-C` in its terminal (or kill the process if backgrounded).
+
+---
+
+## Live viewing during a scan
+
+`strix view` works on **live or finished** runs. So you can watch a scan as it happens:
+open a second terminal while a scan is running and `strix view <run> --port 7331`, then open the
+token URL — the agent tree and findings update in real time.
+
+(When Claude drives a scan, it runs the scan headless in the background **and** starts this viewer,
+then hands you the `?token=` URL to watch live — "Model A" in the plan doc.)

--- a/orders/src/main/java/com/oneday/orders/api/WalletController.java
+++ b/orders/src/main/java/com/oneday/orders/api/WalletController.java
@@ -65,7 +65,7 @@ class WalletController {
             @AuthenticationPrincipal AuthUserDetails principal,
             @Valid @RequestBody WalletRechargeConfirmRequest req) {
         return wallet.confirmRecharge(ownedAccountId(principal), req.getRazorpayOrderId(),
-                req.getRazorpayPaymentId(), req.getSignature(), req.getAmountPaise());
+                req.getRazorpayPaymentId(), req.getSignature());
     }
 
     /** The B2B account owned by the caller, or 404 (also gates the endpoint to B2B users). */

--- a/orders/src/main/java/com/oneday/orders/domain/WalletRechargeOrder.java
+++ b/orders/src/main/java/com/oneday/orders/domain/WalletRechargeOrder.java
@@ -1,0 +1,46 @@
+package com.oneday.orders.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Server-side record of the amount a wallet recharge was ORDERED for, keyed by the gateway order id.
+ * Confirmation reads the credited amount from here — never from the client — because Razorpay's HMAC
+ * signature covers only {@code orderId|paymentId} and does not sign the amount. Append-only.
+ */
+@Entity
+@Table(name = "wallet_recharge_order")
+@Getter
+@Setter
+@NoArgsConstructor
+public class WalletRechargeOrder {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "razorpay_order_id", length = 80, nullable = false, updatable = false, unique = true)
+    private String razorpayOrderId;
+
+    @Column(name = "b2b_account_id", nullable = false, updatable = false)
+    private UUID b2bAccountId;
+
+    @Column(name = "amount_paise", nullable = false, updatable = false)
+    private Long amountPaise;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private Instant createdAt;
+}

--- a/orders/src/main/java/com/oneday/orders/dto/WalletRechargeConfirmRequest.java
+++ b/orders/src/main/java/com/oneday/orders/dto/WalletRechargeConfirmRequest.java
@@ -1,17 +1,19 @@
 package com.oneday.orders.dto;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
-/** Confirm a wallet recharge after the gateway checkout completes. */
+/**
+ * Confirm a wallet recharge after the gateway checkout completes.
+ *
+ * <p>The credited amount is intentionally NOT taken from the client: it is resolved server-side from
+ * the {@code wallet_recharge_order} recorded at order-creation time. Razorpay's signature covers only
+ * {@code orderId|paymentId}, so a client-supplied amount cannot be trusted.</p>
+ */
 public class WalletRechargeConfirmRequest {
 
     @NotBlank private String razorpayOrderId;
     @NotBlank private String razorpayPaymentId;
     @NotBlank private String signature;
-    @NotNull @Min(10_000) @Max(50_000_000) private Long amountPaise;
 
     public String getRazorpayOrderId()          { return razorpayOrderId; }
     public void setRazorpayOrderId(String v)     { this.razorpayOrderId = v; }
@@ -21,7 +23,4 @@ public class WalletRechargeConfirmRequest {
 
     public String getSignature()                 { return signature; }
     public void setSignature(String v)           { this.signature = v; }
-
-    public Long getAmountPaise()                 { return amountPaise; }
-    public void setAmountPaise(Long v)           { this.amountPaise = v; }
 }

--- a/orders/src/main/java/com/oneday/orders/repository/WalletRechargeOrderRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/WalletRechargeOrderRepository.java
@@ -1,0 +1,13 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.WalletRechargeOrder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface WalletRechargeOrderRepository extends JpaRepository<WalletRechargeOrder, UUID> {
+
+    /** The recharge order for this gateway id, scoped to the owning account (defence in depth). */
+    Optional<WalletRechargeOrder> findByRazorpayOrderIdAndB2bAccountId(String razorpayOrderId, UUID b2bAccountId);
+}

--- a/orders/src/main/java/com/oneday/orders/service/WalletService.java
+++ b/orders/src/main/java/com/oneday/orders/service/WalletService.java
@@ -24,11 +24,12 @@ public interface WalletService {
     com.oneday.orders.service.PaymentPort.PaymentOrder createRechargeOrder(UUID accountId, long amountPaise);
 
     /**
-     * Verify the gateway signature and credit the wallet. Idempotent on the razorpay payment id —
-     * a duplicate confirm returns the current balance without double-crediting.
+     * Verify the gateway signature and credit the wallet by the amount recorded on the server-side
+     * recharge order (never a client-supplied amount — Razorpay does not sign the amount). Idempotent
+     * on the razorpay payment id — a duplicate confirm returns the current balance without double-crediting.
      */
     WalletResponse confirmRecharge(UUID accountId, String razorpayOrderId, String razorpayPaymentId,
-                                   String signature, long amountPaise);
+                                   String signature);
 
     /**
      * Debit the wallet for a booking. Called INSIDE the booking transaction with a row already

--- a/orders/src/main/java/com/oneday/orders/service/impl/WalletServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/WalletServiceImpl.java
@@ -1,11 +1,13 @@
 package com.oneday.orders.service.impl;
 
 import com.oneday.orders.domain.B2bAccount;
+import com.oneday.orders.domain.WalletRechargeOrder;
 import com.oneday.orders.domain.WalletTransaction;
 import com.oneday.orders.domain.WalletTransactionType;
 import com.oneday.orders.dto.WalletResponse;
 import com.oneday.orders.dto.WalletTransactionResponse;
 import com.oneday.orders.repository.B2bAccountRepository;
+import com.oneday.orders.repository.WalletRechargeOrderRepository;
 import com.oneday.orders.repository.WalletTransactionRepository;
 import com.oneday.orders.service.PaymentPort;
 import com.oneday.orders.service.WalletService;
@@ -26,13 +28,16 @@ class WalletServiceImpl implements WalletService {
 
     private final B2bAccountRepository accounts;
     private final WalletTransactionRepository ledger;
+    private final WalletRechargeOrderRepository rechargeOrders;
     private final PaymentPort paymentPort;
 
     WalletServiceImpl(B2bAccountRepository accounts,
                       WalletTransactionRepository ledger,
+                      WalletRechargeOrderRepository rechargeOrders,
                       PaymentPort paymentPort) {
         this.accounts = accounts;
         this.ledger = ledger;
+        this.rechargeOrders = rechargeOrders;
         this.paymentPort = paymentPort;
     }
 
@@ -55,13 +60,20 @@ class WalletServiceImpl implements WalletService {
     public PaymentPort.PaymentOrder createRechargeOrder(UUID accountId, long amountPaise) {
         require(accountId);
         // Razorpay caps receipt at 40 chars; "wr-" + 32-hex account id = 35.
-        return paymentPort.createOrder(amountPaise, "wr-" + accountId.toString().replace("-", ""));
+        PaymentPort.PaymentOrder order = paymentPort.createOrder(amountPaise, "wr-" + accountId.toString().replace("-", ""));
+        // Record the ordered (gateway-authoritative) amount so confirm never trusts a client value.
+        WalletRechargeOrder ro = new WalletRechargeOrder();
+        ro.setRazorpayOrderId(order.orderId());
+        ro.setB2bAccountId(accountId);
+        ro.setAmountPaise(order.amountPaise());
+        rechargeOrders.save(ro);
+        return order;
     }
 
     @Override
     @Transactional
     public WalletResponse confirmRecharge(UUID accountId, String razorpayOrderId, String razorpayPaymentId,
-                                          String signature, long amountPaise) {
+                                          String signature) {
         B2bAccount a = accounts.findByIdForUpdate(accountId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Account not found"));
         // Idempotent: a payment id credits the wallet exactly once.
@@ -69,6 +81,12 @@ class WalletServiceImpl implements WalletService {
             log.info("Wallet recharge for payment {} already applied; returning current balance", safe(razorpayPaymentId));
             return WalletResponse.of(accountId, balance(a));
         }
+        // Resolve the credited amount from the server-side order record — NEVER from the client.
+        // Razorpay's signature covers only orderId|paymentId, so the amount cannot be trusted from the body.
+        long amountPaise = rechargeOrders.findByRazorpayOrderIdAndB2bAccountId(razorpayOrderId, accountId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "No recharge order for orderId " + safe(razorpayOrderId)))
+                .getAmountPaise();
         // A tampered signature throws PaymentVerificationException → mapped to 402 by the handler.
         paymentPort.verifySignature(razorpayOrderId, razorpayPaymentId, signature);
         paymentPort.capture(razorpayPaymentId, amountPaise);

--- a/orders/src/main/resources/db/migration/orders/V4_35__wallet_recharge_order.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_35__wallet_recharge_order.sql
@@ -1,0 +1,13 @@
+-- Server-side record of the amount each wallet recharge was ORDERED for.
+-- Razorpay's payment signature covers only orderId|paymentId (NOT the amount), so wallet-recharge
+-- confirmation must resolve the credited amount from this table rather than trusting the client body
+-- (which previously let a user pay ₹100 and self-credit up to ₹5,00,000). Append-only.
+CREATE TABLE wallet_recharge_order (
+    id                UUID PRIMARY KEY,
+    razorpay_order_id VARCHAR(80) NOT NULL UNIQUE,
+    b2b_account_id    UUID NOT NULL REFERENCES b2b_accounts(id),
+    amount_paise      BIGINT NOT NULL,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_wallet_recharge_order_account ON wallet_recharge_order (b2b_account_id, created_at DESC);

--- a/orders/src/test/java/com/oneday/orders/service/impl/WalletServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/WalletServiceImplTest.java
@@ -1,0 +1,105 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.domain.B2bAccount;
+import com.oneday.orders.domain.WalletRechargeOrder;
+import com.oneday.orders.dto.WalletResponse;
+import com.oneday.orders.repository.B2bAccountRepository;
+import com.oneday.orders.repository.WalletRechargeOrderRepository;
+import com.oneday.orders.repository.WalletTransactionRepository;
+import com.oneday.orders.service.PaymentPort;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Guards the fix for the wallet-recharge amount-manipulation flaw: the credited amount must come
+ * from the server-side recharge order, never from the client (Razorpay's signature does not sign
+ * the amount, so a client value cannot be trusted).
+ */
+@ExtendWith(MockitoExtension.class)
+class WalletServiceImplTest {
+
+    @Mock private B2bAccountRepository accounts;
+    @Mock private WalletTransactionRepository ledger;
+    @Mock private WalletRechargeOrderRepository rechargeOrders;
+    @Mock private PaymentPort paymentPort;
+
+    private static final UUID ACCOUNT = UUID.randomUUID();
+    private static final String ORDER_ID = "order_abc";
+    private static final String PAYMENT_ID = "pay_abc";
+    private static final String SIG = "sig";
+
+    private WalletServiceImpl service() {
+        return new WalletServiceImpl(accounts, ledger, rechargeOrders, paymentPort);
+    }
+
+    @Test
+    void confirmRecharge_creditsServerSideOrderAmount() {
+        B2bAccount acc = new B2bAccount();
+        acc.setWalletBalancePaise(0L);
+        when(accounts.findByIdForUpdate(ACCOUNT)).thenReturn(Optional.of(acc));
+        when(ledger.existsByReference(PAYMENT_ID)).thenReturn(false);
+
+        WalletRechargeOrder order = new WalletRechargeOrder();
+        order.setRazorpayOrderId(ORDER_ID);
+        order.setB2bAccountId(ACCOUNT);
+        order.setAmountPaise(10_000L); // ₹100 — the amount actually ordered/paid
+        when(rechargeOrders.findByRazorpayOrderIdAndB2bAccountId(ORDER_ID, ACCOUNT))
+                .thenReturn(Optional.of(order));
+
+        WalletResponse res = service().confirmRecharge(ACCOUNT, ORDER_ID, PAYMENT_ID, SIG);
+
+        // Credited with the stored order amount, and the gateway captured that exact amount.
+        assertThat(res.balancePaise()).isEqualTo(10_000L);
+        assertThat(acc.getWalletBalancePaise()).isEqualTo(10_000L);
+        verify(paymentPort).capture(PAYMENT_ID, 10_000L);
+    }
+
+    @Test
+    void confirmRecharge_throwsWhenNoServerSideOrder() {
+        B2bAccount acc = new B2bAccount();
+        acc.setWalletBalancePaise(0L);
+        when(accounts.findByIdForUpdate(ACCOUNT)).thenReturn(Optional.of(acc));
+        when(ledger.existsByReference(PAYMENT_ID)).thenReturn(false);
+        when(rechargeOrders.findByRazorpayOrderIdAndB2bAccountId(ORDER_ID, ACCOUNT))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service().confirmRecharge(ACCOUNT, ORDER_ID, PAYMENT_ID, SIG))
+                .isInstanceOf(ResponseStatusException.class);
+
+        // No spoofed order → nothing captured, balance untouched.
+        verify(paymentPort, never()).capture(anyString(), anyLong());
+        assertThat(acc.getWalletBalancePaise()).isEqualTo(0L);
+    }
+
+    @Test
+    void createRechargeOrder_persistsGatewayOrderedAmount() {
+        when(accounts.findById(ACCOUNT)).thenReturn(Optional.of(new B2bAccount()));
+        when(paymentPort.createOrder(eq(10_000L), anyString()))
+                .thenReturn(new PaymentPort.PaymentOrder(ORDER_ID, 10_000L, "INR", "key_test"));
+
+        service().createRechargeOrder(ACCOUNT, 10_000L);
+
+        ArgumentCaptor<WalletRechargeOrder> captor = ArgumentCaptor.forClass(WalletRechargeOrder.class);
+        verify(rechargeOrders).save(captor.capture());
+        WalletRechargeOrder saved = captor.getValue();
+        assertThat(saved.getRazorpayOrderId()).isEqualTo(ORDER_ID);
+        assertThat(saved.getB2bAccountId()).isEqualTo(ACCOUNT);
+        assertThat(saved.getAmountPaise()).isEqualTo(10_000L);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Summary
Fix two security vulnerabilities surfaced by the Strix AI pentest (Phase 1): a wallet-recharge amount-manipulation flaw (client-controlled credit amount) and a missing authorization guard on `GET /users/{id}`. Both were code-confirmed against the source.

---

## What Changed
- **Wallet recharge amount is now server-authoritative.** `POST /api/v1/wallet/recharge/confirm` no longer trusts a client `amountPaise`. A new `WalletRechargeOrder` entity + `wallet_recharge_order` table (migration `V4_35`) persist the ordered amount at order-creation time; confirmation resolves the credited amount from that record. `amountPaise` removed from `WalletRechargeConfirmRequest` and the `WalletService.confirmRecharge` signature.
- **Added authorization to `GET /users/{id}`.** `UserController.getUser` now carries `@PreAuthorize("hasAnyRole('ADMIN', 'CALL_CENTER_AGENT') or #id == authentication.principal.userId")`, mirroring the guard already present on the sibling email-lookup endpoint.
- **Tests:** new `WalletServiceImplTest` (3 unit tests) covering the recharge amount path (credits stored amount, rejects confirm with no server-side order, persists gateway amount).
- **Docs:** added `docs/prod-readiness/STRIX-PENTEST-PLAN.md` and `STRIX-VIEWER-GUIDE.md`; gitignore `strix_runs/`.

---

## Why This Change?
- **Wallet manipulation (high impact):** Razorpay's HMAC signature covers only `orderId|paymentId`, not the amount. Because the server credited the client-supplied `amountPaise` (validated only `@Min(10_000) @Max(50_000_000)`), an authenticated B2B user could pay ₹100 and self-credit up to ₹5,00,000 per call, repeatably — unbounded fraudulent wallet balance usable for bookings. Resolving the amount server-side closes this.
- **IDOR on `GET /users/{id}`:** the endpoint had no `@PreAuthorize` and the service did an unconditional `findById`, so any authenticated user (including low-privilege customers) could read any account's email/name/role/city — including ADMIN/STATION_MANAGER — enabling reconnaissance and targeted phishing.

---

## Testing
- [x] Tested locally
- [x] Edge cases considered
- [x] No breaking changes introduced

### Test Evidence
New unit test — `orders/src/test/java/com/oneday/orders/service/impl/WalletServiceImplTest.java`:
```
Test set: com.oneday.orders.service.impl.WalletServiceImplTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
```
- `mvn clean install -pl orders,auth -am -DskipTests` — compiles clean.
- All `orders` **unit** tests pass (0 assertion failures).
- DB-backed `*E2eTest` suites could not run in the local dev environment due to a pre-existing dirty test-DB state (unrelated to this PR): `auth` e2e fails on `missing table [refresh_tokens]` (reproduced with this branch's changes stashed), and `orders` e2e fails on `V4_34` (`scheduled_pickup_start` column already present) before ever reaching `V4_35`. Expected to pass in CI against a fresh DB.

---

## Impact

### Areas Affected
- [x] Backend
- [ ] Frontend
- [ ] Routing
- [ ] Infra
- [x] Database
- [ ] NA

### Modules Affected
- [x] M1 — Auth
- [ ] M2 — Pricing
- [ ] M3 — Grid
- [x] M4 — Orders
- [ ] M5 — Dispatch
- [ ] M6 — Routing
- [ ] M7 — Hub
- [ ] M8 — Barcode
- [ ] M9 — Airline
- [ ] M10 — SLA
- [ ] M11 — Exceptions
- [ ] NA

---

## Risks / Concerns
- **API contract:** `amountPaise` is dropped from the wallet recharge *confirm* request body. Clients that still send it are unaffected (the field is now ignored; unknown JSON properties are not rejected). The recharge *order* request is unchanged.
- **Migration:** `V4_35` only adds a new table (`wallet_recharge_order`); no existing data touched. Recharge orders created before this deploy have no stored amount, so a confirm against a pre-existing pending order would 404 — acceptable given recharges are completed within a session.
- Otherwise low risk: one added authorization annotation and a server-side lookup replacing a trusted client value.

---

## Checklist
- [x] Code follows project conventions (package layout, no cross-module internal imports)
- [x] Self-review completed
- [x] Append-only audit trail preserved (no mutations to scan/manifest/role-change records)
- [x] No sensitive data or credentials exposed
- [x] Documentation updated if behaviour changed
- [x] Ready for review
