### PR TITLE
feat(sla): triage priority — band, act-by, urgency + who-to-call

### DIFF
--- a/sla/src/main/java/com/oneday/sla/domain/PriorityBand.java
+++ b/sla/src/main/java/com/oneday/sla/domain/PriorityBand.java
@@ -1,0 +1,32 @@
+package com.oneday.sla.domain;
+
+/**
+ * The station-manager triage band a parcel sits in — the coarse, stable bucket the control tower
+ * groups by (round-2 model decision 4). Ordered most-urgent first; {@link #rank()} feeds the
+ * priority score so the band always dominates finer signals (act-by, overshoot).
+ *
+ * <p>Bands are intentionally few so a manager works the top bucket first and builds muscle memory;
+ * the fine ordering happens <em>within</em> a band via act-by then overshoot.</p>
+ */
+public enum PriorityBand {
+
+    /** Breached, act-by imminent (≤30m), or the customer promise is already blown — act now. */
+    CRITICAL(3),
+
+    /** RED, or an act-by window closing soon (≤2h) — queue up next. */
+    HIGH(2),
+
+    /** AMBER / weather-exposed / plenty of headroom — keep an eye, no fire. */
+    WATCH(1);
+
+    private final int rank;
+
+    PriorityBand(int rank) {
+        this.rank = rank;
+    }
+
+    /** Higher = more urgent. Used as the dominant term of the priority score. */
+    public int rank() {
+        return rank;
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/domain/SlaShipment.java
+++ b/sla/src/main/java/com/oneday/sla/domain/SlaShipment.java
@@ -75,4 +75,27 @@ public class SlaShipment extends MutableBaseEntity {
 
     @Column(name = "breached", nullable = false)
     private boolean breached;
+
+    // ── Triage priority (written by SlaEngine via PriorityScorer on every recompute) ──────────
+
+    /** Sortable urgency; higher = act sooner. Encodes band > fixable > act-by > overshoot. */
+    @Column(name = "priority_score", nullable = false)
+    private double priorityScore;
+
+    /** Coarse triage bucket the control tower groups by. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "band", nullable = false)
+    private PriorityBand band = PriorityBand.WATCH;
+
+    /** Minutes projected (or already) past the internal target; negative = slack. Null before the clock starts. */
+    @Column(name = "urgency_minutes")
+    private Integer urgencyMinutes;
+
+    /** The soonest hard window the manager is racing (nearest open-leg deadline) — the default sort spine. */
+    @Column(name = "act_by_at")
+    private Instant actByAt;
+
+    /** When the parcel entered its current SLA colour — for "in RED 12m" and ack decay. */
+    @Column(name = "entered_state_at")
+    private Instant enteredStateAt;
 }

--- a/sla/src/main/java/com/oneday/sla/dto/SlaShipmentSummary.java
+++ b/sla/src/main/java/com/oneday/sla/dto/SlaShipmentSummary.java
@@ -3,12 +3,15 @@ package com.oneday.sla.dto;
 import com.oneday.common.domain.enums.DeliveryType;
 import com.oneday.common.domain.enums.SlaLegType;
 import com.oneday.common.domain.enums.SlaState;
+import com.oneday.common.port.CourierOnShipmentPort;
+import com.oneday.common.port.ShipmentContactPort;
+import com.oneday.sla.domain.PriorityBand;
 import com.oneday.sla.domain.SlaShipment;
 
 import java.time.Instant;
 import java.util.UUID;
 
-/** One control-tower row: where a parcel's SLA stands right now. */
+/** One control-tower row: where a parcel's SLA stands right now, its triage priority, and who to call. */
 public record SlaShipmentSummary(
         UUID shipmentId,
         String shipmentRef,
@@ -23,13 +26,38 @@ public record SlaShipmentSummary(
         Instant internalTargetAt,
         Instant publicPromiseAt,
         Instant projectedFinishAt,
-        Instant deliveredAt) {
+        Instant deliveredAt,
+        // Triage priority (PriorityScorer)
+        PriorityBand band,
+        Integer urgencyMinutes,
+        Instant actByAt,
+        Instant enteredStateAt,
+        // Who to call — the current handler (DA today; van/hub/GHA to come) + the receiving customer.
+        String handlerName,
+        String handlerPhone,
+        String handlerRole,
+        String receiverName,
+        String receiverPhone) {
 
+    /** Entity-only mapping — contact fields null. Used where a per-row contact lookup isn't warranted. */
     public static SlaShipmentSummary from(SlaShipment s) {
+        return from(s, null, null);
+    }
+
+    /** Full row including the resolved current handler and receiving customer. */
+    public static SlaShipmentSummary from(SlaShipment s,
+                                          CourierOnShipmentPort.Courier handler,
+                                          ShipmentContactPort.ShipmentContact contact) {
         return new SlaShipmentSummary(
                 s.getShipmentId(), s.getShipmentRef(), s.getOriginCity(), s.getDestCity(), s.getLane(),
                 s.getDeliveryType(), s.getOverallState(), s.getCurrentLeg(), s.isBreached(),
                 s.getBookedAt(), s.getInternalTargetAt(), s.getPublicPromiseAt(),
-                s.getProjectedFinishAt(), s.getDeliveredAt());
+                s.getProjectedFinishAt(), s.getDeliveredAt(),
+                s.getBand(), s.getUrgencyMinutes(), s.getActByAt(), s.getEnteredStateAt(),
+                handler == null ? null : handler.name(),
+                handler == null ? null : handler.phone(),
+                handler == null ? null : handler.role().name(),
+                contact == null ? null : contact.receiverName(),
+                contact == null ? null : contact.receiverPhone());
     }
 }

--- a/sla/src/main/java/com/oneday/sla/repository/SlaShipmentRepository.java
+++ b/sla/src/main/java/com/oneday/sla/repository/SlaShipmentRepository.java
@@ -31,7 +31,7 @@ public interface SlaShipmentRepository extends JpaRepository<SlaShipment, UUID> 
             where s.closedAt is null
               and (:state is null or s.overallState = :state)
               and (:city is null or s.originCity = :city or s.destCity = :city)
-            order by s.updatedAt desc
+            order by s.priorityScore desc
             """)
     Page<SlaShipment> controlTower(@Param("state") SlaState state,
                                    @Param("city") String city,

--- a/sla/src/main/java/com/oneday/sla/service/PriorityScorer.java
+++ b/sla/src/main/java/com/oneday/sla/service/PriorityScorer.java
@@ -1,0 +1,112 @@
+package com.oneday.sla.service;
+
+import com.oneday.common.domain.enums.SlaLegType;
+import com.oneday.common.domain.enums.SlaState;
+import com.oneday.sla.domain.PriorityBand;
+import com.oneday.sla.domain.SlaLeg;
+import com.oneday.sla.domain.SlaShipment;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Turns a shipment's SLA state into a triage priority: which band it's in, the act-by deadline the
+ * manager is really racing, how many minutes it is projected to miss by, and a single sortable score.
+ *
+ * <p>Pure and side-effect-free — the engine calls it on every recompute and persists the result so
+ * the control tower is a cheap indexed {@code ORDER BY priority_score DESC}. The score encodes the
+ * settled model, most-significant term first:
+ * <ol>
+ *   <li><b>band</b> (CRITICAL &gt; HIGH &gt; WATCH) — dominates everything;</li>
+ *   <li><b>fixable</b> — a parcel the manager can still influence outranks one locked in the air;</li>
+ *   <li><b>act-by</b> — the sooner the intervention window closes, the higher (the default spine);</li>
+ *   <li><b>overshoot</b> — larger projected/actual SLA miss breaks ties (1h over beats 30m over).</li>
+ * </ol>
+ */
+@Component
+public class PriorityScorer {
+
+    // Score term weights — kept far enough apart that a higher term never inverts under a lower one.
+    // ponytail: weights are a calibration knob; tune against real breach outcomes, keep band dominant.
+    private static final double BAND_WEIGHT = 1_000_000_000d;
+    private static final double FIXABLE_WEIGHT = 1_000_000d;
+    private static final long ACT_BY_HORIZON_MIN = 100_000; // an absent/far act-by sorts last in-band
+
+    private static final int CRITICAL_ACT_BY_MIN = 30;
+    private static final int HIGH_ACT_BY_MIN = 120;
+
+    /** The computed triage result for one shipment. */
+    public record Scored(PriorityBand band, Integer urgencyMinutes, Instant actByAt,
+                         double score, boolean fixable) {}
+
+    public Scored score(SlaShipment ss, List<SlaLeg> legs, Instant now) {
+        Instant target = ss.getInternalTargetAt();
+        Instant actByAt = nearestOpenLegDeadline(legs);
+        boolean fixable = isFixable(ss.getCurrentLeg());
+
+        // Minutes we are projected (or already) to miss the internal target by. Positive = over,
+        // negative = slack remaining. Breach measures from now (it only grows); else from projection.
+        Integer urgencyMinutes = null;
+        if (target != null) {
+            Instant finish = ss.isBreached()
+                    ? now
+                    : (ss.getProjectedFinishAt() != null ? ss.getProjectedFinishAt() : now);
+            urgencyMinutes = (int) minutesBetween(target, finish);
+        }
+
+        PriorityBand band = band(ss, actByAt, now);
+        double score = score(band, fixable, actByAt, urgencyMinutes, now);
+        return new Scored(band, urgencyMinutes, actByAt, score, fixable);
+    }
+
+    private PriorityBand band(SlaShipment ss, Instant actByAt, Instant now) {
+        boolean promiseBlown = ss.getPublicPromiseAt() != null && now.isAfter(ss.getPublicPromiseAt());
+        long actByMin = actByAt == null ? Long.MAX_VALUE : minutesBetween(now, actByAt);
+
+        if (ss.isBreached() || promiseBlown || actByMin <= CRITICAL_ACT_BY_MIN) {
+            return PriorityBand.CRITICAL;
+        }
+        if (ss.getOverallState() == SlaState.RED || actByMin <= HIGH_ACT_BY_MIN) {
+            return PriorityBand.HIGH;
+        }
+        return PriorityBand.WATCH;
+    }
+
+    private double score(PriorityBand band, boolean fixable, Instant actByAt,
+                         Integer urgencyMinutes, Instant now) {
+        double s = band.rank() * BAND_WEIGHT;
+        s += (fixable ? 1 : 0) * FIXABLE_WEIGHT;
+        // Sooner act-by → higher, in [0, ACT_BY_HORIZON_MIN]. Null act-by contributes 0 (sorts last).
+        long actByMin = actByAt == null ? ACT_BY_HORIZON_MIN : Math.max(0, minutesBetween(now, actByAt));
+        s += Math.max(0, ACT_BY_HORIZON_MIN - actByMin);
+        // Overshoot tie-break — small weight so it never crosses an act-by band inside the same band.
+        if (urgencyMinutes != null) {
+            s += Math.max(0, urgencyMinutes) / 1000.0;
+        }
+        return s;
+    }
+
+    /** The soonest deadline among legs still open — the nearest hard window the manager is racing. */
+    private Instant nearestOpenLegDeadline(List<SlaLeg> legs) {
+        return legs.stream()
+                .filter(l -> l.getCompletedAt() == null && l.getDeadlineAt() != null)
+                .map(SlaLeg::getDeadlineAt)
+                .min(Instant::compareTo)
+                .orElse(null);
+    }
+
+    /**
+     * Can the station manager still change the outcome? Everything but a parcel in the air is
+     * intervenable (reassign DA, expedite hub, push next flight, call GHA). A parcel mid-AIR is
+     * locked — it ranks below fixable peers in the same band.
+     */
+    private boolean isFixable(SlaLegType currentLeg) {
+        return currentLeg != SlaLegType.AIR;
+    }
+
+    private static long minutesBetween(Instant from, Instant to) {
+        return Duration.between(from, to).toMinutes();
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/service/SlaEngine.java
+++ b/sla/src/main/java/com/oneday/sla/service/SlaEngine.java
@@ -25,13 +25,16 @@ public class SlaEngine {
     private final SlaLegRepository legRepo;
     private final ProjectionCalculator projection;
     private final EscalationService escalation;
+    private final PriorityScorer priorityScorer;
 
     public SlaEngine(SlaShipmentRepository shipmentRepo, SlaLegRepository legRepo,
-                     ProjectionCalculator projection, EscalationService escalation) {
+                     ProjectionCalculator projection, EscalationService escalation,
+                     PriorityScorer priorityScorer) {
         this.shipmentRepo = shipmentRepo;
         this.legRepo = legRepo;
         this.projection = projection;
         this.escalation = escalation;
+        this.priorityScorer = priorityScorer;
     }
 
     @Transactional
@@ -56,7 +59,8 @@ public class SlaEngine {
                     .findFirst()
                     .orElse(null);
             ss.setCurrentLeg(pendingLeg);
-            ss.setOverallState(SlaState.GREEN);
+            applyState(ss, SlaState.GREEN, now);
+            applyPriority(ss, legs, now);
             shipmentRepo.save(ss);
             return;
         }
@@ -79,7 +83,8 @@ public class SlaEngine {
             overall = SlaState.BREACHED;
             ss.setBreached(true);
         }
-        ss.setOverallState(overall);
+        applyState(ss, overall, now);
+        applyPriority(ss, legs, now);
         shipmentRepo.save(ss);
 
         // Escalate on entering RED / BREACHED (idempotent downstream).
@@ -88,5 +93,22 @@ public class SlaEngine {
         } else if (overall == SlaState.RED && previous != SlaState.RED && previous != SlaState.BREACHED) {
             escalation.raiseRed(ss, currentLeg, previous);
         }
+    }
+
+    /** Set the colour, stamping entered_state_at only when it actually changes (for "in RED 12m"). */
+    private void applyState(SlaShipment ss, SlaState next, Instant now) {
+        if (ss.getOverallState() != next || ss.getEnteredStateAt() == null) {
+            ss.setEnteredStateAt(now);
+        }
+        ss.setOverallState(next);
+    }
+
+    /** Recompute + store the triage priority (band, act-by, urgency, score). */
+    private void applyPriority(SlaShipment ss, List<SlaLeg> legs, Instant now) {
+        PriorityScorer.Scored scored = priorityScorer.score(ss, legs, now);
+        ss.setBand(scored.band());
+        ss.setActByAt(scored.actByAt());
+        ss.setUrgencyMinutes(scored.urgencyMinutes());
+        ss.setPriorityScore(scored.score());
     }
 }

--- a/sla/src/main/java/com/oneday/sla/service/impl/SlaQueryServiceImpl.java
+++ b/sla/src/main/java/com/oneday/sla/service/impl/SlaQueryServiceImpl.java
@@ -1,6 +1,8 @@
 package com.oneday.sla.service.impl;
 
 import com.oneday.common.domain.enums.SlaState;
+import com.oneday.common.port.CourierOnShipmentPort;
+import com.oneday.common.port.ShipmentContactPort;
 import com.oneday.sla.domain.SlaAction;
 import com.oneday.sla.domain.SlaActionType;
 import com.oneday.sla.domain.SlaEscalation;
@@ -25,7 +27,9 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 public class SlaQueryServiceImpl implements SlaQueryService {
@@ -36,13 +40,18 @@ public class SlaQueryServiceImpl implements SlaQueryService {
     private final SlaLegRepository legRepo;
     private final SlaEscalationRepository escalationRepo;
     private final SlaActionRepository actionRepo;
+    private final CourierOnShipmentPort courierPort;
+    private final ShipmentContactPort contactPort;
 
     public SlaQueryServiceImpl(SlaShipmentRepository shipmentRepo, SlaLegRepository legRepo,
-                               SlaEscalationRepository escalationRepo, SlaActionRepository actionRepo) {
+                               SlaEscalationRepository escalationRepo, SlaActionRepository actionRepo,
+                               CourierOnShipmentPort courierPort, ShipmentContactPort contactPort) {
         this.shipmentRepo = shipmentRepo;
         this.legRepo = legRepo;
         this.escalationRepo = escalationRepo;
         this.actionRepo = actionRepo;
+        this.courierPort = courierPort;
+        this.contactPort = contactPort;
     }
 
     @Override
@@ -51,7 +60,15 @@ public class SlaQueryServiceImpl implements SlaQueryService {
         int p = Math.max(0, page);
         int s = Math.min(Math.max(1, size), MAX_PAGE_SIZE);
         Page<SlaShipment> result = shipmentRepo.controlTower(state, cityScope, PageRequest.of(p, s));
-        List<SlaShipmentSummary> items = result.getContent().stream().map(SlaShipmentSummary::from).toList();
+        // Batch the customer contacts (one findAllById); the current handler (DA) is per-row today.
+        Map<UUID, ShipmentContactPort.ShipmentContact> contacts = contactPort.contactsFor(
+                result.getContent().stream().map(SlaShipment::getShipmentId).collect(Collectors.toSet()));
+        List<SlaShipmentSummary> items = result.getContent().stream()
+                .map(ss -> SlaShipmentSummary.from(
+                        ss,
+                        courierPort.forShipment(ss.getShipmentId()).orElse(null),
+                        contacts.get(ss.getShipmentId())))
+                .toList();
         return new SlaControlTowerResponse(p, s, result.getTotalElements(), items);
     }
 
@@ -66,7 +83,11 @@ public class SlaQueryServiceImpl implements SlaQueryService {
         List<SlaEscalationView> escalations = escalationRepo
                 .findByShipmentIdOrderByCreatedAtDesc(ss.getShipmentId()).stream()
                 .map(this::toEscalationView).toList();
-        return new SlaShipmentDetailResponse(SlaShipmentSummary.from(ss), legs, escalations);
+        SlaShipmentSummary summary = SlaShipmentSummary.from(
+                ss,
+                courierPort.forShipment(ss.getShipmentId()).orElse(null),
+                contactPort.contactsFor(List.of(ss.getShipmentId())).get(ss.getShipmentId()));
+        return new SlaShipmentDetailResponse(summary, legs, escalations);
     }
 
     @Override

--- a/sla/src/main/resources/db/migration/sla/V10_3__sla_priority.sql
+++ b/sla/src/main/resources/db/migration/sla/V10_3__sla_priority.sql
@@ -1,0 +1,12 @@
+-- M10 triage priority: the sweeper (SlaEngine + PriorityScorer) writes these on every recompute so
+-- the control tower is a cheap indexed sort instead of a client-side scramble over hundreds of rows.
+ALTER TABLE sla_shipment
+    ADD COLUMN priority_score   DOUBLE PRECISION NOT NULL DEFAULT 0,
+    ADD COLUMN band             VARCHAR(12)      NOT NULL DEFAULT 'WATCH',
+    ADD COLUMN urgency_minutes  INTEGER,
+    ADD COLUMN act_by_at        TIMESTAMPTZ,
+    ADD COLUMN entered_state_at TIMESTAMPTZ;
+
+-- The control-tower query is: open rows, city-scoped, ordered by priority. Partial index keeps the
+-- ranked read index-only over just the open set.
+CREATE INDEX idx_sla_shipment_priority ON sla_shipment (priority_score DESC) WHERE closed_at IS NULL;

--- a/sla/src/test/java/com/oneday/sla/service/PriorityScorerTest.java
+++ b/sla/src/test/java/com/oneday/sla/service/PriorityScorerTest.java
@@ -1,0 +1,109 @@
+package com.oneday.sla.service;
+
+import com.oneday.common.domain.enums.SlaLegType;
+import com.oneday.common.domain.enums.SlaState;
+import com.oneday.sla.domain.PriorityBand;
+import com.oneday.sla.domain.SlaLeg;
+import com.oneday.sla.domain.SlaShipment;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** The triage priority ordering invariants — the model must never invert these. */
+class PriorityScorerTest {
+
+    private final PriorityScorer scorer = new PriorityScorer();
+    private final Instant now = Instant.parse("2026-08-21T12:00:00Z");
+
+    private SlaShipment ship(SlaState state, boolean breached, SlaLegType currentLeg,
+                             Instant target, Instant projectedFinish, Instant publicPromise) {
+        SlaShipment s = new SlaShipment();
+        s.setOverallState(state);
+        s.setBreached(breached);
+        s.setCurrentLeg(currentLeg);
+        s.setInternalTargetAt(target);
+        s.setProjectedFinishAt(projectedFinish);
+        s.setPublicPromiseAt(publicPromise);
+        return s;
+    }
+
+    /** One open leg with the given deadline (drives act-by). */
+    private List<SlaLeg> legDue(Instant deadline) {
+        SlaLeg l = new SlaLeg();
+        l.setLeg(SlaLegType.LAST_MILE);
+        l.setSeq(1);
+        l.setBudgetMinutes(60);
+        l.setDeadlineAt(deadline);
+        return List.of(l);
+    }
+
+    private Instant plus(int min) { return now.plus(Duration.ofMinutes(min)); }
+    private Instant minus(int min) { return now.minus(Duration.ofMinutes(min)); }
+
+    @Test
+    void breachedIsCriticalAndOutranksRed() {
+        var breached = scorer.score(
+                ship(SlaState.BREACHED, true, SlaLegType.DEST_HUB, minus(60), now, null),
+                legDue(minus(10)), now);
+        var red = scorer.score(
+                ship(SlaState.RED, false, SlaLegType.DEST_HUB, plus(60), plus(120), null),
+                legDue(plus(90)), now);
+
+        assertThat(breached.band()).isEqualTo(PriorityBand.CRITICAL);
+        assertThat(red.band()).isEqualTo(PriorityBand.HIGH);
+        assertThat(breached.score()).isGreaterThan(red.score());
+    }
+
+    @Test
+    void deeperBreachOutranksShallower() {
+        var deep = scorer.score(ship(SlaState.BREACHED, true, SlaLegType.DEST_HUB, minus(60), now, null),
+                List.of(), now);          // no open leg → act-by null on both, so overshoot decides
+        var shallow = scorer.score(ship(SlaState.BREACHED, true, SlaLegType.DEST_HUB, minus(30), now, null),
+                List.of(), now);
+        assertThat(deep.urgencyMinutes()).isGreaterThan(shallow.urgencyMinutes());
+        assertThat(deep.score()).isGreaterThan(shallow.score());
+    }
+
+    @Test
+    void fixableOutranksLockedInSameBand() {
+        var fixable = scorer.score(ship(SlaState.RED, false, SlaLegType.DEST_HUB, plus(60), plus(120), null),
+                legDue(plus(90)), now);
+        var locked = scorer.score(ship(SlaState.RED, false, SlaLegType.AIR, plus(60), plus(120), null),
+                legDue(plus(90)), now);
+        assertThat(fixable.fixable()).isTrue();
+        assertThat(locked.fixable()).isFalse();
+        assertThat(fixable.band()).isEqualTo(locked.band());
+        assertThat(fixable.score()).isGreaterThan(locked.score());
+    }
+
+    @Test
+    void soonerActByOutranksLaterInSameBand() {
+        var soon = scorer.score(ship(SlaState.RED, false, SlaLegType.DEST_HUB, plus(300), plus(360), null),
+                legDue(plus(40)), now);   // 40m: >30 (not critical), ≤120 → HIGH
+        var later = scorer.score(ship(SlaState.RED, false, SlaLegType.DEST_HUB, plus(300), plus(360), null),
+                legDue(plus(90)), now);
+        assertThat(soon.band()).isEqualTo(PriorityBand.HIGH);
+        assertThat(later.band()).isEqualTo(PriorityBand.HIGH);
+        assertThat(soon.score()).isGreaterThan(later.score());
+    }
+
+    @Test
+    void imminentActByForcesCriticalEvenWhenColourIsGreen() {
+        var s = scorer.score(
+                ship(SlaState.GREEN, false, SlaLegType.FIRST_MILE, plus(600), plus(120), null),
+                legDue(plus(15)), now);   // must act in 15m regardless of the healthy colour
+        assertThat(s.band()).isEqualTo(PriorityBand.CRITICAL);
+    }
+
+    @Test
+    void publicPromiseBreachIsCritical() {
+        var s = scorer.score(
+                ship(SlaState.AMBER, false, SlaLegType.LAST_MILE, plus(120), plus(60), minus(5)),
+                legDue(plus(200)), now);  // customer 24h promise already blown
+        assertThat(s.band()).isEqualTo(PriorityBand.CRITICAL);
+    }
+}


### PR DESCRIPTION
## What
Ranks every open parcel so a station manager at ~1000 orders/day works a **focus queue**, not a 200-row wall. The SLA sweeper now scores each shipment and stores it, so the control tower is a cheap indexed sort.

## The model (settled with product)
Priority = **band > fixable > act-by > overshoot**:
- **Band** — CRITICAL / HIGH / WATCH (stable buckets the manager works top-down).
- **Fixable-first** — a parcel the manager can still influence outranks one locked mid-AIR.
- **Act-by** — the nearest open-leg deadline (the real "act by 14:00", not the far SLA breach) — the default sort spine.
- **Overshoot** — minutes projected/actually past target breaks ties (1h over beats 30m over).

## Changes
- **`PriorityScorer`** (pure, unit-tested) → band + act-by + urgency minutes + score.
- **`SlaEngine.recompute`** writes `priority_score / band / urgency_minutes / act_by_at / entered_state_at` on every pass; **`V10_3`** adds the columns + a partial index over the open set.
- **`controlTower`** now orders by `priority_score desc` (was `updatedAt`).
- **`SlaShipmentSummary`** carries the priority fields **+ who-to-call**: the current handler (DA via `CourierOnShipmentPort`) and the receiving customer (`ShipmentContactPort`).

## Testing
- `PriorityScorerTest` (6, green): breached > red, deeper breach first, **fixable > locked**, sooner act-by first, imminent act-by / public-promise breach → CRITICAL. Full `sla` suite 18 green.
- Verified end-to-end on a local DB: 16 open → CRITICAL 5 / HIGH 7 / WATCH 4, breached first, fixable-before-locked, DA phone on the last-mile rows.

## Scope / follow-ups
P1 of the design. Next: trajectory/velocity boost, van/hub/GHA contacts, a backend weather port + Weather Watch, cause-grouping, ack-decay, and wiring the (already-built, unused) `oneday.sla.events` seam to alerts.

Frontend: Sidarthapati/oneday-web `feat/sla-priority-triage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)