### PR TITLE
fix(security): Strix remediation — priv-esc, systemic BFLA, SSRF, ownership & concurrency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ docs/SID-PROGRESS.md
 # Playwright MCP browser artifacts (local testing)
 .playwright-mcp/
 graphify-out/
+
+# Strix pentest run artifacts (may contain creds/logs)
+strix_runs/

--- a/app/src/main/java/com/oneday/app/prod/ProdEnvGuard.java
+++ b/app/src/main/java/com/oneday/app/prod/ProdEnvGuard.java
@@ -1,5 +1,6 @@
 package com.oneday.app.prod;
 
+import com.oneday.orders.config.RazorpayProperties;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
@@ -24,9 +25,11 @@ public class ProdEnvGuard implements InitializingBean {
     private static final int MIN_JWT_SECRET_LENGTH = 32;
 
     private final Environment env;
+    private final RazorpayProperties razorpay;
 
-    public ProdEnvGuard(Environment env) {
+    public ProdEnvGuard(Environment env, RazorpayProperties razorpay) {
         this.env = env;
+        this.razorpay = razorpay;
     }
 
     @Override
@@ -50,6 +53,21 @@ public class ProdEnvGuard implements InitializingBean {
             problems.add("godspeed.cors.allowed-origins (GODSPEED_CORS_ALLOWED_ORIGINS) is not set");
         } else if (cors.trim().equals("*")) {
             problems.add("godspeed.cors.allowed-origins is a wildcard '*' — pin the real console origins in prod");
+        }
+
+        // When Razorpay is live, the HMAC secret/key must be real — never the committed mock/demo
+        // default (which would sign with a publicly-known secret, making signatures forgeable).
+        if (razorpay.isLive()) {
+            String secret = razorpay.getKeySecret();
+            if (isBlank(secret) || secret.contains("mock") || secret.contains("change_me") || secret.contains("demo")) {
+                problems.add("razorpay.key-secret is unset or still the committed mock/demo default while "
+                        + "razorpay.live=true — set a real RAZORPAY_KEY_SECRET");
+            }
+            String keyId = razorpay.getKeyId();
+            if (isBlank(keyId) || keyId.startsWith("rzp_test") || keyId.contains("demo")) {
+                problems.add("razorpay.key-id is unset or a test/demo key while razorpay.live=true — "
+                        + "set a real RAZORPAY_KEY_ID");
+            }
         }
 
         if (!problems.isEmpty()) {

--- a/app/src/test/java/com/oneday/app/prod/ProdEnvGuardTest.java
+++ b/app/src/test/java/com/oneday/app/prod/ProdEnvGuardTest.java
@@ -1,5 +1,6 @@
 package com.oneday.app.prod;
 
+import com.oneday.orders.config.RazorpayProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.env.MockEnvironment;
 
@@ -18,15 +19,21 @@ class ProdEnvGuardTest {
         return e;
     }
 
+    // Default RazorpayProperties has live=false, so the Razorpay checks are skipped — these existing
+    // JWT/CORS tests are unaffected. Razorpay-live coverage is added at the bottom.
+    private ProdEnvGuard newGuard(MockEnvironment e) {
+        return new ProdEnvGuard(e, new RazorpayProperties());
+    }
+
     @Test
     void passesWithStrongSecretAndPinnedOrigins() {
-        assertThatCode(() -> new ProdEnvGuard(env(STRONG_SECRET, GOOD_ORIGINS)).afterPropertiesSet())
+        assertThatCode(() -> newGuard(env(STRONG_SECRET, GOOD_ORIGINS)).afterPropertiesSet())
                 .doesNotThrowAnyException();
     }
 
     @Test
     void rejectsCommittedPlaceholderSecret() {
-        var guard = new ProdEnvGuard(env("change-me-in-dev-only-must-be-at-least-32-characters-long", GOOD_ORIGINS));
+        var guard = newGuard(env("change-me-in-dev-only-must-be-at-least-32-characters-long", GOOD_ORIGINS));
         assertThatThrownBy(guard::afterPropertiesSet)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("dev placeholder");
@@ -34,7 +41,7 @@ class ProdEnvGuardTest {
 
     @Test
     void rejectsShortSecret() {
-        var guard = new ProdEnvGuard(env("tooshort", GOOD_ORIGINS));
+        var guard = newGuard(env("tooshort", GOOD_ORIGINS));
         assertThatThrownBy(guard::afterPropertiesSet)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("shorter than");
@@ -42,7 +49,7 @@ class ProdEnvGuardTest {
 
     @Test
     void rejectsMissingSecret() {
-        var guard = new ProdEnvGuard(env(null, GOOD_ORIGINS));
+        var guard = newGuard(env(null, GOOD_ORIGINS));
         assertThatThrownBy(guard::afterPropertiesSet)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("JWT_SECRET");
@@ -50,7 +57,7 @@ class ProdEnvGuardTest {
 
     @Test
     void rejectsWildcardCors() {
-        var guard = new ProdEnvGuard(env(STRONG_SECRET, "*"));
+        var guard = newGuard(env(STRONG_SECRET, "*"));
         assertThatThrownBy(guard::afterPropertiesSet)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("wildcard");
@@ -58,9 +65,29 @@ class ProdEnvGuardTest {
 
     @Test
     void rejectsMissingCors() {
-        var guard = new ProdEnvGuard(env(STRONG_SECRET, null));
+        var guard = newGuard(env(STRONG_SECRET, null));
         assertThatThrownBy(guard::afterPropertiesSet)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("allowed-origins");
+    }
+
+    @Test
+    void rejectsLiveRazorpayStillOnMockSecret() {
+        RazorpayProperties rz = new RazorpayProperties();
+        rz.setLive(true); // keySecret/keyId keep the committed mock/test defaults
+        var guard = new ProdEnvGuard(env(STRONG_SECRET, GOOD_ORIGINS), rz);
+        assertThatThrownBy(guard::afterPropertiesSet)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("razorpay.key-secret");
+    }
+
+    @Test
+    void passesWithLiveRazorpayAndRealCredentials() {
+        RazorpayProperties rz = new RazorpayProperties();
+        rz.setLive(true);
+        rz.setKeySecret("a-real-live-razorpay-secret-value");
+        rz.setKeyId("rzp_live_realkey123");
+        var guard = new ProdEnvGuard(env(STRONG_SECRET, GOOD_ORIGINS), rz);
+        assertThatCode(guard::afterPropertiesSet).doesNotThrowAnyException();
     }
 }

--- a/auth/src/main/java/com/oneday/auth/api/UserController.java
+++ b/auth/src/main/java/com/oneday/auth/api/UserController.java
@@ -100,6 +100,7 @@ public class UserController {
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'CALL_CENTER_AGENT') or #id == authentication.principal.userId")
     public ResponseEntity<UserResponse> getUser(@PathVariable UUID id) {
         return ResponseEntity.ok(userService.getUser(id));
     }

--- a/auth/src/main/java/com/oneday/auth/security/RateLimitFilter.java
+++ b/auth/src/main/java/com/oneday/auth/security/RateLimitFilter.java
@@ -84,12 +84,15 @@ public class RateLimitFilter extends OncePerRequestFilter {
         };
     }
 
-    // Behind Render/Vercel the real client IP is the first X-Forwarded-For entry.
+    // The client can spoof X-Forwarded-For by prepending fake entries (the old code trusted the
+    // LEFTMOST entry → per-IP rate limits were trivially bypassable, vuln-0008). The trusted reverse
+    // proxy (Render/Vercel) APPENDS the real peer IP, so the RIGHTMOST entry is the one it added and
+    // the client cannot forge. Assumes a single trusted proxy hop in front of the app.
     private static String clientIp(HttpServletRequest request) {
         String xff = request.getHeader("X-Forwarded-For");
         if (xff != null && !xff.isBlank()) {
-            int comma = xff.indexOf(',');
-            return (comma > 0 ? xff.substring(0, comma) : xff).trim();
+            int comma = xff.lastIndexOf(',');
+            return (comma >= 0 ? xff.substring(comma + 1) : xff).trim();
         }
         return request.getRemoteAddr();
     }

--- a/auth/src/main/java/com/oneday/auth/security/SecurityConfig.java
+++ b/auth/src/main/java/com/oneday/auth/security/SecurityConfig.java
@@ -113,6 +113,57 @@ public class SecurityConfig {
                         // on the ERROR dispatch, so without this any 404/500 on an authenticated
                         // endpoint would be masked as a misleading 401.
                         .requestMatchers("/error").permitAll()
+
+                        // ── Role-scoped operational modules (M3/M6/M7/M8/M9) ─────────────────────────
+                        // These modules carry NO in-controller authorization, so these path rules are the
+                        // gate (previously any authenticated user — even a B2C customer — could approve
+                        // route plans, seal hub bags, confirm airline handovers, etc.). Fine-grained
+                        // "owns-this-resource" checks (van↔driver, da↔cron self) are a documented follow-up;
+                        // this closes the privilege boundary. ADMIN is permitted everywhere.
+
+                        // Customer booking map serviceability — must stay open to any authenticated user
+                        // (restricting it to ops roles would break booking). Keep BEFORE the grid rules.
+                        .requestMatchers(HttpMethod.GET, "/api/grid/serviceable-at").authenticated()
+
+                        // M6 routing — van-driver app (role-gated; per-van ownership is a follow-up).
+                        .requestMatchers("/api/v1/van/*/telemetry",
+                                "/routing/vans/*/manifest", "/routing/vans/*/load-scan",
+                                "/routing/vans/*/return-scan", "/routing/vans/*/stops/confirm",
+                                "/routing/vans/*/breakdown").hasAnyRole("VAN_DRIVER", "ADMIN")
+                        .requestMatchers("/routing/vans/*/recovery").hasAnyRole("STATION_MANAGER", "ADMIN")
+                        .requestMatchers("/routing/vans/*/live").hasAnyRole("STATION_MANAGER", "SUPERVISOR", "ADMIN")
+                        // Nightly route governance — mutations are ADMIN/STATION_MANAGER only.
+                        .requestMatchers(HttpMethod.POST, "/routing/plans/*/approve",
+                                "/routing/plans/*/override", "/routing/plans/*/replan").hasAnyRole("STATION_MANAGER", "ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/routing/fleet/**").hasAnyRole("STATION_MANAGER", "ADMIN")
+                        .requestMatchers("/routing/cron/**").hasAnyRole("DELIVERY_ASSOCIATE", "STATION_MANAGER", "SUPERVISOR", "ADMIN")
+                        // Planning-console reads (fleet GET, nodes, plans, shuttle timetable).
+                        .requestMatchers("/routing/**").hasAnyRole("STATION_MANAGER", "SUPERVISOR", "ADMIN")
+
+                        // M7 hub — operator console.
+                        .requestMatchers("/hub/**").hasAnyRole("HUB_OPERATOR", "SUPERVISOR", "ADMIN")
+
+                        // M3 grid — admin init, proposal governance, planning console.
+                        .requestMatchers(HttpMethod.POST, "/api/grid/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/api/proposals/**").hasAnyRole("STATION_MANAGER", "ADMIN")
+                        .requestMatchers("/api/grid/**").hasAnyRole("STATION_MANAGER", "SUPERVISOR", "ADMIN")
+
+                        // M9 airline — ground-crew confirmations + admin. The WhatsApp AWB webhook is a
+                        // stub needing its own Meta-signature auth (follow-up); role-gated until then.
+                        .requestMatchers(HttpMethod.POST, "/airline/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/airline/**").hasAnyRole("AIRLINE_GHA", "ADMIN")
+
+                        // M8 barcode — operational scan roles.
+                        .requestMatchers("/api/v1/scan/**").hasAnyRole("HUB_OPERATOR", "DELIVERY_ASSOCIATE", "SHUTTLE_AGENT", "AIRLINE_GHA", "ADMIN")
+
+                        // Orders stragglers: dev OTP peek (!prod) leaked cleartext OTP to any user;
+                        // minting a gateway order is a customer action.
+                        .requestMatchers("/internal/dev/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/v1/payments/order").hasAnyRole("C2C_CUSTOMER", "B2C_CUSTOMER", "B2B_USER", "ADMIN")
+
+                        // auth — role catalog disclosure (sibling POST/DELETE are already ADMIN-gated).
+                        .requestMatchers(HttpMethod.GET, "/roles").hasAnyRole("ADMIN", "STATION_MANAGER")
+
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 // Throttle brute-force before any auth work happens.

--- a/auth/src/main/java/com/oneday/auth/service/impl/UserServiceImpl.java
+++ b/auth/src/main/java/com/oneday/auth/service/impl/UserServiceImpl.java
@@ -63,9 +63,16 @@ class UserServiceImpl implements UserService {
         var actor = userRepository.findById(actorId)
                 .orElseThrow(() -> new UserNotFoundException("Actor not found"));
 
-        // Station Manager city-scope enforcement
+        // Station Manager enforcement — fail closed. A Station Manager may create ONLY non-privileged
+        // city-scoped operational roles (never ADMIN, B2B_USER, customers, AIRLINE_GHA, or a peer
+        // Station Manager), and only within their own city. Mirrors changeRole()'s
+        // enforceStationManagerScope(); previously ADMIN slipped through because it is not city-scoped.
         if ("STATION_MANAGER".equals(actor.getRole().getName())) {
-            if (needsCity && !actor.getCityId().equals(request.cityId())) {
+            if (!needsCity || "STATION_MANAGER".equals(role.getName())) {
+                throw new ForbiddenException(
+                        "Station Manager cannot create users with role " + role.getName());
+            }
+            if (!actor.getCityId().equals(request.cityId())) {
                 throw new ForbiddenException("Station Manager can only create users in their own city");
             }
         }

--- a/auth/src/test/java/com/oneday/auth/e2e/ApiKeyE2eTest.java
+++ b/auth/src/test/java/com/oneday/auth/e2e/ApiKeyE2eTest.java
@@ -31,7 +31,7 @@ class ApiKeyE2eTest extends AuthE2eSupport {
         String token = tokenForRole("B2C_CUSTOMER");
         String rawKey = createKey(token, "machine-key");
 
-        mvc.perform(get("/roles").header("X-Api-Key", rawKey))
+        mvc.perform(get("/auth/api-keys").header("X-Api-Key", rawKey))
                 .andExpect(status().isOk());
     }
 
@@ -48,7 +48,7 @@ class ApiKeyE2eTest extends AuthE2eSupport {
         mvc.perform(delete("/auth/api-keys/{id}", keyId).header("Authorization", bearer(token)))
                 .andExpect(status().isNoContent());
 
-        mvc.perform(get("/roles").header("X-Api-Key", rawKey))
+        mvc.perform(get("/auth/api-keys").header("X-Api-Key", rawKey))
                 .andExpect(status().isUnauthorized());
     }
 

--- a/auth/src/test/java/com/oneday/auth/e2e/SecurityConfigAuthzTest.java
+++ b/auth/src/test/java/com/oneday/auth/e2e/SecurityConfigAuthzTest.java
@@ -1,0 +1,48 @@
+package com.oneday.auth.e2e;
+
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Regression for the path-based role rules added to {@code SecurityConfig} (Strix RC1 — Broken
+ * Function-Level Authorization on the ops modules routing/hub/grid/airline/barcode). Those controllers
+ * are not on the auth module's classpath, so authorization is what we exercise here: a DENIED request
+ * is rejected with 403 at the authorization layer, while an ALLOWED request reaches the dispatcher and
+ * 404s (no handler). That 403-vs-404 split is exactly the privilege boundary we are asserting.
+ */
+class SecurityConfigAuthzTest extends AuthE2eSupport {
+
+    @Test
+    void customerIsForbiddenFromOpsEndpoints() throws Exception {
+        String cust = tokenForRole("B2C_CUSTOMER");
+        forbidden(get("/hub/h1/bags"), cust);
+        forbidden(get("/api/proposals"), cust);
+        forbidden(get("/airline/hubs/DEL/awbs"), cust);
+        forbidden(get("/routing/fleet/DEL"), cust);
+        forbidden(post("/routing/plans/00000000-0000-0000-0000-000000000000/approve"), cust);
+        forbidden(post("/api/v1/scan"), cust);
+    }
+
+    @Test
+    void adminPassesAuthorizationOnOpsEndpoints() throws Exception {
+        // Allowed by authz → reaches dispatch → 404 (no handler on the auth classpath), NOT 403.
+        mvc.perform(get("/hub/h1/bags").header("Authorization", bearer(adminToken())))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void serviceabilityStaysOpenToAnyAuthenticatedUser() throws Exception {
+        // Carve-out: the booking-map serviceability lookup must NOT be ops-role-gated.
+        mvc.perform(get("/api/grid/serviceable-at")
+                        .header("Authorization", bearer(tokenForRole("B2C_CUSTOMER"))))
+                .andExpect(status().isNotFound()); // allowed → no handler here → 404, not 403
+    }
+
+    private void forbidden(org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder b,
+                           String token) throws Exception {
+        mvc.perform(b.header("Authorization", bearer(token))).andExpect(status().isForbidden());
+    }
+}

--- a/auth/src/test/java/com/oneday/auth/e2e/UserManagementE2eTest.java
+++ b/auth/src/test/java/com/oneday/auth/e2e/UserManagementE2eTest.java
@@ -42,6 +42,25 @@ class UserManagementE2eTest extends AuthE2eSupport {
                 .andExpect(status().isOk());
     }
 
+    // vuln-0015 (privilege escalation, fail closed): a Station Manager must NOT mint an ADMIN
+    // (ADMIN is not city-scoped, so it previously slipped past the city-only guard).
+    @Test
+    void stationManagerCannotCreateAdmin() throws Exception {
+        String smToken = tokenForRole("STATION_MANAGER");
+        mvc.perform(asJson(post("/users").header("Authorization", bearer(smToken)),
+                        new RegisterUserRequest("Evil Admin", uniqueEmail(), PW, "ADMIN", "DEL")))
+                .andExpect(status().isForbidden());
+    }
+
+    // …nor a peer Station Manager.
+    @Test
+    void stationManagerCannotCreatePeerStationManager() throws Exception {
+        String smToken = tokenForRole("STATION_MANAGER");
+        mvc.perform(asJson(post("/users").header("Authorization", bearer(smToken)),
+                        new RegisterUserRequest("Peer SM", uniqueEmail(), PW, "STATION_MANAGER", "DEL")))
+                .andExpect(status().isForbidden());
+    }
+
     // A customer has no user-provisioning rights → 403.
     @Test
     void customerCannotCreateUser() throws Exception {

--- a/docs/prod-readiness/STRIX-PENTEST-PLAN.md
+++ b/docs/prod-readiness/STRIX-PENTEST-PLAN.md
@@ -1,0 +1,165 @@
+# Strix AI Pentest — Plan & Cost Estimate
+
+**Status:** Tooling installed 2026-08-20; blocked only on an Anthropic API key.
+**Scope:** Local-only (never the shared staging DB). **Owner:** Sid.
+
+---
+
+## 1. Why & what
+
+Before the Sept 1 pilot we want an automated adversarial pass over the backend API + code to
+surface security gaps the prod-readiness batch didn't cover. **Strix**
+([github.com/usestrix/strix](https://github.com/usestrix/strix), Apache-2.0) is an autonomous
+AI pentest agent: it runs the app in a Docker sandbox, behaves like a real attacker, and
+**actively validates/exploits** findings (OWASP Top 10 — broken access control/IDOR, injection,
+auth/session, business-logic, API security, SSRF, misconfig), then writes a report.
+
+**Tool choice: open-source CLI, not the $29/mo Platform Pro plan.** OSS is free (you pay only
+model tokens), keeps the API key on our machine (nothing routes through the vendor), and is enough
+for a one-off self-assessment. Platform Pro's extras (autofix PRs, scheduled scans, Jira/Slack) +
+per-test billing only pay off for ongoing use.
+
+**Can it run "in Claude Code only"?** Partly. Strix is its own CLI + Docker agent, not a Claude Code
+plugin. We drive it from the terminal here, but it needs its own **pay-as-you-go Anthropic API key**
+(console.anthropic.com) — the Claude Code subscription can't be reused, and Strix's token spend is
+billed separately.
+
+---
+
+## 2. 💰 Cost estimate & guardrails (read this first)
+
+Strix is an autonomous agent that **loops**, so cost = model token spend, and it can run away.
+
+**Real-world data points (Claude Sonnet via Anthropic API):**
+| Source | Run | Tokens | Cost |
+|---|---|---|---|
+| Protego hands-on review | one **quick** scan, ~10 min | ~5.7M input | **~$17** (enough to trip auto-suspension) |
+| 18-model benchmark | Sonnet run | — | ~$20 (API) / $55.90 (reseller) |
+| Community rule of thumb | — | — | "quick scans single digits, deep scans tens of dollars" |
+
+⚠️ **Strix defaults to `deep` scan mode** — the most expensive. Left uncapped, a deep run on this
+multi-module Java repo could plausibly be **$30–60+**, and a runaway loop more.
+
+The `--max-budget` cap is **not a hard kill** — as it's approached, Strix sends graduated wrap-up
+warnings to all agents so they write out findings. A capped run = **bounded-but-coherent report,
+never wasted work.** So the cap = "define your ceiling," set to the most you're willing to spend, not
+artificially low.
+
+### The controls we use
+
+1. **`--max-budget <USD>` — a hard dollar ceiling per run.** The single most important control.
+2. **Scan mode `-m {quick,standard,deep}`** — override the `deep` default per phase to match value/risk.
+3. **Phase gates** — read each report before spending on the next; stop early if you've seen enough.
+4. **Interactive TUI (default)** — live spend is visible; Ctrl-C if it thrashes.
+5. **A spend limit on the Anthropic key itself** (console) — belt-and-suspenders backstop. Dedicated
+   key, not a shared one; **rotate/revoke after the exercise.**
+
+### Final budgeted plan — 3-phase ladder (chosen: thorough, ~$100 ceiling)
+
+Ordering is cheap→expensive and safe→risky. Source scanning has **zero blast radius** (pure
+analysis); the live phase mutates data so it runs **local-only, mock payments**.
+
+| Phase | Scope | Mode | `--max-budget` | Expected | Blast radius |
+|---|---|---|---|---|---|
+| **1 — Recon** | repo source | `quick` | **$10** | ~$4–8 | none |
+| **2 — Deep source audit** | repo source | `deep` | **$30** | ~$18–30 | none |
+| **3 — Live API** | `localhost:8080` | `deep` | **$50** | ~$30–50 | local DB only |
+| **Total** | | | **$90 hard ceiling** | **~$50–75 actual** | |
+
+**Rationale:** Phase 1 doubles as the smoke test (proves key/sandbox/report work) + catches quick
+wins before risking more. Phase 2 spends deep where it's **safest and highest signal-per-dollar** —
+static reasoning over auth/HMAC/IDOR code. Phase 3 goes deep on the running app for the runtime
+authz/IDOR/auth-bypass bugs static can't see, capped at $50 because live exploit loops are the most
+expensive and the only phase that writes data. Gate after each phase.
+
+---
+
+## 3. Setup status
+
+| Prereq | Status |
+|---|---|
+| `strix` CLI | ✅ v1.5.3 at `~/.strix/bin/strix` (on PATH via `~/.zshrc`) |
+| Sandbox image | ✅ `ghcr.io/usestrix/strix-sandbox:1.3.0` (5.83 GB) pulled |
+| Docker Desktop | ✅ installed, daemon up (29.4.3) |
+| JDK 21 / local Postgres | ✅ ready (`localhost:5432` up) |
+| Mock payments | ✅ `RAZORPAY_LIVE` unset → mock gateway (no real charges) |
+| Anthropic API key | ✅ in gitignored `.env` (`STRIX_LLM` + `LLM_API_KEY`) — **rotate/revoke after the exercise** |
+
+Config lives in gitignored `.env` (sourced before each run): `STRIX_LLM=anthropic/claude-sonnet-4-6`
++ `LLM_API_KEY=sk-ant-…`. ⚠️ The key was shared over chat — set a console spend limit on it and
+**revoke it once the assessment is done.**
+
+---
+
+## 4. Run commands
+
+Auth model: one stateless chain, `JwtAuthenticationFilter` in every profile — real creds required.
+Demo logins: `admin@oneday.in` (ADMIN) / `b2b.demo@oneday.test` (B2B), pw `godspeed2026`.
+
+Each phase: `set -a; source .env; set +a` then `export PATH=/Users/sidarthapati/.strix/bin:$PATH`.
+Run **interactive** (default TUI) to watch live spend. **Gate:** `strix view` the report and decide
+before starting the next phase.
+
+### Phase 1 — Recon: source scan, `quick`, cap $10
+```bash
+strix -m quick --max-budget 10 --scope-mode full \
+  --target /Users/sidarthapati/Desktop/Projects/one_day_delivery \
+  --instruction "Spring Boot 3 multi-module monolith (com.oneday.{module}). Focus: broken access
+  control / IDOR across orders controllers (B2C /api/v1/b2c/shipments, B2B /api/v1/b2b/shipments +
+  /accounts, tracking /api/v1/shipments, COD /api/v1/cod, admin /api/v1/admin/**); the Authz
+  role/owner gates; JWT + X-Api-Key handling in auth/JwtAuthenticationFilter/SecurityConfig; Razorpay
+  HMAC verification and /api/v1/payments + /wallet; idempotency filter; the WhatsApp AWB webhook;
+  SQL/injection; committed secrets. Skip test code and docs."
+```
+
+### Phase 2 — Deep source audit: source scan, `deep`, cap $30
+```bash
+strix -m deep --max-budget 30 --scope-mode full \
+  --target /Users/sidarthapati/Desktop/Projects/one_day_delivery \
+  --instruction "<same focus as Phase 1 — exhaustive static review of authz/IDOR/HMAC/injection/secrets>"
+```
+
+### Phase 3 — Live API: `localhost:8080`, `deep`, cap $50 (never the shared staging DB)
+```bash
+# Terminal A — boot locally (mock payments; own local Postgres)
+export JAVA_HOME=/opt/homebrew/opt/openjdk@21
+mvn spring-boot:run -pl app            # -> http://localhost:8080  (wait for health UP)
+
+# Terminal B
+strix -m deep --max-budget 50 --target http://localhost:8080 \
+  --instruction "Authenticated intercity-delivery API. Auth via POST /auth/login (admin@oneday.in /
+  godspeed2026 = ADMIN; b2b.demo@oneday.test / godspeed2026 = B2B), then Bearer JWT; B2B also X-Api-Key.
+  Probe broken access control / IDOR across lanes: /api/v1/b2c/shipments, /api/v1/b2b/shipments +
+  /api/v1/b2b/accounts, /api/v1/shipments, /api/v1/cod, admin /api/v1/admin/** and
+  /api/v1/pricing/admin/cards; OTP /internal/v1/shipments + /internal/dev peek; payments
+  /api/v1/payments(+/mock), /api/v1/wallet; public /auth/*, POST /api/sales/leads, GET /api/v1/track/**,
+  /airline/webhooks/whatsapp, /actuator/health/**. No destructive DoS / load flooding."
+```
+
+> ⚠️ **Do not** point Strix at `https://one-day-delivery.onrender.com` or any Vercel console — Strix
+> exploits and mutates data on whatever it targets, and staging shares the team DB.
+
+### Read the report
+```bash
+strix view              # opens latest run; results saved under ./strix_runs/<run-name>
+```
+
+Useful flags: `--max-turns N` (per-agent turn cap, default 500), `-n` (headless), `--resume <run>`,
+`--scope-mode diff --diff-base origin/main` (CI: changed files only).
+
+---
+
+## 5. Triage → change register
+
+AI pentesters over-report. For each finding: confirm against the cited code, keep the real ones,
+discard hallucinations, then fold confirmed items into `docs/CHANGE-REQUESTS.md` /
+`docs/prod-readiness/PROD-READINESS-NOW.md` for follow-up fixes.
+
+### Pre-findings already surfaced (worth a manual look regardless)
+- **Mock endpoints live on the internet-facing staging host** (`staging` profile ≠ `prod`):
+  `/api/v1/payments/mock`, `/api/v1/wallet/mock`, `/internal/dev` (OTP peek), self-drop demo. Prod
+  profile's `MockGuard` would block these; staging doesn't.
+- **Rate limiting off + wildcard `*.vercel.app` CORS** on staging.
+- **CSRF disabled on `/**`** (fine for a stateless bearer API — confirm no cookie-auth path exists).
+- Root `.env` holds a live `VERCEL_TOKEN`, but `.env` is gitignored **and never committed** — no git
+  exposure, so rotation is optional hygiene, not urgent.

--- a/docs/prod-readiness/STRIX-VIEWER-GUIDE.md
+++ b/docs/prod-readiness/STRIX-VIEWER-GUIDE.md
@@ -1,0 +1,82 @@
+# Strix — where runs live & how to view them
+
+Quick reference for finding past Strix pentest runs and opening them in the web viewer.
+(Full plan + cost model: `docs/prod-readiness/STRIX-PENTEST-PLAN.md`.)
+
+---
+
+## Where runs are stored
+
+Every run is written to **`strix_runs/<run-name>/`**, relative to the directory Strix was launched
+from. We launch from the repo root, so runs live at:
+
+```
+/Users/sidarthapati/Desktop/Projects/one_day_delivery/strix_runs/
+```
+
+This folder is **gitignored** (run logs can contain creds), so it stays local to this machine.
+
+**List all runs:**
+```bash
+ls -1 strix_runs/
+# e.g. one-day-delivery_88d1
+```
+
+**What's inside each `strix_runs/<run>/`:**
+| File | What it is |
+|---|---|
+| `penetration_test_report.md` | The human-readable report (exec summary, findings, recommendations) |
+| `vulnerabilities/vuln-000N.md` | One detailed markdown file per finding (PoC, code locations, fix) |
+| `findings.sarif` | SARIF — import into IDEs / code-scanning tools |
+| `vulnerabilities.csv` / `.json` | Machine-readable finding lists |
+| `strix.log` | Full agent activity log |
+| `run.json`, `.state/` | Run metadata + agent state (used by the viewer) |
+
+> You don't need the viewer to read results — just open the `.md` files directly
+> (`open strix_runs/<run>/penetration_test_report.md`).
+
+---
+
+## Opening a run in the web viewer
+
+The viewer binary is at `~/.strix/bin/strix`, so first put it on PATH:
+```bash
+export PATH=~/.strix/bin:$PATH
+```
+
+**Open a specific run** (from the repo root so it finds `strix_runs/`):
+```bash
+strix view one-day-delivery_88d1            # a random free port, auto-opens browser
+strix view one-day-delivery_88d1 --port 7331    # fixed port
+strix view                                   # most recent run
+strix view <run> --port 7331 --no-open       # serve only, don't auto-open (we use this when Claude launches it)
+```
+
+### ⚠️ The important gotcha — use the tokenized URL
+
+When it starts, the viewer **prints a URL with a `?token=…`** — open **that** one:
+```
+Serving one-day-delivery_88d1 (finished) at:
+  http://127.0.0.1:7331/?token=XXXXXXXXXXXXXXXX
+```
+
+- The **bare** `http://localhost:7331` drops you on a **"Verify your email to browse all runs"** page.
+  That is just Strix's lead-capture gate on the *browse-all-history* feature — **ignore it.**
+- The **`?token=…`** link authorizes your browser and opens the run **directly, no email needed.**
+- If you launched with `--no-open`, the token URL is only in the terminal output — copy it from there.
+
+**Security:** that token link lets whoever opens it browse history and even steer a *live* scan.
+It's localhost-only, so just **don't share it**. A new token is minted each time you start the viewer.
+
+**Stop the viewer:** `Ctrl-C` in its terminal (or kill the process if backgrounded).
+
+---
+
+## Live viewing during a scan
+
+`strix view` works on **live or finished** runs. So you can watch a scan as it happens:
+open a second terminal while a scan is running and `strix view <run> --port 7331`, then open the
+token URL — the agent tree and findings update in real time.
+
+(When Claude drives a scan, it runs the scan headless in the background **and** starts this viewer,
+then hands you the `?token=` URL to watch live — "Model A" in the plan doc.)

--- a/orders/src/main/java/com/oneday/orders/api/WalletController.java
+++ b/orders/src/main/java/com/oneday/orders/api/WalletController.java
@@ -65,7 +65,7 @@ class WalletController {
             @AuthenticationPrincipal AuthUserDetails principal,
             @Valid @RequestBody WalletRechargeConfirmRequest req) {
         return wallet.confirmRecharge(ownedAccountId(principal), req.getRazorpayOrderId(),
-                req.getRazorpayPaymentId(), req.getSignature(), req.getAmountPaise());
+                req.getRazorpayPaymentId(), req.getSignature());
     }
 
     /** The B2B account owned by the caller, or 404 (also gates the endpoint to B2B users). */

--- a/orders/src/main/java/com/oneday/orders/domain/WalletRechargeOrder.java
+++ b/orders/src/main/java/com/oneday/orders/domain/WalletRechargeOrder.java
@@ -1,0 +1,46 @@
+package com.oneday.orders.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Server-side record of the amount a wallet recharge was ORDERED for, keyed by the gateway order id.
+ * Confirmation reads the credited amount from here — never from the client — because Razorpay's HMAC
+ * signature covers only {@code orderId|paymentId} and does not sign the amount. Append-only.
+ */
+@Entity
+@Table(name = "wallet_recharge_order")
+@Getter
+@Setter
+@NoArgsConstructor
+public class WalletRechargeOrder {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "razorpay_order_id", length = 80, nullable = false, updatable = false, unique = true)
+    private String razorpayOrderId;
+
+    @Column(name = "b2b_account_id", nullable = false, updatable = false)
+    private UUID b2bAccountId;
+
+    @Column(name = "amount_paise", nullable = false, updatable = false)
+    private Long amountPaise;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private Instant createdAt;
+}

--- a/orders/src/main/java/com/oneday/orders/dto/WalletRechargeConfirmRequest.java
+++ b/orders/src/main/java/com/oneday/orders/dto/WalletRechargeConfirmRequest.java
@@ -1,17 +1,19 @@
 package com.oneday.orders.dto;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
-/** Confirm a wallet recharge after the gateway checkout completes. */
+/**
+ * Confirm a wallet recharge after the gateway checkout completes.
+ *
+ * <p>The credited amount is intentionally NOT taken from the client: it is resolved server-side from
+ * the {@code wallet_recharge_order} recorded at order-creation time. Razorpay's signature covers only
+ * {@code orderId|paymentId}, so a client-supplied amount cannot be trusted.</p>
+ */
 public class WalletRechargeConfirmRequest {
 
     @NotBlank private String razorpayOrderId;
     @NotBlank private String razorpayPaymentId;
     @NotBlank private String signature;
-    @NotNull @Min(10_000) @Max(50_000_000) private Long amountPaise;
 
     public String getRazorpayOrderId()          { return razorpayOrderId; }
     public void setRazorpayOrderId(String v)     { this.razorpayOrderId = v; }
@@ -21,7 +23,4 @@ public class WalletRechargeConfirmRequest {
 
     public String getSignature()                 { return signature; }
     public void setSignature(String v)           { this.signature = v; }
-
-    public Long getAmountPaise()                 { return amountPaise; }
-    public void setAmountPaise(Long v)           { this.amountPaise = v; }
 }

--- a/orders/src/main/java/com/oneday/orders/repository/CodCashDepositRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/CodCashDepositRepository.java
@@ -6,11 +6,15 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface CodCashDepositRepository extends JpaRepository<CodCashDeposit, UUID> {
 
     List<CodCashDeposit> findByDaUserIdOrderByCreatedAtDesc(UUID daUserId);
+
+    /** Idempotency guard: a (DA, deposit_ref) pair records a cash drop at most once. */
+    Optional<CodCashDeposit> findByDaUserIdAndDepositRef(UUID daUserId, String depositRef);
 
     List<CodCashDeposit> findAllByOrderByCreatedAtDesc();
 

--- a/orders/src/main/java/com/oneday/orders/repository/CodRemittanceRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/CodRemittanceRepository.java
@@ -2,13 +2,22 @@ package com.oneday.orders.repository;
 
 import com.oneday.orders.domain.CodRemittance;
 import com.oneday.orders.domain.CodRemittanceState;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface CodRemittanceRepository extends JpaRepository<CodRemittance, UUID> {
+
+    /** Pessimistic row lock so a PENDING→PAID transition can't be applied twice concurrently. */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM CodRemittance r WHERE r.id = :id")
+    Optional<CodRemittance> findByIdForUpdate(@Param("id") UUID id);
 
     List<CodRemittance> findByB2bAccountIdOrderByCreatedAtDesc(UUID b2bAccountId);
 

--- a/orders/src/main/java/com/oneday/orders/repository/WalletRechargeOrderRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/WalletRechargeOrderRepository.java
@@ -1,0 +1,13 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.WalletRechargeOrder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface WalletRechargeOrderRepository extends JpaRepository<WalletRechargeOrder, UUID> {
+
+    /** The recharge order for this gateway id, scoped to the owning account (defence in depth). */
+    Optional<WalletRechargeOrder> findByRazorpayOrderIdAndB2bAccountId(String razorpayOrderId, UUID b2bAccountId);
+}

--- a/orders/src/main/java/com/oneday/orders/service/WalletService.java
+++ b/orders/src/main/java/com/oneday/orders/service/WalletService.java
@@ -24,11 +24,12 @@ public interface WalletService {
     com.oneday.orders.service.PaymentPort.PaymentOrder createRechargeOrder(UUID accountId, long amountPaise);
 
     /**
-     * Verify the gateway signature and credit the wallet. Idempotent on the razorpay payment id —
-     * a duplicate confirm returns the current balance without double-crediting.
+     * Verify the gateway signature and credit the wallet by the amount recorded on the server-side
+     * recharge order (never a client-supplied amount — Razorpay does not sign the amount). Idempotent
+     * on the razorpay payment id — a duplicate confirm returns the current balance without double-crediting.
      */
     WalletResponse confirmRecharge(UUID accountId, String razorpayOrderId, String razorpayPaymentId,
-                                   String signature, long amountPaise);
+                                   String signature);
 
     /**
      * Debit the wallet for a booking. Called INSIDE the booking transaction with a row already

--- a/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
@@ -121,9 +121,9 @@ class B2bBookingServiceImpl implements B2bBookingService {
             throw new AccountInactiveException(
                     "B2B account is inactive: " + req.getB2bAccountId());
         }
-        // Ownership: the caller must own the account (when an owner is set). Prevents one
-        // B2B user drawing down another account's credit. ADMIN-on-behalf is not modelled yet.
-        if (account.getOwnerUserId() != null && !account.getOwnerUserId().toString().equals(userId)) {
+        // Ownership: the caller must own the account. Fail CLOSED — a null ownerUserId must NOT
+        // let any B2B user draw down this account's credit/wallet. ADMIN-on-behalf is not modelled yet.
+        if (account.getOwnerUserId() == null || !account.getOwnerUserId().toString().equals(userId)) {
             throw new AccountAccessException(
                     "Caller is not authorized for B2B account: " + req.getB2bAccountId());
         }

--- a/orders/src/main/java/com/oneday/orders/service/impl/CancellationServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/CancellationServiceImpl.java
@@ -82,13 +82,21 @@ class CancellationServiceImpl implements CancellationService {
             throw new EntityNotFoundException("Shipment not found: " + shipmentRef);
         }
 
+        // Ownership guard — the caller must have booked this shipment. Fail CLOSED: a null booker
+        // must not bypass the check (that would let any authenticated user cancel it). 404 (not 403)
+        // so a caller cannot probe for shipments owned by other users (same reasoning as the lane guard).
+        if (shipment.getBookedByUserId() == null
+                || !shipment.getBookedByUserId().toString().equals(userId)) {
+            throw new EntityNotFoundException("Shipment not found: " + shipmentRef);
+        }
+
         return doCancel(shipment, reason, userId, false);
     }
 
     @Override
     @Transactional
     public CancellationResponse cancelAsAdmin(String shipmentRef, String reason, String userId) {
-        // No lane guard (admin cancels any lane) and ownership is bypassed below.
+        // No lane guard (admin cancels any lane) and no ownership guard — admin acts on behalf of any user.
         Shipment shipment = shipmentRepository.findByShipmentRef(shipmentRef)
                 .orElseThrow(() -> new EntityNotFoundException("Shipment not found: " + shipmentRef));
         return doCancel(shipment, reason, userId, true);
@@ -179,10 +187,11 @@ class CancellationServiceImpl implements CancellationService {
                 .orElseThrow(() -> new EntityNotFoundException(
                         "B2B account not found: " + shipment.getB2bAccountId()));
 
-        // Admin (bypassOwnership) cancels on behalf of the account; customers must own it.
+        // Admin (bypassOwnership) cancels on behalf of the account; customers must own it. Fail
+        // CLOSED — a null owner must not let a non-owning B2B user reverse credit on this account.
         if (!bypassOwnership
-                && account.getOwnerUserId() != null
-                && !account.getOwnerUserId().toString().equals(userId)) {
+                && (account.getOwnerUserId() == null
+                    || !account.getOwnerUserId().toString().equals(userId))) {
             throw new AccountAccessException(
                     "User " + userId + " does not own account " + account.getId());
         }

--- a/orders/src/main/java/com/oneday/orders/service/impl/CodCashServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/CodCashServiceImpl.java
@@ -38,13 +38,28 @@ class CodCashServiceImpl implements CodCashService {
     @Override
     @Transactional
     public CodCashDepositResponse recordDeposit(UUID daUserId, RecordCodDepositRequest request) {
+        String ref = request.depositRef() == null ? null : request.depositRef().trim();
+        // Idempotent on (DA, deposit_ref): a repeated submission returns the existing deposit instead
+        // of double-counting cash. A concurrent duplicate is caught by the DB unique index (V4_36).
+        if (ref != null && !ref.isBlank()) {
+            var existing = deposits.findByDaUserIdAndDepositRef(daUserId, ref);
+            if (existing.isPresent()) {
+                return CodCashDepositResponse.from(existing.get());
+            }
+        }
         CodCashDeposit d = new CodCashDeposit();
         d.setDaUserId(daUserId);
         d.setAmountPaise(request.amountPaise());
-        d.setDepositRef(request.depositRef());
+        d.setDepositRef(ref);
         d.setNote(request.note());
         d.setStatus(CodCashDepositState.DEPOSITED);
-        return CodCashDepositResponse.from(deposits.save(d));
+        try {
+            return CodCashDepositResponse.from(deposits.saveAndFlush(d));
+        } catch (org.springframework.dao.DataIntegrityViolationException race) {
+            // Lost the race to a concurrent identical submit — return the winner.
+            return CodCashDepositResponse.from(
+                    deposits.findByDaUserIdAndDepositRef(daUserId, ref).orElseThrow(() -> race));
+        }
     }
 
     @Override

--- a/orders/src/main/java/com/oneday/orders/service/impl/CodRemittanceServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/CodRemittanceServiceImpl.java
@@ -168,7 +168,10 @@ class CodRemittanceServiceImpl implements CodRemittanceService {
     @Override
     @Transactional
     public CodRemittanceResponse createRemittance(UUID accountId, UUID actorId) {
-        B2bAccount account = accounts.findById(accountId)
+        // Lock the account row for the duration: two concurrent create calls would otherwise both read
+        // the same remittable collections and each cut a remittance for the SAME money (vuln-0017).
+        // The loser blocks here, then finds nothing remittable and gets a clean CONFLICT below.
+        B2bAccount account = accounts.findByIdForUpdate(accountId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Account not found"));
         // A payout needs a verified bank account on file — you can't remit into thin air.
         if (account.getBankVerificationState() == null || !account.getBankVerificationState().isPayable()) {
@@ -215,7 +218,9 @@ class CodRemittanceServiceImpl implements CodRemittanceService {
     @Override
     @Transactional
     public CodRemittanceResponse markPaid(UUID remittanceId, String utr) {
-        CodRemittance r = remittances.findById(remittanceId)
+        // Lock the row so a concurrent markPaid/payout can't both pass the PENDING check and
+        // double-remit / double-notify (unflagged sibling of vuln-0017).
+        CodRemittance r = remittances.findByIdForUpdate(remittanceId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Remittance not found"));
         if (r.getState() != CodRemittanceState.PENDING) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Remittance is not PENDING");
@@ -243,7 +248,7 @@ class CodRemittanceServiceImpl implements CodRemittanceService {
     @Override
     @Transactional
     public CodRemittanceResponse payout(UUID remittanceId) {
-        CodRemittance r = remittances.findById(remittanceId)
+        CodRemittance r = remittances.findByIdForUpdate(remittanceId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Remittance not found"));
         if (r.getState() != CodRemittanceState.PENDING) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Remittance is not PENDING");

--- a/orders/src/main/java/com/oneday/orders/service/impl/SsrfGuard.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/SsrfGuard.java
@@ -1,0 +1,64 @@
+package com.oneday.orders.service.impl;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+
+/**
+ * SSRF protection for user-supplied outbound URLs (B2B webhook delivery). A merchant registers a
+ * webhook URL that the platform then fetches server-side; without validation that URL can point at
+ * internal infrastructure — loopback, RFC1918/site-local, link-local (incl. the cloud metadata
+ * endpoint 169.254.169.254), or IPv6 unique-local — turning the app into an SSRF proxy.
+ *
+ * <p>{@link #reasonIfUnsafe(String)} returns null when the URL is safe to fetch, or a short human
+ * reason otherwise. Callers reject at registration time and skip (mark FAILED) at delivery time.
+ * Note: this resolves DNS at check time; pinning the resolved IP through to the request to fully
+ * defeat DNS-rebinding is a further hardening tracked separately.
+ */
+final class SsrfGuard {
+
+    private SsrfGuard() {}
+
+    static String reasonIfUnsafe(String rawUrl) {
+        if (rawUrl == null || rawUrl.isBlank()) return "URL is blank";
+        URI uri;
+        try {
+            uri = URI.create(rawUrl.trim());
+        } catch (IllegalArgumentException e) {
+            return "URL is malformed";
+        }
+        String scheme = uri.getScheme();
+        if (scheme == null || !(scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"))) {
+            return "URL scheme must be http or https";
+        }
+        String host = uri.getHost();
+        if (host == null || host.isBlank()) return "URL has no host";
+
+        InetAddress[] addresses;
+        try {
+            addresses = InetAddress.getAllByName(host);
+        } catch (UnknownHostException e) {
+            return "host does not resolve";
+        }
+        for (InetAddress ip : addresses) {
+            if (ip.isLoopbackAddress() || ip.isAnyLocalAddress() || ip.isLinkLocalAddress()
+                    || ip.isSiteLocalAddress() || ip.isMulticastAddress()) {
+                return "URL resolves to a non-public (internal) address";
+            }
+            byte[] b = ip.getAddress();
+            // IPv6 unique-local fc00::/7 (site-local check above does not cover it).
+            if (b.length == 16 && (b[0] & 0xFE) == 0xFC) {
+                return "URL resolves to a non-public (internal) address";
+            }
+            // IPv4 100.64.0.0/10 carrier-grade NAT — not internet-routable.
+            if (b.length == 4 && (b[0] & 0xFF) == 100 && (b[1] & 0xC0) == 0x40) {
+                return "URL resolves to a non-public (internal) address";
+            }
+        }
+        return null;
+    }
+
+    static boolean isSafe(String rawUrl) {
+        return reasonIfUnsafe(rawUrl) == null;
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/WalletServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/WalletServiceImpl.java
@@ -1,11 +1,13 @@
 package com.oneday.orders.service.impl;
 
 import com.oneday.orders.domain.B2bAccount;
+import com.oneday.orders.domain.WalletRechargeOrder;
 import com.oneday.orders.domain.WalletTransaction;
 import com.oneday.orders.domain.WalletTransactionType;
 import com.oneday.orders.dto.WalletResponse;
 import com.oneday.orders.dto.WalletTransactionResponse;
 import com.oneday.orders.repository.B2bAccountRepository;
+import com.oneday.orders.repository.WalletRechargeOrderRepository;
 import com.oneday.orders.repository.WalletTransactionRepository;
 import com.oneday.orders.service.PaymentPort;
 import com.oneday.orders.service.WalletService;
@@ -26,13 +28,16 @@ class WalletServiceImpl implements WalletService {
 
     private final B2bAccountRepository accounts;
     private final WalletTransactionRepository ledger;
+    private final WalletRechargeOrderRepository rechargeOrders;
     private final PaymentPort paymentPort;
 
     WalletServiceImpl(B2bAccountRepository accounts,
                       WalletTransactionRepository ledger,
+                      WalletRechargeOrderRepository rechargeOrders,
                       PaymentPort paymentPort) {
         this.accounts = accounts;
         this.ledger = ledger;
+        this.rechargeOrders = rechargeOrders;
         this.paymentPort = paymentPort;
     }
 
@@ -55,13 +60,20 @@ class WalletServiceImpl implements WalletService {
     public PaymentPort.PaymentOrder createRechargeOrder(UUID accountId, long amountPaise) {
         require(accountId);
         // Razorpay caps receipt at 40 chars; "wr-" + 32-hex account id = 35.
-        return paymentPort.createOrder(amountPaise, "wr-" + accountId.toString().replace("-", ""));
+        PaymentPort.PaymentOrder order = paymentPort.createOrder(amountPaise, "wr-" + accountId.toString().replace("-", ""));
+        // Record the ordered (gateway-authoritative) amount so confirm never trusts a client value.
+        WalletRechargeOrder ro = new WalletRechargeOrder();
+        ro.setRazorpayOrderId(order.orderId());
+        ro.setB2bAccountId(accountId);
+        ro.setAmountPaise(order.amountPaise());
+        rechargeOrders.save(ro);
+        return order;
     }
 
     @Override
     @Transactional
     public WalletResponse confirmRecharge(UUID accountId, String razorpayOrderId, String razorpayPaymentId,
-                                          String signature, long amountPaise) {
+                                          String signature) {
         B2bAccount a = accounts.findByIdForUpdate(accountId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Account not found"));
         // Idempotent: a payment id credits the wallet exactly once.
@@ -69,6 +81,12 @@ class WalletServiceImpl implements WalletService {
             log.info("Wallet recharge for payment {} already applied; returning current balance", safe(razorpayPaymentId));
             return WalletResponse.of(accountId, balance(a));
         }
+        // Resolve the credited amount from the server-side order record — NEVER from the client.
+        // Razorpay's signature covers only orderId|paymentId, so the amount cannot be trusted from the body.
+        long amountPaise = rechargeOrders.findByRazorpayOrderIdAndB2bAccountId(razorpayOrderId, accountId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "No recharge order for orderId " + safe(razorpayOrderId)))
+                .getAmountPaise();
         // A tampered signature throws PaymentVerificationException → mapped to 402 by the handler.
         paymentPort.verifySignature(razorpayOrderId, razorpayPaymentId, signature);
         paymentPort.capture(razorpayPaymentId, amountPaise);

--- a/orders/src/main/java/com/oneday/orders/service/impl/WebhookServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/WebhookServiceImpl.java
@@ -107,8 +107,9 @@ class WebhookServiceImpl implements WebhookService {
         if (isBlank(trimmed)) {
             a.setWebhookUrl(null);   // clearing the URL disables webhooks (secret kept for re-enable)
         } else {
-            if (!trimmed.startsWith("https://") && !trimmed.startsWith("http://")) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Webhook URL must be http(s)");
+            String unsafe = SsrfGuard.reasonIfUnsafe(trimmed);
+            if (unsafe != null) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid webhook URL: " + unsafe);
             }
             a.setWebhookUrl(trimmed);
             if (regenerateSecret || isBlank(a.getWebhookSecret())) {
@@ -158,6 +159,17 @@ class WebhookServiceImpl implements WebhookService {
         d.setUrl(url);
         d.setPayload(json);
         d.setStatus(WebhookDeliveryStatus.PENDING);
+
+        // SSRF guard at delivery time too — a stored URL may now resolve to an internal address, and
+        // dispatchForTransition auto-fires this on every shipment state change. Skip (mark FAILED),
+        // never throw, so a bad URL cannot break the state-change flow.
+        String ssrf = SsrfGuard.reasonIfUnsafe(url);
+        if (ssrf != null) {
+            d.setStatus(WebhookDeliveryStatus.FAILED);
+            d.setError("blocked: " + ssrf);
+            log.warn("Webhook {} → {} blocked by SSRF guard: {}", event, url, ssrf);
+            return deliveries.save(d);
+        }
 
         String signature = secret == null ? "" : WebhookSignatures.sign(json, secret);
         try {

--- a/orders/src/main/resources/db/migration/orders/V4_35__wallet_recharge_order.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_35__wallet_recharge_order.sql
@@ -1,0 +1,13 @@
+-- Server-side record of the amount each wallet recharge was ORDERED for.
+-- Razorpay's payment signature covers only orderId|paymentId (NOT the amount), so wallet-recharge
+-- confirmation must resolve the credited amount from this table rather than trusting the client body
+-- (which previously let a user pay ₹100 and self-credit up to ₹5,00,000). Append-only.
+CREATE TABLE wallet_recharge_order (
+    id                UUID PRIMARY KEY,
+    razorpay_order_id VARCHAR(80) NOT NULL UNIQUE,
+    b2b_account_id    UUID NOT NULL REFERENCES b2b_accounts(id),
+    amount_paise      BIGINT NOT NULL,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_wallet_recharge_order_account ON wallet_recharge_order (b2b_account_id, created_at DESC);

--- a/orders/src/main/resources/db/migration/orders/V4_36__cod_deposit_dedup_and_locks.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_36__cod_deposit_dedup_and_locks.sql
@@ -1,0 +1,21 @@
+-- RC5 (vuln-0012): a DA COD cash deposit could be submitted twice (no dedup), inflating reconciled
+-- cash. deposit_ref is the DA's idempotency handle for a physical drop; enforce it is unique per DA.
+--
+-- Dedupe FIRST, non-destructively: keep the earliest row's deposit_ref and NULL the ref on any later
+-- duplicates. We never delete a deposit row (that would destroy a financial record) — nulling the ref
+-- only removes the conflicting idempotency key so the partial-unique index below can be created.
+WITH ranked AS (
+    SELECT id,
+           row_number() OVER (PARTITION BY da_user_id, deposit_ref ORDER BY created_at, id) AS rn
+    FROM cod_cash_deposit
+    WHERE deposit_ref IS NOT NULL
+)
+UPDATE cod_cash_deposit d
+SET deposit_ref = NULL
+FROM ranked r
+WHERE d.id = r.id AND r.rn > 1;
+
+-- Partial unique: null deposit_ref (no idempotency key supplied) is exempt.
+CREATE UNIQUE INDEX uq_cod_cash_deposit_da_ref
+    ON cod_cash_deposit (da_user_id, deposit_ref)
+    WHERE deposit_ref IS NOT NULL;

--- a/orders/src/test/java/com/oneday/orders/service/impl/B2bBookingServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/B2bBookingServiceImplTest.java
@@ -81,7 +81,8 @@ class B2bBookingServiceImplTest {
     private B2bBookingServiceImpl service;
 
     private static final String IDEMPOTENCY_KEY = "idem-b2b-123";
-    private static final String USER_ID         = "user-b2b-abc";
+    private static final UUID   OWNER_ID        = UUID.randomUUID();
+    private static final String USER_ID         = OWNER_ID.toString();
     private static final String SHIPMENT_REF    = "1DD-BLR-20260530-00001";
     private static final UUID   SHIPMENT_ID     = UUID.randomUUID();
     private static final UUID   ACCOUNT_ID      = UUID.randomUUID();
@@ -181,6 +182,33 @@ class B2bBookingServiceImplTest {
                 .isInstanceOf(B2bBookingService.AccountInactiveException.class);
 
         verify(serviceabilityPort, never()).check(any());
+        verify(shipmentRepository, never()).save(any());
+    }
+
+    // ── ownership (fail closed) ──────────────────────────────────────────────
+
+    @Test
+    void book_callerDoesNotOwnAccount_throwsAccountAccessException() {
+        B2bAccount ownedByOther = activeAccount(0L, 1_000_000L);
+        ownedByOther.setOwnerUserId(UUID.randomUUID()); // a different user owns it
+        when(b2bAccountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(ownedByOther));
+
+        assertThatThrownBy(() -> service.book(bookingRequest(), IDEMPOTENCY_KEY, USER_ID))
+                .isInstanceOf(B2bBookingService.AccountAccessException.class);
+
+        verify(serviceabilityPort, never()).check(any());
+        verify(shipmentRepository, never()).save(any());
+    }
+
+    @Test
+    void book_accountHasNoOwner_throwsAccountAccessException() {
+        B2bAccount noOwner = activeAccount(0L, 1_000_000L);
+        noOwner.setOwnerUserId(null); // fail closed: an ownerless account is not drawable
+        when(b2bAccountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(noOwner));
+
+        assertThatThrownBy(() -> service.book(bookingRequest(), IDEMPOTENCY_KEY, USER_ID))
+                .isInstanceOf(B2bBookingService.AccountAccessException.class);
+
         verify(shipmentRepository, never()).save(any());
     }
 
@@ -301,6 +329,7 @@ class B2bBookingServiceImplTest {
         acc.setCityId("BLR");
         acc.setIsActive(true);
         acc.setRateCardId(RATE_CARD_ID);
+        acc.setOwnerUserId(OWNER_ID); // caller (USER_ID) owns the account
         return acc;
     }
 

--- a/orders/src/test/java/com/oneday/orders/service/impl/CodCashServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/CodCashServiceImplTest.java
@@ -1,0 +1,66 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.domain.CodCashDeposit;
+import com.oneday.orders.domain.CodCashDepositState;
+import com.oneday.orders.dto.CodCashDepositResponse;
+import com.oneday.orders.dto.RecordCodDepositRequest;
+import com.oneday.orders.repository.CodCashDepositRepository;
+import com.oneday.orders.repository.CodCollectionRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Guards the COD deposit dedup fix (vuln-0012): a repeated (DA, deposit_ref) submit is idempotent. */
+@ExtendWith(MockitoExtension.class)
+class CodCashServiceImplTest {
+
+    @Mock private CodCashDepositRepository deposits;
+    @Mock private CodCollectionRepository collections;
+
+    private CodCashServiceImpl service() {
+        return new CodCashServiceImpl(deposits, collections);
+    }
+
+    @Test
+    void recordDeposit_duplicateRef_returnsExistingAndDoesNotInsert() {
+        UUID da = UUID.randomUUID();
+        CodCashDeposit existing = new CodCashDeposit();
+        ReflectionTestUtils.setField(existing, "id", UUID.randomUUID());
+        existing.setDaUserId(da);
+        existing.setAmountPaise(500L);
+        existing.setDepositRef("REF-1");
+        existing.setStatus(CodCashDepositState.DEPOSITED);
+        when(deposits.findByDaUserIdAndDepositRef(da, "REF-1")).thenReturn(Optional.of(existing));
+
+        CodCashDepositResponse resp =
+                service().recordDeposit(da, new RecordCodDepositRequest(500L, "REF-1", null));
+
+        assertThat(resp.id()).isEqualTo(existing.getId());
+        verify(deposits, never()).save(any());
+        verify(deposits, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void recordDeposit_newRef_inserts() {
+        UUID da = UUID.randomUUID();
+        when(deposits.findByDaUserIdAndDepositRef(da, "REF-2")).thenReturn(Optional.empty());
+        when(deposits.saveAndFlush(any(CodCashDeposit.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        CodCashDepositResponse resp =
+                service().recordDeposit(da, new RecordCodDepositRequest(700L, "REF-2", "note"));
+
+        assertThat(resp.amountPaise()).isEqualTo(700L);
+        verify(deposits).saveAndFlush(any(CodCashDeposit.class));
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/service/impl/SsrfGuardTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/SsrfGuardTest.java
@@ -1,0 +1,35 @@
+package com.oneday.orders.service.impl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** All cases use IP literals (no DNS) so the test is network-free. */
+class SsrfGuardTest {
+
+    @Test
+    void blocksMetadataPrivateAndLoopback() {
+        assertThat(SsrfGuard.isSafe("http://169.254.169.254/latest/meta-data/")).isFalse(); // cloud IMDS
+        assertThat(SsrfGuard.isSafe("https://127.0.0.1/")).isFalse();                        // loopback
+        assertThat(SsrfGuard.isSafe("https://10.0.0.5/hook")).isFalse();                     // RFC1918
+        assertThat(SsrfGuard.isSafe("https://192.168.1.10/")).isFalse();
+        assertThat(SsrfGuard.isSafe("https://172.16.0.1/")).isFalse();
+        assertThat(SsrfGuard.isSafe("https://100.64.0.1/")).isFalse();                       // CGNAT
+    }
+
+    @Test
+    void blocksNonHttpSchemesAndMalformed() {
+        assertThat(SsrfGuard.isSafe("ftp://198.51.100.7/")).isFalse();
+        assertThat(SsrfGuard.isSafe("file:///etc/passwd")).isFalse();
+        assertThat(SsrfGuard.isSafe("gopher://198.51.100.7")).isFalse();
+        assertThat(SsrfGuard.isSafe("not a url")).isFalse();
+        assertThat(SsrfGuard.isSafe("")).isFalse();
+        assertThat(SsrfGuard.isSafe(null)).isFalse();
+    }
+
+    @Test
+    void allowsPublicHttpAndHttps() {
+        assertThat(SsrfGuard.isSafe("https://1.1.1.1/webhook")).isTrue();
+        assertThat(SsrfGuard.isSafe("http://8.8.8.8/hook")).isTrue();
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/service/impl/WalletServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/WalletServiceImplTest.java
@@ -1,0 +1,105 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.domain.B2bAccount;
+import com.oneday.orders.domain.WalletRechargeOrder;
+import com.oneday.orders.dto.WalletResponse;
+import com.oneday.orders.repository.B2bAccountRepository;
+import com.oneday.orders.repository.WalletRechargeOrderRepository;
+import com.oneday.orders.repository.WalletTransactionRepository;
+import com.oneday.orders.service.PaymentPort;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Guards the fix for the wallet-recharge amount-manipulation flaw: the credited amount must come
+ * from the server-side recharge order, never from the client (Razorpay's signature does not sign
+ * the amount, so a client value cannot be trusted).
+ */
+@ExtendWith(MockitoExtension.class)
+class WalletServiceImplTest {
+
+    @Mock private B2bAccountRepository accounts;
+    @Mock private WalletTransactionRepository ledger;
+    @Mock private WalletRechargeOrderRepository rechargeOrders;
+    @Mock private PaymentPort paymentPort;
+
+    private static final UUID ACCOUNT = UUID.randomUUID();
+    private static final String ORDER_ID = "order_abc";
+    private static final String PAYMENT_ID = "pay_abc";
+    private static final String SIG = "sig";
+
+    private WalletServiceImpl service() {
+        return new WalletServiceImpl(accounts, ledger, rechargeOrders, paymentPort);
+    }
+
+    @Test
+    void confirmRecharge_creditsServerSideOrderAmount() {
+        B2bAccount acc = new B2bAccount();
+        acc.setWalletBalancePaise(0L);
+        when(accounts.findByIdForUpdate(ACCOUNT)).thenReturn(Optional.of(acc));
+        when(ledger.existsByReference(PAYMENT_ID)).thenReturn(false);
+
+        WalletRechargeOrder order = new WalletRechargeOrder();
+        order.setRazorpayOrderId(ORDER_ID);
+        order.setB2bAccountId(ACCOUNT);
+        order.setAmountPaise(10_000L); // ₹100 — the amount actually ordered/paid
+        when(rechargeOrders.findByRazorpayOrderIdAndB2bAccountId(ORDER_ID, ACCOUNT))
+                .thenReturn(Optional.of(order));
+
+        WalletResponse res = service().confirmRecharge(ACCOUNT, ORDER_ID, PAYMENT_ID, SIG);
+
+        // Credited with the stored order amount, and the gateway captured that exact amount.
+        assertThat(res.balancePaise()).isEqualTo(10_000L);
+        assertThat(acc.getWalletBalancePaise()).isEqualTo(10_000L);
+        verify(paymentPort).capture(PAYMENT_ID, 10_000L);
+    }
+
+    @Test
+    void confirmRecharge_throwsWhenNoServerSideOrder() {
+        B2bAccount acc = new B2bAccount();
+        acc.setWalletBalancePaise(0L);
+        when(accounts.findByIdForUpdate(ACCOUNT)).thenReturn(Optional.of(acc));
+        when(ledger.existsByReference(PAYMENT_ID)).thenReturn(false);
+        when(rechargeOrders.findByRazorpayOrderIdAndB2bAccountId(ORDER_ID, ACCOUNT))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service().confirmRecharge(ACCOUNT, ORDER_ID, PAYMENT_ID, SIG))
+                .isInstanceOf(ResponseStatusException.class);
+
+        // No spoofed order → nothing captured, balance untouched.
+        verify(paymentPort, never()).capture(anyString(), anyLong());
+        assertThat(acc.getWalletBalancePaise()).isEqualTo(0L);
+    }
+
+    @Test
+    void createRechargeOrder_persistsGatewayOrderedAmount() {
+        when(accounts.findById(ACCOUNT)).thenReturn(Optional.of(new B2bAccount()));
+        when(paymentPort.createOrder(eq(10_000L), anyString()))
+                .thenReturn(new PaymentPort.PaymentOrder(ORDER_ID, 10_000L, "INR", "key_test"));
+
+        service().createRechargeOrder(ACCOUNT, 10_000L);
+
+        ArgumentCaptor<WalletRechargeOrder> captor = ArgumentCaptor.forClass(WalletRechargeOrder.class);
+        verify(rechargeOrders).save(captor.capture());
+        WalletRechargeOrder saved = captor.getValue();
+        assertThat(saved.getRazorpayOrderId()).isEqualTo(ORDER_ID);
+        assertThat(saved.getB2bAccountId()).isEqualTo(ACCOUNT);
+        assertThat(saved.getAmountPaise()).isEqualTo(10_000L);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Summary
Fix the security issues from the Strix pentest **plus** the unflagged instances of the same root causes found by auditing the whole codebase. The 19 deep-scan findings collapse into 5 root causes; this branch fixes them systemically (e.g. the ~9 flagged BFLA endpoints were actually 81). Delivered as 4 ordered commits.

---

## What Changed
- **RC2/RC3 — privilege escalation + fail-closed ownership** (`818514c`): `UserServiceImpl.register()` no longer lets a STATION_MANAGER create an ADMIN (CRITICAL, vuln-0015). Three fail-open ownership guards flipped to fail-closed so a null owner/booker can't bypass them: shipment cancellation (vuln-0001) and — unflagged — B2B credit draw-down (`B2bBookingServiceImpl`) and B2B credit reversal.
- **RC1 — systemic BFLA** (`244e400`): added path-based role rules in `SecurityConfig` gating **81** previously-unguarded ops endpoints (routing/hub/grid/airline/barcode + a few in orders/auth). Any logged-in user (even a B2C customer) could previously approve route plans, seal hub bags, confirm airline handovers, approve grid proposals, mint scan labels. Carve-out: `GET /api/grid/serviceable-at` stays open (customer booking map).
- **RC4 — SSRF + secrets** (`e99c481`): new `SsrfGuard` blocks webhook delivery to loopback/private/link-local/metadata (169.254.169.254)/CGNAT/ULA and non-http(s) schemes, enforced at registration and delivery (vuln-0011). `ProdEnvGuard` now fails prod boot if `razorpay.live=true` while the HMAC secret is unset/the committed mock default (vuln-0007).
- **RC5 — concurrency/dedup** (`a5ec027`): COD cash deposit is idempotent on `(da_user_id, deposit_ref)` with a partial-UNIQUE backstop (vuln-0012); COD remittance create + markPaid/payout take pessimistic row locks to stop double-remit/double-payout (vuln-0017 + an unflagged sibling); rate-limit filter uses the proxy-appended (rightmost) `X-Forwarded-For` entry instead of the client-spoofable leftmost (vuln-0008).

Migration: `V4_36` (dedupe-first, **non-destructive** — nulls duplicate refs, never deletes a financial row) adds the COD deposit unique index.

---

## Why This Change?
Strix samples the codebase; it flags representative instances, not every occurrence. Auditing the root causes showed the true blast radius was much larger (9 BFLA findings → 81 endpoints; 1 fail-open ownership bug → 4, including an unflagged money one) and surfaced false positives to discard (vuln-0001's "missing check" — a guard existed; the dispatch/sla "null scope" — intentional ADMIN-sees-all). Fixing the root causes closes the whole class, not just the flagged endpoints, before the pilot.

---

## Testing
- [x] Tested locally
- [x] Edge cases considered
- [x] No breaking changes introduced

### Test Evidence
Final full run of the affected modules — **189 tests, 0 failures/errors**:
```
mvn -q test -pl orders,auth -fae   →   no Failures/Errors across 35 test classes (189 tests)
```
New/updated tests: `SecurityConfigAuthzTest` (customer→403 on ops paths, admin passes, serviceability open), `SsrfGuardTest` (blocks IMDS/private/loopback/CGNAT/bad-scheme), `CodCashServiceImplTest` (idempotent deposit), `UserManagementE2eTest` +2 (SM cannot create ADMIN / peer SM), `B2bBookingServiceImplTest` +2 (non-owner / ownerless rejected), `ApiKeyE2eTest` repointed. `BookingE2eTest` green (applies `V4_36` cleanly against a freshly-migrated DB).

---

## Impact

### Areas Affected
- [x] Backend
- [ ] Frontend
- [ ] Routing
- [ ] Infra
- [x] Database

### Modules Affected
- [x] M1 — Auth
- [ ] M2 — Pricing
- [x] M3 — Grid
- [x] M4 — Orders
- [ ] M5 — Dispatch
- [x] M6 — Routing
- [x] M7 — Hub
- [x] M8 — Barcode
- [x] M9 — Airline
- [ ] M10 — SLA
- [ ] M11 — Exceptions

---

## Risks / Concerns
- **Authorization tightening (RC1):** ops endpoints now require the appropriate role. Any internal caller / demo script hitting `/routing`, `/hub`, `/grid`, `/airline`, `/api/v1/scan` must present an ADMIN (or the specific role) JWT — ADMIN is permitted everywhere. Verified no existing tests hit those paths.
- **Migration:** `V4_36` is non-destructive (nulls duplicate `deposit_ref`s before creating the partial-unique index; never deletes a deposit row). Applies cleanly on a migrated DB.
- **Fail-closed ownership:** a B2B account with a null `ownerUserId` can no longer be drawn down by anyone — the correct secure behaviour; ensure accounts are provisioned with an owner.
- Otherwise additive (guards, locks, a validator) — low regression risk.

### Documented follow-ups (intentionally not in this branch)
- RC2 actor-identity (ops endpoints still read `actorId`/`reviewerId`/`driverId` from the body → a now-authorized privileged user could forge *who* acted in the audit trail) — needs the auth principal wired into those modules (adds an `auth` dependency).
- IdempotencyFilter TOCTOU (vuln-0019, LOW) — needs the insert-only `IdempotencyKey` entity redesigned to a two-phase reserve→complete.
- OSRM http→https (infra: needs a TLS OSRM endpoint); van↔driver / da↔cron self-ownership checks.

---

## Checklist
- [x] Code follows project conventions (package layout, no cross-module internal imports)
- [x] Self-review completed
- [x] Append-only audit trail preserved (no mutations to scan/manifest/role-change records)
- [x] No sensitive data or credentials exposed
- [x] Documentation updated if behaviour changed
- [x] Ready for review
