### PR TITLE
feat(sla): who-to-call (P2b) + cause-grouping + ack/snooze decay (P4)

### DIFF
--- a/auth/src/main/java/com/oneday/auth/repository/UserRepository.java
+++ b/auth/src/main/java/com/oneday/auth/repository/UserRepository.java
@@ -1,10 +1,12 @@
 package com.oneday.auth.repository;
 
 import com.oneday.auth.domain.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -25,4 +27,16 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByIdWithPermissions(@Param("id") UUID id);
 
     boolean existsByRoleId(UUID roleId);
+
+    /**
+     * A reachable on-duty staffer for a role, optionally scoped to a city — the "desk" contact for a
+     * hub or GHA custody stage. Active, with a phone; {@code city} null matches any city.
+     */
+    @Query("""
+            SELECT u FROM User u JOIN u.role r
+            WHERE r.name = :role AND u.active = true AND u.phone IS NOT NULL
+              AND (:city IS NULL OR u.cityId = :city)
+            ORDER BY u.name
+            """)
+    List<User> findStaffByRoleAndCity(@Param("role") String role, @Param("city") String city, Pageable pageable);
 }

--- a/auth/src/main/java/com/oneday/auth/service/impl/StageContactPortAdapter.java
+++ b/auth/src/main/java/com/oneday/auth/service/impl/StageContactPortAdapter.java
@@ -1,0 +1,41 @@
+package com.oneday.auth.service.impl;
+
+import com.oneday.auth.domain.User;
+import com.oneday.auth.repository.UserRepository;
+import com.oneday.common.port.StageContactPort;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * The single {@link StageContactPort} implementation — the hub / GHA desk contact read from the auth
+ * user directory by role (+ city for hubs). Mirrors {@link DaDirectoryPortAdapter} for the DA legs.
+ */
+@Component
+class StageContactPortAdapter implements StageContactPort {
+
+    private final UserRepository userRepository;
+
+    StageContactPortAdapter(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public Optional<Contact> hubDesk(String cityCode) {
+        // Prefer the hub operator; fall back to the station manager for that city.
+        return firstStaff("HUB_OPERATOR", cityCode)
+                .or(() -> firstStaff("STATION_MANAGER", cityCode));
+    }
+
+    @Override
+    public Optional<Contact> ghaDesk() {
+        return firstStaff("AIRLINE_GHA", null);
+    }
+
+    private Optional<Contact> firstStaff(String role, String cityCode) {
+        return userRepository.findStaffByRoleAndCity(role, cityCode, PageRequest.of(0, 1)).stream()
+                .findFirst()
+                .map(u -> new Contact(u.getName(), u.getPhone(), u.getRole().getName()));
+    }
+}

--- a/common/src/main/java/com/oneday/common/port/StageContactPort.java
+++ b/common/src/main/java/com/oneday/common/port/StageContactPort.java
@@ -1,0 +1,24 @@
+package com.oneday.common.port;
+
+import java.util.Optional;
+
+/**
+ * The on-duty desk contact for a non-DA custody stage — who to call when a parcel is sitting in a hub
+ * or moving through the airline. Implemented in auth (M1) over {@code users} (role + city_id); consumed
+ * by the SLA control tower's "who to call" so hub and air legs resolve a phone, the way
+ * {@link CourierOnShipmentPort} already does for the DA legs.
+ *
+ * <p>There is no per-hub or per-flight staffing table in v1, so these resolve the representative
+ * on-duty staffer by role: a {@code HUB_OPERATOR} (or {@code STATION_MANAGER}) in the hub's city, and
+ * an {@code AIRLINE_GHA} nationally. It's a desk contact, not a named individual assignment.</p>
+ */
+public interface StageContactPort {
+
+    /** Hub desk for a city (IATA code): its on-duty HUB_OPERATOR, else a STATION_MANAGER. */
+    Optional<Contact> hubDesk(String cityCode);
+
+    /** The airline ground-handling (GHA) desk — national, not city-scoped. */
+    Optional<Contact> ghaDesk();
+
+    record Contact(String name, String phone, String role) {}
+}

--- a/sla/src/main/java/com/oneday/sla/api/SlaDashboardController.java
+++ b/sla/src/main/java/com/oneday/sla/api/SlaDashboardController.java
@@ -3,6 +3,7 @@ package com.oneday.sla.api;
 import com.oneday.auth.security.AuthUserDetails;
 import com.oneday.common.domain.enums.SlaState;
 import com.oneday.sla.dto.SlaActionRequest;
+import com.oneday.sla.dto.SlaClusterResponse;
 import com.oneday.sla.dto.SlaControlTowerResponse;
 import com.oneday.sla.dto.SlaEscalationView;
 import com.oneday.sla.dto.SlaPassRateResponse;
@@ -49,6 +50,13 @@ public class SlaDashboardController {
             @RequestParam(defaultValue = "50") int size) {
         Authz.requireRole(principal, Authz.STATION_MANAGER, Authz.SUPERVISOR);
         return service.controlTower(state, Authz.cityScope(principal), page, size);
+    }
+
+    /** The at-risk queue collapsed to shared root causes — one row per cause, with the one desk to call. */
+    @GetMapping("/clusters")
+    public SlaClusterResponse clusters(@AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireRole(principal, Authz.STATION_MANAGER, Authz.SUPERVISOR);
+        return service.clusters(Authz.cityScope(principal));
     }
 
     /** Per-parcel leg breakdown + escalation history. */

--- a/sla/src/main/java/com/oneday/sla/domain/SlaShipment.java
+++ b/sla/src/main/java/com/oneday/sla/domain/SlaShipment.java
@@ -98,4 +98,12 @@ public class SlaShipment extends MutableBaseEntity {
     /** When the parcel entered its current SLA colour — for "in RED 12m" and ack decay. */
     @Column(name = "entered_state_at")
     private Instant enteredStateAt;
+
+    /** When a manager last acknowledged/acted on this parcel — sinks it within its band for a cooldown. */
+    @Column(name = "acknowledged_at")
+    private Instant acknowledgedAt;
+
+    /** Who acknowledged it — shown as "being handled by X" on the queue. */
+    @Column(name = "acknowledged_by")
+    private String acknowledgedBy;
 }

--- a/sla/src/main/java/com/oneday/sla/dto/SlaClusterResponse.java
+++ b/sla/src/main/java/com/oneday/sla/dto/SlaClusterResponse.java
@@ -1,0 +1,28 @@
+package com.oneday.sla.dto;
+
+import com.oneday.sla.domain.PriorityBand;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * The at-risk queue collapsed to shared root causes — one cluster = one decision, one desk to call.
+ * At 1000/day the failures correlate (one late flight puts a dozen parcels RED); ranking the causes
+ * instead of the individual cards turns ~200 rows into ~10 calls. Clusters are ordered worst-band
+ * first (never a band-jump), then by size (12 affected beats 1), then soonest act-by.
+ */
+public record SlaClusterResponse(List<Cluster> clusters) {
+
+    public record Cluster(
+            String stage,                       // PICKUP | HUB | AIR | DELIVERY
+            String scope,                       // city code, or lane "BLR→DEL" for AIR
+            String label,                       // "Delivery · BLR", "Airline (GHA) · BLR→DEL"
+            PriorityBand band,                  // worst member's band
+            int size,
+            int breachedCount,
+            Instant earliestActBy,              // soonest hard window across members
+            List<String> refs,                  // member refs, worst-first (capped)
+            SlaShipmentSummary.Handler contact  // the single desk to call for the whole cluster (null if unresolved)
+    ) {
+    }
+}

--- a/sla/src/main/java/com/oneday/sla/dto/SlaShipmentSummary.java
+++ b/sla/src/main/java/com/oneday/sla/dto/SlaShipmentSummary.java
@@ -38,7 +38,10 @@ public record SlaShipmentSummary(
         String receiverName,
         String receiverPhone,
         // True when the parcel is on a ground leg heading into a city with adverse weather right now.
-        boolean weatherExposed) {
+        boolean weatherExposed,
+        // Anti-fatigue: a manager is on it (acknowledged, cooldown live, not since re-escalated) + who.
+        boolean beingHandled,
+        String acknowledgedBy) {
 
     /** The resolved current handler for a parcel — DA, hub desk, or GHA desk — normalised to strings. */
     public record Handler(String name, String phone, String role) {}
@@ -64,6 +67,8 @@ public record SlaShipmentSummary(
                 handler == null ? null : handler.role(),
                 contact == null ? null : contact.receiverName(),
                 contact == null ? null : contact.receiverPhone(),
-                weatherExposed);
+                weatherExposed,
+                com.oneday.sla.service.PriorityScorer.ackIsLive(s, Instant.now()),
+                s.getAcknowledgedBy());
     }
 }

--- a/sla/src/main/java/com/oneday/sla/dto/SlaShipmentSummary.java
+++ b/sla/src/main/java/com/oneday/sla/dto/SlaShipmentSummary.java
@@ -3,7 +3,6 @@ package com.oneday.sla.dto;
 import com.oneday.common.domain.enums.DeliveryType;
 import com.oneday.common.domain.enums.SlaLegType;
 import com.oneday.common.domain.enums.SlaState;
-import com.oneday.common.port.CourierOnShipmentPort;
 import com.oneday.common.port.ShipmentContactPort;
 import com.oneday.sla.domain.PriorityBand;
 import com.oneday.sla.domain.SlaShipment;
@@ -41,6 +40,9 @@ public record SlaShipmentSummary(
         // True when the parcel is on a ground leg heading into a city with adverse weather right now.
         boolean weatherExposed) {
 
+    /** The resolved current handler for a parcel — DA, hub desk, or GHA desk — normalised to strings. */
+    public record Handler(String name, String phone, String role) {}
+
     /** Entity-only mapping — contact + weather null/false. Used where per-row enrichment isn't warranted. */
     public static SlaShipmentSummary from(SlaShipment s) {
         return from(s, null, null, false);
@@ -48,7 +50,7 @@ public record SlaShipmentSummary(
 
     /** Full row including the resolved current handler, receiving customer, and weather exposure. */
     public static SlaShipmentSummary from(SlaShipment s,
-                                          CourierOnShipmentPort.Courier handler,
+                                          Handler handler,
                                           ShipmentContactPort.ShipmentContact contact,
                                           boolean weatherExposed) {
         return new SlaShipmentSummary(
@@ -59,7 +61,7 @@ public record SlaShipmentSummary(
                 s.getBand(), s.getUrgencyMinutes(), s.getActByAt(), s.getEnteredStateAt(),
                 handler == null ? null : handler.name(),
                 handler == null ? null : handler.phone(),
-                handler == null ? null : handler.role().name(),
+                handler == null ? null : handler.role(),
                 contact == null ? null : contact.receiverName(),
                 contact == null ? null : contact.receiverPhone(),
                 weatherExposed);

--- a/sla/src/main/java/com/oneday/sla/service/PriorityScorer.java
+++ b/sla/src/main/java/com/oneday/sla/service/PriorityScorer.java
@@ -44,13 +44,20 @@ public class PriorityScorer {
     // ponytail: calibration knob; velocity (Δ projected-finish) is a later refinement.
     private static final double FRESHNESS_WEIGHT = 30_000d;
     private static final long FRESHNESS_WINDOW_MIN = 20;
+    // Ack decay (R4, anti-fatigue): once a manager attends to a parcel, sink it within its band so the
+    // queue keeps showing new fires. Weight sits just above the whole within-band range (fixable + act-by
+    // + freshness + weather ≈ 1.13e6) so a worked parcel drops below its un-worked band-peers but never
+    // crosses into a lower band — an acked breach is still a breach, just handled. Decays back to zero
+    // over the cooldown so an unresolved parcel resurfaces. ponytail: calibration knob.
+    private static final double ACK_DECAY_WEIGHT = 2_000_000d;
+    private static final long ACK_COOLDOWN_MIN = 30;
 
     private static final int CRITICAL_ACT_BY_MIN = 30;
     private static final int HIGH_ACT_BY_MIN = 120;
 
     /** The computed triage result for one shipment. */
     public record Scored(PriorityBand band, Integer urgencyMinutes, Instant actByAt,
-                         double score, boolean fixable, boolean weatherExposed) {}
+                         double score, boolean fixable, boolean weatherExposed, boolean acknowledged) {}
 
     /** No-weather overload (event lifecycle paths where a live weather read isn't warranted). */
     public Scored score(SlaShipment ss, List<SlaLeg> legs, Instant now) {
@@ -76,7 +83,35 @@ public class PriorityScorer {
         PriorityBand band = band(ss, actByAt, now);
         double score = score(band, fixable, actByAt, urgencyMinutes, weatherExposed,
                 freshnessBoost(band, ss.getEnteredStateAt(), now), now);
-        return new Scored(band, urgencyMinutes, actByAt, score, fixable, weatherExposed);
+        score += ackDecay(ss, now);
+        return new Scored(band, urgencyMinutes, actByAt, score, fixable, weatherExposed, ackIsLive(ss, now));
+    }
+
+    /**
+     * Has a manager attended to this parcel's <em>current</em> state, with the cooldown not yet lapsed?
+     * A worsening after the ack (a later {@code enteredStateAt}) is a fresh fire the ack no longer
+     * covers, so the parcel resurfaces. Shared by the score's decay and the "being handled" summary flag.
+     */
+    public static boolean ackIsLive(SlaShipment ss, Instant now) {
+        Instant acked = ss.getAcknowledgedAt();
+        if (acked == null) {
+            return false;
+        }
+        if (ss.getEnteredStateAt() != null && ss.getEnteredStateAt().isAfter(acked)) {
+            return false;
+        }
+        long mins = minutesBetween(acked, now);
+        return mins >= 0 && mins < ACK_COOLDOWN_MIN;
+    }
+
+    /** A negative, decaying term that sinks an acknowledged parcel within its band over the cooldown. */
+    private double ackDecay(SlaShipment ss, Instant now) {
+        if (!ackIsLive(ss, now)) {
+            return 0;
+        }
+        long mins = Math.max(0, minutesBetween(ss.getAcknowledgedAt(), now));
+        double decay = 1.0 - (double) mins / ACK_COOLDOWN_MIN;
+        return -ACK_DECAY_WEIGHT * decay;
     }
 
     /** A decaying nudge for a parcel that just entered an urgent band — new fires over stale ones. */

--- a/sla/src/main/java/com/oneday/sla/service/SlaQueryService.java
+++ b/sla/src/main/java/com/oneday/sla/service/SlaQueryService.java
@@ -1,6 +1,7 @@
 package com.oneday.sla.service;
 
 import com.oneday.common.domain.enums.SlaState;
+import com.oneday.sla.dto.SlaClusterResponse;
 import com.oneday.sla.dto.SlaControlTowerResponse;
 import com.oneday.sla.dto.SlaEscalationView;
 import com.oneday.sla.dto.SlaPassRateResponse;
@@ -17,6 +18,9 @@ import java.util.List;
 public interface SlaQueryService {
 
     SlaControlTowerResponse controlTower(SlaState state, String cityScope, int page, int size);
+
+    /** The at-risk queue grouped by shared root cause — one row per cause, with the one desk to call. */
+    SlaClusterResponse clusters(String cityScope);
 
     SlaShipmentDetailResponse detail(String shipmentRef, String cityScope);
 

--- a/sla/src/main/java/com/oneday/sla/service/impl/SlaQueryServiceImpl.java
+++ b/sla/src/main/java/com/oneday/sla/service/impl/SlaQueryServiceImpl.java
@@ -149,10 +149,12 @@ public class SlaQueryServiceImpl implements SlaQueryService {
     @Override
     @Transactional(readOnly = true)
     public SlaClusterResponse clusters(String cityScope) {
-        // The actionable set: open parcels that are actually at risk (not GREEN) — a healthy parcel is no fire.
+        // The actionable set = the fire bands (CRITICAL/HIGH). WATCH is "keep an eye, no fire" — and this
+        // is the band, not the colour: a parcel that's colour-GREEN but racing a 60-min flight cutoff is
+        // a HIGH-band fire and belongs here, while a slack AMBER (WATCH band) does not.
         Map<Cause, List<SlaShipment>> grouped = shipmentRepo.findByClosedAtIsNull().stream()
                 .filter(ss -> visible(ss, cityScope))
-                .filter(ss -> ss.getOverallState() != SlaState.GREEN)
+                .filter(ss -> ss.getBand() != null && ss.getBand() != PriorityBand.WATCH)
                 .collect(Collectors.groupingBy(SlaQueryServiceImpl::causeOf));
 
         List<SlaClusterResponse.Cluster> clusters = grouped.entrySet().stream()

--- a/sla/src/main/java/com/oneday/sla/service/impl/SlaQueryServiceImpl.java
+++ b/sla/src/main/java/com/oneday/sla/service/impl/SlaQueryServiceImpl.java
@@ -277,6 +277,14 @@ public class SlaQueryServiceImpl implements SlaQueryService {
         action.setActedByRole(role);
         action.setNotes(notes);
         actionRepo.save(action);
+
+        // Anti-fatigue (R4): stamp the parcel so the scorer sinks it within its band for a cooldown —
+        // a manager who's on it shouldn't keep seeing it top the queue. A later escalation clears this.
+        shipmentRepo.findByShipmentId(esc.getShipmentId()).ifPresent(ss -> {
+            ss.setAcknowledgedAt(Instant.now());
+            ss.setAcknowledgedBy(userId);
+            shipmentRepo.save(ss);
+        });
     }
 
     private SlaEscalationView toEscalationView(SlaEscalation e) {

--- a/sla/src/main/java/com/oneday/sla/service/impl/SlaQueryServiceImpl.java
+++ b/sla/src/main/java/com/oneday/sla/service/impl/SlaQueryServiceImpl.java
@@ -5,10 +5,12 @@ import com.oneday.common.domain.enums.SlaState;
 import com.oneday.common.port.CourierOnShipmentPort;
 import com.oneday.common.port.ShipmentContactPort;
 import com.oneday.common.port.StageContactPort;
+import com.oneday.sla.domain.PriorityBand;
 import com.oneday.sla.domain.SlaAction;
 import com.oneday.sla.domain.SlaActionType;
 import com.oneday.sla.domain.SlaEscalation;
 import com.oneday.sla.domain.SlaShipment;
+import com.oneday.sla.dto.SlaClusterResponse;
 import com.oneday.sla.dto.SlaControlTowerResponse;
 import com.oneday.sla.dto.SlaEscalationView;
 import com.oneday.sla.dto.SlaLegView;
@@ -30,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Instant;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -112,6 +115,69 @@ public class SlaQueryServiceImpl implements SlaQueryService {
                         weatherExposed(ss, adverse)))
                 .toList();
         return new SlaControlTowerResponse(p, s, result.getTotalElements(), items);
+    }
+
+    /** The operational cause a parcel shares with its peers — the group key for the clustered queue. */
+    private record Cause(String stage, String scope, String label) {}
+
+    private static Cause causeOf(SlaShipment ss) {
+        SlaLegType leg = ss.getCurrentLeg();
+        if (leg == null) {
+            return new Cause("PICKUP", ss.getOriginCity(), "Awaiting pickup · " + ss.getOriginCity());
+        }
+        return switch (leg) {
+            case FIRST_MILE -> new Cause("PICKUP", ss.getOriginCity(), "Pickup · " + ss.getOriginCity());
+            case LAST_MILE -> new Cause("DELIVERY", ss.getDestCity(), "Delivery · " + ss.getDestCity());
+            case ORIGIN_HUB -> new Cause("HUB", ss.getOriginCity(), "Hub · " + ss.getOriginCity());
+            case DEST_HUB -> new Cause("HUB", ss.getDestCity(), "Hub · " + ss.getDestCity());
+            // ponytail: no flight number on sla_shipment, so air legs cluster by lane, not by flight —
+            // sharpen to "AI-501 → 12 RED" once M9 flight assignment is joined onto the shipment.
+            case ORIGIN_AIRPORT, AIR, DEST_AIRPORT -> {
+                String lane = ss.getOriginCity() + "→" + ss.getDestCity();
+                yield new Cause("AIR", lane, "Airline (GHA) · " + lane);
+            }
+        };
+    }
+
+    /** The single desk to call for a whole cluster: the city hub/dispatch desk, or the national GHA for air. */
+    private SlaShipmentSummary.Handler deskFor(Cause c) {
+        return "AIR".equals(c.stage())
+                ? toHandler(stageContactPort.ghaDesk())
+                : toHandler(stageContactPort.hubDesk(c.scope()));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SlaClusterResponse clusters(String cityScope) {
+        // The actionable set: open parcels that are actually at risk (not GREEN) — a healthy parcel is no fire.
+        Map<Cause, List<SlaShipment>> grouped = shipmentRepo.findByClosedAtIsNull().stream()
+                .filter(ss -> visible(ss, cityScope))
+                .filter(ss -> ss.getOverallState() != SlaState.GREEN)
+                .collect(Collectors.groupingBy(SlaQueryServiceImpl::causeOf));
+
+        List<SlaClusterResponse.Cluster> clusters = grouped.entrySet().stream()
+                .map(e -> {
+                    Cause c = e.getKey();
+                    List<SlaShipment> members = e.getValue().stream()
+                            .sorted(Comparator.comparingDouble(SlaShipment::getPriorityScore).reversed())
+                            .toList();
+                    PriorityBand band = members.stream()
+                            .map(SlaShipment::getBand).filter(java.util.Objects::nonNull)
+                            .max(Comparator.comparingInt(PriorityBand::rank)).orElse(PriorityBand.WATCH);
+                    int breached = (int) members.stream().filter(SlaShipment::isBreached).count();
+                    Instant earliestActBy = members.stream()
+                            .map(SlaShipment::getActByAt).filter(java.util.Objects::nonNull)
+                            .min(Comparator.naturalOrder()).orElse(null);
+                    List<String> refs = members.stream().map(SlaShipment::getShipmentRef).limit(50).toList();
+                    return new SlaClusterResponse.Cluster(c.stage(), c.scope(), c.label(), band,
+                            members.size(), breached, earliestActBy, refs, deskFor(c));
+                })
+                // Worst band first (never a band-jump), then bigger cluster, then soonest deadline.
+                .sorted(Comparator.comparingInt((SlaClusterResponse.Cluster cl) -> cl.band().rank()).reversed()
+                        .thenComparing(Comparator.comparingInt(SlaClusterResponse.Cluster::size).reversed())
+                        .thenComparing(cl -> cl.earliestActBy() == null ? Instant.MAX : cl.earliestActBy()))
+                .toList();
+        return new SlaClusterResponse(clusters);
     }
 
     @Override

--- a/sla/src/main/java/com/oneday/sla/service/impl/SlaQueryServiceImpl.java
+++ b/sla/src/main/java/com/oneday/sla/service/impl/SlaQueryServiceImpl.java
@@ -1,8 +1,10 @@
 package com.oneday.sla.service.impl;
 
+import com.oneday.common.domain.enums.SlaLegType;
 import com.oneday.common.domain.enums.SlaState;
 import com.oneday.common.port.CourierOnShipmentPort;
 import com.oneday.common.port.ShipmentContactPort;
+import com.oneday.common.port.StageContactPort;
 import com.oneday.sla.domain.SlaAction;
 import com.oneday.sla.domain.SlaActionType;
 import com.oneday.sla.domain.SlaEscalation;
@@ -43,20 +45,46 @@ public class SlaQueryServiceImpl implements SlaQueryService {
     private final SlaEscalationRepository escalationRepo;
     private final SlaActionRepository actionRepo;
     private final CourierOnShipmentPort courierPort;
+    private final StageContactPort stageContactPort;
     private final ShipmentContactPort contactPort;
     private final WeatherService weatherService;
 
     public SlaQueryServiceImpl(SlaShipmentRepository shipmentRepo, SlaLegRepository legRepo,
                                SlaEscalationRepository escalationRepo, SlaActionRepository actionRepo,
-                               CourierOnShipmentPort courierPort, ShipmentContactPort contactPort,
-                               WeatherService weatherService) {
+                               CourierOnShipmentPort courierPort, StageContactPort stageContactPort,
+                               ShipmentContactPort contactPort, WeatherService weatherService) {
         this.shipmentRepo = shipmentRepo;
         this.legRepo = legRepo;
         this.escalationRepo = escalationRepo;
         this.actionRepo = actionRepo;
         this.courierPort = courierPort;
+        this.stageContactPort = stageContactPort;
         this.contactPort = contactPort;
         this.weatherService = weatherService;
+    }
+
+    /**
+     * Who to call for a parcel, by the stage it's in: the DA on the first/last mile, the hub desk while
+     * it sits in a hub, the GHA desk while it moves through the airline. Empty when nothing resolves
+     * (e.g. no DA assigned yet) — the row then falls back to the customer contact.
+     */
+    private SlaShipmentSummary.Handler handlerFor(SlaShipment ss) {
+        SlaLegType leg = ss.getCurrentLeg();
+        if (leg == null) {
+            return null;
+        }
+        return switch (leg) {
+            case FIRST_MILE, LAST_MILE -> courierPort.forShipment(ss.getShipmentId())
+                    .map(c -> new SlaShipmentSummary.Handler(c.name(), c.phone(), c.role().name()))
+                    .orElse(null);
+            case ORIGIN_HUB -> toHandler(stageContactPort.hubDesk(ss.getOriginCity()));
+            case DEST_HUB -> toHandler(stageContactPort.hubDesk(ss.getDestCity()));
+            case ORIGIN_AIRPORT, AIR, DEST_AIRPORT -> toHandler(stageContactPort.ghaDesk());
+        };
+    }
+
+    private static SlaShipmentSummary.Handler toHandler(java.util.Optional<StageContactPort.Contact> c) {
+        return c.map(x -> new SlaShipmentSummary.Handler(x.name(), x.phone(), x.role())).orElse(null);
     }
 
     /** True when this parcel is on a ground leg heading into a currently-adverse city. */
@@ -79,7 +107,7 @@ public class SlaQueryServiceImpl implements SlaQueryService {
         List<SlaShipmentSummary> items = result.getContent().stream()
                 .map(ss -> SlaShipmentSummary.from(
                         ss,
-                        courierPort.forShipment(ss.getShipmentId()).orElse(null),
+                        handlerFor(ss),
                         contacts.get(ss.getShipmentId()),
                         weatherExposed(ss, adverse)))
                 .toList();
@@ -99,7 +127,7 @@ public class SlaQueryServiceImpl implements SlaQueryService {
                 .map(this::toEscalationView).toList();
         SlaShipmentSummary summary = SlaShipmentSummary.from(
                 ss,
-                courierPort.forShipment(ss.getShipmentId()).orElse(null),
+                handlerFor(ss),
                 contactPort.contactsFor(List.of(ss.getShipmentId())).get(ss.getShipmentId()),
                 weatherExposed(ss, weatherService.adverseCities()));
         return new SlaShipmentDetailResponse(summary, legs, escalations);

--- a/sla/src/main/resources/db/migration/sla/V10_4__sla_ack_decay.sql
+++ b/sla/src/main/resources/db/migration/sla/V10_4__sla_ack_decay.sql
@@ -1,0 +1,7 @@
+-- M10 anti-fatigue (R4): when a manager acknowledges a fire, stamp it here so the priority scorer can
+-- sink the parcel within its band for a cooldown — the queue keeps surfacing NEW fires, not the ones
+-- already being worked. A worsening after the ack invalidates it (the scorer checks entered_state_at),
+-- so a re-escalation resurfaces on its own.
+ALTER TABLE sla_shipment
+    ADD COLUMN acknowledged_at TIMESTAMPTZ,
+    ADD COLUMN acknowledged_by VARCHAR(64);

--- a/sla/src/test/java/com/oneday/sla/service/PriorityScorerTest.java
+++ b/sla/src/test/java/com/oneday/sla/service/PriorityScorerTest.java
@@ -140,6 +140,32 @@ class PriorityScorerTest {
     }
 
     @Test
+    void acknowledgedParcelSinksWithinBandButNeverBelowIt() {
+        SlaShipment worked = ship(SlaState.BREACHED, true, SlaLegType.DEST_HUB, minus(60), now, null);
+        worked.setEnteredStateAt(minus(45));
+        worked.setAcknowledgedAt(minus(2));      // a manager just acked — cooldown live, not since re-escalated
+        SlaShipment fresh = ship(SlaState.BREACHED, true, SlaLegType.DEST_HUB, minus(60), now, null);
+        fresh.setEnteredStateAt(minus(45));      // same state, nobody's on it
+
+        var w = scorer.score(worked, legDue(minus(5)), now);
+        var f = scorer.score(fresh, legDue(minus(5)), now);
+        assertThat(w.acknowledged()).isTrue();
+        assertThat(f.acknowledged()).isFalse();
+        assertThat(w.band()).isEqualTo(PriorityBand.CRITICAL);     // an acked breach is still CRITICAL
+        assertThat(w.score()).isLessThan(f.score());               // but drops below its un-worked peer
+        assertThat(w.score()).isGreaterThan(PriorityBand.HIGH.rank() * 1_000_000_000d); // never a band-jump down
+    }
+
+    @Test
+    void aReEscalationAfterTheAckResurfacesTheParcel() {
+        SlaShipment reescalated = ship(SlaState.BREACHED, true, SlaLegType.DEST_HUB, minus(60), now, null);
+        reescalated.setAcknowledgedAt(minus(10));
+        reescalated.setEnteredStateAt(minus(2));   // worsened AFTER the ack → the ack no longer covers it
+        var r = scorer.score(reescalated, legDue(minus(5)), now);
+        assertThat(r.acknowledged()).isFalse();    // resurfaces — the decay is gone
+    }
+
+    @Test
     void weatherOnlyExposesGroundLegsHeadingIntoTheAdverseCity() {
         // In the air → not exposed (can't act, and dest weather isn't the parcel's ground risk yet).
         SlaShipment inAir = ship(SlaState.GREEN, false, SlaLegType.AIR, plus(600), plus(120), null);

--- a/sla/src/test/java/com/oneday/sla/service/impl/SlaClusterTest.java
+++ b/sla/src/test/java/com/oneday/sla/service/impl/SlaClusterTest.java
@@ -61,13 +61,14 @@ class SlaClusterTest {
                 // Three hub parcels in BLR, all HIGH → one bigger HIGH cluster.
                 ship("H1", "BLR", "MAA", SlaLegType.ORIGIN_HUB, SlaState.RED, PriorityBand.HIGH, false, 2_000_020),
                 ship("H2", "BLR", "HYD", SlaLegType.ORIGIN_HUB, SlaState.RED, PriorityBand.HIGH, false, 2_000_010),
-                ship("H3", "BLR", "HYD", SlaLegType.ORIGIN_HUB, SlaState.AMBER, PriorityBand.WATCH, false, 1_000_000),
-                // A healthy parcel must never appear.
-                ship("G1", "BLR", "DEL", SlaLegType.LAST_MILE, SlaState.GREEN, PriorityBand.WATCH, false, 500)));
+                ship("H3", "BLR", "HYD", SlaLegType.ORIGIN_HUB, SlaState.GREEN, PriorityBand.HIGH, false, 2_000_005),
+                // A WATCH-band parcel is no fire — even AMBER — and must never appear.
+                ship("W1", "BLR", "DEL", SlaLegType.LAST_MILE, SlaState.AMBER, PriorityBand.WATCH, false, 1_000_000)));
 
         List<SlaClusterResponse.Cluster> clusters = svc.clusters(null).clusters();
 
-        // Two clusters (AIR lane + BLR hub); the GREEN parcel is excluded.
+        // Two clusters (AIR lane + BLR hub); the WATCH-band parcel is excluded. H3 is colour-GREEN but
+        // HIGH band (racing a cutoff) and still clusters — the fire cut is the band, not the colour.
         assertThat(clusters).hasSize(2);
 
         // Worst band first: the AIR cluster carries a CRITICAL member, so it tops the all-HIGH hub cluster.

--- a/sla/src/test/java/com/oneday/sla/service/impl/SlaClusterTest.java
+++ b/sla/src/test/java/com/oneday/sla/service/impl/SlaClusterTest.java
@@ -1,0 +1,89 @@
+package com.oneday.sla.service.impl;
+
+import com.oneday.common.domain.enums.SlaLegType;
+import com.oneday.common.domain.enums.SlaState;
+import com.oneday.common.port.CourierOnShipmentPort;
+import com.oneday.common.port.ShipmentContactPort;
+import com.oneday.common.port.StageContactPort;
+import com.oneday.sla.domain.PriorityBand;
+import com.oneday.sla.domain.SlaShipment;
+import com.oneday.sla.dto.SlaClusterResponse;
+import com.oneday.sla.repository.SlaActionRepository;
+import com.oneday.sla.repository.SlaEscalationRepository;
+import com.oneday.sla.repository.SlaLegRepository;
+import com.oneday.sla.repository.SlaShipmentRepository;
+import com.oneday.sla.service.WeatherService;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Clustering invariants: shared cause groups together, worst band floats up, one desk per cluster. */
+class SlaClusterTest {
+
+    private final SlaShipmentRepository shipmentRepo = mock(SlaShipmentRepository.class);
+    private final StageContactPort stageContactPort = mock(StageContactPort.class);
+    private final SlaQueryServiceImpl svc = new SlaQueryServiceImpl(
+            shipmentRepo, mock(SlaLegRepository.class), mock(SlaEscalationRepository.class),
+            mock(SlaActionRepository.class), mock(CourierOnShipmentPort.class), stageContactPort,
+            mock(ShipmentContactPort.class), mock(WeatherService.class));
+
+    private SlaShipment ship(String ref, String origin, String dest, SlaLegType leg,
+                             SlaState state, PriorityBand band, boolean breached, double score) {
+        SlaShipment s = new SlaShipment();
+        s.setShipmentRef(ref);
+        s.setOriginCity(origin);
+        s.setDestCity(dest);
+        s.setCurrentLeg(leg);
+        s.setOverallState(state);
+        s.setBand(band);
+        s.setBreached(breached);
+        s.setPriorityScore(score);
+        return s;
+    }
+
+    @Test
+    void groupsByCauseRanksWorstBandFirstAndResolvesOneDesk() {
+        when(stageContactPort.hubDesk(any())).thenReturn(
+                Optional.of(new StageContactPort.Contact("BLR Hub Desk", "+91900000001", "HUB_OPERATOR")));
+        when(stageContactPort.ghaDesk()).thenReturn(
+                Optional.of(new StageContactPort.Contact("GHA Desk", "+91900000002", "AIRLINE_GHA")));
+
+        when(shipmentRepo.findByClosedAtIsNull()).thenReturn(List.of(
+                // Two air parcels on the same lane → one AIR/BLR→DEL cluster, one of them CRITICAL.
+                ship("A1", "BLR", "DEL", SlaLegType.AIR, SlaState.BREACHED, PriorityBand.CRITICAL, true, 3_000_100),
+                ship("A2", "BLR", "DEL", SlaLegType.DEST_AIRPORT, SlaState.RED, PriorityBand.HIGH, false, 2_000_050),
+                // Three hub parcels in BLR, all HIGH → one bigger HIGH cluster.
+                ship("H1", "BLR", "MAA", SlaLegType.ORIGIN_HUB, SlaState.RED, PriorityBand.HIGH, false, 2_000_020),
+                ship("H2", "BLR", "HYD", SlaLegType.ORIGIN_HUB, SlaState.RED, PriorityBand.HIGH, false, 2_000_010),
+                ship("H3", "BLR", "HYD", SlaLegType.ORIGIN_HUB, SlaState.AMBER, PriorityBand.WATCH, false, 1_000_000),
+                // A healthy parcel must never appear.
+                ship("G1", "BLR", "DEL", SlaLegType.LAST_MILE, SlaState.GREEN, PriorityBand.WATCH, false, 500)));
+
+        List<SlaClusterResponse.Cluster> clusters = svc.clusters(null).clusters();
+
+        // Two clusters (AIR lane + BLR hub); the GREEN parcel is excluded.
+        assertThat(clusters).hasSize(2);
+
+        // Worst band first: the AIR cluster carries a CRITICAL member, so it tops the all-HIGH hub cluster.
+        SlaClusterResponse.Cluster air = clusters.get(0);
+        assertThat(air.stage()).isEqualTo("AIR");
+        assertThat(air.scope()).isEqualTo("BLR→DEL");
+        assertThat(air.band()).isEqualTo(PriorityBand.CRITICAL);
+        assertThat(air.size()).isEqualTo(2);
+        assertThat(air.breachedCount()).isEqualTo(1);
+        assertThat(air.contact().role()).isEqualTo("AIRLINE_GHA");
+        assertThat(air.refs()).containsExactly("A1", "A2"); // worst score first
+
+        SlaClusterResponse.Cluster hub = clusters.get(1);
+        assertThat(hub.stage()).isEqualTo("HUB");
+        assertThat(hub.band()).isEqualTo(PriorityBand.HIGH);
+        assertThat(hub.size()).isEqualTo(3);
+        assertThat(hub.contact().role()).isEqualTo("HUB_OPERATOR");
+    }
+}


### PR DESCRIPTION
Three related pieces of the SLA control-tower triage model, each its own commit.

## 1. Rescued P2b — who-to-call beyond the DA
Current leg resolves the right desk end-to-end: FIRST/LAST mile → DA, ORIGIN/DEST hub → hub desk (city), airport/air → GHA desk. New `StageContactPort` (common) + auth adapter over `users` (role + city_id). No schema change. *(Written earlier but stranded off-main; the foundation the two features below reuse.)*

## 2. Cause-grouping — the scale lever
`GET /api/v1/sla/clusters` collapses the at-risk queue into shared-cause clusters so 200 cards become ~10 calls:
- Groups open **non-GREEN** parcels by `(stage, scope)` — PICKUP/DELIVERY/HUB by city, AIR by lane.
- Per cluster: **band = worst member**, breached count, **soonest act-by**, member refs (worst-first), the **one desk to call**.
- Ranked **worst-band-first** (never a band-jump), then **size** (12 > 1), then soonest act-by.
- `ponytail:` air clusters by lane not flight (no flight id on `sla_shipment` yet).

## 3. Ack/snooze decay — anti-fatigue (R4)
A manager who acks a fire shouldn't keep seeing it top the queue. On ack/resolve, stamp `acknowledged_at/by`; the scorer sinks the parcel **within its band** (never below — an acked breach is still a breach) over a 30m cooldown. A worsening after the ack invalidates it, so a real re-escalation resurfaces. **V10_4** migration. Reachable today via the existing Acknowledge buttons.

## Tests
`SlaClusterTest` (grouping/ranking) + `PriorityScorerTest` +2 (ack sinks-within-band, re-escalation resurfaces). Full sla suite green (24). App assembles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an SLA risk-clusters view grouping at-risk shipments by operational cause.
  * Cluster results include priority, breach counts, deadlines, shipment references, and responsible contacts.
  * Added city-scoped hub and airline contact resolution with role-based fallback.
  * Enhanced shipment summaries with handler and acknowledgment details.
  * Added SLA acknowledgment tracking with temporary priority reduction and automatic re-escalation.
* **Tests**
  * Added coverage for clustering, prioritization, filtering, aggregation, contact resolution, and acknowledgment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->