### PR TITLE
feat(exceptions): M11 problem-solve / RTO engine (P1+P2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ graphify-out/
 
 # Strix pentest run artifacts (may contain creds/logs)
 strix_runs/
+.env.bak*

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -195,3 +195,7 @@ sla:
     DEST_AIRPORT: 90       # landing → unload/break/sort/release
     DEST_HUB: 60           # dest hub processing
     LAST_MILE: 150         # hub out-scan → delivered   (Σ = 810m = 13.5h)
+
+# M11 exceptions — re-attempts before a failed pickup/delivery is flagged UNDELIVERABLE (recommend RTO).
+exceptions:
+  max-reattempts: 2

--- a/exceptions/src/main/java/com/oneday/exceptions/api/Authz.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/api/Authz.java
@@ -1,0 +1,61 @@
+package com.oneday.exceptions.api;
+
+import com.oneday.auth.security.AuthUserDetails;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Auth helpers for the M11 exceptions endpoints. Identity + role come from the M1 JWT principal.
+ * Mirrors {@code sla.api.Authz}.
+ */
+final class Authz {
+
+    static final String ADMIN = "ADMIN";
+    static final String STATION_MANAGER = "STATION_MANAGER";
+    static final String SUPERVISOR = "SUPERVISOR";
+    static final String CALL_CENTER_AGENT = "CALL_CENTER_AGENT";
+
+    private Authz() {}
+
+    static String requireUserId(AuthUserDetails principal) {
+        if (principal == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authentication required");
+        }
+        return principal.getUserId().toString();
+    }
+
+    static String role(AuthUserDetails principal) {
+        if (principal == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authentication required");
+        }
+        return principal.getUser().getRole().getName();
+    }
+
+    /** Authorize against {@code allowedRoles}; ADMIN is always allowed. */
+    static void requireRole(AuthUserDetails principal, String... allowedRoles) {
+        String role = role(principal);
+        if (ADMIN.equals(role)) {
+            return;
+        }
+        for (String allowed : allowedRoles) {
+            if (allowed.equals(role)) {
+                return;
+            }
+        }
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                "Role " + role + " is not permitted to view exceptions");
+    }
+
+    /** The city an ops query is scoped to: {@code null} for ADMIN, else the user's own city (403 if none). */
+    static String cityScope(AuthUserDetails principal) {
+        String role = role(principal);
+        if (ADMIN.equals(role)) {
+            return null;
+        }
+        String city = principal.getUser().getCityId();
+        if (city == null || city.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "No city assigned to this user");
+        }
+        return city;
+    }
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/api/ExceptionController.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/api/ExceptionController.java
@@ -1,0 +1,76 @@
+package com.oneday.exceptions.api;
+
+import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.exceptions.domain.ExceptionType;
+import com.oneday.exceptions.dto.ExceptionCaseDetail;
+import com.oneday.exceptions.dto.ExceptionQueueResponse;
+import com.oneday.exceptions.dto.ExceptionSummaryResponse;
+import com.oneday.exceptions.dto.ResolveRequest;
+import com.oneday.exceptions.service.ExceptionCaseService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+/**
+ * The M11 exceptions / problem-solve console for STATION_MANAGER (own city) and ADMIN (all cities).
+ * Reads are role-gated + city-scoped like the SLA control tower; the resolve action additionally admits
+ * the CALL_CENTER_AGENT.
+ */
+@RestController
+@RequestMapping("/api/v1/exceptions")
+public class ExceptionController {
+
+    private final ExceptionCaseService service;
+
+    public ExceptionController(ExceptionCaseService service) {
+        this.service = service;
+    }
+
+    /** The problem-solve queue: live cases, city-scoped, optional type filter, freshest first. */
+    @GetMapping("/queue")
+    public ExceptionQueueResponse queue(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @RequestParam(required = false) ExceptionType type,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "50") int size) {
+        Authz.requireRole(principal, Authz.STATION_MANAGER, Authz.SUPERVISOR);
+        return service.queue(Authz.cityScope(principal), type, page, size);
+    }
+
+    /** Disposition rollups over the live queue — the header cards. */
+    @GetMapping("/summary")
+    public ExceptionSummaryResponse summary(@AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireRole(principal, Authz.STATION_MANAGER, Authz.SUPERVISOR);
+        return service.summary(Authz.cityScope(principal));
+    }
+
+    /** One case + its append-only action history. */
+    @GetMapping("/{id}")
+    public ExceptionCaseDetail detail(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @PathVariable UUID id) {
+        Authz.requireRole(principal, Authz.STATION_MANAGER, Authz.SUPERVISOR);
+        return service.detail(id, Authz.cityScope(principal));
+    }
+
+    /** Take a problem-solve action (reschedule / RTO / resolve) — drives M4 + records the action. */
+    @PostMapping("/{id}/resolve")
+    public ResponseEntity<Void> resolve(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @PathVariable UUID id,
+            @Valid @RequestBody ResolveRequest body) {
+        Authz.requireRole(principal, Authz.STATION_MANAGER, Authz.SUPERVISOR, Authz.CALL_CENTER_AGENT);
+        service.resolve(id, body.action(), Authz.cityScope(principal),
+                Authz.requireUserId(principal), Authz.role(principal), body.notes());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/config/ExceptionProperties.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/config/ExceptionProperties.java
@@ -1,0 +1,33 @@
+package com.oneday.exceptions.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * M11 tuning knobs. Lives in the <b>app</b>'s {@code application.yml} (the runtime source of truth),
+ * picked up by the app component-scan — same pattern as {@code SlaProperties}.
+ *
+ * <pre>{@code
+ * exceptions:
+ *   max-reattempts: 2
+ * }</pre>
+ */
+@Component
+@ConfigurationProperties(prefix = "exceptions")
+public class ExceptionProperties {
+
+    /**
+     * How many re-attempts a failed pickup/delivery gets before the case is flagged UNDELIVERABLE and
+     * RTO is recommended (so {@code maxReattempts + 1} total attempts). ponytail: global for v1;
+     * per-lane/category is a later refinement (PRD F1).
+     */
+    private int maxReattempts = 2;
+
+    public int maxReattempts() {
+        return maxReattempts;
+    }
+
+    public void setMaxReattempts(int maxReattempts) {
+        this.maxReattempts = maxReattempts;
+    }
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/domain/Disposition.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/domain/Disposition.java
@@ -1,0 +1,13 @@
+package com.oneday.exceptions.domain;
+
+/** The outcome axis the ops rollups group by — "how is this parcel going to end up?" */
+public enum Disposition {
+    /** Still worth another attempt (under the attempt cap). */
+    REATTEMPTABLE,
+    /** Attempt cap hit — recommend RTO. */
+    UNDELIVERABLE,
+    /** RTO in flight or done. */
+    RETURNED,
+    /** Case closed successfully. */
+    RESOLVED
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/domain/ExceptionAction.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/domain/ExceptionAction.java
@@ -1,0 +1,35 @@
+package com.oneday.exceptions.domain;
+
+import com.oneday.common.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+/** Append-only audit of every action taken on a case — who did what, when. Never mutated. */
+@Entity
+@Table(name = "exception_action")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ExceptionAction extends BaseEntity {
+
+    @Column(name = "case_id", nullable = false)
+    private UUID caseId;
+
+    @Column(name = "action", nullable = false)
+    private String action;
+
+    @Column(name = "acted_by")
+    private String actedBy;
+
+    @Column(name = "acted_by_role")
+    private String actedByRole;
+
+    @Column(name = "notes")
+    private String notes;
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/domain/ExceptionCase.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/domain/ExceptionCase.java
@@ -1,0 +1,81 @@
+package com.oneday.exceptions.domain;
+
+import com.oneday.common.domain.MutableBaseEntity;
+import com.oneday.common.domain.enums.DeliveryType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/** One live problem-solve case for a shipment: what failed, why, how many attempts, and where it's headed. */
+@Entity
+@Table(name = "exception_case")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ExceptionCase extends MutableBaseEntity {
+
+    @Column(name = "shipment_id", nullable = false)
+    private UUID shipmentId;
+
+    @Column(name = "shipment_ref")
+    private String shipmentRef;
+
+    @Column(name = "origin_city")
+    private String originCity;
+
+    @Column(name = "dest_city")
+    private String destCity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "delivery_type")
+    private DeliveryType deliveryType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private ExceptionType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reason_code", nullable = false)
+    private ExceptionReason reasonCode = ExceptionReason.UNKNOWN;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private ExceptionStatus status = ExceptionStatus.OPEN;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "disposition", nullable = false)
+    private Disposition disposition = Disposition.REATTEMPTABLE;
+
+    @Column(name = "attempt_no", nullable = false)
+    private int attemptNo = 1;
+
+    @Column(name = "da_attributable", nullable = false)
+    private boolean daAttributable;
+
+    @Column(name = "assigned_to")
+    private String assignedTo;
+
+    @Column(name = "assigned_role")
+    private String assignedRole;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "resolution")
+    private ResolveAction resolution;
+
+    @Column(name = "notes")
+    private String notes;
+
+    @Column(name = "opened_at", nullable = false)
+    private Instant openedAt = Instant.now();
+
+    @Column(name = "resolved_at")
+    private Instant resolvedAt;
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/domain/ExceptionReason.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/domain/ExceptionReason.java
@@ -17,7 +17,7 @@ public enum ExceptionReason {
     OTHER,
     UNKNOWN;
 
-    /** Best-effort map of M5's free-text reason string onto the taxonomy. Null/unrecognised → UNKNOWN. */
+    /** Best-effort map of M5's free-text reason string onto the taxonomy. Null/blank → UNKNOWN; unrecognised → OTHER. */
     public static ExceptionReason fromCode(String code) {
         if (code == null || code.isBlank()) {
             return UNKNOWN;

--- a/exceptions/src/main/java/com/oneday/exceptions/domain/ExceptionReason.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/domain/ExceptionReason.java
@@ -1,0 +1,42 @@
+package com.oneday.exceptions.domain;
+
+/**
+ * The failure reason taxonomy. M5 sends a free-text {@code reasonCode} string on the DA event; we map
+ * it best-effort onto this enum (unknown → {@link #OTHER}), turning "failures are free-text" into a
+ * reportable dimension. Extend as the ops vocabulary grows.
+ */
+public enum ExceptionReason {
+    CUSTOMER_UNAVAILABLE,
+    ADDRESS_INCORRECT,
+    CUSTOMER_REFUSED,
+    COD_NOT_READY,
+    DA_NO_SHOW,
+    CRON_MISSED,
+    FLIGHT_MISSED,
+    PARCEL_DAMAGED,
+    OTHER,
+    UNKNOWN;
+
+    /** Best-effort map of M5's free-text reason string onto the taxonomy. Null/unrecognised → UNKNOWN. */
+    public static ExceptionReason fromCode(String code) {
+        if (code == null || code.isBlank()) {
+            return UNKNOWN;
+        }
+        String c = code.trim().toUpperCase();
+        for (ExceptionReason r : values()) {
+            if (r.name().equals(c)) {
+                return r;
+            }
+        }
+        // A few known aliases from the M5 vocabulary.
+        return switch (c) {
+            case "PICKUP_FAILED", "DROP_FAILED", "DELIVERY_FAILED" -> OTHER; // a bare failure, no reason given
+            case "NOT_AVAILABLE", "CUSTOMER_NOT_AVAILABLE", "NO_ONE_HOME" -> CUSTOMER_UNAVAILABLE;
+            case "WRONG_ADDRESS", "BAD_ADDRESS", "ADDRESS_NOT_FOUND" -> ADDRESS_INCORRECT;
+            case "REFUSED", "REJECTED" -> CUSTOMER_REFUSED;
+            case "COD_NOT_PAID", "NO_CASH" -> COD_NOT_READY;
+            case "DAMAGED", "DAMAGE" -> PARCEL_DAMAGED;
+            default -> OTHER;
+        };
+    }
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/domain/ExceptionStatus.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/domain/ExceptionStatus.java
@@ -1,0 +1,11 @@
+package com.oneday.exceptions.domain;
+
+/** Where a case is in the problem-solve workflow. Terminal: RESOLVED, CANCELLED. */
+public enum ExceptionStatus {
+    OPEN,
+    IN_PROGRESS,
+    RESCHEDULED,
+    RTO,
+    RESOLVED,
+    CANCELLED
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/domain/ExceptionType.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/domain/ExceptionType.java
@@ -1,0 +1,9 @@
+package com.oneday.exceptions.domain;
+
+/** What kind of failure opened the case — drives which resolve actions apply. */
+public enum ExceptionType {
+    PICKUP_FAILED,
+    DELIVERY_FAILED,
+    CRON_MISSED,
+    FLIGHT_MISSED
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/domain/ResolveAction.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/domain/ResolveAction.java
@@ -1,0 +1,28 @@
+package com.oneday.exceptions.domain;
+
+import com.oneday.common.kafka.enums.ExceptionsEventType;
+
+/**
+ * A problem-solve action a manager/agent takes on a case. Most actions drive M4 by publishing the
+ * matching {@link ExceptionsEventType} to {@code oneday.exceptions.events} — the orders consumer
+ * already turns each into a state transition (reschedule = re-assign; RTO = the return path).
+ */
+public enum ResolveAction {
+    RESCHEDULE_PICKUP(ExceptionsEventType.PICKUP_RESCHEDULED),
+    RESCHEDULE_DELIVERY(ExceptionsEventType.DELIVERY_RESCHEDULED),
+    INITIATE_RTO(ExceptionsEventType.RTO_INITIATED),
+    COMPLETE_RTO(ExceptionsEventType.RTO_COMPLETED),
+    /** Close the case without moving the shipment — the issue was handled offline. */
+    MARK_RESOLVED(null);
+
+    private final ExceptionsEventType event;
+
+    ResolveAction(ExceptionsEventType event) {
+        this.event = event;
+    }
+
+    /** The M4-driving event to publish, or null when the action only closes the case. */
+    public ExceptionsEventType event() {
+        return event;
+    }
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/dto/ExceptionActionView.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/dto/ExceptionActionView.java
@@ -1,0 +1,13 @@
+package com.oneday.exceptions.dto;
+
+import com.oneday.exceptions.domain.ExceptionAction;
+
+import java.time.Instant;
+
+/** One entry in a case's action history. */
+public record ExceptionActionView(String action, String actedBy, String actedByRole, String notes, Instant at) {
+
+    public static ExceptionActionView from(ExceptionAction a) {
+        return new ExceptionActionView(a.getAction(), a.getActedBy(), a.getActedByRole(), a.getNotes(), a.getCreatedAt());
+    }
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/dto/ExceptionCaseDetail.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/dto/ExceptionCaseDetail.java
@@ -1,7 +1,21 @@
 package com.oneday.exceptions.dto;
 
+import com.oneday.orders.dto.JourneyStep;
+
 import java.util.List;
 
-/** A case plus its append-only action history. */
-public record ExceptionCaseDetail(ExceptionCaseSummary caseSummary, List<ExceptionActionView> actions) {
+/**
+ * A case plus the full picture the manager needs to act: the M11 action log, the shipment's whole
+ * internal journey (every step, timestamped, with actor + source), and the people to call at the
+ * failed stage — the current handler (DA) and the receiving customer.
+ */
+public record ExceptionCaseDetail(
+        ExceptionCaseSummary caseSummary,
+        List<ExceptionActionView> actions,
+        List<JourneyStep> journey,
+        Contact handler,
+        Contact receiver) {
+
+    /** A callable person: name + phone (+ role for the handler). */
+    public record Contact(String name, String phone, String role) {}
 }

--- a/exceptions/src/main/java/com/oneday/exceptions/dto/ExceptionCaseDetail.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/dto/ExceptionCaseDetail.java
@@ -1,0 +1,7 @@
+package com.oneday.exceptions.dto;
+
+import java.util.List;
+
+/** A case plus its append-only action history. */
+public record ExceptionCaseDetail(ExceptionCaseSummary caseSummary, List<ExceptionActionView> actions) {
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/dto/ExceptionCaseSummary.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/dto/ExceptionCaseSummary.java
@@ -1,0 +1,36 @@
+package com.oneday.exceptions.dto;
+
+import com.oneday.common.domain.enums.DeliveryType;
+import com.oneday.exceptions.domain.Disposition;
+import com.oneday.exceptions.domain.ExceptionCase;
+import com.oneday.exceptions.domain.ExceptionReason;
+import com.oneday.exceptions.domain.ExceptionStatus;
+import com.oneday.exceptions.domain.ExceptionType;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/** One row of the problem-solve queue. */
+public record ExceptionCaseSummary(
+        UUID id,
+        UUID shipmentId,
+        String shipmentRef,
+        String originCity,
+        String destCity,
+        DeliveryType deliveryType,
+        ExceptionType type,
+        ExceptionReason reasonCode,
+        ExceptionStatus status,
+        Disposition disposition,
+        int attemptNo,
+        boolean daAttributable,
+        String assignedTo,
+        Instant openedAt) {
+
+    public static ExceptionCaseSummary from(ExceptionCase c) {
+        return new ExceptionCaseSummary(
+                c.getId(), c.getShipmentId(), c.getShipmentRef(), c.getOriginCity(), c.getDestCity(),
+                c.getDeliveryType(), c.getType(), c.getReasonCode(), c.getStatus(), c.getDisposition(),
+                c.getAttemptNo(), c.isDaAttributable(), c.getAssignedTo(), c.getOpenedAt());
+    }
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/dto/ExceptionQueueResponse.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/dto/ExceptionQueueResponse.java
@@ -1,0 +1,7 @@
+package com.oneday.exceptions.dto;
+
+import java.util.List;
+
+/** A page of the problem-solve queue. */
+public record ExceptionQueueResponse(int page, int size, long total, List<ExceptionCaseSummary> items) {
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/dto/ExceptionSummaryResponse.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/dto/ExceptionSummaryResponse.java
@@ -1,0 +1,9 @@
+package com.oneday.exceptions.dto;
+
+/** Disposition rollups over the live queue — the header cards on the station Exceptions page. */
+public record ExceptionSummaryResponse(
+        long open,
+        long reattemptable,
+        long undeliverable,
+        long returned) {
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/dto/ResolveRequest.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/dto/ResolveRequest.java
@@ -1,0 +1,8 @@
+package com.oneday.exceptions.dto;
+
+import com.oneday.exceptions.domain.ResolveAction;
+import jakarta.validation.constraints.NotNull;
+
+/** The problem-solve action a manager/agent takes on a case, with optional free-text notes. */
+public record ResolveRequest(@NotNull ResolveAction action, String notes) {
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/events/ExceptionDaEventsConsumer.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/events/ExceptionDaEventsConsumer.java
@@ -1,0 +1,44 @@
+package com.oneday.exceptions.events;
+
+import com.oneday.common.kafka.events.DaLifecycleEvent;
+import com.oneday.exceptions.domain.ExceptionReason;
+import com.oneday.exceptions.domain.ExceptionType;
+import com.oneday.exceptions.service.ExceptionCaseService;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Consumes M5's {@code oneday.da.events} — the authoritative failure signal, carrying the free-text
+ * {@code reasonCode} M4 drops. A DROP/PICKUP failure opens (or bumps the attempt on) a case; a cron miss
+ * opens one too when it's shipment-scoped. This is the single opener/attempt-counter, so one failure =
+ * one attempt (no double-count against the shipment-event stream).
+ */
+@Component
+public class ExceptionDaEventsConsumer {
+
+    private final ExceptionCaseService service;
+
+    public ExceptionDaEventsConsumer(ExceptionCaseService service) {
+        this.service = service;
+    }
+
+    @RabbitListener(queues = ExceptionMessagingTopology.DA_QUEUE)
+    public void onDaEvent(DaLifecycleEvent event) {
+        if (event.eventType() == null) {
+            return;
+        }
+        ExceptionReason reason = ExceptionReason.fromCode(event.reasonCode());
+        switch (event.eventType()) {
+            case DROP_FAILED -> capture(event, ExceptionType.DELIVERY_FAILED, reason);
+            case PICKUP_FAILED -> capture(event, ExceptionType.PICKUP_FAILED, reason);
+            case CRON_MISSED -> capture(event, ExceptionType.CRON_MISSED, ExceptionReason.CRON_MISSED);
+            default -> { /* not a failure signal */ }
+        }
+    }
+
+    private void capture(DaLifecycleEvent event, ExceptionType type, ExceptionReason reason) {
+        // DA-attributable when the DA is the cause: a no-show, or a missed cron.
+        boolean daAttributable = reason == ExceptionReason.DA_NO_SHOW || type == ExceptionType.CRON_MISSED;
+        service.captureDaFailure(event.shipmentId(), event.shipmentRef(), type, reason, daAttributable);
+    }
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/events/ExceptionEventProducer.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/events/ExceptionEventProducer.java
@@ -1,0 +1,28 @@
+package com.oneday.exceptions.events;
+
+import com.oneday.common.kafka.EventPublisher;
+import com.oneday.common.kafka.EventStreams;
+import com.oneday.common.kafka.enums.ExceptionsEventType;
+import com.oneday.common.kafka.events.ExceptionsEvent;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+/**
+ * Publishes M11's outbound events on {@code oneday.exceptions.events}. This is the seam that was
+ * always reserved but never driven: the orders {@code ExceptionsEventsConsumer} turns each event into
+ * a state transition (reschedule / RTO), and SLA re-evaluates on the same stream.
+ */
+@Component
+public class ExceptionEventProducer {
+
+    private final EventPublisher eventPublisher;
+
+    public ExceptionEventProducer(EventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    public void publish(UUID shipmentId, ExceptionsEventType type) {
+        eventPublisher.publish(EventStreams.EXCEPTIONS_EVENTS, new ExceptionsEvent(shipmentId, type));
+    }
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/events/ExceptionMessagingTopology.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/events/ExceptionMessagingTopology.java
@@ -1,0 +1,31 @@
+package com.oneday.exceptions.events;
+
+import com.oneday.common.kafka.EventStreams;
+import com.oneday.common.kafka.RabbitStreamSupport;
+import org.springframework.amqp.core.Declarables;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * M11's RabbitMQ topology: the {@code oneday.exceptions.events} exchange it produces to (already
+ * consumed by M4 orders + M10 SLA), plus the queues it consumes failure signals on — M4 shipment
+ * state changes and M5 DA lifecycle events (which carry the failure reason M4 drops). Each queue is
+ * {@code exceptions.<stream>} so M11 gets its own copy alongside the other modules' consumers.
+ *
+ * <p>Flight-missed capture (from M9/M10) is a later input — not wired in v1.</p>
+ */
+@Configuration
+public class ExceptionMessagingTopology {
+
+    public static final String SHIPMENTS_QUEUE = "exceptions.shipments";
+    public static final String DA_QUEUE        = "exceptions.da";
+
+    /** Exchange M11 publishes reschedule / RTO events to (→ M4 orders, M10 SLA). */
+    @Bean
+    Declarables exceptionsEventsExchange() {
+        return RabbitStreamSupport.exchange(EventStreams.EXCEPTIONS_EVENTS);
+    }
+
+    @Bean Declarables exceptionsShipmentsBinding() { return RabbitStreamSupport.consumer(SHIPMENTS_QUEUE, EventStreams.SHIPMENTS_EVENTS); }
+    @Bean Declarables exceptionsDaBinding()        { return RabbitStreamSupport.consumer(DA_QUEUE, EventStreams.DA_EVENTS); }
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/events/ExceptionShipmentEventsConsumer.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/events/ExceptionShipmentEventsConsumer.java
@@ -1,0 +1,29 @@
+package com.oneday.exceptions.events;
+
+import com.oneday.common.kafka.events.BaseShipmentEvent;
+import com.oneday.common.kafka.events.ShipmentStateChangedEvent;
+import com.oneday.exceptions.service.ExceptionCaseService;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Consumes M4's {@code oneday.shipments.events} to advance a case's lifecycle: RTO progression and a
+ * successful terminal delivery (which auto-resolves a lingering case). Pickup/delivery <em>failures</em>
+ * are opened via the DA path ({@link ExceptionDaEventsConsumer}), which carries the reason M4 drops.
+ */
+@Component
+public class ExceptionShipmentEventsConsumer {
+
+    private final ExceptionCaseService service;
+
+    public ExceptionShipmentEventsConsumer(ExceptionCaseService service) {
+        this.service = service;
+    }
+
+    @RabbitListener(queues = ExceptionMessagingTopology.SHIPMENTS_QUEUE)
+    public void onShipmentEvent(BaseShipmentEvent event) {
+        if (event instanceof ShipmentStateChangedEvent changed && changed.getToState() != null) {
+            service.onShipmentStateChanged(changed.getShipmentId(), changed.getToState());
+        }
+    }
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/repository/ExceptionActionRepository.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/repository/ExceptionActionRepository.java
@@ -1,0 +1,12 @@
+package com.oneday.exceptions.repository;
+
+import com.oneday.exceptions.domain.ExceptionAction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ExceptionActionRepository extends JpaRepository<ExceptionAction, UUID> {
+
+    List<ExceptionAction> findByCaseIdOrderByCreatedAtAsc(UUID caseId);
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/repository/ExceptionCaseRepository.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/repository/ExceptionCaseRepository.java
@@ -1,0 +1,45 @@
+package com.oneday.exceptions.repository;
+
+import com.oneday.exceptions.domain.ExceptionCase;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ExceptionCaseRepository extends JpaRepository<ExceptionCase, UUID> {
+
+    /** The one live (unresolved) case for a shipment, if any — the idempotency key for open/bump. */
+    Optional<ExceptionCase> findFirstByShipmentIdAndResolvedAtIsNull(UUID shipmentId);
+
+    /**
+     * The problem-solve queue: live cases, city-scoped (origin or dest matches), optional type filter,
+     * freshest first. {@code city == null} = admin (all cities).
+     */
+    @Query("""
+            select c from ExceptionCase c
+            where c.resolvedAt is null
+              and (:city is null or c.originCity = :city or c.destCity = :city)
+              and (:type is null or c.type = :type)
+            order by c.openedAt desc
+            """)
+    Page<ExceptionCase> queue(@Param("city") String city,
+                              @Param("type") com.oneday.exceptions.domain.ExceptionType type,
+                              Pageable pageable);
+
+    /** Disposition rollup counts over the live set for a city scope. */
+    @Query("""
+            select c.disposition, count(c) from ExceptionCase c
+            where c.resolvedAt is null
+              and (:city is null or c.originCity = :city or c.destCity = :city)
+            group by c.disposition
+            """)
+    List<Object[]> countOpenByDisposition(@Param("city") String city);
+
+    /** Convenience count for a single disposition — used by the summary card totals. */
+    long countByResolvedAtIsNull();
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/service/ExceptionCaseService.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/service/ExceptionCaseService.java
@@ -1,0 +1,38 @@
+package com.oneday.exceptions.service;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.exceptions.domain.ExceptionReason;
+import com.oneday.exceptions.domain.ExceptionType;
+import com.oneday.exceptions.domain.ResolveAction;
+import com.oneday.exceptions.dto.ExceptionCaseDetail;
+import com.oneday.exceptions.dto.ExceptionQueueResponse;
+import com.oneday.exceptions.dto.ExceptionSummaryResponse;
+
+import java.util.UUID;
+
+/**
+ * M11's read + problem-solve API. {@code cityScope == null} means admin (all cities); a non-null value
+ * restricts to a city (matched on origin or destination).
+ */
+public interface ExceptionCaseService {
+
+    /**
+     * Open (or bump the attempt on) a case from a DA-reported failure — the authoritative failure signal,
+     * which carries the reason M4 drops. Idempotent per live case: a repeat failure increments the attempt.
+     */
+    void captureDaFailure(UUID shipmentId, String shipmentRef, ExceptionType type,
+                          ExceptionReason reason, boolean daAttributable);
+
+    /** React to a shipment state change: RTO progression closes/advances the case; a successful terminal
+     *  delivery auto-resolves any live case. (Pickup/delivery failures are owned by {@link #captureDaFailure}.) */
+    void onShipmentStateChanged(UUID shipmentId, ShipmentState toState);
+
+    ExceptionQueueResponse queue(String cityScope, ExceptionType type, int page, int size);
+
+    ExceptionSummaryResponse summary(String cityScope);
+
+    ExceptionCaseDetail detail(UUID caseId, String cityScope);
+
+    /** Take a problem-solve action — publishes the M4-driving event and records the action. */
+    void resolve(UUID caseId, ResolveAction action, String cityScope, String userId, String role, String notes);
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImpl.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImpl.java
@@ -1,0 +1,239 @@
+package com.oneday.exceptions.service.impl;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.exceptions.config.ExceptionProperties;
+import com.oneday.exceptions.domain.Disposition;
+import com.oneday.exceptions.domain.ExceptionAction;
+import com.oneday.exceptions.domain.ExceptionCase;
+import com.oneday.exceptions.domain.ExceptionReason;
+import com.oneday.exceptions.domain.ExceptionStatus;
+import com.oneday.exceptions.domain.ExceptionType;
+import com.oneday.exceptions.domain.ResolveAction;
+import com.oneday.exceptions.dto.ExceptionActionView;
+import com.oneday.exceptions.dto.ExceptionCaseDetail;
+import com.oneday.exceptions.dto.ExceptionCaseSummary;
+import com.oneday.exceptions.dto.ExceptionQueueResponse;
+import com.oneday.exceptions.dto.ExceptionSummaryResponse;
+import com.oneday.exceptions.events.ExceptionEventProducer;
+import com.oneday.exceptions.repository.ExceptionActionRepository;
+import com.oneday.exceptions.repository.ExceptionCaseRepository;
+import com.oneday.exceptions.service.ExceptionCaseService;
+import com.oneday.orders.service.ShipmentLookupService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class ExceptionCaseServiceImpl implements ExceptionCaseService {
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final ExceptionCaseRepository caseRepo;
+    private final ExceptionActionRepository actionRepo;
+    private final ShipmentLookupService shipmentLookup;
+    private final ExceptionEventProducer producer;
+    private final ExceptionProperties props;
+
+    public ExceptionCaseServiceImpl(ExceptionCaseRepository caseRepo, ExceptionActionRepository actionRepo,
+                                    ShipmentLookupService shipmentLookup, ExceptionEventProducer producer,
+                                    ExceptionProperties props) {
+        this.caseRepo = caseRepo;
+        this.actionRepo = actionRepo;
+        this.shipmentLookup = shipmentLookup;
+        this.producer = producer;
+        this.props = props;
+    }
+
+    // ── Capture ───────────────────────────────────────────────────────────────────────────────────
+
+    @Override
+    @Transactional
+    public void captureDaFailure(UUID shipmentId, String shipmentRef, ExceptionType type,
+                                 ExceptionReason reason, boolean daAttributable) {
+        if (shipmentId == null) {
+            return; // DA-scoped event with no shipment (e.g. a fleet-wide cron miss) — nothing to case yet.
+        }
+        Optional<ExceptionCase> live = caseRepo.findFirstByShipmentIdAndResolvedAtIsNull(shipmentId);
+        ExceptionCase c = live.orElseGet(() -> openCase(shipmentId, shipmentRef, type));
+        if (live.isPresent()) {
+            // A repeat failure on the same live case → another attempt; re-open it for action.
+            c.setAttemptNo(c.getAttemptNo() + 1);
+            c.setStatus(ExceptionStatus.OPEN);
+            c.setType(type);
+        }
+        if (reason != null && reason != ExceptionReason.UNKNOWN) {
+            c.setReasonCode(reason);
+        }
+        if (daAttributable) {
+            c.setDaAttributable(true);
+        }
+        c.setDisposition(dispositionFor(c));
+        caseRepo.save(c);
+        logAction(c.getId(), "FAILURE_CAPTURED", "system", null,
+                "attempt " + c.getAttemptNo() + (reason != null ? " · " + reason : ""));
+    }
+
+    private ExceptionCase openCase(UUID shipmentId, String shipmentRef, ExceptionType type) {
+        ExceptionCase c = new ExceptionCase();
+        c.setShipmentId(shipmentId);
+        c.setShipmentRef(shipmentRef);
+        c.setType(type);
+        c.setStatus(ExceptionStatus.OPEN);
+        c.setAttemptNo(1);
+        c.setOpenedAt(Instant.now());
+        // Enrich routing facts from M4 (the failure event doesn't carry cities / delivery type).
+        if (shipmentRef != null) {
+            shipmentLookup.findByRef(shipmentRef).ifPresent(info -> {
+                c.setOriginCity(info.originCity());
+                c.setDestCity(info.destCity());
+                c.setDeliveryType(info.deliveryType());
+            });
+        }
+        return c;
+    }
+
+    @Override
+    @Transactional
+    public void onShipmentStateChanged(UUID shipmentId, ShipmentState toState) {
+        Optional<ExceptionCase> live = caseRepo.findFirstByShipmentIdAndResolvedAtIsNull(shipmentId);
+        if (live.isEmpty()) {
+            return; // No open case — nothing to advance (pickup/delivery failures open via the DA path).
+        }
+        ExceptionCase c = live.get();
+        switch (toState) {
+            case RTO_INITIATED, RTO_IN_TRANSIT -> {
+                c.setStatus(ExceptionStatus.RTO);
+                c.setDisposition(Disposition.RETURNED);
+                caseRepo.save(c);
+            }
+            case RTO_COMPLETED -> close(c, ExceptionStatus.RTO, Disposition.RETURNED);
+            // A successful terminal delivery clears any lingering case (e.g. a reschedule that landed).
+            case DROPPED, HUB_COLLECTED -> close(c, ExceptionStatus.RESOLVED, Disposition.RESOLVED);
+            default -> { /* other transitions don't affect the case */ }
+        }
+    }
+
+    private void close(ExceptionCase c, ExceptionStatus status, Disposition disposition) {
+        c.setStatus(status);
+        c.setDisposition(disposition);
+        c.setResolvedAt(Instant.now());
+        caseRepo.save(c);
+    }
+
+    /** Attempt policy (R2/F1): pickup/delivery gets {@code maxReattempts} re-tries before it's flagged
+     *  UNDELIVERABLE (recommend RTO). Cron/flight-missed aren't attempt-based — they stay reattemptable. */
+    private Disposition dispositionFor(ExceptionCase c) {
+        if (c.getType() == ExceptionType.CRON_MISSED || c.getType() == ExceptionType.FLIGHT_MISSED) {
+            return Disposition.REATTEMPTABLE;
+        }
+        int reattemptsUsed = c.getAttemptNo() - 1;
+        return reattemptsUsed >= props.maxReattempts() ? Disposition.UNDELIVERABLE : Disposition.REATTEMPTABLE;
+    }
+
+    // ── Queries ───────────────────────────────────────────────────────────────────────────────────
+
+    @Override
+    @Transactional(readOnly = true)
+    public ExceptionQueueResponse queue(String cityScope, ExceptionType type, int page, int size) {
+        int p = Math.max(0, page);
+        int s = Math.min(Math.max(1, size), MAX_PAGE_SIZE);
+        Page<ExceptionCase> result = caseRepo.queue(cityScope, type, PageRequest.of(p, s));
+        List<ExceptionCaseSummary> items = result.getContent().stream().map(ExceptionCaseSummary::from).toList();
+        return new ExceptionQueueResponse(p, s, result.getTotalElements(), items);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ExceptionSummaryResponse summary(String cityScope) {
+        long open = 0, reattemptable = 0, undeliverable = 0, returned = 0;
+        for (Object[] row : caseRepo.countOpenByDisposition(cityScope)) {
+            Disposition d = (Disposition) row[0];
+            long n = (Long) row[1];
+            open += n;
+            switch (d) {
+                case REATTEMPTABLE -> reattemptable += n;
+                case UNDELIVERABLE -> undeliverable += n;
+                case RETURNED -> returned += n;
+                case RESOLVED -> { /* resolved cases aren't in the live set */ }
+            }
+        }
+        return new ExceptionSummaryResponse(open, reattemptable, undeliverable, returned);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ExceptionCaseDetail detail(UUID caseId, String cityScope) {
+        ExceptionCase c = caseRepo.findById(caseId)
+                .filter(x -> visible(x, cityScope))
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Case not found"));
+        List<ExceptionActionView> actions = actionRepo.findByCaseIdOrderByCreatedAtAsc(caseId).stream()
+                .map(ExceptionActionView::from).toList();
+        return new ExceptionCaseDetail(ExceptionCaseSummary.from(c), actions);
+    }
+
+    // ── Resolve ───────────────────────────────────────────────────────────────────────────────────
+
+    @Override
+    @Transactional
+    public void resolve(UUID caseId, ResolveAction action, String cityScope,
+                        String userId, String role, String notes) {
+        ExceptionCase c = caseRepo.findById(caseId)
+                .filter(x -> visible(x, cityScope))
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Case not found"));
+        if (c.getResolvedAt() != null) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Case is already closed");
+        }
+
+        // Drive M4 (and, downstream, M10) by publishing the matching event — the orders consumer transitions.
+        if (action.event() != null) {
+            producer.publish(c.getShipmentId(), action.event());
+        }
+
+        c.setResolution(action);
+        c.setAssignedTo(userId);
+        c.setAssignedRole(role);
+        if (notes != null && !notes.isBlank()) {
+            c.setNotes(notes);
+        }
+        switch (action) {
+            case RESCHEDULE_PICKUP, RESCHEDULE_DELIVERY -> {
+                c.setStatus(ExceptionStatus.RESCHEDULED);
+                caseRepo.save(c);
+            }
+            case INITIATE_RTO -> {
+                c.setStatus(ExceptionStatus.RTO);
+                c.setDisposition(Disposition.RETURNED);
+                caseRepo.save(c);
+            }
+            case COMPLETE_RTO -> close(c, ExceptionStatus.RTO, Disposition.RETURNED);
+            case MARK_RESOLVED -> close(c, ExceptionStatus.RESOLVED, Disposition.RESOLVED);
+        }
+        logAction(c.getId(), action.name(), userId, role, notes);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────────────────────────
+
+    private void logAction(UUID caseId, String action, String actedBy, String actedByRole, String notes) {
+        ExceptionAction a = new ExceptionAction();
+        a.setCaseId(caseId);
+        a.setAction(action);
+        a.setActedBy(actedBy);
+        a.setActedByRole(actedByRole);
+        a.setNotes(notes);
+        actionRepo.save(a);
+    }
+
+    private boolean visible(ExceptionCase c, String cityScope) {
+        return cityScope == null
+                || cityScope.equals(c.getOriginCity())
+                || cityScope.equals(c.getDestCity());
+    }
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImpl.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImpl.java
@@ -27,6 +27,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Instant;
@@ -35,7 +37,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Service
-public class ExceptionCaseServiceImpl implements ExceptionCaseService {
+class ExceptionCaseServiceImpl implements ExceptionCaseService {
 
     private static final int MAX_PAGE_SIZE = 100;
 
@@ -72,6 +74,13 @@ public class ExceptionCaseServiceImpl implements ExceptionCaseService {
             return; // DA-scoped event with no shipment (e.g. a fleet-wide cron miss) — nothing to case yet.
         }
         Optional<ExceptionCase> live = caseRepo.findFirstByShipmentIdAndResolvedAtIsNull(shipmentId);
+        if (live.isPresent() && live.get().getStatus() == ExceptionStatus.RTO) {
+            // Already returning to origin — a failure on the return leg isn't a fresh delivery attempt,
+            // so don't reset the case to OPEN/REATTEMPTABLE. Just record it on the trail.
+            logAction(live.get().getId(), "FAILURE_CAPTURED", "system", null,
+                    "failure during RTO" + (reason != null ? " · " + reason : ""));
+            return;
+        }
         ExceptionCase c = live.orElseGet(() -> openCase(shipmentId, shipmentRef, type));
         if (live.isPresent()) {
             // A repeat failure on the same live case → another attempt; re-open it for action.
@@ -127,6 +136,9 @@ public class ExceptionCaseServiceImpl implements ExceptionCaseService {
             case RTO_COMPLETED -> close(c, ExceptionStatus.RTO, Disposition.RETURNED);
             // A successful terminal delivery clears any lingering case (e.g. a reschedule that landed).
             case DROPPED, HUB_COLLECTED -> close(c, ExceptionStatus.RESOLVED, Disposition.RESOLVED);
+            // Shipment cancelled (M4 allows it from PICKUP_FAILED, which opened this case) — close the
+            // case so it doesn't sit OPEN forever, and so no agent can later drive an illegal RTO from it.
+            case CANCELLED -> close(c, ExceptionStatus.CANCELLED, c.getDisposition());
             default -> { /* other transitions don't affect the case */ }
         }
     }
@@ -211,8 +223,15 @@ public class ExceptionCaseServiceImpl implements ExceptionCaseService {
         }
 
         // Drive M4 (and, downstream, M10) by publishing the matching event — the orders consumer transitions.
+        // Publish only AFTER this tx commits (matches orders' ShipmentEventProducer): the broker send is
+        // synchronous and swallows errors, so publishing inline would let M4 act on an event a later
+        // rollback erases — a permanent M11/M4 divergence with no audit row.
         if (action.event() != null) {
-            producer.publish(c.getShipmentId(), action.event());
+            var evt = action.event();
+            var sid = c.getShipmentId();
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override public void afterCommit() { producer.publish(sid, evt); }
+            });
         }
 
         c.setResolution(action);

--- a/exceptions/src/main/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImpl.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImpl.java
@@ -15,9 +15,12 @@ import com.oneday.exceptions.dto.ExceptionCaseSummary;
 import com.oneday.exceptions.dto.ExceptionQueueResponse;
 import com.oneday.exceptions.dto.ExceptionSummaryResponse;
 import com.oneday.exceptions.events.ExceptionEventProducer;
+import com.oneday.common.port.CourierOnShipmentPort;
+import com.oneday.common.port.ShipmentContactPort;
 import com.oneday.exceptions.repository.ExceptionActionRepository;
 import com.oneday.exceptions.repository.ExceptionCaseRepository;
 import com.oneday.exceptions.service.ExceptionCaseService;
+import com.oneday.orders.service.ShipmentJourneyService;
 import com.oneday.orders.service.ShipmentLookupService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -39,15 +42,22 @@ public class ExceptionCaseServiceImpl implements ExceptionCaseService {
     private final ExceptionCaseRepository caseRepo;
     private final ExceptionActionRepository actionRepo;
     private final ShipmentLookupService shipmentLookup;
+    private final ShipmentJourneyService journeyService;
+    private final CourierOnShipmentPort courierPort;
+    private final ShipmentContactPort contactPort;
     private final ExceptionEventProducer producer;
     private final ExceptionProperties props;
 
     public ExceptionCaseServiceImpl(ExceptionCaseRepository caseRepo, ExceptionActionRepository actionRepo,
-                                    ShipmentLookupService shipmentLookup, ExceptionEventProducer producer,
-                                    ExceptionProperties props) {
+                                    ShipmentLookupService shipmentLookup, ShipmentJourneyService journeyService,
+                                    CourierOnShipmentPort courierPort, ShipmentContactPort contactPort,
+                                    ExceptionEventProducer producer, ExceptionProperties props) {
         this.caseRepo = caseRepo;
         this.actionRepo = actionRepo;
         this.shipmentLookup = shipmentLookup;
+        this.journeyService = journeyService;
+        this.courierPort = courierPort;
+        this.contactPort = contactPort;
         this.producer = producer;
         this.props = props;
     }
@@ -176,7 +186,15 @@ public class ExceptionCaseServiceImpl implements ExceptionCaseService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Case not found"));
         List<ExceptionActionView> actions = actionRepo.findByCaseIdOrderByCreatedAtAsc(caseId).stream()
                 .map(ExceptionActionView::from).toList();
-        return new ExceptionCaseDetail(ExceptionCaseSummary.from(c), actions);
+        // The full picture: the shipment's whole internal trail + who to call at the failed stage.
+        List<com.oneday.orders.dto.JourneyStep> journey = journeyService.journey(c.getShipmentId());
+        ExceptionCaseDetail.Contact handler = courierPort.forShipment(c.getShipmentId())
+                .map(x -> new ExceptionCaseDetail.Contact(x.name(), x.phone(), x.role().name())).orElse(null);
+        ShipmentContactPort.ShipmentContact contact =
+                contactPort.contactsFor(List.of(c.getShipmentId())).get(c.getShipmentId());
+        ExceptionCaseDetail.Contact receiver = contact == null ? null
+                : new ExceptionCaseDetail.Contact(contact.receiverName(), contact.receiverPhone(), "CUSTOMER");
+        return new ExceptionCaseDetail(ExceptionCaseSummary.from(c), actions, journey, handler, receiver);
     }
 
     // ── Resolve ───────────────────────────────────────────────────────────────────────────────────

--- a/exceptions/src/main/resources/db/migration/exceptions/V11_1__create_exceptions.sql
+++ b/exceptions/src/main/resources/db/migration/exceptions/V11_1__create_exceptions.sql
@@ -1,0 +1,43 @@
+-- M11 exceptions / problem-solve / RTO. One live case per shipment (opened by a failure event,
+-- closed on resolution) + an append-only action log. Enum-like columns are VARCHAR + app-side
+-- @Enumerated(STRING) — no PG enum coupling, same convention as M10.
+
+CREATE TABLE exception_case (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    shipment_id      UUID        NOT NULL,
+    shipment_ref     VARCHAR(64),
+    origin_city      VARCHAR(8),
+    dest_city        VARCHAR(8),
+    delivery_type    VARCHAR(16),
+    type             VARCHAR(24) NOT NULL,   -- PICKUP_FAILED | DELIVERY_FAILED | CRON_MISSED | FLIGHT_MISSED
+    reason_code      VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN',
+    status           VARCHAR(16) NOT NULL DEFAULT 'OPEN',       -- OPEN|IN_PROGRESS|RESCHEDULED|RTO|RESOLVED|CANCELLED
+    disposition      VARCHAR(16) NOT NULL DEFAULT 'REATTEMPTABLE', -- REATTEMPTABLE|UNDELIVERABLE|RETURNED|RESOLVED
+    attempt_no       INTEGER     NOT NULL DEFAULT 1,
+    da_attributable  BOOLEAN     NOT NULL DEFAULT false,
+    assigned_to      VARCHAR(64),
+    assigned_role    VARCHAR(32),
+    resolution       VARCHAR(32),            -- the resolve action that closed it (nullable while open)
+    notes            TEXT,
+    opened_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    resolved_at      TIMESTAMPTZ,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- The problem-solve queue is: open cases, city-scoped, freshest first. Partial index keeps the read
+-- index-only over just the live set.
+CREATE INDEX idx_exception_case_open ON exception_case (origin_city, opened_at DESC) WHERE resolved_at IS NULL;
+-- One live (unresolved) case per shipment — enforced in code, this index makes the lookup cheap.
+CREATE INDEX idx_exception_case_live_shipment ON exception_case (shipment_id) WHERE resolved_at IS NULL;
+
+CREATE TABLE exception_action (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    case_id        UUID        NOT NULL REFERENCES exception_case (id),
+    action         VARCHAR(32) NOT NULL,
+    acted_by       VARCHAR(64),
+    acted_by_role  VARCHAR(32),
+    notes          TEXT,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_exception_action_case ON exception_action (case_id, created_at);

--- a/exceptions/src/main/resources/db/migration/exceptions/V11_1__create_exceptions.sql
+++ b/exceptions/src/main/resources/db/migration/exceptions/V11_1__create_exceptions.sql
@@ -38,6 +38,7 @@ CREATE TABLE exception_action (
     acted_by       VARCHAR(64),
     acted_by_role  VARCHAR(32),
     notes          TEXT,
-    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()   -- BaseEntity carries @UpdateTimestamp; append-only in practice
 );
 CREATE INDEX idx_exception_action_case ON exception_action (case_id, created_at);

--- a/exceptions/src/main/resources/db/migration/exceptions/V11_2__unique_live_case.sql
+++ b/exceptions/src/main/resources/db/migration/exceptions/V11_2__unique_live_case.sql
@@ -1,0 +1,8 @@
+-- One live (unresolved) case per shipment — now enforced at the DB layer.
+-- V11_1 created this as a plain partial index; the check-then-insert in
+-- ExceptionCaseServiceImpl.captureDaFailure could race two concurrent failure
+-- events into two live rows, splitting attempt_no so the UNDELIVERABLE/RTO cap
+-- never trips. UNIQUE makes the second insert fail instead.
+DROP INDEX IF EXISTS idx_exception_case_live_shipment;
+CREATE UNIQUE INDEX idx_exception_case_live_shipment
+    ON exception_case (shipment_id) WHERE resolved_at IS NULL;

--- a/exceptions/src/test/java/com/oneday/exceptions/domain/ExceptionReasonTest.java
+++ b/exceptions/src/test/java/com/oneday/exceptions/domain/ExceptionReasonTest.java
@@ -1,0 +1,29 @@
+package com.oneday.exceptions.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** The free-text → taxonomy mapping (M5 sends a loose reason string; we normalise it). */
+class ExceptionReasonTest {
+
+    @Test
+    void mapsExactEnumNames() {
+        assertThat(ExceptionReason.fromCode("CUSTOMER_REFUSED")).isEqualTo(ExceptionReason.CUSTOMER_REFUSED);
+        assertThat(ExceptionReason.fromCode("da_no_show")).isEqualTo(ExceptionReason.DA_NO_SHOW);
+    }
+
+    @Test
+    void mapsKnownAliases() {
+        assertThat(ExceptionReason.fromCode("NO_ONE_HOME")).isEqualTo(ExceptionReason.CUSTOMER_UNAVAILABLE);
+        assertThat(ExceptionReason.fromCode("wrong_address")).isEqualTo(ExceptionReason.ADDRESS_INCORRECT);
+        assertThat(ExceptionReason.fromCode("REFUSED")).isEqualTo(ExceptionReason.CUSTOMER_REFUSED);
+    }
+
+    @Test
+    void unknownOrBlankFallsBack() {
+        assertThat(ExceptionReason.fromCode(null)).isEqualTo(ExceptionReason.UNKNOWN);
+        assertThat(ExceptionReason.fromCode("   ")).isEqualTo(ExceptionReason.UNKNOWN);
+        assertThat(ExceptionReason.fromCode("something-nobody-mapped")).isEqualTo(ExceptionReason.OTHER);
+    }
+}

--- a/exceptions/src/test/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImplTest.java
+++ b/exceptions/src/test/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImplTest.java
@@ -15,6 +15,7 @@ import com.oneday.exceptions.repository.ExceptionCaseRepository;
 import com.oneday.orders.service.ShipmentLookupService;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -45,6 +46,18 @@ class ExceptionCaseServiceImplTest {
             new ExceptionCaseServiceImpl(caseRepo, actionRepo, lookup, journey, courier, contact, producer, props);
 
     private final UUID shipmentId = UUID.randomUUID();
+
+    /** resolve() defers the broker publish to afterCommit; run it inside an active synchronization and
+     *  fire the commit callbacks so the publish actually happens (no real tx in a unit test). */
+    private void resolveInTx(Runnable call) {
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            call.run();
+            TransactionSynchronizationManager.getSynchronizations().forEach(s -> s.afterCommit());
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
 
     private ExceptionCase saved() {
         ArgumentCaptor<ExceptionCase> cap = ArgumentCaptor.forClass(ExceptionCase.class);
@@ -106,7 +119,7 @@ class ExceptionCaseServiceImplTest {
         when(caseRepo.findById(caseId)).thenReturn(Optional.of(c));
         when(caseRepo.save(any())).thenAnswer(i -> i.getArgument(0));
 
-        svc.resolve(caseId, ResolveAction.RESCHEDULE_DELIVERY, null, "u1", "STATION_MANAGER", "retry tonight");
+        resolveInTx(() -> svc.resolve(caseId, ResolveAction.RESCHEDULE_DELIVERY, null, "u1", "STATION_MANAGER", "retry tonight"));
 
         verify(producer).publish(shipmentId, ExceptionsEventType.DELIVERY_RESCHEDULED);
         assertThat(c.getStatus()).isEqualTo(ExceptionStatus.RESCHEDULED);
@@ -121,7 +134,7 @@ class ExceptionCaseServiceImplTest {
         when(caseRepo.findById(caseId)).thenReturn(Optional.of(c));
         when(caseRepo.save(any())).thenAnswer(i -> i.getArgument(0));
 
-        svc.resolve(caseId, ResolveAction.INITIATE_RTO, null, "u1", "STATION_MANAGER", null);
+        resolveInTx(() -> svc.resolve(caseId, ResolveAction.INITIATE_RTO, null, "u1", "STATION_MANAGER", null));
 
         verify(producer).publish(shipmentId, ExceptionsEventType.RTO_INITIATED);
         assertThat(c.getStatus()).isEqualTo(ExceptionStatus.RTO);
@@ -141,6 +154,37 @@ class ExceptionCaseServiceImplTest {
         verify(producer, never()).publish(any(), any());
         assertThat(c.getResolvedAt()).isNotNull();
         assertThat(c.getStatus()).isEqualTo(ExceptionStatus.RESOLVED);
+    }
+
+    @Test
+    void daFailureDuringRtoDoesNotReopenTheCase() {
+        ExceptionCase live = new ExceptionCase();
+        live.setShipmentId(shipmentId);
+        live.setStatus(ExceptionStatus.RTO);
+        live.setDisposition(Disposition.RETURNED);
+        live.setAttemptNo(3);
+        when(caseRepo.findFirstByShipmentIdAndResolvedAtIsNull(shipmentId)).thenReturn(Optional.of(live));
+
+        // Return-leg drop fails and re-emits a DELIVERY_FAILED — must not reset the RTO case to OPEN.
+        svc.captureDaFailure(shipmentId, "1DD-BLR-1", ExceptionType.DELIVERY_FAILED, ExceptionReason.UNKNOWN, false);
+
+        assertThat(live.getStatus()).isEqualTo(ExceptionStatus.RTO);
+        assertThat(live.getDisposition()).isEqualTo(Disposition.RETURNED);
+        assertThat(live.getAttemptNo()).isEqualTo(3);
+        verify(caseRepo, never()).save(any()); // trail-only; no mutation of the case
+    }
+
+    @Test
+    void cancellationClosesTheLiveCase() {
+        ExceptionCase live = new ExceptionCase();
+        live.setStatus(ExceptionStatus.OPEN);
+        when(caseRepo.findFirstByShipmentIdAndResolvedAtIsNull(shipmentId)).thenReturn(Optional.of(live));
+        when(caseRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        svc.onShipmentStateChanged(shipmentId, ShipmentState.CANCELLED);
+
+        assertThat(live.getResolvedAt()).isNotNull();
+        assertThat(live.getStatus()).isEqualTo(ExceptionStatus.CANCELLED);
     }
 
     @Test

--- a/exceptions/src/test/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImplTest.java
+++ b/exceptions/src/test/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImplTest.java
@@ -32,11 +32,17 @@ class ExceptionCaseServiceImplTest {
     private final ExceptionCaseRepository caseRepo = mock(ExceptionCaseRepository.class);
     private final ExceptionActionRepository actionRepo = mock(ExceptionActionRepository.class);
     private final ShipmentLookupService lookup = mock(ShipmentLookupService.class);
+    private final com.oneday.orders.service.ShipmentJourneyService journey =
+            mock(com.oneday.orders.service.ShipmentJourneyService.class);
+    private final com.oneday.common.port.CourierOnShipmentPort courier =
+            mock(com.oneday.common.port.CourierOnShipmentPort.class);
+    private final com.oneday.common.port.ShipmentContactPort contact =
+            mock(com.oneday.common.port.ShipmentContactPort.class);
     private final ExceptionEventProducer producer = mock(ExceptionEventProducer.class);
     private final ExceptionProperties props = new ExceptionProperties(); // maxReattempts = 2
 
     private final ExceptionCaseServiceImpl svc =
-            new ExceptionCaseServiceImpl(caseRepo, actionRepo, lookup, producer, props);
+            new ExceptionCaseServiceImpl(caseRepo, actionRepo, lookup, journey, courier, contact, producer, props);
 
     private final UUID shipmentId = UUID.randomUUID();
 

--- a/exceptions/src/test/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImplTest.java
+++ b/exceptions/src/test/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImplTest.java
@@ -1,0 +1,151 @@
+package com.oneday.exceptions.service.impl;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.kafka.enums.ExceptionsEventType;
+import com.oneday.exceptions.config.ExceptionProperties;
+import com.oneday.exceptions.domain.Disposition;
+import com.oneday.exceptions.domain.ExceptionCase;
+import com.oneday.exceptions.domain.ExceptionReason;
+import com.oneday.exceptions.domain.ExceptionStatus;
+import com.oneday.exceptions.domain.ExceptionType;
+import com.oneday.exceptions.domain.ResolveAction;
+import com.oneday.exceptions.events.ExceptionEventProducer;
+import com.oneday.exceptions.repository.ExceptionActionRepository;
+import com.oneday.exceptions.repository.ExceptionCaseRepository;
+import com.oneday.orders.service.ShipmentLookupService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** M11 capture idempotency + attempt policy + resolve→producer wiring. */
+class ExceptionCaseServiceImplTest {
+
+    private final ExceptionCaseRepository caseRepo = mock(ExceptionCaseRepository.class);
+    private final ExceptionActionRepository actionRepo = mock(ExceptionActionRepository.class);
+    private final ShipmentLookupService lookup = mock(ShipmentLookupService.class);
+    private final ExceptionEventProducer producer = mock(ExceptionEventProducer.class);
+    private final ExceptionProperties props = new ExceptionProperties(); // maxReattempts = 2
+
+    private final ExceptionCaseServiceImpl svc =
+            new ExceptionCaseServiceImpl(caseRepo, actionRepo, lookup, producer, props);
+
+    private final UUID shipmentId = UUID.randomUUID();
+
+    private ExceptionCase saved() {
+        ArgumentCaptor<ExceptionCase> cap = ArgumentCaptor.forClass(ExceptionCase.class);
+        verify(caseRepo, org.mockito.Mockito.atLeastOnce()).save(cap.capture());
+        return cap.getValue();
+    }
+
+    @Test
+    void firstFailureOpensAReattemptableCase() {
+        when(caseRepo.findFirstByShipmentIdAndResolvedAtIsNull(shipmentId)).thenReturn(Optional.empty());
+        when(lookup.findByRef(any())).thenReturn(Optional.empty());
+        when(caseRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        svc.captureDaFailure(shipmentId, "1DD-BLR-1", ExceptionType.DELIVERY_FAILED,
+                ExceptionReason.CUSTOMER_UNAVAILABLE, false);
+
+        ExceptionCase c = saved();
+        assertThat(c.getAttemptNo()).isEqualTo(1);
+        assertThat(c.getStatus()).isEqualTo(ExceptionStatus.OPEN);
+        assertThat(c.getReasonCode()).isEqualTo(ExceptionReason.CUSTOMER_UNAVAILABLE);
+        assertThat(c.getDisposition()).isEqualTo(Disposition.REATTEMPTABLE);
+    }
+
+    @Test
+    void attemptCapFlipsToUndeliverable() {
+        ExceptionCase live = new ExceptionCase();
+        live.setShipmentId(shipmentId);
+        live.setType(ExceptionType.DELIVERY_FAILED);
+        live.setAttemptNo(2); // already two attempts; the third crosses maxReattempts=2
+        when(caseRepo.findFirstByShipmentIdAndResolvedAtIsNull(shipmentId)).thenReturn(Optional.of(live));
+        when(caseRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        svc.captureDaFailure(shipmentId, "1DD-BLR-1", ExceptionType.DELIVERY_FAILED, ExceptionReason.UNKNOWN, false);
+
+        assertThat(live.getAttemptNo()).isEqualTo(3);
+        assertThat(live.getStatus()).isEqualTo(ExceptionStatus.OPEN); // re-opened for action
+        assertThat(live.getDisposition()).isEqualTo(Disposition.UNDELIVERABLE);
+    }
+
+    @Test
+    void secondAttemptStaysReattemptable() {
+        ExceptionCase live = new ExceptionCase();
+        live.setType(ExceptionType.DELIVERY_FAILED);
+        live.setAttemptNo(1);
+        when(caseRepo.findFirstByShipmentIdAndResolvedAtIsNull(shipmentId)).thenReturn(Optional.of(live));
+        when(caseRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        svc.captureDaFailure(shipmentId, "1DD-BLR-1", ExceptionType.DELIVERY_FAILED, ExceptionReason.UNKNOWN, false);
+
+        assertThat(live.getAttemptNo()).isEqualTo(2);
+        assertThat(live.getDisposition()).isEqualTo(Disposition.REATTEMPTABLE);
+    }
+
+    @Test
+    void resolveRescheduleDeliveryPublishesTheDrivingEvent() {
+        UUID caseId = UUID.randomUUID();
+        ExceptionCase c = new ExceptionCase();
+        c.setShipmentId(shipmentId);
+        when(caseRepo.findById(caseId)).thenReturn(Optional.of(c));
+        when(caseRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        svc.resolve(caseId, ResolveAction.RESCHEDULE_DELIVERY, null, "u1", "STATION_MANAGER", "retry tonight");
+
+        verify(producer).publish(shipmentId, ExceptionsEventType.DELIVERY_RESCHEDULED);
+        assertThat(c.getStatus()).isEqualTo(ExceptionStatus.RESCHEDULED);
+        assertThat(c.getResolution()).isEqualTo(ResolveAction.RESCHEDULE_DELIVERY);
+    }
+
+    @Test
+    void resolveInitiateRtoMarksReturnedAndPublishes() {
+        UUID caseId = UUID.randomUUID();
+        ExceptionCase c = new ExceptionCase();
+        c.setShipmentId(shipmentId);
+        when(caseRepo.findById(caseId)).thenReturn(Optional.of(c));
+        when(caseRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        svc.resolve(caseId, ResolveAction.INITIATE_RTO, null, "u1", "STATION_MANAGER", null);
+
+        verify(producer).publish(shipmentId, ExceptionsEventType.RTO_INITIATED);
+        assertThat(c.getStatus()).isEqualTo(ExceptionStatus.RTO);
+        assertThat(c.getDisposition()).isEqualTo(Disposition.RETURNED);
+    }
+
+    @Test
+    void markResolvedClosesWithoutPublishing() {
+        UUID caseId = UUID.randomUUID();
+        ExceptionCase c = new ExceptionCase();
+        c.setShipmentId(shipmentId);
+        when(caseRepo.findById(caseId)).thenReturn(Optional.of(c));
+        when(caseRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        svc.resolve(caseId, ResolveAction.MARK_RESOLVED, null, "u1", "STATION_MANAGER", "sorted offline");
+
+        verify(producer, never()).publish(any(), any());
+        assertThat(c.getResolvedAt()).isNotNull();
+        assertThat(c.getStatus()).isEqualTo(ExceptionStatus.RESOLVED);
+    }
+
+    @Test
+    void successfulTerminalDeliveryClosesTheLiveCase() {
+        ExceptionCase live = new ExceptionCase();
+        when(caseRepo.findFirstByShipmentIdAndResolvedAtIsNull(shipmentId)).thenReturn(Optional.of(live));
+        when(caseRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        svc.onShipmentStateChanged(shipmentId, ShipmentState.DROPPED);
+
+        assertThat(live.getResolvedAt()).isNotNull();
+        assertThat(live.getDisposition()).isEqualTo(Disposition.RESOLVED);
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/dto/JourneyStep.java
+++ b/orders/src/main/java/com/oneday/orders/dto/JourneyStep.java
@@ -1,0 +1,18 @@
+package com.oneday.orders.dto;
+
+import com.oneday.common.domain.enums.ShipmentState;
+
+import java.time.Instant;
+
+/**
+ * One step of a shipment's internal state trail — the ops-facing counterpart to the customer-labelled
+ * milestones in {@link ShipmentTrackResponse}. Sourced from {@code ShipmentStateHistory}, so it carries
+ * the actor and source the customer view hides.
+ */
+public record JourneyStep(
+        ShipmentState toState,
+        Instant occurredAt,
+        String triggeredBy,
+        String triggerSource,
+        String notes) {
+}

--- a/orders/src/main/java/com/oneday/orders/service/ShipmentJourneyService.java
+++ b/orders/src/main/java/com/oneday/orders/service/ShipmentJourneyService.java
@@ -1,0 +1,17 @@
+package com.oneday.orders.service;
+
+import com.oneday.orders.dto.JourneyStep;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Public, read-only access to a shipment's full internal state trail (every transition, timestamped,
+ * with actor + source + notes). The ops-facing counterpart to {@link TrackingService}'s customer view;
+ * consumed cross-module (M11 exceptions) by importing this interface + {@link JourneyStep}.
+ */
+public interface ShipmentJourneyService {
+
+    /** The ordered state trail for a shipment (oldest first); empty if the shipment is unknown. */
+    List<JourneyStep> journey(UUID shipmentId);
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/ShipmentJourneyServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/ShipmentJourneyServiceImpl.java
@@ -1,0 +1,33 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.dto.JourneyStep;
+import com.oneday.orders.repository.ShipmentStateHistoryRepository;
+import com.oneday.orders.service.ShipmentJourneyService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+class ShipmentJourneyServiceImpl implements ShipmentJourneyService {
+
+    private final ShipmentStateHistoryRepository historyRepo;
+
+    ShipmentJourneyServiceImpl(ShipmentStateHistoryRepository historyRepo) {
+        this.historyRepo = historyRepo;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<JourneyStep> journey(UUID shipmentId) {
+        return historyRepo.findByShipmentIdOrderByOccurredAtAsc(shipmentId).stream()
+                .map(h -> new JourneyStep(
+                        h.getToState(),
+                        h.getOccurredAt(),
+                        h.getTriggeredBy(),
+                        h.getTriggerSource() != null ? h.getTriggerSource().name() : null,
+                        h.getNotes()))
+                .toList();
+    }
+}


### PR DESCRIPTION
**Before:** the `exceptions` module was an empty shell (just a `pom.xml`) and the station `/exceptions` page said "M11 isn't built yet" — the teardown's #1 gap. Failure reasons were dropped, there was no attempt counter, no RTO workflow, and nothing published the exception events the rest of the system already waited on.

**Now:** a working M11. Failures are captured from the DA event stream (carrying the reason M4 drops) into a live problem-solve queue with an attempt counter and a reason taxonomy; each case has one recommended move — **reschedule / RTO / resolve** — which publishes the event that drives M4's state machine (and M10 re-eval) through the seam that was always reserved but never driven.

## What's in it
- `GET /api/v1/exceptions/queue` · `/summary` (disposition rollups) · `/{id}` (detail + action log); `POST /{id}/resolve`. Role-gated, city-scoped.
- Capture is idempotent (one live case per shipment; a repeat failure bumps the attempt). Attempt policy `exceptions.max-reattempts` (default 2) → REATTEMPTABLE, then UNDELIVERABLE (recommend RTO).
- `V11_1` (exception_case + append-only exception_action). Reuses the existing `ExceptionsEventsConsumer` / RTO+reschedule transitions / `ShipmentLookupService` — no new state or edges.

## Scope
P1 (capture + queue) + P2 (problem-solve producer). Deferred: RTO-as-billable-return-shipment + KPIs (P4), call-center assignment + batch + CSV export (P3), flight-missed capture.

## Verified
10 unit tests (reason mapping, capture idempotency, attempt-cap, resolve→producer, terminal-close). App assembles; end-to-end on local: queue/summary/detail + `MARK_RESOLVED` close the loop. (Reschedule/RTO publish needs a broker — unit-tested.)

## Review plan
Read in dependency order — shape first, then the flow through it, then the surface, then proof. Follow the data as it moves.

1. **This description** — the empty-shell → working-M11 framing and scope (P1+P2) before any file makes sense.
2. **The shape (what an exception *is*)** — `V11_1__create_exceptions.sql` (the two tables) → enums in order `ExceptionType` → `ExceptionReason` → `ExceptionStatus` → `Disposition` → `ResolveAction` (skim) → `ExceptionCase` + `ExceptionAction` entities.
3. **The flow IN (capture)** — `ExceptionDaEventsConsumer` + `ExceptionShipmentEventsConsumer` (where the dropped reason is picked up) → `ExceptionMessagingTopology` (what they listen on).
4. **The brain (slow down here)** — `ExceptionCaseServiceImpl`: capture idempotency (one live case/shipment, repeat bumps attempt), attempt-cap → REATTEMPTABLE → UNDELIVERABLE/RTO, resolve. Plus `ExceptionProperties` (`max-reattempts`, default 2).
5. **The flow OUT** — `ExceptionEventProducer`: publishes into the M4/M10 seam. **Confirm event contracts match what those modules consume — this is the main risk surface.**
6. **The surface** — `ExceptionController` (queue/summary/{id}/resolve) + `Authz` (role + city scope); DTOs as a batch (just projections, glance).
7. **Side channel (least coupled, review last)** — `ShipmentJourneyServiceImpl` + `JourneyStep` (journey trail / who-to-call).
8. **Proof** — `ExceptionReasonTest` + `ExceptionCaseServiceImplTest`, read as the spec for step 4.

**Flag up front:** reschedule/RTO publish is unit-tested only (needs a broker); only queue/summary/detail + `MARK_RESOLVED` were run end-to-end on local. Spend review time on step 5's contracts, not the DTOs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an exception-management queue with filtering, summaries, case details, assignment visibility, and city-scoped access.
  - Added case resolution actions, notes, shipment journey history, and handler/receiver contact details.
  - Added automatic exception capture from pickup, delivery, and shipment events.
  - Added configurable retry handling, with cases flagged undeliverable after two re-attempts.
  - Added audit history for exception actions and resolution events.

- **Bug Fixes**
  - Prevented duplicate unresolved cases for the same shipment.
  - Improved handling of cancellations, terminal deliveries, and return-to-origin cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
