### PR TITLE
feat(sla): weather-aware triage + trajectory freshness (P2/P3)

### DIFF
--- a/sla/src/main/java/com/oneday/sla/api/SlaDashboardController.java
+++ b/sla/src/main/java/com/oneday/sla/api/SlaDashboardController.java
@@ -7,6 +7,7 @@ import com.oneday.sla.dto.SlaControlTowerResponse;
 import com.oneday.sla.dto.SlaEscalationView;
 import com.oneday.sla.dto.SlaPassRateResponse;
 import com.oneday.sla.dto.SlaShipmentDetailResponse;
+import com.oneday.sla.dto.WeatherWatchResponse;
 import com.oneday.sla.service.SlaQueryService;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -57,6 +58,13 @@ public class SlaDashboardController {
             @PathVariable String ref) {
         Authz.requireRole(principal, Authz.STATION_MANAGER, Authz.SUPERVISOR);
         return service.detail(ref, Authz.cityScope(principal));
+    }
+
+    /** Proactive weather advisories: adverse operating cities + how many open parcels are exposed. */
+    @GetMapping("/weather-watch")
+    public WeatherWatchResponse weatherWatch(@AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireRole(principal, Authz.STATION_MANAGER, Authz.SUPERVISOR);
+        return service.weatherWatch(Authz.cityScope(principal));
     }
 
     /** Open escalations awaiting action (RED / BREACHED). */

--- a/sla/src/main/java/com/oneday/sla/dto/SlaShipmentSummary.java
+++ b/sla/src/main/java/com/oneday/sla/dto/SlaShipmentSummary.java
@@ -37,17 +37,20 @@ public record SlaShipmentSummary(
         String handlerPhone,
         String handlerRole,
         String receiverName,
-        String receiverPhone) {
+        String receiverPhone,
+        // True when the parcel is on a ground leg heading into a city with adverse weather right now.
+        boolean weatherExposed) {
 
-    /** Entity-only mapping — contact fields null. Used where a per-row contact lookup isn't warranted. */
+    /** Entity-only mapping — contact + weather null/false. Used where per-row enrichment isn't warranted. */
     public static SlaShipmentSummary from(SlaShipment s) {
-        return from(s, null, null);
+        return from(s, null, null, false);
     }
 
-    /** Full row including the resolved current handler and receiving customer. */
+    /** Full row including the resolved current handler, receiving customer, and weather exposure. */
     public static SlaShipmentSummary from(SlaShipment s,
                                           CourierOnShipmentPort.Courier handler,
-                                          ShipmentContactPort.ShipmentContact contact) {
+                                          ShipmentContactPort.ShipmentContact contact,
+                                          boolean weatherExposed) {
         return new SlaShipmentSummary(
                 s.getShipmentId(), s.getShipmentRef(), s.getOriginCity(), s.getDestCity(), s.getLane(),
                 s.getDeliveryType(), s.getOverallState(), s.getCurrentLeg(), s.isBreached(),
@@ -58,6 +61,7 @@ public record SlaShipmentSummary(
                 handler == null ? null : handler.phone(),
                 handler == null ? null : handler.role().name(),
                 contact == null ? null : contact.receiverName(),
-                contact == null ? null : contact.receiverPhone());
+                contact == null ? null : contact.receiverPhone(),
+                weatherExposed);
     }
 }

--- a/sla/src/main/java/com/oneday/sla/dto/WeatherWatchResponse.java
+++ b/sla/src/main/java/com/oneday/sla/dto/WeatherWatchResponse.java
@@ -1,0 +1,14 @@
+package com.oneday.sla.dto;
+
+import java.util.List;
+
+/**
+ * Proactive weather advisories for the control tower: one row per operating city whose weather is
+ * adverse right now, with how many open parcels are exposed to it (on a ground leg heading into that
+ * city). Surfaces "BOM rain → 12 inbound last-mile at risk" as a single card instead of flooding the
+ * board with 12 individual rows.
+ */
+public record WeatherWatchResponse(List<CityAdvisory> cities) {
+
+    public record CityAdvisory(String city, String condition, double tempC, int exposedCount) {}
+}

--- a/sla/src/main/java/com/oneday/sla/service/PriorityScorer.java
+++ b/sla/src/main/java/com/oneday/sla/service/PriorityScorer.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Turns a shipment's SLA state into a triage priority: which band it's in, the act-by deadline the
@@ -33,15 +34,24 @@ public class PriorityScorer {
     private static final double BAND_WEIGHT = 1_000_000_000d;
     private static final double FIXABLE_WEIGHT = 1_000_000d;
     private static final long ACT_BY_HORIZON_MIN = 100_000; // an absent/far act-by sorts last in-band
+    // Weather nudge: capped well below the act-by term so a weather-exposed parcel rises within its
+    // band (a rainy last-mile beats a dry one) but never outranks an actual breach or a sooner cutoff.
+    // ponytail: calibration knob.
+    private static final double WEATHER_WEIGHT = 40_000d;
 
     private static final int CRITICAL_ACT_BY_MIN = 30;
     private static final int HIGH_ACT_BY_MIN = 120;
 
     /** The computed triage result for one shipment. */
     public record Scored(PriorityBand band, Integer urgencyMinutes, Instant actByAt,
-                         double score, boolean fixable) {}
+                         double score, boolean fixable, boolean weatherExposed) {}
 
+    /** No-weather overload (event lifecycle paths where a live weather read isn't warranted). */
     public Scored score(SlaShipment ss, List<SlaLeg> legs, Instant now) {
+        return score(ss, legs, now, Set.of());
+    }
+
+    public Scored score(SlaShipment ss, List<SlaLeg> legs, Instant now, Set<String> adverseCities) {
         Instant target = ss.getInternalTargetAt();
         Instant actByAt = nearestOpenLegDeadline(legs);
         boolean fixable = isFixable(ss.getCurrentLeg());
@@ -56,9 +66,19 @@ public class PriorityScorer {
             urgencyMinutes = (int) minutesBetween(target, finish);
         }
 
+        boolean weatherExposed = isWeatherExposed(ss, adverseCities);
         PriorityBand band = band(ss, actByAt, now);
-        double score = score(band, fixable, actByAt, urgencyMinutes, now);
-        return new Scored(band, urgencyMinutes, actByAt, score, fixable);
+        double score = score(band, fixable, actByAt, urgencyMinutes, weatherExposed, now);
+        return new Scored(band, urgencyMinutes, actByAt, score, fixable, weatherExposed);
+    }
+
+    /** True when the parcel is on a ground leg heading into (or picked up in) a city with adverse weather. */
+    private boolean isWeatherExposed(SlaShipment ss, Set<String> adverseCities) {
+        if (adverseCities.isEmpty() || !WeatherService.isWeatherExposedLeg(ss.getCurrentLeg())) {
+            return false;
+        }
+        String city = WeatherService.relevantCity(ss.getCurrentLeg(), ss.getOriginCity(), ss.getDestCity());
+        return city != null && adverseCities.contains(city);
     }
 
     private PriorityBand band(SlaShipment ss, Instant actByAt, Instant now) {
@@ -75,12 +95,15 @@ public class PriorityScorer {
     }
 
     private double score(PriorityBand band, boolean fixable, Instant actByAt,
-                         Integer urgencyMinutes, Instant now) {
+                         Integer urgencyMinutes, boolean weatherExposed, Instant now) {
         double s = band.rank() * BAND_WEIGHT;
         s += (fixable ? 1 : 0) * FIXABLE_WEIGHT;
         // Sooner act-by → higher, in [0, ACT_BY_HORIZON_MIN]. Null act-by contributes 0 (sorts last).
         long actByMin = actByAt == null ? ACT_BY_HORIZON_MIN : Math.max(0, minutesBetween(now, actByAt));
         s += Math.max(0, ACT_BY_HORIZON_MIN - actByMin);
+        if (weatherExposed) {
+            s += WEATHER_WEIGHT;
+        }
         // Overshoot tie-break — small weight so it never crosses an act-by band inside the same band.
         if (urgencyMinutes != null) {
             s += Math.max(0, urgencyMinutes) / 1000.0;

--- a/sla/src/main/java/com/oneday/sla/service/PriorityScorer.java
+++ b/sla/src/main/java/com/oneday/sla/service/PriorityScorer.java
@@ -38,6 +38,12 @@ public class PriorityScorer {
     // band (a rainy last-mile beats a dry one) but never outranks an actual breach or a sooner cutoff.
     // ponytail: calibration knob.
     private static final double WEATHER_WEIGHT = 40_000d;
+    // Freshness (trajectory): a parcel that *just* escalated is a new fire the manager hasn't seen;
+    // it should surface above the stale ones already being worked. Full boost on entry, decaying to
+    // zero over the window. Only in the urgent bands — a fresh WATCH parcel isn't a fire.
+    // ponytail: calibration knob; velocity (Δ projected-finish) is a later refinement.
+    private static final double FRESHNESS_WEIGHT = 30_000d;
+    private static final long FRESHNESS_WINDOW_MIN = 20;
 
     private static final int CRITICAL_ACT_BY_MIN = 30;
     private static final int HIGH_ACT_BY_MIN = 120;
@@ -68,8 +74,19 @@ public class PriorityScorer {
 
         boolean weatherExposed = isWeatherExposed(ss, adverseCities);
         PriorityBand band = band(ss, actByAt, now);
-        double score = score(band, fixable, actByAt, urgencyMinutes, weatherExposed, now);
+        double score = score(band, fixable, actByAt, urgencyMinutes, weatherExposed,
+                freshnessBoost(band, ss.getEnteredStateAt(), now), now);
         return new Scored(band, urgencyMinutes, actByAt, score, fixable, weatherExposed);
+    }
+
+    /** A decaying nudge for a parcel that just entered an urgent band — new fires over stale ones. */
+    private double freshnessBoost(PriorityBand band, Instant enteredStateAt, Instant now) {
+        if (band == PriorityBand.WATCH || enteredStateAt == null) {
+            return 0;
+        }
+        long minsInState = Math.max(0, minutesBetween(enteredStateAt, now));
+        double decay = Math.max(0, 1.0 - (double) minsInState / FRESHNESS_WINDOW_MIN);
+        return FRESHNESS_WEIGHT * decay;
     }
 
     /** True when the parcel is on a ground leg heading into (or picked up in) a city with adverse weather. */
@@ -95,12 +112,13 @@ public class PriorityScorer {
     }
 
     private double score(PriorityBand band, boolean fixable, Instant actByAt,
-                         Integer urgencyMinutes, boolean weatherExposed, Instant now) {
+                         Integer urgencyMinutes, boolean weatherExposed, double freshnessBoost, Instant now) {
         double s = band.rank() * BAND_WEIGHT;
         s += (fixable ? 1 : 0) * FIXABLE_WEIGHT;
         // Sooner act-by → higher, in [0, ACT_BY_HORIZON_MIN]. Null act-by contributes 0 (sorts last).
         long actByMin = actByAt == null ? ACT_BY_HORIZON_MIN : Math.max(0, minutesBetween(now, actByAt));
         s += Math.max(0, ACT_BY_HORIZON_MIN - actByMin);
+        s += freshnessBoost;
         if (weatherExposed) {
             s += WEATHER_WEIGHT;
         }

--- a/sla/src/main/java/com/oneday/sla/service/SlaEngine.java
+++ b/sla/src/main/java/com/oneday/sla/service/SlaEngine.java
@@ -26,15 +26,17 @@ public class SlaEngine {
     private final ProjectionCalculator projection;
     private final EscalationService escalation;
     private final PriorityScorer priorityScorer;
+    private final WeatherService weatherService;
 
     public SlaEngine(SlaShipmentRepository shipmentRepo, SlaLegRepository legRepo,
                      ProjectionCalculator projection, EscalationService escalation,
-                     PriorityScorer priorityScorer) {
+                     PriorityScorer priorityScorer, WeatherService weatherService) {
         this.shipmentRepo = shipmentRepo;
         this.legRepo = legRepo;
         this.projection = projection;
         this.escalation = escalation;
         this.priorityScorer = priorityScorer;
+        this.weatherService = weatherService;
     }
 
     @Transactional
@@ -103,9 +105,9 @@ public class SlaEngine {
         ss.setOverallState(next);
     }
 
-    /** Recompute + store the triage priority (band, act-by, urgency, score). */
+    /** Recompute + store the triage priority (band, act-by, urgency, score, incl. weather nudge). */
     private void applyPriority(SlaShipment ss, List<SlaLeg> legs, Instant now) {
-        PriorityScorer.Scored scored = priorityScorer.score(ss, legs, now);
+        PriorityScorer.Scored scored = priorityScorer.score(ss, legs, now, weatherService.adverseCities());
         ss.setBand(scored.band());
         ss.setActByAt(scored.actByAt());
         ss.setUrgencyMinutes(scored.urgencyMinutes());

--- a/sla/src/main/java/com/oneday/sla/service/SlaQueryService.java
+++ b/sla/src/main/java/com/oneday/sla/service/SlaQueryService.java
@@ -5,6 +5,7 @@ import com.oneday.sla.dto.SlaControlTowerResponse;
 import com.oneday.sla.dto.SlaEscalationView;
 import com.oneday.sla.dto.SlaPassRateResponse;
 import com.oneday.sla.dto.SlaShipmentDetailResponse;
+import com.oneday.sla.dto.WeatherWatchResponse;
 
 import java.time.Instant;
 import java.util.List;
@@ -22,6 +23,9 @@ public interface SlaQueryService {
     List<SlaEscalationView> redQueue(String cityScope);
 
     SlaPassRateResponse passRate(Instant from, Instant to, String cityScope);
+
+    /** Proactive weather advisories: adverse cities + how many open parcels are exposed. */
+    WeatherWatchResponse weatherWatch(String cityScope);
 
     void acknowledge(java.util.UUID escalationId, String cityScope, String userId, String role, String notes);
 

--- a/sla/src/main/java/com/oneday/sla/service/WeatherService.java
+++ b/sla/src/main/java/com/oneday/sla/service/WeatherService.java
@@ -1,0 +1,151 @@
+package com.oneday.sla.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+/**
+ * Current weather per operating city, for the ops control tower's weather-aware triage. Pulls
+ * Open-Meteo (keyless, free) once for all five metros and caches it for an hour — weather moves
+ * slowly and the sweeper reads {@link #adverseCities()} every 60s. Fully best-effort: a provider
+ * hiccup yields an empty adverse set (no boost, no advisory) and never breaks scoring.
+ *
+ * <p>ponytail: JDK HttpClient + one cached multi-city call — no new dependency, no per-parcel fetch.
+ * Open-Meteo's free tier is non-commercial; all weather I/O is behind this one class, so swapping to
+ * a keyed provider later is a single-file change.</p>
+ */
+@Service
+public class WeatherService {
+
+    private static final Logger log = LoggerFactory.getLogger(WeatherService.class);
+    private static final long TTL_MILLIS = 60 * 60 * 1000L; // 1h
+
+    /** The five pilot metros (IATA → lat/lon), matching the station console's city list. */
+    private static final Map<String, double[]> CITIES = Map.of(
+            "DEL", new double[]{28.61, 77.21},
+            "BOM", new double[]{19.08, 72.88},
+            "BLR", new double[]{12.97, 77.59},
+            "HYD", new double[]{17.39, 78.49},
+            "MAA", new double[]{13.08, 80.27});
+    // Stable order so the multi-city response maps back correctly.
+    private static final String[] ORDER = {"DEL", "BOM", "BLR", "HYD", "MAA"};
+
+    /** One city's current conditions. {@code adverse} = weather that slows last-mile / delays flights. */
+    public record CityWeather(String code, double tempC, int wmo, String condition, boolean adverse) {}
+
+    private record Cache(long at, Map<String, CityWeather> byCity) {}
+
+    private final HttpClient http = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final AtomicReference<Cache> cache = new AtomicReference<>();
+
+    /** Current weather for every operating city (cached ~1h). Empty on a provider failure. */
+    public Map<String, CityWeather> current() {
+        Cache c = cache.get();
+        if (c != null && System.currentTimeMillis() - c.at() < TTL_MILLIS) {
+            return c.byCity();
+        }
+        Map<String, CityWeather> fresh = fetch();
+        // Only overwrite the cache on success; keep serving the last good reading through an outage.
+        if (!fresh.isEmpty()) {
+            cache.set(new Cache(System.currentTimeMillis(), fresh));
+            return fresh;
+        }
+        return c != null ? c.byCity() : Map.of();
+    }
+
+    /** IATA codes whose weather is currently adverse for logistics (fog / heavy rain / storm / snow). */
+    public Set<String> adverseCities() {
+        return current().values().stream()
+                .filter(CityWeather::adverse)
+                .map(CityWeather::code)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * The city whose weather actually bears on this parcel right now: origin while it's still being
+     * picked up, destination once it's moving toward delivery. (Weather during the air leg matters at
+     * the destination it's landing into.)
+     */
+    public static String relevantCity(com.oneday.common.domain.enums.SlaLegType currentLeg,
+                                      String originCity, String destCity) {
+        if (currentLeg == com.oneday.common.domain.enums.SlaLegType.FIRST_MILE
+                || currentLeg == com.oneday.common.domain.enums.SlaLegType.ORIGIN_HUB) {
+            return originCity;
+        }
+        return destCity;
+    }
+
+    /**
+     * A ground leg where weather actually slows the parcel (pickup or delivery on the road, hub yards).
+     * Mid-air is excluded — rain doesn't speed or slow a plane in cruise, and the manager can't act on it.
+     */
+    public static boolean isWeatherExposedLeg(com.oneday.common.domain.enums.SlaLegType leg) {
+        return leg != null && leg != com.oneday.common.domain.enums.SlaLegType.AIR;
+    }
+
+    private Map<String, CityWeather> fetch() {
+        try {
+            String lat = String.join(",", java.util.Arrays.stream(ORDER).map(c -> String.valueOf(CITIES.get(c)[0])).toList());
+            String lon = String.join(",", java.util.Arrays.stream(ORDER).map(c -> String.valueOf(CITIES.get(c)[1])).toList());
+            URI uri = URI.create("https://api.open-meteo.com/v1/forecast?latitude=" + lat + "&longitude=" + lon
+                    + "&current=temperature_2m,weather_code&timezone=auto");
+            HttpResponse<String> res = http.send(
+                    HttpRequest.newBuilder(uri).timeout(Duration.ofSeconds(8)).GET().build(),
+                    HttpResponse.BodyHandlers.ofString());
+            if (res.statusCode() != 200) {
+                log.warn("Open-Meteo returned {}", res.statusCode());
+                return Map.of();
+            }
+            JsonNode body = mapper.readTree(res.body());
+            // Multi-city responses come back as a JSON array, one entry per coord, in request order.
+            Map<String, CityWeather> out = new LinkedHashMap<>();
+            for (int i = 0; i < ORDER.length; i++) {
+                JsonNode e = body.isArray() ? body.get(i) : body;
+                if (e == null) continue;
+                JsonNode cur = e.path("current");
+                double temp = cur.path("temperature_2m").asDouble(Double.NaN);
+                int wmo = cur.path("weather_code").asInt(-1);
+                out.put(ORDER[i], new CityWeather(ORDER[i], temp, wmo, describe(wmo), isAdverse(wmo)));
+            }
+            return out;
+        } catch (Exception ex) {
+            log.warn("Weather fetch failed: {}", ex.toString());
+            return Map.of();
+        }
+    }
+
+    /**
+     * WMO codes that slow ground delivery or threaten flights: fog (45,48) and any precipitation
+     * (drizzle 51–57, rain 61–67, snow 71–77, showers 80–86, thunderstorm 95–99). Everything below 45
+     * is clear/cloud. ponytail: threshold is a calibration knob — raise it if drizzle proves too noisy.
+     */
+    private static boolean isAdverse(int wmo) {
+        return wmo >= 45;
+    }
+
+    private static String describe(int wmo) {
+        if (wmo <= 0) return "Clear";
+        if (wmo <= 3) return "Cloudy";
+        if (wmo <= 48) return "Fog";
+        if (wmo <= 57) return "Drizzle";
+        if (wmo <= 67) return "Rain";
+        if (wmo <= 77) return "Snow";
+        if (wmo <= 82) return "Showers";
+        if (wmo <= 86) return "Snow showers";
+        return "Thunderstorm";
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/service/impl/SlaQueryServiceImpl.java
+++ b/sla/src/main/java/com/oneday/sla/service/impl/SlaQueryServiceImpl.java
@@ -13,6 +13,8 @@ import com.oneday.sla.dto.SlaLegView;
 import com.oneday.sla.dto.SlaPassRateResponse;
 import com.oneday.sla.dto.SlaShipmentDetailResponse;
 import com.oneday.sla.dto.SlaShipmentSummary;
+import com.oneday.sla.dto.WeatherWatchResponse;
+import com.oneday.sla.service.WeatherService;
 import com.oneday.sla.repository.SlaActionRepository;
 import com.oneday.sla.repository.SlaEscalationRepository;
 import com.oneday.sla.repository.SlaLegRepository;
@@ -42,16 +44,26 @@ public class SlaQueryServiceImpl implements SlaQueryService {
     private final SlaActionRepository actionRepo;
     private final CourierOnShipmentPort courierPort;
     private final ShipmentContactPort contactPort;
+    private final WeatherService weatherService;
 
     public SlaQueryServiceImpl(SlaShipmentRepository shipmentRepo, SlaLegRepository legRepo,
                                SlaEscalationRepository escalationRepo, SlaActionRepository actionRepo,
-                               CourierOnShipmentPort courierPort, ShipmentContactPort contactPort) {
+                               CourierOnShipmentPort courierPort, ShipmentContactPort contactPort,
+                               WeatherService weatherService) {
         this.shipmentRepo = shipmentRepo;
         this.legRepo = legRepo;
         this.escalationRepo = escalationRepo;
         this.actionRepo = actionRepo;
         this.courierPort = courierPort;
         this.contactPort = contactPort;
+        this.weatherService = weatherService;
+    }
+
+    /** True when this parcel is on a ground leg heading into a currently-adverse city. */
+    private boolean weatherExposed(SlaShipment ss, java.util.Set<String> adverse) {
+        if (adverse.isEmpty() || !WeatherService.isWeatherExposedLeg(ss.getCurrentLeg())) return false;
+        String city = WeatherService.relevantCity(ss.getCurrentLeg(), ss.getOriginCity(), ss.getDestCity());
+        return city != null && adverse.contains(city);
     }
 
     @Override
@@ -63,11 +75,13 @@ public class SlaQueryServiceImpl implements SlaQueryService {
         // Batch the customer contacts (one findAllById); the current handler (DA) is per-row today.
         Map<UUID, ShipmentContactPort.ShipmentContact> contacts = contactPort.contactsFor(
                 result.getContent().stream().map(SlaShipment::getShipmentId).collect(Collectors.toSet()));
+        java.util.Set<String> adverse = weatherService.adverseCities();
         List<SlaShipmentSummary> items = result.getContent().stream()
                 .map(ss -> SlaShipmentSummary.from(
                         ss,
                         courierPort.forShipment(ss.getShipmentId()).orElse(null),
-                        contacts.get(ss.getShipmentId())))
+                        contacts.get(ss.getShipmentId()),
+                        weatherExposed(ss, adverse)))
                 .toList();
         return new SlaControlTowerResponse(p, s, result.getTotalElements(), items);
     }
@@ -86,7 +100,8 @@ public class SlaQueryServiceImpl implements SlaQueryService {
         SlaShipmentSummary summary = SlaShipmentSummary.from(
                 ss,
                 courierPort.forShipment(ss.getShipmentId()).orElse(null),
-                contactPort.contactsFor(List.of(ss.getShipmentId())).get(ss.getShipmentId()));
+                contactPort.contactsFor(List.of(ss.getShipmentId())).get(ss.getShipmentId()),
+                weatherExposed(ss, weatherService.adverseCities()));
         return new SlaShipmentDetailResponse(summary, legs, escalations);
     }
 
@@ -107,6 +122,38 @@ public class SlaQueryServiceImpl implements SlaQueryService {
         long closed = shipmentRepo.countClosedBetween(from, to, cityScope);
         long breached = shipmentRepo.countBreachedBetween(from, to, cityScope);
         return SlaPassRateResponse.of(from, to, cityScope, closed, breached);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public WeatherWatchResponse weatherWatch(String cityScope) {
+        Map<String, WeatherService.CityWeather> weather = weatherService.current();
+        java.util.Set<String> adverse = weatherService.adverseCities();
+        if (adverse.isEmpty()) {
+            return new WeatherWatchResponse(List.of());
+        }
+        // Count open, weather-exposed parcels per adverse city (respecting the caller's city scope).
+        Map<String, Long> exposedByCity = shipmentRepo.findByClosedAtIsNull().stream()
+                .filter(ss -> cityScope == null
+                        || cityScope.equals(ss.getOriginCity()) || cityScope.equals(ss.getDestCity()))
+                .filter(ss -> weatherExposed(ss, adverse))
+                .collect(Collectors.groupingBy(
+                        ss -> WeatherService.relevantCity(ss.getCurrentLeg(), ss.getOriginCity(), ss.getDestCity()),
+                        Collectors.counting()));
+
+        List<WeatherWatchResponse.CityAdvisory> advisories = adverse.stream()
+                .filter(city -> cityScope == null || cityScope.equals(city))
+                .map(city -> {
+                    WeatherService.CityWeather w = weather.get(city);
+                    return new WeatherWatchResponse.CityAdvisory(
+                            city,
+                            w != null ? w.condition() : "Adverse",
+                            w != null ? w.tempC() : Double.NaN,
+                            exposedByCity.getOrDefault(city, 0L).intValue());
+                })
+                .sorted((a, b) -> Integer.compare(b.exposedCount(), a.exposedCount()))
+                .toList();
+        return new WeatherWatchResponse(advisories);
     }
 
     @Override

--- a/sla/src/test/java/com/oneday/sla/service/PriorityScorerTest.java
+++ b/sla/src/test/java/com/oneday/sla/service/PriorityScorerTest.java
@@ -127,6 +127,19 @@ class PriorityScorerTest {
     }
 
     @Test
+    void aJustEscalatedParcelOutranksAStaleOneInTheSameBand() {
+        SlaShipment fresh = ship(SlaState.BREACHED, true, SlaLegType.DEST_HUB, minus(60), now, null);
+        fresh.setEnteredStateAt(now);           // new fire
+        SlaShipment stale = ship(SlaState.BREACHED, true, SlaLegType.DEST_HUB, minus(60), now, null);
+        stale.setEnteredStateAt(minus(60));     // been critical an hour → boost decayed to zero
+
+        var f = scorer.score(fresh, legDue(minus(5)), now);
+        var s = scorer.score(stale, legDue(minus(5)), now);
+        assertThat(f.band()).isEqualTo(s.band());
+        assertThat(f.score()).isGreaterThan(s.score());
+    }
+
+    @Test
     void weatherOnlyExposesGroundLegsHeadingIntoTheAdverseCity() {
         // In the air → not exposed (can't act, and dest weather isn't the parcel's ground risk yet).
         SlaShipment inAir = ship(SlaState.GREEN, false, SlaLegType.AIR, plus(600), plus(120), null);

--- a/sla/src/test/java/com/oneday/sla/service/PriorityScorerTest.java
+++ b/sla/src/test/java/com/oneday/sla/service/PriorityScorerTest.java
@@ -106,4 +106,31 @@ class PriorityScorerTest {
                 legDue(plus(200)), now);  // customer 24h promise already blown
         assertThat(s.band()).isEqualTo(PriorityBand.CRITICAL);
     }
+
+    @Test
+    void weatherExposureLiftsWithinBandButNeverAcrossIt() {
+        SlaShipment toBom = ship(SlaState.GREEN, false, SlaLegType.LAST_MILE, plus(600), plus(120), null);
+        toBom.setOriginCity("DEL"); toBom.setDestCity("BOM");
+        var dry = scorer.score(toBom, legDue(plus(300)), now, java.util.Set.of());
+        var rainy = scorer.score(toBom, legDue(plus(300)), now, java.util.Set.of("BOM")); // dest adverse
+
+        assertThat(rainy.weatherExposed()).isTrue();
+        assertThat(dry.weatherExposed()).isFalse();
+        assertThat(rainy.band()).isEqualTo(dry.band());                 // still WATCH — no band jump
+        assertThat(rainy.score()).isGreaterThan(dry.score());           // but ranks above its dry twin
+
+        // A weather-exposed WATCH parcel must never outrank a real breach.
+        var breached = scorer.score(
+                ship(SlaState.BREACHED, true, SlaLegType.DEST_HUB, minus(60), now, null),
+                legDue(minus(5)), now, java.util.Set.of("BOM"));
+        assertThat(breached.score()).isGreaterThan(rainy.score());
+    }
+
+    @Test
+    void weatherOnlyExposesGroundLegsHeadingIntoTheAdverseCity() {
+        // In the air → not exposed (can't act, and dest weather isn't the parcel's ground risk yet).
+        SlaShipment inAir = ship(SlaState.GREEN, false, SlaLegType.AIR, plus(600), plus(120), null);
+        inAir.setOriginCity("DEL"); inAir.setDestCity("BOM");
+        assertThat(scorer.score(inAir, legDue(plus(300)), now, java.util.Set.of("BOM")).weatherExposed()).isFalse();
+    }
 }


### PR DESCRIPTION
Builds on the priority triage (#113, merged). Two model refinements the product owner signed off on.

## P3 — weather-aware
- **WeatherService**: keyless Open-Meteo (JDK HttpClient, one cached multi-city call, 1h TTL), best-effort — a provider hiccup yields no boost and never breaks scoring.
- **weatherBoost** in `PriorityScorer`: a capped nudge lifts a parcel on a ground leg heading into an adverse city *within* its band (rainy last-mile beats a dry one), never *across* a band — can't outrank a real breach.
- **GET /api/v1/sla/weather-watch**: grouped advisory — one row per adverse city + exposed count ("BOM drizzle → N inbound"), instead of N cards.
- control-tower rows carry `weather_exposed`.

## P2 — trajectory freshness
- A just-escalated parcel is a new fire; a decaying **freshness boost** (from `entered_state_at`, full on entry → 0 over 20m, urgent bands only) surfaces it above the stale ones already being worked. Capped below act-by so the deadline still leads.

## Testing
`PriorityScorerTest` +3 (weather lifts within band never across; only ground legs into the adverse city; fresh outranks stale). Full `sla` suite **21 green**; module compiles.

## Depends on
#114 (duplicate-V4_35 hotfix) to boot `main` — orthogonal to this diff (no migration here).

Frontend: Sidarthapati/oneday-web#18 (Weather Watch panel, weather + time-in-state chips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)