### PR TITLE
First-mile parcel dimension scan (server-side ArUco CV + R2 evidence)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,12 @@ jobs:
       # its native tests self-skip (graceful), but installing them lets those tests actually run.
       # The same libs are required on the deploy runtime (Render) for the feature to measure.
       - name: Install OpenCV native runtime deps
-        run: sudo apt-get update && sudo apt-get install -y libgl1 libgomp1 libglib2.0-0 libgtk-3-0
+        # bytedeco OpenCV's highgui is built against GTK2 (not GTK3), plus GL/X11 deps. On Ubuntu 24.04
+        # the GTK2 package is renamed with the t64 suffix; fall back to the old name for older runners.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1 libgomp1 libglib2.0-0 libsm6 libxext6 libxrender1
+          sudo apt-get install -y libgtk2.0-0t64 || sudo apt-get install -y libgtk2.0-0
 
       - name: Build and test all modules
         # Exclude the "e2e" group: those are full-stack @SpringBootTest suites that need a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,13 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
+      # OpenCV (vision module, bytedeco) needs a few system libs to load on a headless runner —
+      # notably highgui's GTK/GL deps. Without these the ArUco engine reports itself unavailable and
+      # its native tests self-skip (graceful), but installing them lets those tests actually run.
+      # The same libs are required on the deploy runtime (Render) for the feature to measure.
+      - name: Install OpenCV native runtime deps
+        run: sudo apt-get update && sudo apt-get install -y libgl1 libgomp1 libglib2.0-0 libgtk-3-0
+
       - name: Build and test all modules
         # Exclude the "e2e" group: those are full-stack @SpringBootTest suites that need a
         # real Postgres (and run locally against the dev DB). CI has no database, so they

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,16 @@ RUN mvn -B -ntp -pl app -am clean package -DskipTests
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 
+# OpenCV (vision module, bytedeco) native runtime deps — the ArUco dimension engine's objdetect/
+# highgui modules won't load on a headless image without these, and measurement silently degrades to
+# "photos stored, no dims". highgui links GTK2 (not GTK3); on this Ubuntu-24.04 (Noble) base the GTK2
+# package carries the t64 suffix. Proven to load OpenCV headless in CI. Clean apt lists to stay small.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libgl1 libgomp1 libglib2.0-0 libsm6 libxext6 libxrender1 \
+    && (apt-get install -y --no-install-recommends libgtk2.0-0t64 \
+        || apt-get install -y --no-install-recommends libgtk2.0-0) \
+    && rm -rf /var/lib/apt/lists/*
+
 # The spring-boot-maven-plugin repackage produces the executable app jar
 # (app-<version>.jar); the plain jar is app-<version>.jar.original and is skipped.
 COPY --from=build /build/app/target/app-*.jar app.jar

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -195,3 +195,33 @@ sla:
     DEST_AIRPORT: 90       # landing → unload/break/sort/release
     DEST_HUB: 60           # dest hub processing
     LAST_MILE: 150         # hub out-scan → delivered   (Σ = 810m = 13.5h)
+
+# Object storage (Cloudflare R2, S3-compatible) for parcel-dimension evidence photos.
+# Credentials come from env ONLY — never commit. Blank locally → storage disabled, feature degrades.
+storage:
+  endpoint: ${R2_ENDPOINT:}
+  region: ${R2_REGION:auto}
+  access-key-id: ${R2_ACCESS_KEY_ID:}
+  secret-access-key: ${R2_SECRET_ACCESS_KEY:}
+  bucket: ${R2_BUCKET:}
+  # Environment folder-prefix so dev/staging/prod never intermix in a shared bucket. Defaults to the
+  # active Spring profile (prod → "prod", staging → "staging"), or "local" when no profile is set;
+  # override with R2_KEY_PREFIX. For hard isolation, also point each env at its own R2_BUCKET.
+  key-prefix: ${R2_KEY_PREFIX:${spring.profiles.active:local}}
+
+# First-mile "scan dimensions" CV engine (OpenCV/ArUco). markerSizeCm MUST match the printed board.
+vision:
+  marker-size-cm: ${VISION_MARKER_SIZE_CM:5.0}
+  dictionary-id: ${VISION_DICT_ID:4}          # 4 = DICT_5X5_50 (the fleet marker)
+  timeout-ms: ${VISION_TIMEOUT_MS:8000}
+  max-image-edge-px: 2000
+  min-confidence: 0.35
+
+# Discrepancy tolerance (moderate) + evidence limits.
+measurement:
+  tolerance-pct: ${MEASUREMENT_TOLERANCE_PCT:10.0}
+  tolerance-side-cm: ${MEASUREMENT_TOLERANCE_SIDE_CM:2.0}
+  volumetric-divisor: 5000
+  max-evidence-photos: 4
+  upload-url-ttl-seconds: 300
+  view-url-ttl-seconds: 600

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -223,5 +223,6 @@ measurement:
   tolerance-side-cm: ${MEASUREMENT_TOLERANCE_SIDE_CM:2.0}
   volumetric-divisor: 5000
   max-evidence-photos: 4
+  max-evidence-bytes: ${MEASUREMENT_MAX_EVIDENCE_BYTES:15728640}   # 15 MB/photo; oversized rejected pre-buffer
   upload-url-ttl-seconds: 300
   view-url-ttl-seconds: 600

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -42,9 +42,26 @@
             <artifactId>logstash-logback-encoder</artifactId>
             <version>7.4</version>
         </dependency>
+        <!-- Object storage via the S3-compatible API (Cloudflare R2). Only s3 + presigner; no other
+             AWS services. Versions come from the AWS SDK BOM in the root dependencyManagement. -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- MinIO (S3-compatible) for the storage-adapter integration tests. -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/common/src/main/java/com/oneday/common/kafka/enums/MeasurementEventType.java
+++ b/common/src/main/java/com/oneday/common/kafka/enums/MeasurementEventType.java
@@ -1,0 +1,9 @@
+package com.oneday.common.kafka.enums;
+
+/** Event types for parcel-dimension measurements (produced by M4 on the shipments stream). */
+public enum MeasurementEventType {
+    /** A measurement was recorded (any outcome). */
+    MEASUREMENT_RECORDED,
+    /** A measurement showed the parcel materially exceeds the declared dimensions. */
+    DIMENSION_DISCREPANCY_FLAGGED
+}

--- a/common/src/main/java/com/oneday/common/kafka/events/ParcelMeasuredEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/ParcelMeasuredEvent.java
@@ -1,0 +1,45 @@
+package com.oneday.common.kafka.events;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.oneday.common.kafka.DomainEvent;
+import com.oneday.common.kafka.enums.MeasurementEventType;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * A parcel-dimension measurement was recorded at some point in the chain (first-mile DA scan today).
+ * Emitted by M4 on {@code oneday.shipments.events}. The routing key is the {@link MeasurementEventType}
+ * — {@code DIMENSION_DISCREPANCY_FLAGGED} is the hook a future chargeback/ops flow consumes; the hub
+ * measurement remains the billing source of truth, so this event never charges anyone by itself.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ParcelMeasuredEvent(
+        UUID eventId,
+        MeasurementEventType eventType,
+        Instant occurredAt,
+        UUID shipmentId,
+        String shipmentRef,
+        String source,
+        String status,
+        Double lengthCm,
+        Double widthCm,
+        Double heightCm,
+        Integer volumetricWeightGrams,
+        Short declaredLengthCm,
+        Short declaredWidthCm,
+        Short declaredHeightCm,
+        boolean overDeclared,
+        String discrepancyDetail,
+        UUID measuredBy) implements DomainEvent {
+
+    @Override
+    public String partitionKey() {
+        return shipmentId != null ? shipmentId.toString() : shipmentRef;
+    }
+
+    @Override
+    public String eventTypeName() {
+        return eventType.name();
+    }
+}

--- a/common/src/main/java/com/oneday/common/port/ObjectStoragePort.java
+++ b/common/src/main/java/com/oneday/common/port/ObjectStoragePort.java
@@ -1,0 +1,35 @@
+package com.oneday.common.port;
+
+import java.time.Duration;
+
+/**
+ * Blob storage for platform binaries (parcel-dimension evidence photos today; proof-of-delivery
+ * photos, server-side PDFs, etc. later). Backed by the S3-compatible API — the default adapter
+ * targets Cloudflare R2. Buckets are private; browsers/apps read and write only through the
+ * short-lived presigned URLs this port hands out.
+ *
+ * <p>Callers must treat this as best-effort infrastructure: every method can throw
+ * {@code ObjectStorageException}, and {@link #isAvailable()} is false when storage is not
+ * configured (e.g. local runs without R2 credentials). Business flows that use it (evidence
+ * capture) must degrade gracefully rather than fail the user action.</p>
+ */
+public interface ObjectStoragePort {
+
+    /** True when storage is configured (endpoint + credentials present) and usable. */
+    boolean isAvailable();
+
+    /**
+     * A presigned {@code PUT} URL the client uploads a single object to directly (bypassing the JVM).
+     * The upload must send the same {@code Content-Type}. Key is chosen server-side by the caller.
+     */
+    String presignPut(String key, String contentType, Duration ttl);
+
+    /** A presigned {@code GET} URL for reading one object (e.g. showing evidence in the ops console). */
+    String presignGet(String key, Duration ttl);
+
+    /** True if the object exists (HEAD). Used to verify a client actually completed its upload. */
+    boolean exists(String key);
+
+    /** The object's bytes — used server-side to feed the CV engine. Throws if the object is missing. */
+    byte[] getBytes(String key);
+}

--- a/common/src/main/java/com/oneday/common/port/ObjectStoragePort.java
+++ b/common/src/main/java/com/oneday/common/port/ObjectStoragePort.java
@@ -30,6 +30,9 @@ public interface ObjectStoragePort {
     /** True if the object exists (HEAD). Used to verify a client actually completed its upload. */
     boolean exists(String key);
 
+    /** The object's size in bytes (HEAD), or -1 if it doesn't exist. Used to reject oversized uploads. */
+    long size(String key);
+
     /** The object's bytes — used server-side to feed the CV engine. Throws if the object is missing. */
     byte[] getBytes(String key);
 }

--- a/common/src/main/java/com/oneday/common/port/PickupAssignmentPort.java
+++ b/common/src/main/java/com/oneday/common/port/PickupAssignmentPort.java
@@ -1,0 +1,14 @@
+package com.oneday.common.port;
+
+import java.util.UUID;
+
+/**
+ * Answers "is this DA the one M5 actually assigned to pick up this shipment?" — implemented in
+ * dispatch (which owns the assignment), consumed by orders to authorize first-mile measurement so a
+ * delivery associate can only measure a parcel they were assigned. Both depend only on {@code common}.
+ */
+public interface PickupAssignmentPort {
+
+    /** True if {@code daId} holds the active (QUEUED/IN_PROGRESS) pickup task for {@code shipmentId}. */
+    boolean isActivePickupDa(UUID daId, UUID shipmentId);
+}

--- a/common/src/main/java/com/oneday/common/storage/ObjectStorageException.java
+++ b/common/src/main/java/com/oneday/common/storage/ObjectStorageException.java
@@ -1,0 +1,12 @@
+package com.oneday.common.storage;
+
+/** Wraps any failure from the object-storage backend (network, missing object, auth). */
+public class ObjectStorageException extends RuntimeException {
+    public ObjectStorageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ObjectStorageException(String message) {
+        super(message);
+    }
+}

--- a/common/src/main/java/com/oneday/common/storage/ObjectStorageProperties.java
+++ b/common/src/main/java/com/oneday/common/storage/ObjectStorageProperties.java
@@ -1,0 +1,66 @@
+package com.oneday.common.storage;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Object-storage (Cloudflare R2 / S3-compatible) configuration.
+ *
+ * <p>Credentials are supplied via environment variables ONLY — never committed. Bind e.g.
+ * {@code R2_ENDPOINT}, {@code R2_ACCESS_KEY_ID}, {@code R2_SECRET_ACCESS_KEY}, {@code R2_BUCKET}
+ * through {@code application.yml} placeholders (see app config). When {@code endpoint}/{@code bucket}
+ * or the keys are blank the adapter reports {@code isAvailable()=false} and storage-backed features
+ * degrade gracefully.</p>
+ */
+@Component
+@ConfigurationProperties(prefix = "storage")
+public class ObjectStorageProperties {
+
+    /** S3 API endpoint, e.g. https://<accountid>.r2.cloudflarestorage.com (no bucket suffix). */
+    private String endpoint = "";
+
+    /** R2 is region-agnostic; the SDK still needs a value — use "auto". */
+    private String region = "auto";
+
+    private String accessKeyId = "";
+
+    private String secretAccessKey = "";
+
+    /** Bucket name, e.g. oneday-parcel-evidence. May be env-suffixed for hard per-env isolation. */
+    private String bucket = "";
+
+    /**
+     * Environment key-prefix (e.g. "dev", "staging", "prod"). Applied transparently by the adapter to
+     * every object key, so environments sharing one bucket never intermix. Blank = no prefix.
+     * App/DB keep using logical keys ({@code pickup-measurements/...}); the adapter stores them under
+     * {@code <prefix>/pickup-measurements/...}.
+     */
+    private String keyPrefix = "";
+
+    public String getEndpoint() { return endpoint; }
+    public void setEndpoint(String endpoint) { this.endpoint = endpoint; }
+
+    public String getRegion() { return region; }
+    public void setRegion(String region) { this.region = region; }
+
+    public String getAccessKeyId() { return accessKeyId; }
+    public void setAccessKeyId(String accessKeyId) { this.accessKeyId = accessKeyId; }
+
+    public String getSecretAccessKey() { return secretAccessKey; }
+    public void setSecretAccessKey(String secretAccessKey) { this.secretAccessKey = secretAccessKey; }
+
+    public String getBucket() { return bucket; }
+    public void setBucket(String bucket) { this.bucket = bucket; }
+
+    public String getKeyPrefix() { return keyPrefix; }
+    public void setKeyPrefix(String keyPrefix) { this.keyPrefix = keyPrefix; }
+
+    /** True when endpoint, bucket, and both keys are all present. */
+    public boolean isConfigured() {
+        return notBlank(endpoint) && notBlank(bucket) && notBlank(accessKeyId) && notBlank(secretAccessKey);
+    }
+
+    private static boolean notBlank(String s) {
+        return s != null && !s.isBlank();
+    }
+}

--- a/common/src/main/java/com/oneday/common/storage/R2ObjectStorageAdapter.java
+++ b/common/src/main/java/com/oneday/common/storage/R2ObjectStorageAdapter.java
@@ -112,6 +112,22 @@ public class R2ObjectStorageAdapter implements ObjectStoragePort {
     }
 
     @Override
+    public long size(String key) {
+        requireAvailable();
+        try {
+            return s3.headObject(HeadObjectRequest.builder()
+                    .bucket(props.getBucket()).key(physicalKey(key)).build()).contentLength();
+        } catch (NoSuchKeyException e) {
+            return -1;
+        } catch (S3Exception e) {
+            if (e.statusCode() == 404) {
+                return -1;
+            }
+            throw new ObjectStorageException("HEAD (size) failed for key " + key, e);
+        }
+    }
+
+    @Override
     public byte[] getBytes(String key) {
         requireAvailable();
         try {

--- a/common/src/main/java/com/oneday/common/storage/R2ObjectStorageAdapter.java
+++ b/common/src/main/java/com/oneday/common/storage/R2ObjectStorageAdapter.java
@@ -1,0 +1,146 @@
+package com.oneday.common.storage;
+
+import com.oneday.common.port.ObjectStoragePort;
+import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.net.URI;
+import java.time.Duration;
+
+/**
+ * {@link ObjectStoragePort} backed by the S3-compatible API (Cloudflare R2 by default).
+ *
+ * <p>Uses static credentials + an endpoint override with path-style addressing (required for a
+ * custom S3 endpoint). When {@link ObjectStorageProperties#isConfigured()} is false the adapter
+ * stays inert ({@code isAvailable()=false}) so local/CI runs without R2 credentials still boot.</p>
+ */
+@Component
+public class R2ObjectStorageAdapter implements ObjectStoragePort {
+
+    private static final Logger log = LoggerFactory.getLogger(R2ObjectStorageAdapter.class);
+
+    private final ObjectStorageProperties props;
+    private final S3Client s3;            // null when not configured
+    private final S3Presigner presigner;  // null when not configured
+
+    public R2ObjectStorageAdapter(ObjectStorageProperties props) {
+        this.props = props;
+        if (!props.isConfigured()) {
+            log.warn("Object storage not configured (missing endpoint/bucket/keys) — evidence upload disabled");
+            this.s3 = null;
+            this.presigner = null;
+            return;
+        }
+        var creds = StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(props.getAccessKeyId(), props.getSecretAccessKey()));
+        var region = Region.of(props.getRegion());
+        var endpoint = URI.create(props.getEndpoint());
+        var s3cfg = S3Configuration.builder().pathStyleAccessEnabled(true).build();
+        this.s3 = S3Client.builder()
+                .endpointOverride(endpoint).region(region).credentialsProvider(creds)
+                .serviceConfiguration(s3cfg).build();
+        this.presigner = S3Presigner.builder()
+                .endpointOverride(endpoint).region(region).credentialsProvider(creds)
+                .serviceConfiguration(s3cfg).build();
+        log.info("Object storage adapter ready (bucket={})", props.getBucket());
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return s3 != null && presigner != null;
+    }
+
+    @Override
+    public String presignPut(String key, String contentType, Duration ttl) {
+        requireAvailable();
+        try {
+            PutObjectRequest put = PutObjectRequest.builder()
+                    .bucket(props.getBucket()).key(physicalKey(key)).contentType(contentType).build();
+            PutObjectPresignRequest presign = PutObjectPresignRequest.builder()
+                    .signatureDuration(ttl).putObjectRequest(put).build();
+            return presigner.presignPutObject(presign).url().toString();
+        } catch (S3Exception e) {
+            throw new ObjectStorageException("Failed to presign PUT for key " + key, e);
+        }
+    }
+
+    @Override
+    public String presignGet(String key, Duration ttl) {
+        requireAvailable();
+        try {
+            GetObjectRequest get = GetObjectRequest.builder().bucket(props.getBucket()).key(physicalKey(key)).build();
+            GetObjectPresignRequest presign = GetObjectPresignRequest.builder()
+                    .signatureDuration(ttl).getObjectRequest(get).build();
+            return presigner.presignGetObject(presign).url().toString();
+        } catch (S3Exception e) {
+            throw new ObjectStorageException("Failed to presign GET for key " + key, e);
+        }
+    }
+
+    @Override
+    public boolean exists(String key) {
+        requireAvailable();
+        try {
+            s3.headObject(HeadObjectRequest.builder().bucket(props.getBucket()).key(physicalKey(key)).build());
+            return true;
+        } catch (NoSuchKeyException e) {
+            return false;
+        } catch (S3Exception e) {
+            // R2 returns 404 for a missing key on HEAD without the typed NoSuchKeyException.
+            if (e.statusCode() == 404) {
+                return false;
+            }
+            throw new ObjectStorageException("HEAD failed for key " + key, e);
+        }
+    }
+
+    @Override
+    public byte[] getBytes(String key) {
+        requireAvailable();
+        try {
+            ResponseBytes<GetObjectResponse> bytes = s3.getObjectAsBytes(
+                    GetObjectRequest.builder().bucket(props.getBucket()).key(physicalKey(key)).build());
+            return bytes.asByteArray();
+        } catch (S3Exception e) {
+            throw new ObjectStorageException("GET failed for key " + key, e);
+        }
+    }
+
+    private void requireAvailable() {
+        if (!isAvailable()) {
+            throw new ObjectStorageException("Object storage is not configured");
+        }
+    }
+
+    /** Prepend the environment key-prefix (if any) so environments sharing a bucket never intermix. */
+    private String physicalKey(String logicalKey) {
+        String prefix = props.getKeyPrefix();
+        if (prefix == null || prefix.isBlank()) {
+            return logicalKey;
+        }
+        return prefix.replaceAll("/+$", "") + "/" + logicalKey;
+    }
+
+    @PreDestroy
+    void close() {
+        if (s3 != null) s3.close();
+        if (presigner != null) presigner.close();
+    }
+}

--- a/common/src/test/java/com/oneday/common/storage/R2LiveSmokeTest.java
+++ b/common/src/test/java/com/oneday/common/storage/R2LiveSmokeTest.java
@@ -1,0 +1,56 @@
+package com.oneday.common.storage;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Live round-trip against the real Cloudflare R2 bucket, exercising the exact presign→PUT→exists→GET
+ * path the app uses. Runs ONLY when the R2 env vars are present (source .env first), so CI without
+ * credentials skips it. Writes a tiny object under {@code smoke-test/} and reads it back.
+ */
+@EnabledIfEnvironmentVariable(named = "R2_ENDPOINT", matches = ".+")
+class R2LiveSmokeTest {
+
+    @Test
+    void presignUploadAndReadBack() throws Exception {
+        ObjectStorageProperties props = new ObjectStorageProperties();
+        props.setEndpoint(System.getenv("R2_ENDPOINT"));
+        props.setRegion(getenvOr("R2_REGION", "auto"));
+        props.setAccessKeyId(System.getenv("R2_ACCESS_KEY_ID"));
+        props.setSecretAccessKey(System.getenv("R2_SECRET_ACCESS_KEY"));
+        props.setBucket(System.getenv("R2_BUCKET"));
+
+        R2ObjectStorageAdapter adapter = new R2ObjectStorageAdapter(props);
+        assertThat(adapter.isAvailable()).isTrue();
+
+        String key = "smoke-test/" + UUID.randomUUID() + ".txt";
+        byte[] body = ("hello-r2-" + System.nanoTime()).getBytes(StandardCharsets.UTF_8);
+
+        String putUrl = adapter.presignPut(key, "text/plain", Duration.ofMinutes(5));
+        HttpResponse<Void> put = HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder(URI.create(putUrl))
+                        .header("Content-Type", "text/plain")
+                        .PUT(HttpRequest.BodyPublishers.ofByteArray(body)).build(),
+                HttpResponse.BodyHandlers.discarding());
+        assertThat(put.statusCode()).isBetween(200, 204);
+
+        assertThat(adapter.exists(key)).isTrue();
+        assertThat(adapter.getBytes(key)).isEqualTo(body);
+        assertThat(adapter.exists("smoke-test/does-not-exist-" + UUID.randomUUID())).isFalse();
+    }
+
+    private static String getenvOr(String k, String d) {
+        String v = System.getenv(k);
+        return v == null || v.isBlank() ? d : v;
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/port/PickupAssignmentAdapter.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/port/PickupAssignmentAdapter.java
@@ -1,0 +1,32 @@
+package com.oneday.dispatch.port;
+
+import com.oneday.common.port.PickupAssignmentPort;
+import com.oneday.dispatch.domain.TaskType;
+import com.oneday.dispatch.repository.DispatchQueueRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+/**
+ * Dispatch-side implementation of {@link PickupAssignmentPort}: the active pickup task for a shipment
+ * (the one that survives the partial-unique index, FAILED/CANCELLED excluded) names the DA M5 assigned.
+ */
+@Component
+class PickupAssignmentAdapter implements PickupAssignmentPort {
+
+    private final DispatchQueueRepository queueRepository;
+
+    PickupAssignmentAdapter(DispatchQueueRepository queueRepository) {
+        this.queueRepository = queueRepository;
+    }
+
+    @Override
+    public boolean isActivePickupDa(UUID daId, UUID shipmentId) {
+        if (daId == null || shipmentId == null) {
+            return false;
+        }
+        return queueRepository.findActiveByShipmentIdAndTaskType(shipmentId, TaskType.PICKUP)
+                .map(q -> daId.equals(q.getDaId()))
+                .orElse(false);
+    }
+}

--- a/docs/DIMENSION-CHECKER-PLAN.md
+++ b/docs/DIMENSION-CHECKER-PLAN.md
@@ -1,6 +1,15 @@
 # First-Mile Parcel Dimension Checker — Design & Plan
 
-> Status: **DRAFT / for discussion.** Branch `f-dimension-checker`. Not yet implemented.
+> Status: **IMPLEMENTED** on branch `f-dimension-checker` (PRs: backend #121, driver #34, web #23).
+>
+> **As-built note (supersedes options explored below).** The measurement runs **server-side in the
+> Java monolith** via a new `vision` module (bytedeco **OpenCV/ArUco**) — *not* a Python CV sidecar
+> (that option was evaluated and rejected because `grid`/`routing` already ship OR-Tools native-in-JVM).
+> The DA capture endpoints live in **`orders`** at `/internal/v1/shipments/{ref}/measurement` (role
+> `DELIVERY_ASSOCIATE`), *not* in `dispatch`; the merchant view reads `GET /api/v1/shipments/mine/{ref}/measurements`.
+> Marker = **DICT_5X5_50, 5 cm**. Migration is **`V4_38`**. Evidence lives in Cloudflare R2 under an
+> environment key-prefix. The sections below record the original decision process; where they differ
+> from this note, this note is authoritative.
 
 ## Context
 

--- a/docs/DIMENSION-CHECKER-PLAN.md
+++ b/docs/DIMENSION-CHECKER-PLAN.md
@@ -1,0 +1,86 @@
+# First-Mile Parcel Dimension Checker — Design & Plan
+
+> Status: **DRAFT / for discussion.** Branch `f-dimension-checker`. Not yet implemented.
+
+## Context
+
+**Problem.** Merchants under-declare parcel L×W×H at booking. The true (larger) dimensions are only discovered at the hub, triggering a chargeback to the merchant's wallet and downstream disputes. We want to catch this at the **first mile** — when the delivery agent (DA) picks the parcel up — using the DA's phone camera.
+
+**Two hard constraints:** (1) phone-camera only, on a heterogeneous, mostly-Android, mostly-cheap fleet; (2) error margin must be low enough to be trusted for evidence.
+
+## Decisions locked (initial discussion)
+
+- **Role of the scan = evidence + early-catch**, NOT the billing source of truth. The hub measurement stays authoritative. The pickup scan produces an *estimate + photographic evidence* and flags gross mismatches on the spot, so disputes become resolvable and merchants can't claim "I declared correctly."
+- **A printed reference marker is acceptable** for DAs to carry/place. This is the single biggest accuracy lever — it injects a *known* real-world scale, so we no longer estimate absolute scale from an unknown camera.
+- **Open-source / self-built** engine for v1: **OpenCV + ArUco**. (Monocular AI depth like Depth Anything V2 was ruled out — ~0.45 m real-world error, not billing-grade. Commercial SDKs like Scandit are the fallback only if the open-source benchmark fails.)
+- **Hybrid processing:** on-device ArUco for live capture guidance/preview; the **authoritative measurement is recomputed server-side** so results are consistent across all devices and tunable in one place.
+- **Moderate discrepancy tolerance:** flag when measured exceeds declared by **>10% of volume OR any single side by >2 cm**. Tunable via config.
+
+## Tooling survey (why ArUco + OpenCV)
+
+| Approach | Verdict | Notes |
+|----------|---------|-------|
+| **OpenCV + ArUco** (`opencv-contrib`) | ✅ **Primary** | Known-size marker injects real-world scale → lowest, most *controllable* error on any camera. Free. |
+| **ARCore Depth API** ([arcore-depth-lab](https://github.com/googlesamples/arcore-depth-lab), [ArCoreMeasurement](https://github.com/Kashif-E/ArCoreMeasurement)) | ➕ Assist | Depth-from-motion, no special hardware, ~88% Android coverage; few-cm error that degrades on cheap phones. |
+| **Monocular AI depth** (Depth Anything V2, ZoeDepth) | ❌ Ruled out | ~0.45 m real-world error; no reliable absolute scale from a single RGB frame. |
+| **Commercial SDK** (Scandit, MobileDemand) | 🅱️ Fallback | Contractually-warranted accuracy, paid. Only if the open-source benchmark fails. |
+
+## Current-state findings (all green-field)
+
+- **DA app** = React Native + Expo (`~57`), EAS/dev-client builds, JWT bearer auth, `expo-camera ~57.0.3` already present (barcode-only). `src/api.ts` is JSON-only (no upload plumbing); wire format is snake_case. Pickup flow is a single-screen state machine `DETAIL→ENROUTE→ARRIVED→OTP→PICKED_UP→DONE` — captures **no** dimensions today. (Repo: `oneday-driver-app`, sibling of the backend.)
+- **Backend** = no object storage (no S3/R2/disk), no photo/POD capture anywhere, no PDF generation. Only multipart prior art is an **in-memory** Excel upload (`BulkUploadController`). Shipment dimension columns are `updatable=false` (frozen at booking). Wallet exists but has **no chargeback transaction type**; no reweigh/discrepancy pipeline exists in code — today's chargeback is a manual/operational process.
+
+## Approach: ArUco marker + hybrid CV, evidence-grade
+
+### End-to-end flow
+1. DA reaches `ARRIVED`/`PICKED_UP`, taps **Scan dimensions**.
+2. DA lays the printed **ArUco marker mat** on a flat surface, places the parcel on it, follows on-screen guidance. On-device ArUco gives a live "markers detected / rough size" overlay (Android; iOS = capture-only in v1).
+3. App captures the guided photo(s), uploads them directly to object storage via a **presigned URL**, then posts the object keys + on-device preliminary dims to the backend.
+4. Backend calls the **CV service** (Python/OpenCV) which recomputes authoritative L×W×H + confidence from the stored photos. This is the number of record.
+5. Backend writes an append-only `pickup_measurement` row (declared vs measured + evidence keys + method + confidence), computes the discrepancy against the frozen booking dims, and emits an event.
+6. App shows the DA the measured dims + a clear "matches / over-declared by X" verdict to confirm before completing pickup.
+
+### Marker fixture (accuracy foundation)
+- Printed **ArUco board/mat** — multiple markers of exactly-known size (e.g. an A3 grid). Multi-marker → robust plane pose even when the parcel occludes some markers. The mat is the ground plane and the scale reference.
+- **Height** is the trickiest CV step. v1 default: **two guided captures** — top-down (marker coplanar with the parcel base → L×W) and an oblique/side shot (→ H). A single-oblique-shot method (`solvePnP` ground-plane pose, back-project base + top corners) is a stretch goal validated by the spike.
+- Cheap-phone intrinsics variance is mitigated because marker and parcel base are coplanar (planar homography is robust to unknown focal length) — a core reason the marker approach beats markerless here.
+
+### Component 1 — DA app (React Native / Expo)
+- New `DimensionScanner` component modeled on `src/components/BarcodeScanner.tsx` (same `expo-camera` permission/`CameraView` pattern).
+- New on-device Android **Expo native module** (Kotlin + OpenCV Android SDK + `aruco`) exposing `detectMarkers/roughDims` for the live overlay. Android-first; iOS = capture-and-upload only in v1.
+- New "Scan dimensions" step wired into `src/screens/pickups/PickupDetailScreen.tsx` (available in `ARRIVED`/`PICKED_UP`).
+- `src/api.ts`: add `getEvidenceUploadUrl(...)` (presigned) + `submitDimensions(daId, taskId, body, token)` following the existing `taskAction`/`dropCompleted` house style (positional `token`, snake_case). Add `expo-file-system` for the direct-to-storage upload.
+
+### Component 2 — CV service (new Python/OpenCV sidecar)
+- Small **FastAPI** service, `opencv-contrib-python` (ArUco). `POST /measure` takes storage object keys, returns `{length_cm, width_cm, height_cm, confidence, method}`. Deployed alongside the backend (Render/Hetzner).
+- Rationale over JavaCV-in-JVM: cleaner CV iteration/tuning in Python; avoids packaging native OpenCV into the Spring JAR. (This would be the platform's first non-JVM service — open decision.)
+
+### Component 3 — Backend (orders + dispatch)
+- **Object storage:** introduce an S3-compatible store (recommend **Cloudflare R2** — S3 API, no egress; swappable). New storage config + a **presigned-PUT endpoint** so photos upload directly (not proxied through the JVM, unlike `BulkUploadController`). Render-disk is the fallback.
+- **New endpoint:** `POST /dispatch/da/{daId}/tasks/{taskId}/dimensions` on `dispatch/.../api/DaDispatchController.java`, authorized via the existing `Authz.requireDaSelf(principal, daId)` — mirrors the existing `drop-completed`/`failed` endpoints. New request/response DTOs alongside `TaskFailedRequest`/`DropCompletedRequest`.
+- **New append-only entity** `PickupMeasurement` (orders `domain/`) + Flyway migration (next `V4_x`): shipment ref, declared L/W/H snapshot, measured L/W/H, method (`ARUCO`/`MANUAL`), confidence, evidence object keys, `over_declared` flag, actor DA id, timestamp. Do **not** mutate `Shipment` (dims are `updatable=false` by design — fits the append-only audit ethos).
+- **Discrepancy service:** compare measured vs frozen booking dims using the moderate tolerance (`>10%` volume OR `>2 cm` any side), configurable. Sets the flag; does **not** touch the wallet in v1.
+- **Event:** emit a new `DimensionDiscrepancyFlagged` (common `events/`) on `oneday.shipments.events` via the existing `ShipmentEventProducer` AFTER_COMMIT pattern — the hook a future chargeback/ops module consumes.
+
+### Out of scope for v1
+Automated wallet chargeback. This is evidence-grade only; the hub stays the billing source of truth. The emitted event is the integration hook for a later chargeback/ops flow.
+
+## Phasing (de-risk accuracy before full build)
+
+- **Phase 0 — Accuracy spike (gate).** Build the marker mat + a throwaway Python ArUco script. Measure ~30 real parcels on the target cheap Android device(s) vs caliper ground truth. **Acceptance gate:** median error within the moderate tolerance. If it fails → revisit fixture geometry / more views, or escalate to the paid-SDK fallback. *Do this before the app/native-module work.*
+- **Phase 1 — v1 build.** CV service → backend storage + endpoint + entity + discrepancy + event → DA-app capture/upload + on-device Android preview → DA confirmation UX.
+
+## Open decisions to resolve
+
+- Object storage provider: **Cloudflare R2** (recommended) vs Render disk vs other.
+- Standing up the **first Python service** in an otherwise all-JVM platform (vs JavaCV in the monolith).
+- iOS scope for v1 (recommend Android-first live preview; iOS capture-and-upload only).
+- Exact marker geometry: two-photo (robust, simple) vs single-oblique-shot mat (one capture, more CV) — decided by the Phase 0 spike.
+
+## Verification
+
+- **Accuracy benchmark (Phase 0 gate):** scripted CV-output vs caliper ground truth on ~30 parcels/target devices; median error within the moderate tolerance.
+- **Backend:** integration test for `POST .../dimensions` (auth via `requireDaSelf`, presigned-upload happy path, `PickupMeasurement` persisted append-only, discrepancy flag at boundary cases, event emitted).
+- **CV service:** unit tests on a fixture image set with known dimensions.
+- **DA app:** Maestro E2E extending the pickup flow through the scan step; manual run on a real Android device end-to-end.
+- **Demo:** deliberately under-declare a parcel at booking, run the DA pickup scan, confirm the app flags the over-declaration and the `pickup_measurement` row + evidence photos land in storage.

--- a/orders/pom.xml
+++ b/orders/pom.xml
@@ -30,6 +30,10 @@
         </dependency>
         <dependency>
             <groupId>com.oneday</groupId>
+            <artifactId>vision</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oneday</groupId>
             <artifactId>barcode</artifactId>
         </dependency>
         <dependency>

--- a/orders/src/main/java/com/oneday/orders/api/MyShipmentsController.java
+++ b/orders/src/main/java/com/oneday/orders/api/MyShipmentsController.java
@@ -1,10 +1,12 @@
 package com.oneday.orders.api;
 
 import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.orders.dto.MeasurementView;
 import com.oneday.orders.dto.MyShipmentDetailResponse;
 import com.oneday.orders.dto.MyShipmentSummaryResponse;
 import com.oneday.orders.dto.ShipmentLabelResponse;
 import com.oneday.orders.service.CustomerOrderQueryService;
+import com.oneday.orders.service.ParcelMeasurementService;
 import com.oneday.orders.service.PickupOtpService;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -29,11 +31,14 @@ class MyShipmentsController {
 
     private final CustomerOrderQueryService customerOrderQueryService;
     private final PickupOtpService pickupOtpService;
+    private final ParcelMeasurementService parcelMeasurementService;
 
     MyShipmentsController(CustomerOrderQueryService customerOrderQueryService,
-                         PickupOtpService pickupOtpService) {
+                         PickupOtpService pickupOtpService,
+                         ParcelMeasurementService parcelMeasurementService) {
         this.customerOrderQueryService = customerOrderQueryService;
         this.pickupOtpService = pickupOtpService;
+        this.parcelMeasurementService = parcelMeasurementService;
     }
 
     @GetMapping("/mine")
@@ -64,6 +69,22 @@ class MyShipmentsController {
         return customerOrderQueryService
                 .shipmentLabel(Authz.requireUserId(principal), ref)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No such shipment: " + ref));
+    }
+
+    /**
+     * The dimension measurements recorded for the caller's own shipment (declared vs measured +
+     * evidence photos), so the merchant can see the proof behind any weight/size adjustment. Evidence
+     * photo URLs are short-lived presigned GETs. Owner-scoped: 404 if the caller didn't book it.
+     */
+    @GetMapping("/mine/{ref}/measurements")
+    public List<MeasurementView> myShipmentMeasurements(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @PathVariable("ref") String ref) {
+        Authz.requireCustomerRole(principal, "C2C_CUSTOMER", "B2C_CUSTOMER", "B2B_USER");
+        // Ownership gate: reuse the detail lookup (empty → not the caller's shipment → 404).
+        customerOrderQueryService.myShipmentDetail(Authz.requireUserId(principal), ref)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No such shipment: " + ref));
+        return parcelMeasurementService.history(ref, true);
     }
 
     /** The pickup OTP for the caller's own shipment, so the merchant can read it to the pickup associate. */

--- a/orders/src/main/java/com/oneday/orders/api/ParcelMeasurementController.java
+++ b/orders/src/main/java/com/oneday/orders/api/ParcelMeasurementController.java
@@ -1,0 +1,66 @@
+package com.oneday.orders.api;
+
+import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.orders.dto.EvidenceUpload;
+import com.oneday.orders.dto.MeasurementSubmitRequest;
+import com.oneday.orders.dto.MeasurementView;
+import com.oneday.orders.service.ParcelMeasurementService;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * First-mile "scan dimensions" endpoints for the DA app. The DA presigns upload slots, uploads the
+ * evidence photos straight to object storage, then submits the keys for authoritative server-side
+ * measurement. A read endpoint (ADMIN) backs the ops/dispute console.
+ *
+ * <p>On {@code /internal/v1/} behind the JWT security filter, mirroring {@link PickupOtpController}.
+ * DA actions require the {@code DELIVERY_ASSOCIATE} role (ADMIN allowed); the console read is
+ * ADMIN-only.</p>
+ */
+@RestController
+@RequestMapping("/internal/v1/shipments/{ref}/measurement")
+public class ParcelMeasurementController {
+
+    private final ParcelMeasurementService measurementService;
+
+    public ParcelMeasurementController(ParcelMeasurementService measurementService) {
+        this.measurementService = measurementService;
+    }
+
+    /** Presign {@code count} (default 2) upload slots for this shipment's evidence photos. */
+    @PostMapping("/upload-urls")
+    public List<EvidenceUpload> uploadUrls(@PathVariable String ref,
+                                           @AuthenticationPrincipal AuthUserDetails principal,
+                                           @RequestParam(defaultValue = "2") int count) {
+        Authz.requireRole(principal, "DELIVERY_ASSOCIATE");
+        return measurementService.presignUploads(ref, count);
+    }
+
+    /** Submit uploaded evidence for measurement; returns the measured dims + over-declared verdict. */
+    @PostMapping
+    public MeasurementView submit(@PathVariable String ref,
+                                  @AuthenticationPrincipal AuthUserDetails principal,
+                                  @Valid @RequestBody MeasurementSubmitRequest request) {
+        Authz.requireRole(principal, "DELIVERY_ASSOCIATE");
+        UUID daUserId = principal.getUserId();
+        return measurementService.recordDaPickupMeasurement(ref, daUserId, request.captures());
+    }
+
+    /** All measurements for a shipment, with short-lived evidence photo URLs (ops/dispute console). */
+    @GetMapping
+    public List<MeasurementView> history(@PathVariable String ref,
+                                         @AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireRole(principal);   // ADMIN only
+        return measurementService.history(ref, true);
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/api/ParcelMeasurementController.java
+++ b/orders/src/main/java/com/oneday/orders/api/ParcelMeasurementController.java
@@ -43,7 +43,7 @@ public class ParcelMeasurementController {
                                            @AuthenticationPrincipal AuthUserDetails principal,
                                            @RequestParam(defaultValue = "2") int count) {
         Authz.requireRole(principal, "DELIVERY_ASSOCIATE");
-        return measurementService.presignUploads(ref, count);
+        return measurementService.presignUploads(ref, count, principal.getUserId(), isAdmin(principal));
     }
 
     /** Submit uploaded evidence for measurement; returns the measured dims + over-declared verdict. */
@@ -53,7 +53,11 @@ public class ParcelMeasurementController {
                                   @Valid @RequestBody MeasurementSubmitRequest request) {
         Authz.requireRole(principal, "DELIVERY_ASSOCIATE");
         UUID daUserId = principal.getUserId();
-        return measurementService.recordDaPickupMeasurement(ref, daUserId, request.captures());
+        return measurementService.recordDaPickupMeasurement(ref, daUserId, isAdmin(principal), request.captures());
+    }
+
+    private static boolean isAdmin(AuthUserDetails principal) {
+        return principal != null && Authz.ADMIN.equals(principal.getUser().getRole().getName());
     }
 
     /** All measurements for a shipment, with short-lived evidence photo URLs (ops/dispute console). */

--- a/orders/src/main/java/com/oneday/orders/config/MeasurementProperties.java
+++ b/orders/src/main/java/com/oneday/orders/config/MeasurementProperties.java
@@ -1,0 +1,49 @@
+package com.oneday.orders.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * First-mile dimension-scan tunables: discrepancy tolerance (moderate by default), evidence-upload
+ * limits, and presigned-URL TTLs.
+ */
+@Component
+@ConfigurationProperties(prefix = "measurement")
+public class MeasurementProperties {
+
+    /** Flag when measured volume exceeds declared volume by more than this percent. */
+    private double tolerancePct = 10.0;
+
+    /** ...or when any (size-sorted) side exceeds the declared side by more than this many cm. */
+    private double toleranceSideCm = 2.0;
+
+    /** Volumetric divisor (cm³/kg). L*W*H / divisor = volumetric kg; matches M4 booking math. */
+    private int volumetricDivisor = 5000;
+
+    /** Max evidence photos accepted per measurement. */
+    private int maxEvidencePhotos = 4;
+
+    /** TTL (seconds) of the presigned PUT URLs handed to the app for upload. */
+    private long uploadUrlTtlSeconds = 300;
+
+    /** TTL (seconds) of the presigned GET URLs handed to the ops console for viewing. */
+    private long viewUrlTtlSeconds = 600;
+
+    public double getTolerancePct() { return tolerancePct; }
+    public void setTolerancePct(double tolerancePct) { this.tolerancePct = tolerancePct; }
+
+    public double getToleranceSideCm() { return toleranceSideCm; }
+    public void setToleranceSideCm(double toleranceSideCm) { this.toleranceSideCm = toleranceSideCm; }
+
+    public int getVolumetricDivisor() { return volumetricDivisor; }
+    public void setVolumetricDivisor(int volumetricDivisor) { this.volumetricDivisor = volumetricDivisor; }
+
+    public int getMaxEvidencePhotos() { return maxEvidencePhotos; }
+    public void setMaxEvidencePhotos(int maxEvidencePhotos) { this.maxEvidencePhotos = maxEvidencePhotos; }
+
+    public long getUploadUrlTtlSeconds() { return uploadUrlTtlSeconds; }
+    public void setUploadUrlTtlSeconds(long uploadUrlTtlSeconds) { this.uploadUrlTtlSeconds = uploadUrlTtlSeconds; }
+
+    public long getViewUrlTtlSeconds() { return viewUrlTtlSeconds; }
+    public void setViewUrlTtlSeconds(long viewUrlTtlSeconds) { this.viewUrlTtlSeconds = viewUrlTtlSeconds; }
+}

--- a/orders/src/main/java/com/oneday/orders/config/MeasurementProperties.java
+++ b/orders/src/main/java/com/oneday/orders/config/MeasurementProperties.java
@@ -23,6 +23,9 @@ public class MeasurementProperties {
     /** Max evidence photos accepted per measurement. */
     private int maxEvidencePhotos = 4;
 
+    /** Max bytes for a single evidence object; larger uploads are rejected before buffering into heap. */
+    private long maxEvidenceBytes = 15L * 1024 * 1024;
+
     /** TTL (seconds) of the presigned PUT URLs handed to the app for upload. */
     private long uploadUrlTtlSeconds = 300;
 
@@ -40,6 +43,9 @@ public class MeasurementProperties {
 
     public int getMaxEvidencePhotos() { return maxEvidencePhotos; }
     public void setMaxEvidencePhotos(int maxEvidencePhotos) { this.maxEvidencePhotos = maxEvidencePhotos; }
+
+    public long getMaxEvidenceBytes() { return maxEvidenceBytes; }
+    public void setMaxEvidenceBytes(long maxEvidenceBytes) { this.maxEvidenceBytes = maxEvidenceBytes; }
 
     public long getUploadUrlTtlSeconds() { return uploadUrlTtlSeconds; }
     public void setUploadUrlTtlSeconds(long uploadUrlTtlSeconds) { this.uploadUrlTtlSeconds = uploadUrlTtlSeconds; }

--- a/orders/src/main/java/com/oneday/orders/domain/MeasurementMethod.java
+++ b/orders/src/main/java/com/oneday/orders/domain/MeasurementMethod.java
@@ -1,0 +1,11 @@
+package com.oneday.orders.domain;
+
+/** How a measurement's numbers were produced. */
+public enum MeasurementMethod {
+    /** Server-side OpenCV/ArUco from photos. */
+    ARUCO,
+    /** Hand-entered by an operator. */
+    MANUAL,
+    /** Copied from the customer's declaration. */
+    DECLARED
+}

--- a/orders/src/main/java/com/oneday/orders/domain/MeasurementSource.java
+++ b/orders/src/main/java/com/oneday/orders/domain/MeasurementSource.java
@@ -1,0 +1,15 @@
+package com.oneday.orders.domain;
+
+/**
+ * Who/what produced a parcel-dimension observation. Extensible — new sources append without a
+ * schema change. The customer's declared dimensions live on {@code Shipment} and are never mutated;
+ * these are additional observations of the same parcel.
+ */
+public enum MeasurementSource {
+    /** What the merchant declared at booking (kept on Shipment; a row here is optional/for parity). */
+    CUSTOMER_DECLARED,
+    /** Measured by the delivery associate's phone at first-mile pickup (this feature). */
+    DA_PICKUP,
+    /** Measured at the hub (future). */
+    HUB
+}

--- a/orders/src/main/java/com/oneday/orders/domain/ParcelMeasurement.java
+++ b/orders/src/main/java/com/oneday/orders/domain/ParcelMeasurement.java
@@ -1,0 +1,85 @@
+package com.oneday.orders.domain;
+
+import com.oneday.common.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * One append-only observation of a parcel's dimensions (see {@code V4_35}). Never mutated after
+ * insert. The declared dimensions are snapshotted here so the row is self-contained evidence for a
+ * dispute; the customer's declaration on {@code Shipment} is never changed.
+ */
+@Entity
+@Table(name = "parcel_measurement")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ParcelMeasurement extends BaseEntity {
+
+    @Column(name = "shipment_id", nullable = false, updatable = false)
+    private UUID shipmentId;
+
+    @Column(name = "shipment_ref", length = 30, nullable = false, updatable = false)
+    private String shipmentRef;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source", length = 20, nullable = false, updatable = false)
+    private MeasurementSource source;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "method", length = 20, nullable = false, updatable = false)
+    private MeasurementMethod method;
+
+    /** OK / NO_MARKER / LOW_CONFIDENCE / TIMEOUT / ENGINE_UNAVAILABLE / BAD_INPUT / ERROR. */
+    @Column(name = "status", length = 30, nullable = false, updatable = false)
+    private String status;
+
+    @Column(name = "length_cm", updatable = false)
+    private Double lengthCm;
+
+    @Column(name = "width_cm", updatable = false)
+    private Double widthCm;
+
+    @Column(name = "height_cm", updatable = false)
+    private Double heightCm;
+
+    @Column(name = "volumetric_weight_grams", updatable = false)
+    private Integer volumetricWeightGrams;
+
+    @Column(name = "confidence", updatable = false)
+    private Float confidence;
+
+    @Column(name = "declared_length_cm", updatable = false)
+    private Short declaredLengthCm;
+
+    @Column(name = "declared_width_cm", updatable = false)
+    private Short declaredWidthCm;
+
+    @Column(name = "declared_height_cm", updatable = false)
+    private Short declaredHeightCm;
+
+    @Column(name = "over_declared", nullable = false, updatable = false)
+    private boolean overDeclared;
+
+    @Column(name = "discrepancy_detail", length = 300, updatable = false)
+    private String discrepancyDetail;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "evidence_keys", nullable = false, updatable = false)
+    private List<String> evidenceKeys = new ArrayList<>();
+
+    @Column(name = "measured_by", updatable = false)
+    private UUID measuredBy;
+}

--- a/orders/src/main/java/com/oneday/orders/domain/ParcelMeasurement.java
+++ b/orders/src/main/java/com/oneday/orders/domain/ParcelMeasurement.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * One append-only observation of a parcel's dimensions (see {@code V4_35}). Never mutated after
+ * One append-only observation of a parcel's dimensions (see {@code V4_38}). Never mutated after
  * insert. The declared dimensions are snapshotted here so the row is self-contained evidence for a
  * dispute; the customer's declaration on {@code Shipment} is never changed.
  */

--- a/orders/src/main/java/com/oneday/orders/dto/EvidenceCapture.java
+++ b/orders/src/main/java/com/oneday/orders/dto/EvidenceCapture.java
@@ -1,0 +1,9 @@
+package com.oneday.orders.dto;
+
+/**
+ * One uploaded evidence photo the app submits for measurement.
+ *
+ * @param objectKey the key returned by the presign step (must belong to this shipment)
+ * @param view      which face it frames: "TOP", "SIDE", or "UNKNOWN"
+ */
+public record EvidenceCapture(String objectKey, String view) {}

--- a/orders/src/main/java/com/oneday/orders/dto/EvidenceUpload.java
+++ b/orders/src/main/java/com/oneday/orders/dto/EvidenceUpload.java
@@ -1,0 +1,7 @@
+package com.oneday.orders.dto;
+
+/**
+ * A presigned upload slot: the app PUTs one photo's bytes directly to {@code uploadUrl}, then passes
+ * {@code objectKey} back when submitting the measurement. Keys are chosen server-side.
+ */
+public record EvidenceUpload(String objectKey, String uploadUrl) {}

--- a/orders/src/main/java/com/oneday/orders/dto/MeasurementSubmitRequest.java
+++ b/orders/src/main/java/com/oneday/orders/dto/MeasurementSubmitRequest.java
@@ -1,0 +1,9 @@
+package com.oneday.orders.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+/** DA submits the uploaded evidence keys (+ which face each frames) for server-side measurement. */
+public record MeasurementSubmitRequest(
+        @NotEmpty List<EvidenceCapture> captures) {}

--- a/orders/src/main/java/com/oneday/orders/dto/MeasurementView.java
+++ b/orders/src/main/java/com/oneday/orders/dto/MeasurementView.java
@@ -1,0 +1,32 @@
+package com.oneday.orders.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * A recorded measurement, for the DA app (post-scan verdict) and the ops/dispute console.
+ * {@code evidenceUrls} is populated only for console reads (short-lived presigned GETs); the app
+ * gets the verdict fields it needs to show "matches / over-declared".
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record MeasurementView(
+        UUID id,
+        String source,
+        String method,
+        String status,
+        boolean ok,
+        Double lengthCm,
+        Double widthCm,
+        Double heightCm,
+        Integer volumetricWeightGrams,
+        Float confidence,
+        Short declaredLengthCm,
+        Short declaredWidthCm,
+        Short declaredHeightCm,
+        boolean overDeclared,
+        String discrepancyDetail,
+        List<String> evidenceUrls,
+        Instant createdAt) {}

--- a/orders/src/main/java/com/oneday/orders/events/MeasurementEventProducer.java
+++ b/orders/src/main/java/com/oneday/orders/events/MeasurementEventProducer.java
@@ -1,0 +1,48 @@
+package com.oneday.orders.events;
+
+import com.oneday.common.kafka.EventPublisher;
+import com.oneday.common.kafka.EventStreams;
+import com.oneday.common.kafka.enums.MeasurementEventType;
+import com.oneday.common.kafka.events.ParcelMeasuredEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Relays an in-process {@link ParcelMeasured} to {@link EventStreams#SHIPMENTS_EVENTS} once the
+ * measurement transaction commits. An over-declared result routes as
+ * {@code DIMENSION_DISCREPANCY_FLAGGED} (the hook for a future chargeback/ops flow); otherwise
+ * {@code MEASUREMENT_RECORDED}. Publishing is best-effort — a broker hiccup is logged, not thrown.
+ */
+@Component
+public class MeasurementEventProducer {
+
+    private static final Logger log = LoggerFactory.getLogger(MeasurementEventProducer.class);
+
+    private final EventPublisher eventPublisher;
+
+    MeasurementEventProducer(EventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onParcelMeasured(ParcelMeasured e) {
+        MeasurementEventType type = e.overDeclared()
+                ? MeasurementEventType.DIMENSION_DISCREPANCY_FLAGGED
+                : MeasurementEventType.MEASUREMENT_RECORDED;
+        ParcelMeasuredEvent event = new ParcelMeasuredEvent(
+                UUID.randomUUID(), type,
+                e.occurredAt() != null ? e.occurredAt() : Instant.now(),
+                e.shipmentId(), e.shipmentRef(), e.source(), e.status(),
+                e.lengthCm(), e.widthCm(), e.heightCm(), e.volumetricWeightGrams(),
+                e.declaredLengthCm(), e.declaredWidthCm(), e.declaredHeightCm(),
+                e.overDeclared(), e.discrepancyDetail(), e.measuredBy());
+        log.debug("Publishing {} shipmentRef={} overDeclared={}", type, e.shipmentRef(), e.overDeclared());
+        eventPublisher.publish(EventStreams.SHIPMENTS_EVENTS, event);
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/events/ParcelMeasured.java
+++ b/orders/src/main/java/com/oneday/orders/events/ParcelMeasured.java
@@ -1,0 +1,26 @@
+package com.oneday.orders.events;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * In-process event published within the measurement transaction. {@link MeasurementEventProducer}
+ * relays it to the bus AFTER_COMMIT, so a rolled-back measurement never emits a phantom event.
+ */
+public record ParcelMeasured(
+        UUID measurementId,
+        UUID shipmentId,
+        String shipmentRef,
+        String source,
+        String status,
+        Double lengthCm,
+        Double widthCm,
+        Double heightCm,
+        Integer volumetricWeightGrams,
+        Short declaredLengthCm,
+        Short declaredWidthCm,
+        Short declaredHeightCm,
+        boolean overDeclared,
+        String discrepancyDetail,
+        UUID measuredBy,
+        Instant occurredAt) {}

--- a/orders/src/main/java/com/oneday/orders/repository/ParcelMeasurementRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ParcelMeasurementRepository.java
@@ -1,0 +1,13 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.ParcelMeasurement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ParcelMeasurementRepository extends JpaRepository<ParcelMeasurement, UUID> {
+
+    /** All observations for a shipment, newest first (append-only history). */
+    List<ParcelMeasurement> findByShipmentIdOrderByCreatedAtDesc(UUID shipmentId);
+}

--- a/orders/src/main/java/com/oneday/orders/service/DiscrepancyPolicy.java
+++ b/orders/src/main/java/com/oneday/orders/service/DiscrepancyPolicy.java
@@ -1,0 +1,18 @@
+package com.oneday.orders.service;
+
+/**
+ * Decides whether a measured parcel materially exceeds its declared dimensions (the "moderate"
+ * tolerance: volume OR any side). Orientation-independent — dimensions are size-sorted before
+ * comparison, so it doesn't matter which measured axis maps to which declared axis.
+ */
+public interface DiscrepancyPolicy {
+
+    /**
+     * @param declared declared L/W/H in cm (any may be null)
+     * @param measured measured L/W/H in cm (any may be null)
+     * @return the verdict; {@code overDeclared=false} with an explanatory detail when it can't decide
+     */
+    Verdict evaluate(double[] declared, Double[] measured);
+
+    record Verdict(boolean overDeclared, String detail) {}
+}

--- a/orders/src/main/java/com/oneday/orders/service/ParcelMeasurementService.java
+++ b/orders/src/main/java/com/oneday/orders/service/ParcelMeasurementService.java
@@ -17,11 +17,18 @@ import java.util.UUID;
  */
 public interface ParcelMeasurementService {
 
-    /** Presign {@code count} upload slots for a shipment's evidence photos. */
-    List<EvidenceUpload> presignUploads(String shipmentRef, int count);
+    /**
+     * Presign {@code count} upload slots for a shipment's evidence photos. The caller must be the DA
+     * assigned to this pickup (or an ADMIN); otherwise 403.
+     */
+    List<EvidenceUpload> presignUploads(String shipmentRef, int count, UUID callerUserId, boolean admin);
 
-    /** Measure from the uploaded evidence and record the observation (source = DA_PICKUP). */
-    MeasurementView recordDaPickupMeasurement(String shipmentRef, UUID daUserId, List<EvidenceCapture> captures);
+    /**
+     * Measure from the uploaded evidence and record the observation (source = DA_PICKUP). The caller
+     * must be the DA assigned to this pickup (or an ADMIN); otherwise 403.
+     */
+    MeasurementView recordDaPickupMeasurement(String shipmentRef, UUID daUserId, boolean admin,
+                                              List<EvidenceCapture> captures);
 
     /** All recorded measurements for a shipment, newest first. Evidence GET URLs when requested. */
     List<MeasurementView> history(String shipmentRef, boolean withEvidenceUrls);

--- a/orders/src/main/java/com/oneday/orders/service/ParcelMeasurementService.java
+++ b/orders/src/main/java/com/oneday/orders/service/ParcelMeasurementService.java
@@ -1,0 +1,28 @@
+package com.oneday.orders.service;
+
+import com.oneday.orders.dto.EvidenceCapture;
+import com.oneday.orders.dto.EvidenceUpload;
+import com.oneday.orders.dto.MeasurementView;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * First-mile parcel-dimension capture. The DA app presigns upload slots, uploads photos straight to
+ * object storage, then submits the keys; the server measures authoritatively (OpenCV/ArUco), records
+ * an append-only observation, and flags any over-declaration against the customer's booking dims.
+ *
+ * <p>Best-effort by design: storage or CV failure never throws to the caller — the measurement is
+ * still recorded (with a non-OK status) so the pickup flow is unaffected.</p>
+ */
+public interface ParcelMeasurementService {
+
+    /** Presign {@code count} upload slots for a shipment's evidence photos. */
+    List<EvidenceUpload> presignUploads(String shipmentRef, int count);
+
+    /** Measure from the uploaded evidence and record the observation (source = DA_PICKUP). */
+    MeasurementView recordDaPickupMeasurement(String shipmentRef, UUID daUserId, List<EvidenceCapture> captures);
+
+    /** All recorded measurements for a shipment, newest first. Evidence GET URLs when requested. */
+    List<MeasurementView> history(String shipmentRef, boolean withEvidenceUrls);
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/DiscrepancyPolicyImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/DiscrepancyPolicyImpl.java
@@ -5,6 +5,7 @@ import com.oneday.orders.service.DiscrepancyPolicy;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
+import java.util.Locale;
 
 @Component
 class DiscrepancyPolicyImpl implements DiscrepancyPolicy {
@@ -39,10 +40,10 @@ class DiscrepancyPolicyImpl implements DiscrepancyPolicy {
 
         boolean over = volumeExceeded || sideExceeded;
         if (!over) {
-            return new Verdict(false, String.format(
+            return new Verdict(false, String.format(Locale.ROOT,
                     "within tolerance (volume +%.0f%%, worst side +%.1fcm)", volPctOver, worstSideOver));
         }
-        return new Verdict(true, String.format(
+        return new Verdict(true, String.format(Locale.ROOT,
                 "over-declared: volume +%.0f%% (declared %s → measured %s cm), worst side +%.1fcm",
                 volPctOver, fmt(d), fmt(m), worstSideOver));
     }
@@ -58,6 +59,6 @@ class DiscrepancyPolicyImpl implements DiscrepancyPolicy {
     }
 
     private static String fmt(double[] a) {
-        return String.format("%.0fx%.0fx%.0f", a[0], a[1], a[2]);
+        return String.format(Locale.ROOT, "%.0fx%.0fx%.0f", a[0], a[1], a[2]);
     }
 }

--- a/orders/src/main/java/com/oneday/orders/service/impl/DiscrepancyPolicyImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/DiscrepancyPolicyImpl.java
@@ -1,0 +1,63 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.config.MeasurementProperties;
+import com.oneday.orders.service.DiscrepancyPolicy;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Component
+class DiscrepancyPolicyImpl implements DiscrepancyPolicy {
+
+    private final MeasurementProperties props;
+
+    DiscrepancyPolicyImpl(MeasurementProperties props) {
+        this.props = props;
+    }
+
+    @Override
+    public Verdict evaluate(double[] declared, Double[] measured) {
+        if (declared == null || measured == null
+                || anyNullOrNonPositive(declared) || anyNullOrNonPositive(measured)) {
+            return new Verdict(false, "incomplete dimensions — not evaluated");
+        }
+        double[] d = declared.clone();
+        double[] m = new double[]{measured[0], measured[1], measured[2]};
+        Arrays.sort(d);
+        Arrays.sort(m);   // size-sorted → orientation-independent comparison
+
+        double declaredVol = d[0] * d[1] * d[2];
+        double measuredVol = m[0] * m[1] * m[2];
+        double volPctOver = declaredVol > 0 ? (measuredVol - declaredVol) / declaredVol * 100.0 : 0;
+        boolean volumeExceeded = volPctOver > props.getTolerancePct();
+
+        double worstSideOver = 0;
+        for (int i = 0; i < 3; i++) {
+            worstSideOver = Math.max(worstSideOver, m[i] - d[i]);
+        }
+        boolean sideExceeded = worstSideOver > props.getToleranceSideCm();
+
+        boolean over = volumeExceeded || sideExceeded;
+        if (!over) {
+            return new Verdict(false, String.format(
+                    "within tolerance (volume +%.0f%%, worst side +%.1fcm)", volPctOver, worstSideOver));
+        }
+        return new Verdict(true, String.format(
+                "over-declared: volume +%.0f%% (declared %s → measured %s cm), worst side +%.1fcm",
+                volPctOver, fmt(d), fmt(m), worstSideOver));
+    }
+
+    private static boolean anyNullOrNonPositive(double[] a) {
+        for (double v : a) if (v <= 0) return true;
+        return false;
+    }
+
+    private static boolean anyNullOrNonPositive(Double[] a) {
+        for (Double v : a) if (v == null || v <= 0) return true;
+        return false;
+    }
+
+    private static String fmt(double[] a) {
+        return String.format("%.0fx%.0fx%.0f", a[0], a[1], a[2]);
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/MeasurementPersister.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/MeasurementPersister.java
@@ -1,0 +1,41 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.domain.ParcelMeasurement;
+import com.oneday.orders.events.ParcelMeasured;
+import com.oneday.orders.repository.ParcelMeasurementRepository;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+/**
+ * The short transactional step of a measurement: persist the append-only row and publish the
+ * in-process {@link ParcelMeasured} (relayed to the bus AFTER_COMMIT). Kept separate so the slow CV
+ * work runs OUTSIDE any DB transaction — no connection is held during OpenCV.
+ */
+@Component
+class MeasurementPersister {
+
+    private final ParcelMeasurementRepository repository;
+    private final ApplicationEventPublisher events;
+
+    MeasurementPersister(ParcelMeasurementRepository repository, ApplicationEventPublisher events) {
+        this.repository = repository;
+        this.events = events;
+    }
+
+    @Transactional
+    ParcelMeasurement persist(ParcelMeasurement m) {
+        ParcelMeasurement saved = repository.save(m);
+        events.publishEvent(new ParcelMeasured(
+                saved.getId(), saved.getShipmentId(), saved.getShipmentRef(),
+                saved.getSource().name(), saved.getStatus(),
+                saved.getLengthCm(), saved.getWidthCm(), saved.getHeightCm(),
+                saved.getVolumetricWeightGrams(),
+                saved.getDeclaredLengthCm(), saved.getDeclaredWidthCm(), saved.getDeclaredHeightCm(),
+                saved.isOverDeclared(), saved.getDiscrepancyDetail(), saved.getMeasuredBy(),
+                Instant.now()));
+        return saved;
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/ParcelMeasurementServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/ParcelMeasurementServiceImpl.java
@@ -1,0 +1,240 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.port.ObjectStoragePort;
+import com.oneday.orders.config.MeasurementProperties;
+import com.oneday.orders.domain.MeasurementMethod;
+import com.oneday.orders.domain.MeasurementSource;
+import com.oneday.orders.domain.ParcelMeasurement;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.dto.EvidenceCapture;
+import com.oneday.orders.dto.EvidenceUpload;
+import com.oneday.orders.dto.MeasurementView;
+import com.oneday.orders.repository.ParcelMeasurementRepository;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.service.DiscrepancyPolicy;
+import com.oneday.orders.service.ParcelMeasurementService;
+import com.oneday.vision.DimensionEngine;
+import com.oneday.vision.MeasurementResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Orchestrates first-mile dimension capture (see {@link ParcelMeasurementService}). The CV + storage
+ * fetch run OUTSIDE any DB transaction; only the append-only persist ({@link MeasurementPersister})
+ * is transactional. Every storage/CV failure degrades to a recorded non-OK measurement rather than
+ * throwing, so pickup is never blocked.
+ */
+@Service
+class ParcelMeasurementServiceImpl implements ParcelMeasurementService {
+
+    private static final Logger log = LoggerFactory.getLogger(ParcelMeasurementServiceImpl.class);
+    private static final ZoneId IST = ZoneId.of("Asia/Kolkata");
+    private static final String KEY_PREFIX = "pickup-measurements";
+
+    private final ShipmentRepository shipmentRepository;
+    private final ParcelMeasurementRepository measurementRepository;
+    private final ObjectStoragePort storage;
+    private final DimensionEngine engine;
+    private final DiscrepancyPolicy discrepancyPolicy;
+    private final MeasurementPersister persister;
+    private final MeasurementProperties props;
+
+    ParcelMeasurementServiceImpl(ShipmentRepository shipmentRepository,
+                                 ParcelMeasurementRepository measurementRepository,
+                                 ObjectStoragePort storage,
+                                 DimensionEngine engine,
+                                 DiscrepancyPolicy discrepancyPolicy,
+                                 MeasurementPersister persister,
+                                 MeasurementProperties props) {
+        this.shipmentRepository = shipmentRepository;
+        this.measurementRepository = measurementRepository;
+        this.storage = storage;
+        this.engine = engine;
+        this.discrepancyPolicy = discrepancyPolicy;
+        this.persister = persister;
+        this.props = props;
+    }
+
+    @Override
+    public List<EvidenceUpload> presignUploads(String shipmentRef, int count) {
+        Shipment shipment = resolve(shipmentRef);
+        if (count < 1 || count > props.getMaxEvidencePhotos()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "count must be between 1 and " + props.getMaxEvidencePhotos());
+        }
+        if (!storage.isAvailable()) {
+            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "evidence storage unavailable");
+        }
+        List<EvidenceUpload> out = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            String key = buildKey(shipment.getShipmentRef());
+            String url = storage.presignPut(key, "image/jpeg", Duration.ofSeconds(props.getUploadUrlTtlSeconds()));
+            out.add(new EvidenceUpload(key, url));
+        }
+        return out;
+    }
+
+    @Override
+    public MeasurementView recordDaPickupMeasurement(String shipmentRef, UUID daUserId, List<EvidenceCapture> captures) {
+        Shipment shipment = resolve(shipmentRef);
+        if (captures == null || captures.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "no captures");
+        }
+        if (captures.size() > props.getMaxEvidencePhotos()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "too many captures");
+        }
+
+        // Fetch bytes + build engine captures (never throws — a fetch failure just skips that photo).
+        List<String> keys = new ArrayList<>();
+        List<DimensionEngine.Capture> engineCaptures = new ArrayList<>();
+        boolean fetchFailed = false;
+        for (EvidenceCapture c : captures) {
+            String key = c.objectKey();
+            requireOwnedKey(key, shipment.getShipmentRef());
+            keys.add(key);
+            if (!storage.isAvailable()) { fetchFailed = true; continue; }
+            try {
+                if (!storage.exists(key)) { fetchFailed = true; continue; }
+                byte[] bytes = storage.getBytes(key);
+                engineCaptures.add(new DimensionEngine.Capture(bytes, parseView(c.view())));
+            } catch (RuntimeException e) {
+                log.warn("Evidence fetch failed for key {}: {}", key, e.toString());
+                fetchFailed = true;
+            }
+        }
+
+        MeasurementResult result = runEngine(engineCaptures, fetchFailed);
+        ParcelMeasurement m = toEntity(shipment, daUserId, keys, result);
+        ParcelMeasurement saved = persister.persist(m);
+        log.info("Recorded DA_PICKUP measurement ref={} status={} overDeclared={}",
+                shipmentRef, saved.getStatus(), saved.isOverDeclared());
+        return toView(saved, null);
+    }
+
+    @Override
+    public List<MeasurementView> history(String shipmentRef, boolean withEvidenceUrls) {
+        Shipment shipment = resolve(shipmentRef);
+        return measurementRepository.findByShipmentIdOrderByCreatedAtDesc(shipment.getId()).stream()
+                .map(m -> toView(m, withEvidenceUrls ? presignEvidenceGets(m) : null))
+                .toList();
+    }
+
+    // ── internals ─────────────────────────────────────────────────────────────
+
+    private MeasurementResult runEngine(List<DimensionEngine.Capture> captures, boolean fetchFailed) {
+        if (!engine.isAvailable()) {
+            return MeasurementResult.failed(MeasurementResult.Status.ENGINE_UNAVAILABLE, "cv engine offline");
+        }
+        if (captures.isEmpty()) {
+            return MeasurementResult.failed(MeasurementResult.Status.BAD_INPUT,
+                    fetchFailed ? "evidence unreadable" : "no captures");
+        }
+        try {
+            return engine.measure(captures);
+        } catch (RuntimeException e) {   // defensive — engine already swallows, but never let it escape
+            log.warn("Dimension engine threw unexpectedly", e);
+            return MeasurementResult.failed(MeasurementResult.Status.ERROR, e.toString());
+        }
+    }
+
+    private ParcelMeasurement toEntity(Shipment s, UUID daUserId, List<String> keys, MeasurementResult r) {
+        ParcelMeasurement m = new ParcelMeasurement();
+        m.setShipmentId(s.getId());
+        m.setShipmentRef(s.getShipmentRef());
+        m.setSource(MeasurementSource.DA_PICKUP);
+        m.setMethod(MeasurementMethod.ARUCO);
+        m.setStatus(r.status().name());
+        m.setLengthCm(r.lengthCm());
+        m.setWidthCm(r.widthCm());
+        m.setHeightCm(r.heightCm());
+        m.setVolumetricWeightGrams(volumetricGrams(r));
+        m.setConfidence((float) r.confidence());
+        m.setDeclaredLengthCm(s.getLengthCm());
+        m.setDeclaredWidthCm(s.getWidthCm());
+        m.setDeclaredHeightCm(s.getHeightCm());
+        m.setEvidenceKeys(keys);
+        m.setMeasuredBy(daUserId);
+
+        if (r.isOk()) {
+            double[] declared = {nz(s.getLengthCm()), nz(s.getWidthCm()), nz(s.getHeightCm())};
+            Double[] measured = {r.lengthCm(), r.widthCm(), r.heightCm()};
+            DiscrepancyPolicy.Verdict v = discrepancyPolicy.evaluate(declared, measured);
+            m.setOverDeclared(v.overDeclared());
+            m.setDiscrepancyDetail(v.detail());
+        } else {
+            m.setOverDeclared(false);
+            m.setDiscrepancyDetail(r.detail());
+        }
+        return m;
+    }
+
+    private Integer volumetricGrams(MeasurementResult r) {
+        if (!r.isOk() || r.lengthCm() == null || r.widthCm() == null || r.heightCm() == null) return null;
+        // L*W*H (cm³) / divisor = volumetric kg → *1000 for grams. Matches M4 booking math.
+        double kg = (r.lengthCm() * r.widthCm() * r.heightCm()) / props.getVolumetricDivisor();
+        return (int) Math.round(kg * 1000);
+    }
+
+    private List<String> presignEvidenceGets(ParcelMeasurement m) {
+        if (!storage.isAvailable() || m.getEvidenceKeys() == null) return List.of();
+        List<String> urls = new ArrayList<>();
+        for (String key : m.getEvidenceKeys()) {
+            try {
+                urls.add(storage.presignGet(key, Duration.ofSeconds(props.getViewUrlTtlSeconds())));
+            } catch (RuntimeException e) {
+                log.warn("Failed to presign GET for evidence key {}: {}", key, e.toString());
+            }
+        }
+        return urls;
+    }
+
+    private MeasurementView toView(ParcelMeasurement m, List<String> evidenceUrls) {
+        return new MeasurementView(
+                m.getId(), m.getSource().name(), m.getMethod().name(), m.getStatus(),
+                MeasurementResult.Status.OK.name().equals(m.getStatus()),
+                m.getLengthCm(), m.getWidthCm(), m.getHeightCm(),
+                m.getVolumetricWeightGrams(), m.getConfidence(),
+                m.getDeclaredLengthCm(), m.getDeclaredWidthCm(), m.getDeclaredHeightCm(),
+                m.isOverDeclared(), m.getDiscrepancyDetail(), evidenceUrls, m.getCreatedAt());
+    }
+
+    private Shipment resolve(String shipmentRef) {
+        return shipmentRepository.findByShipmentRef(shipmentRef)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "shipment not found"));
+    }
+
+    private void requireOwnedKey(String key, String shipmentRef) {
+        if (key == null || !key.startsWith(KEY_PREFIX + "/") || !key.contains("/" + shipmentRef + "/")) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "evidence key does not belong to this shipment");
+        }
+    }
+
+    private String buildKey(String shipmentRef) {
+        LocalDate d = LocalDate.now(IST);
+        return String.format("%s/%04d/%02d/%02d/%s/%s.jpg",
+                KEY_PREFIX, d.getYear(), d.getMonthValue(), d.getDayOfMonth(), shipmentRef, UUID.randomUUID());
+    }
+
+    private static DimensionEngine.View parseView(String v) {
+        if (v == null) return DimensionEngine.View.UNKNOWN;
+        try {
+            return DimensionEngine.View.valueOf(v.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return DimensionEngine.View.UNKNOWN;
+        }
+    }
+
+    private static double nz(Short s) {
+        return s == null ? 0 : s.doubleValue();
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/ParcelMeasurementServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/ParcelMeasurementServiceImpl.java
@@ -1,6 +1,7 @@
 package com.oneday.orders.service.impl;
 
 import com.oneday.common.port.ObjectStoragePort;
+import com.oneday.common.port.PickupAssignmentPort;
 import com.oneday.orders.config.MeasurementProperties;
 import com.oneday.orders.domain.MeasurementMethod;
 import com.oneday.orders.domain.MeasurementSource;
@@ -48,6 +49,7 @@ class ParcelMeasurementServiceImpl implements ParcelMeasurementService {
     private final DiscrepancyPolicy discrepancyPolicy;
     private final MeasurementPersister persister;
     private final MeasurementProperties props;
+    private final PickupAssignmentPort pickupAssignment;
 
     ParcelMeasurementServiceImpl(ShipmentRepository shipmentRepository,
                                  ParcelMeasurementRepository measurementRepository,
@@ -55,7 +57,8 @@ class ParcelMeasurementServiceImpl implements ParcelMeasurementService {
                                  DimensionEngine engine,
                                  DiscrepancyPolicy discrepancyPolicy,
                                  MeasurementPersister persister,
-                                 MeasurementProperties props) {
+                                 MeasurementProperties props,
+                                 PickupAssignmentPort pickupAssignment) {
         this.shipmentRepository = shipmentRepository;
         this.measurementRepository = measurementRepository;
         this.storage = storage;
@@ -63,11 +66,13 @@ class ParcelMeasurementServiceImpl implements ParcelMeasurementService {
         this.discrepancyPolicy = discrepancyPolicy;
         this.persister = persister;
         this.props = props;
+        this.pickupAssignment = pickupAssignment;
     }
 
     @Override
-    public List<EvidenceUpload> presignUploads(String shipmentRef, int count) {
+    public List<EvidenceUpload> presignUploads(String shipmentRef, int count, UUID callerUserId, boolean admin) {
         Shipment shipment = resolve(shipmentRef);
+        requireAssignedOrAdmin(callerUserId, admin, shipment.getId());
         if (count < 1 || count > props.getMaxEvidencePhotos()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                     "count must be between 1 and " + props.getMaxEvidencePhotos());
@@ -85,8 +90,10 @@ class ParcelMeasurementServiceImpl implements ParcelMeasurementService {
     }
 
     @Override
-    public MeasurementView recordDaPickupMeasurement(String shipmentRef, UUID daUserId, List<EvidenceCapture> captures) {
+    public MeasurementView recordDaPickupMeasurement(String shipmentRef, UUID daUserId, boolean admin,
+                                                     List<EvidenceCapture> captures) {
         Shipment shipment = resolve(shipmentRef);
+        requireAssignedOrAdmin(daUserId, admin, shipment.getId());
         if (captures == null || captures.isEmpty()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "no captures");
         }
@@ -104,7 +111,14 @@ class ParcelMeasurementServiceImpl implements ParcelMeasurementService {
             keys.add(key);
             if (!storage.isAvailable()) { fetchFailed = true; continue; }
             try {
-                if (!storage.exists(key)) { fetchFailed = true; continue; }
+                long sz = storage.size(key);               // one HEAD: existence + size
+                if (sz < 0) { fetchFailed = true; continue; }   // not uploaded
+                if (sz > props.getMaxEvidenceBytes()) {         // reject oversized BEFORE buffering into heap
+                    log.warn("Evidence object {} is {} bytes, over the {} cap — skipping",
+                            logSafe(key), sz, props.getMaxEvidenceBytes());
+                    fetchFailed = true;
+                    continue;
+                }
                 byte[] bytes = storage.getBytes(key);
                 engineCaptures.add(new DimensionEngine.Capture(bytes, parseView(c.view())));
             } catch (RuntimeException e) {
@@ -211,6 +225,17 @@ class ParcelMeasurementServiceImpl implements ParcelMeasurementService {
     private Shipment resolve(String shipmentRef) {
         return shipmentRepository.findByShipmentRef(shipmentRef)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "shipment not found"));
+    }
+
+    /** A DA may only measure a pickup they were assigned to; ADMIN (ops/demo) bypasses. */
+    private void requireAssignedOrAdmin(UUID callerUserId, boolean admin, UUID shipmentId) {
+        if (admin) {
+            return;
+        }
+        if (callerUserId == null || !pickupAssignment.isActivePickupDa(callerUserId, shipmentId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                    "not the delivery associate assigned to this pickup");
+        }
     }
 
     private void requireOwnedKey(String key, String shipmentRef) {

--- a/orders/src/main/java/com/oneday/orders/service/impl/ParcelMeasurementServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/ParcelMeasurementServiceImpl.java
@@ -108,7 +108,7 @@ class ParcelMeasurementServiceImpl implements ParcelMeasurementService {
                 byte[] bytes = storage.getBytes(key);
                 engineCaptures.add(new DimensionEngine.Capture(bytes, parseView(c.view())));
             } catch (RuntimeException e) {
-                log.warn("Evidence fetch failed for key {}: {}", key, e.toString());
+                log.warn("Evidence fetch failed for key {}: {}", logSafe(key), e.toString());
                 fetchFailed = true;
             }
         }
@@ -117,7 +117,7 @@ class ParcelMeasurementServiceImpl implements ParcelMeasurementService {
         ParcelMeasurement m = toEntity(shipment, daUserId, keys, result);
         ParcelMeasurement saved = persister.persist(m);
         log.info("Recorded DA_PICKUP measurement ref={} status={} overDeclared={}",
-                shipmentRef, saved.getStatus(), saved.isOverDeclared());
+                logSafe(shipmentRef), saved.getStatus(), saved.isOverDeclared());
         return toView(saved, null);
     }
 
@@ -214,9 +214,15 @@ class ParcelMeasurementServiceImpl implements ParcelMeasurementService {
     }
 
     private void requireOwnedKey(String key, String shipmentRef) {
-        if (key == null || !key.startsWith(KEY_PREFIX + "/") || !key.contains("/" + shipmentRef + "/")) {
+        if (key == null || !key.startsWith(KEY_PREFIX + "/") || !key.contains("/" + shipmentRef + "/")
+                || key.chars().anyMatch(ch -> ch < 0x20)) {   // reject control chars (log-injection safe)
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "evidence key does not belong to this shipment");
         }
+    }
+
+    /** Strip CR/LF/control chars from a user-supplied value before logging (prevents log forging). */
+    private static String logSafe(String s) {
+        return s == null ? null : s.replaceAll("[\\p{Cntrl}]", "_");
     }
 
     private String buildKey(String shipmentRef) {

--- a/orders/src/main/resources/db/migration/orders/V4_38__parcel_measurement.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_38__parcel_measurement.sql
@@ -1,0 +1,45 @@
+-- Append-only parcel-dimension measurements (first-mile "scan dimensions" feature).
+--
+-- Merchants under-declare L/W/H at booking; this table records additional, source-tagged
+-- observations of the SAME parcel WITHOUT ever mutating the customer's declared dimensions on
+-- `shipments` (those stay the record of what the customer told us, updatable=false by design).
+--
+-- One row per observation (never updated): source = who/what measured it — CUSTOMER_DECLARED,
+-- DA_PICKUP (this feature), HUB (future). Re-measures append new rows; readers take the latest per
+-- source. The declared dimensions are snapshotted onto each row so a dispute has self-contained
+-- evidence even if anything upstream changes. Evidence photo object keys (Cloudflare R2) are stored
+-- as a JSON array; the bucket is private, so the ops console reads them via short-lived presigned GETs.
+CREATE TABLE parcel_measurement (
+    id                       UUID PRIMARY KEY,
+    shipment_id              UUID NOT NULL REFERENCES shipments(id),
+    shipment_ref             VARCHAR(30) NOT NULL,
+    -- CUSTOMER_DECLARED | DA_PICKUP | HUB (extensible)
+    source                   VARCHAR(20) NOT NULL,
+    -- ARUCO | MANUAL | DECLARED — how the numbers were produced
+    method                   VARCHAR(20) NOT NULL,
+    -- OK | NO_MARKER | LOW_CONFIDENCE | TIMEOUT | ENGINE_UNAVAILABLE | BAD_INPUT | ERROR
+    status                   VARCHAR(30) NOT NULL,
+    length_cm                DOUBLE PRECISION,
+    width_cm                 DOUBLE PRECISION,
+    height_cm                DOUBLE PRECISION,
+    volumetric_weight_grams  INTEGER,
+    confidence               REAL,
+    -- declared snapshot at measurement time (immutable evidence)
+    declared_length_cm       SMALLINT,
+    declared_width_cm        SMALLINT,
+    declared_height_cm       SMALLINT,
+    -- discrepancy verdict (moderate tolerance): true when measured materially exceeds declared
+    over_declared            BOOLEAN NOT NULL DEFAULT FALSE,
+    discrepancy_detail       VARCHAR(300),
+    -- R2 object keys for the captured evidence photos
+    evidence_keys            JSONB NOT NULL DEFAULT '[]',
+    -- DA user id who captured it (null for non-DA sources)
+    measured_by              UUID,
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at               TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_parcel_measurement_shipment ON parcel_measurement (shipment_id, created_at DESC);
+-- Fast "which parcels were flagged" scan for the ops/dispute console.
+CREATE INDEX idx_parcel_measurement_flagged ON parcel_measurement (over_declared, created_at DESC)
+    WHERE over_declared = TRUE;

--- a/orders/src/test/java/com/oneday/orders/e2e/OrdersE2eSupport.java
+++ b/orders/src/test/java/com/oneday/orders/e2e/OrdersE2eSupport.java
@@ -11,6 +11,7 @@ import com.oneday.common.domain.enums.PaymentMode;
 import com.oneday.common.domain.enums.PickupType;
 import com.oneday.common.kafka.EventPublisher;
 import com.oneday.common.port.EtaPort;
+import com.oneday.common.port.PickupAssignmentPort;
 import com.oneday.common.port.PricingPort;
 import com.oneday.common.port.ServiceabilityPort;
 import com.oneday.common.port.dto.EtaResult;
@@ -84,6 +85,8 @@ abstract class OrdersE2eSupport {
     @MockBean protected AuthService authService;
     @MockBean protected ApiKeyRepository apiKeyRepository;
     @MockBean protected EventPublisher eventPublisher;
+    // Implemented in dispatch (off the orders test classpath) — mock so the context boots.
+    @MockBean protected PickupAssignmentPort pickupAssignmentPort;
 
     /** Default happy-path stubs for the external ports; individual tests override as needed. */
     @BeforeEach
@@ -99,6 +102,8 @@ abstract class OrdersE2eSupport {
                 new EtaResult(Instant.now().plusSeconds(86_400), 1440));
         // Razorpay: signature/capture/refund all succeed by default (PREPAID happy path).
         lenient().when(paymentPort.initiateRefund(anyString(), anyLong())).thenReturn("rfnd_test_1");
+        // Pickup assignment: the DA is assigned by default; measurement-auth tests override.
+        lenient().when(pickupAssignmentPort.isActivePickupDa(any(), any())).thenReturn(true);
     }
 
     // ── Auth helpers ────────────────────────────────────────────────────────

--- a/orders/src/test/java/com/oneday/orders/e2e/ParcelMeasurementE2eTest.java
+++ b/orders/src/test/java/com/oneday/orders/e2e/ParcelMeasurementE2eTest.java
@@ -1,0 +1,153 @@
+package com.oneday.orders.e2e;
+
+import com.oneday.common.domain.enums.PaymentMode;
+import com.oneday.common.port.ObjectStoragePort;
+import com.oneday.orders.domain.ParcelMeasurement;
+import com.oneday.orders.repository.ParcelMeasurementRepository;
+import com.oneday.vision.DimensionEngine;
+import com.oneday.vision.MeasurementResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Full-stack test of the first-mile "scan dimensions" flow: real HTTP → JWT filter → controller →
+ * service → real Postgres, with object storage + the CV engine mocked (deterministic, no R2/OpenCV).
+ * Also proves the V4_38 migration applies (Flyway runs on context start).
+ */
+class ParcelMeasurementE2eTest extends OrdersE2eSupport {
+
+    @MockBean protected ObjectStoragePort storage;
+    @MockBean protected DimensionEngine engine;
+    @Autowired protected ParcelMeasurementRepository measurementRepository;
+
+    @BeforeEach
+    void storageAndEngineStubs() {
+        lenient().when(storage.isAvailable()).thenReturn(true);
+        lenient().when(storage.presignPut(anyString(), anyString(), any())).thenReturn("https://r2.example/put");
+        lenient().when(storage.presignGet(anyString(), any())).thenReturn("https://r2.example/get");
+        lenient().when(storage.exists(anyString())).thenReturn(true);
+        lenient().when(storage.getBytes(anyString())).thenReturn(new byte[]{1, 2, 3});
+        lenient().when(engine.isAvailable()).thenReturn(true);
+    }
+
+    private String daToken() {
+        return tokenFor("DELIVERY_ASSOCIATE", randomUserId());
+    }
+
+    @Test
+    void presignReturnsUploadSlots() throws Exception {
+        String custToken = tokenFor("C2C_CUSTOMER", randomUserId());
+        String ref = bookB2c(custToken, PaymentMode.PREPAID);   // declared 20x15x10
+
+        mvc.perform(post("/internal/v1/shipments/{ref}/measurement/upload-urls?count=2", ref)
+                        .header("Authorization", "Bearer " + daToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].object_key").exists())
+                .andExpect(jsonPath("$[0].upload_url").value("https://r2.example/put"));
+    }
+
+    @Test
+    void overDeclaredMeasurementIsFlaggedAndPersisted() throws Exception {
+        String custToken = tokenFor("C2C_CUSTOMER", randomUserId());
+        String ref = bookB2c(custToken, PaymentMode.PREPAID);   // declared 20x15x10 (3000 cm³)
+
+        // Measured 40x30x25 (30000 cm³) — grossly over-declared.
+        when(engine.measure(any())).thenReturn(MeasurementResult.ok(40.0, 30.0, 25.0, 0.9, "top+side"));
+
+        String body = json.writeValueAsString(Map.of("captures", List.of(
+                Map.of("object_key", key(ref, "top"), "view", "TOP"),
+                Map.of("object_key", key(ref, "side"), "view", "SIDE"))));
+
+        mvc.perform(post("/internal/v1/shipments/{ref}/measurement", ref)
+                        .header("Authorization", "Bearer " + daToken())
+                        .contentType("application/json").content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(true))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.over_declared").value(true))
+                .andExpect(jsonPath("$.length_cm").value(40.0))
+                .andExpect(jsonPath("$.volumetric_weight_grams").value(6000)); // 40*30*25/5000*1000
+
+        UUID shipmentId = shipmentRepository.findByShipmentRef(ref).orElseThrow().getId();
+        List<ParcelMeasurement> rows = measurementRepository.findByShipmentIdOrderByCreatedAtDesc(shipmentId);
+        assertThat(rows).hasSize(1);
+        ParcelMeasurement m = rows.get(0);
+        assertThat(m.getStatus()).isEqualTo("OK");
+        assertThat(m.isOverDeclared()).isTrue();
+        assertThat(m.getSource().name()).isEqualTo("DA_PICKUP");
+        assertThat(m.getEvidenceKeys()).hasSize(2);
+        assertThat(m.getDeclaredLengthCm()).isEqualTo((short) 20);
+    }
+
+    @Test
+    void withinToleranceNotFlagged() throws Exception {
+        String custToken = tokenFor("C2C_CUSTOMER", randomUserId());
+        String ref = bookB2c(custToken, PaymentMode.PREPAID);   // declared 20x15x10
+
+        when(engine.measure(any())).thenReturn(MeasurementResult.ok(20.5, 15.0, 10.0, 0.9, "top+side"));
+
+        String body = json.writeValueAsString(Map.of("captures", List.of(
+                Map.of("object_key", key(ref, "top"), "view", "TOP"))));
+
+        mvc.perform(post("/internal/v1/shipments/{ref}/measurement", ref)
+                        .header("Authorization", "Bearer " + daToken())
+                        .contentType("application/json").content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.over_declared").value(false));
+    }
+
+    @Test
+    void degradesWhenEngineUnavailableButStillRecords() throws Exception {
+        String custToken = tokenFor("C2C_CUSTOMER", randomUserId());
+        String ref = bookB2c(custToken, PaymentMode.PREPAID);
+        when(engine.isAvailable()).thenReturn(false);   // CV offline
+
+        String body = json.writeValueAsString(Map.of("captures", List.of(
+                Map.of("object_key", key(ref, "top"), "view", "TOP"))));
+
+        mvc.perform(post("/internal/v1/shipments/{ref}/measurement", ref)
+                        .header("Authorization", "Bearer " + daToken())
+                        .contentType("application/json").content(body))
+                .andExpect(status().isOk())                       // never breaks pickup
+                .andExpect(jsonPath("$.ok").value(false))
+                .andExpect(jsonPath("$.status").value("ENGINE_UNAVAILABLE"))
+                .andExpect(jsonPath("$.over_declared").value(false));
+
+        UUID shipmentId = shipmentRepository.findByShipmentRef(ref).orElseThrow().getId();
+        assertThat(measurementRepository.findByShipmentIdOrderByCreatedAtDesc(shipmentId)).hasSize(1);
+    }
+
+    @Test
+    void rejectsForeignEvidenceKey() throws Exception {
+        String custToken = tokenFor("C2C_CUSTOMER", randomUserId());
+        String ref = bookB2c(custToken, PaymentMode.PREPAID);
+
+        String body = json.writeValueAsString(Map.of("captures", List.of(
+                Map.of("object_key", "pickup-measurements/2026/01/01/SOME-OTHER-REF/x.jpg", "view", "TOP"))));
+
+        mvc.perform(post("/internal/v1/shipments/{ref}/measurement", ref)
+                        .header("Authorization", "Bearer " + daToken())
+                        .contentType("application/json").content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    private static String key(String ref, String tag) {
+        return "pickup-measurements/2026/01/01/" + ref + "/" + tag + "-" + UUID.randomUUID() + ".jpg";
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/e2e/ParcelMeasurementE2eTest.java
+++ b/orders/src/test/java/com/oneday/orders/e2e/ParcelMeasurementE2eTest.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -41,6 +43,7 @@ class ParcelMeasurementE2eTest extends OrdersE2eSupport {
         lenient().when(storage.presignPut(anyString(), anyString(), any())).thenReturn("https://r2.example/put");
         lenient().when(storage.presignGet(anyString(), any())).thenReturn("https://r2.example/get");
         lenient().when(storage.exists(anyString())).thenReturn(true);
+        lenient().when(storage.size(anyString())).thenReturn(1_000L);
         lenient().when(storage.getBytes(anyString())).thenReturn(new byte[]{1, 2, 3});
         lenient().when(engine.isAvailable()).thenReturn(true);
     }
@@ -145,6 +148,44 @@ class ParcelMeasurementE2eTest extends OrdersE2eSupport {
                         .header("Authorization", "Bearer " + daToken())
                         .contentType("application/json").content(body))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void unassignedDaIsForbidden() throws Exception {
+        String custToken = tokenFor("C2C_CUSTOMER", randomUserId());
+        String ref = bookB2c(custToken, PaymentMode.PREPAID);
+        // This DA is NOT the one assigned to the pickup.
+        when(pickupAssignmentPort.isActivePickupDa(any(), any())).thenReturn(false);
+
+        String body = json.writeValueAsString(Map.of("captures", List.of(
+                Map.of("object_key", key(ref, "top"), "view", "TOP"))));
+
+        mvc.perform(post("/internal/v1/shipments/{ref}/measurement", ref)
+                        .header("Authorization", "Bearer " + daToken())
+                        .contentType("application/json").content(body))
+                .andExpect(status().isForbidden());
+
+        // ...and presign is gated the same way.
+        mvc.perform(post("/internal/v1/shipments/{ref}/measurement/upload-urls?count=2", ref)
+                        .header("Authorization", "Bearer " + daToken()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void oversizedEvidenceIsRejectedNotBuffered() throws Exception {
+        String custToken = tokenFor("C2C_CUSTOMER", randomUserId());
+        String ref = bookB2c(custToken, PaymentMode.PREPAID);
+        when(storage.size(anyString())).thenReturn(50L * 1024 * 1024);   // 50MB, over the 15MB cap
+
+        String body = json.writeValueAsString(Map.of("captures", List.of(
+                Map.of("object_key", key(ref, "top"), "view", "TOP"))));
+
+        mvc.perform(post("/internal/v1/shipments/{ref}/measurement", ref)
+                        .header("Authorization", "Bearer " + daToken())
+                        .contentType("application/json").content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(false));   // not measured; oversized object never buffered
+        verify(storage, never()).getBytes(anyString());
     }
 
     private static String key(String ref, String tag) {

--- a/orders/src/test/java/com/oneday/orders/service/impl/DiscrepancyPolicyImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/DiscrepancyPolicyImplTest.java
@@ -35,8 +35,9 @@ class DiscrepancyPolicyImplTest {
 
     @Test
     void singleSideOverThresholdFlagged() {
-        // volume barely up but one side +5cm → side rule trips
-        var v = policy.evaluate(new double[]{30, 20, 10}, new Double[]{30.0, 20.0, 15.0});
+        // declared 30x20x10 (6000), measured 33x20x9.5 (6270) → volume only +4.5% (within tolerance),
+        // but the longest side is +3cm → the SIDE rule alone must trip (volume rule stays silent).
+        var v = policy.evaluate(new double[]{30, 20, 10}, new Double[]{33.0, 20.0, 9.5});
         assertThat(v.overDeclared()).isTrue();
     }
 

--- a/orders/src/test/java/com/oneday/orders/service/impl/DiscrepancyPolicyImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/DiscrepancyPolicyImplTest.java
@@ -1,0 +1,56 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.config.MeasurementProperties;
+import com.oneday.orders.service.DiscrepancyPolicy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Boundary behaviour of the moderate tolerance (volume +10% OR any side +2cm), orientation-independent. */
+class DiscrepancyPolicyImplTest {
+
+    private DiscrepancyPolicy policy;
+
+    @BeforeEach
+    void setUp() {
+        MeasurementProperties props = new MeasurementProperties(); // 10% volume, 2cm side
+        policy = new DiscrepancyPolicyImpl(props);
+    }
+
+    @Test
+    void withinToleranceNotFlagged() {
+        // declared 30x20x10, measured 31x20x10 → +1cm side, volume +3.3% → within both
+        var v = policy.evaluate(new double[]{30, 20, 10}, new Double[]{31.0, 20.0, 10.0});
+        assertThat(v.overDeclared()).isFalse();
+    }
+
+    @Test
+    void bigUnderDeclarationFlaggedByVolume() {
+        // declared 30x20x10 (6000), measured 35x25x15 (13125) → +118% volume
+        var v = policy.evaluate(new double[]{30, 20, 10}, new Double[]{35.0, 25.0, 15.0});
+        assertThat(v.overDeclared()).isTrue();
+        assertThat(v.detail()).contains("over-declared");
+    }
+
+    @Test
+    void singleSideOverThresholdFlagged() {
+        // volume barely up but one side +5cm → side rule trips
+        var v = policy.evaluate(new double[]{30, 20, 10}, new Double[]{30.0, 20.0, 15.0});
+        assertThat(v.overDeclared()).isTrue();
+    }
+
+    @Test
+    void orientationIndependent() {
+        // same box, axes permuted → must NOT be flagged (sizes sorted before compare)
+        var v = policy.evaluate(new double[]{30, 20, 10}, new Double[]{10.0, 30.0, 20.0});
+        assertThat(v.overDeclared()).isFalse();
+    }
+
+    @Test
+    void incompleteDimensionsNotFlagged() {
+        var v = policy.evaluate(new double[]{30, 20, 10}, new Double[]{30.0, null, 10.0});
+        assertThat(v.overDeclared()).isFalse();
+        assertThat(v.detail()).contains("incomplete");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <module>grid</module>
         <module>barcode</module>
         <module>orders</module>
+        <module>vision</module>
         <module>dispatch</module>
         <module>routing</module>
         <module>hub</module>
@@ -39,6 +40,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <lombok.version>1.18.44</lombok.version>
         <springdoc.version>2.3.0</springdoc.version>
+        <!-- Object storage (Cloudflare R2 via the S3-compatible API) — see common/ObjectStoragePort. -->
+        <awssdk.version>2.28.16</awssdk.version>
+        <!-- Computer-vision (OpenCV/ArUco) for the vision module. Native libs are bundled per-platform
+             (classifier deps in vision/pom.xml) — same native-in-JVM shape as OR-Tools in grid/routing. -->
+        <javacpp.version>1.5.10</javacpp.version>
+        <opencv.version>4.9.0-1.5.10</opencv.version>
         <!-- Override Spring Boot 3.2.5's managed versions to patched releases that clear the
              HIGH/CRITICAL CVEs flagged by Trivy. Same minor/patch lines (drop-in compatible):
              tomcat 10.1.20 → 10.1.55 (CVE-2025-24813, CVE-2026-41293/43512/43515),
@@ -77,6 +84,19 @@
                 <version>1.19.7</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!-- AWS SDK v2 BOM — pins the s3 + s3-presigner versions used by the R2 storage adapter. -->
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${awssdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.oneday</groupId>
+                <artifactId>vision</artifactId>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.oneday</groupId>

--- a/vision/pom.xml
+++ b/vision/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.oneday</groupId>
+        <artifactId>one-day-delivery</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>vision</artifactId>
+    <name>Vision - OpenCV/ArUco parcel dimensioning</name>
+
+    <properties>
+        <!-- openblas is an OpenCV preset dependency; version is paired with the javacpp/opencv release. -->
+        <openblas.version>0.3.26-1.5.10</openblas.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <!-- OpenCV Java API (bytedeco). ArUco lives in the objdetect module (merged from contrib in 4.7+).
+             The api jar transitively pulls javacpp + openblas api jars; native binaries are added below
+             as per-platform classifier artifacts so we ship only what we run on:
+             linux-x86_64 (Render) + macosx-arm64 (Apple-Silicon dev). Same native-in-JVM pattern as
+             OR-Tools in grid/routing. -->
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>opencv</artifactId>
+            <version>${opencv.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>opencv</artifactId>
+            <version>${opencv.version}</version>
+            <classifier>linux-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>opencv</artifactId>
+            <version>${opencv.version}</version>
+            <classifier>macosx-arm64</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>javacpp</artifactId>
+            <version>${javacpp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>javacpp</artifactId>
+            <version>${javacpp.version}</version>
+            <classifier>linux-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>javacpp</artifactId>
+            <version>${javacpp.version}</version>
+            <classifier>macosx-arm64</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>openblas</artifactId>
+            <version>${openblas.version}</version>
+            <classifier>linux-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>openblas</artifactId>
+            <version>${openblas.version}</version>
+            <classifier>macosx-arm64</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/vision/src/main/java/com/oneday/vision/DimensionEngine.java
+++ b/vision/src/main/java/com/oneday/vision/DimensionEngine.java
@@ -1,0 +1,33 @@
+package com.oneday.vision;
+
+import java.util.List;
+
+/**
+ * Measures a parcel's physical dimensions from photos that include a known-size ArUco reference
+ * marker. The marker supplies real-world scale, so the result is metric (centimetres) and largely
+ * independent of the (unknown, cheap) phone camera.
+ *
+ * <p>The engine is <b>best-effort and never throws</b>: any failure — native library missing, no
+ * marker detected, a corrupt image, a timeout — comes back as a {@link MeasurementResult} with
+ * {@link MeasurementResult#status()} != {@code OK}. Callers store the evidence photos regardless and
+ * degrade gracefully; a measurement failure must never break the pickup flow.</p>
+ */
+public interface DimensionEngine {
+
+    /** True when the native CV library loaded successfully at startup. */
+    boolean isAvailable();
+
+    /**
+     * Measure from one or more captures of the same parcel on the marker.
+     *
+     * @param captures the guided photos (v1: index 0 = top-down for L×W, index 1 = side for H)
+     * @return the measurement, or a non-OK result explaining why it could not be produced
+     */
+    MeasurementResult measure(List<Capture> captures);
+
+    /** One captured image plus which face it frames. */
+    record Capture(byte[] imageBytes, View view) {}
+
+    /** Which parcel face a capture frames, so the engine knows what to read from it. */
+    enum View { TOP, SIDE, UNKNOWN }
+}

--- a/vision/src/main/java/com/oneday/vision/MeasurementResult.java
+++ b/vision/src/main/java/com/oneday/vision/MeasurementResult.java
@@ -1,0 +1,51 @@
+package com.oneday.vision;
+
+/**
+ * Outcome of a dimension measurement. On {@link Status#OK} the L/W/H are populated (centimetres,
+ * longest-first is NOT guaranteed — they map to the parcel axes as measured); otherwise the
+ * dimensions are null and {@link #status()} explains why.
+ *
+ * @param status     outcome
+ * @param lengthCm   measured length in cm (null unless OK)
+ * @param widthCm    measured width in cm (null unless OK)
+ * @param heightCm   measured height in cm (null unless OK)
+ * @param confidence 0..1 quality score (marker count, reprojection error, view coverage)
+ * @param detail     human-readable note for logs / the DA app (e.g. "no marker detected")
+ */
+public record MeasurementResult(
+        Status status,
+        Double lengthCm,
+        Double widthCm,
+        Double heightCm,
+        double confidence,
+        String detail) {
+
+    public enum Status {
+        /** Dimensions produced. */
+        OK,
+        /** Native CV library not loaded — the whole engine is unavailable. */
+        ENGINE_UNAVAILABLE,
+        /** No ArUco marker found in the photo(s), so there is no scale reference. */
+        NO_MARKER,
+        /** A marker was found but the parcel edges could not be resolved reliably. */
+        LOW_CONFIDENCE,
+        /** Bad input (unreadable image, no captures). */
+        BAD_INPUT,
+        /** CV ran too long and was aborted. */
+        TIMEOUT,
+        /** Any unexpected engine failure. */
+        ERROR
+    }
+
+    public boolean isOk() {
+        return status == Status.OK;
+    }
+
+    public static MeasurementResult ok(double l, double w, Double h, double confidence, String detail) {
+        return new MeasurementResult(Status.OK, l, w, h, confidence, detail);
+    }
+
+    public static MeasurementResult failed(Status status, String detail) {
+        return new MeasurementResult(status, null, null, null, 0.0, detail);
+    }
+}

--- a/vision/src/main/java/com/oneday/vision/MeasurementResult.java
+++ b/vision/src/main/java/com/oneday/vision/MeasurementResult.java
@@ -1,9 +1,10 @@
 package com.oneday.vision;
 
 /**
- * Outcome of a dimension measurement. On {@link Status#OK} the L/W/H are populated (centimetres,
- * longest-first is NOT guaranteed — they map to the parcel axes as measured); otherwise the
- * dimensions are null and {@link #status()} explains why.
+ * Outcome of a dimension measurement. On {@link Status#OK} {@code lengthCm} and {@code widthCm} are
+ * always present (centimetres); {@code heightCm} is present only when a side capture succeeded and is
+ * null for the top-only flow. Longest-first is NOT guaranteed — they map to the parcel axes as
+ * measured. For any non-OK status all three dimensions are null and {@link #status()} explains why.
  *
  * @param status     outcome
  * @param lengthCm   measured length in cm (null unless OK)

--- a/vision/src/main/java/com/oneday/vision/OpenCvArucoDimensionEngine.java
+++ b/vision/src/main/java/com/oneday/vision/OpenCvArucoDimensionEngine.java
@@ -1,0 +1,340 @@
+package com.oneday.vision;
+
+import org.bytedeco.javacpp.BytePointer;
+import org.bytedeco.javacpp.indexer.FloatIndexer;
+import org.bytedeco.javacpp.indexer.IntIndexer;
+import org.bytedeco.opencv.opencv_core.Mat;
+import org.bytedeco.opencv.opencv_core.MatVector;
+import org.bytedeco.opencv.opencv_core.Point;
+import org.bytedeco.opencv.opencv_core.Rect;
+import org.bytedeco.opencv.opencv_core.Size;
+import org.bytedeco.opencv.opencv_objdetect.ArucoDetector;
+import org.bytedeco.opencv.opencv_objdetect.DetectorParameters;
+import org.bytedeco.opencv.opencv_objdetect.Dictionary;
+import org.bytedeco.opencv.opencv_objdetect.RefineParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.bytedeco.opencv.global.opencv_core.CV_32FC2;
+import static org.bytedeco.opencv.global.opencv_core.CV_8UC1;
+import static org.bytedeco.opencv.global.opencv_core.perspectiveTransform;
+import static org.bytedeco.opencv.global.opencv_imgcodecs.IMREAD_COLOR;
+import static org.bytedeco.opencv.global.opencv_imgcodecs.imdecode;
+import static org.bytedeco.opencv.global.opencv_imgproc.CHAIN_APPROX_SIMPLE;
+import static org.bytedeco.opencv.global.opencv_imgproc.COLOR_BGR2GRAY;
+import static org.bytedeco.opencv.global.opencv_imgproc.Canny;
+import static org.bytedeco.opencv.global.opencv_imgproc.GaussianBlur;
+import static org.bytedeco.opencv.global.opencv_imgproc.RETR_EXTERNAL;
+import static org.bytedeco.opencv.global.opencv_imgproc.approxPolyDP;
+import static org.bytedeco.opencv.global.opencv_imgproc.arcLength;
+import static org.bytedeco.opencv.global.opencv_imgproc.boundingRect;
+import static org.bytedeco.opencv.global.opencv_imgproc.contourArea;
+import static org.bytedeco.opencv.global.opencv_imgproc.cvtColor;
+import static org.bytedeco.opencv.global.opencv_imgproc.dilate;
+import static org.bytedeco.opencv.global.opencv_imgproc.findContours;
+import static org.bytedeco.opencv.global.opencv_imgproc.getPerspectiveTransform;
+import static org.bytedeco.opencv.global.opencv_imgproc.resize;
+
+/**
+ * ArUco + homography dimension engine (see {@link DimensionEngine}).
+ *
+ * <p><b>Capture protocol (v1):</b> the DA lays the printed ArUco marker <i>flat on the face being
+ * measured</i> and shoots roughly perpendicular. Because the marker is coplanar with that face, the
+ * marker's four corners (known real size) give an exact perspective-correcting homography from image
+ * pixels to centimetres on that plane — so we can measure the parcel outline in that plane without
+ * any 3D reconstruction. TOP photo → length & width; SIDE photo → height.</p>
+ *
+ * <p>Every path is guarded: a missing native lib, unreadable image, absent marker, or timeout all
+ * return a non-OK {@link MeasurementResult} instead of throwing. All OpenCV work runs on a bounded
+ * worker pool with a hard timeout so a slow/hung call can't tie up request threads.</p>
+ */
+@Component
+public class OpenCvArucoDimensionEngine implements DimensionEngine {
+
+    private static final Logger log = LoggerFactory.getLogger(OpenCvArucoDimensionEngine.class);
+
+    /** Attempt to load the native lib once at class-load; never fatal. */
+    private static final boolean NATIVE_OK = tryLoadNative();
+
+    private static boolean tryLoadNative() {
+        try {
+            // Force the javacpp opencv_core preset to load its native library now.
+            org.bytedeco.opencv.global.opencv_core.getBuildInformation();
+            return true;
+        } catch (Throwable t) { // NOSONAR — native load can throw Error (UnsatisfiedLinkError)
+            LoggerFactory.getLogger(OpenCvArucoDimensionEngine.class)
+                    .warn("OpenCV native library unavailable — dimension engine disabled: {}", t.toString());
+            return false;
+        }
+    }
+
+    private final VisionProperties props;
+    private final ExecutorService pool;
+
+    public OpenCvArucoDimensionEngine(VisionProperties props) {
+        this.props = props;
+        this.pool = Executors.newFixedThreadPool(2, daemon("vision-cv"));
+        if (NATIVE_OK) {
+            log.info("OpenCV dimension engine ready (markerSizeCm={}, dict={})",
+                    props.getMarkerSizeCm(), props.getDictionaryId());
+        }
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return NATIVE_OK;
+    }
+
+    @Override
+    public MeasurementResult measure(List<Capture> captures) {
+        if (!NATIVE_OK) {
+            return MeasurementResult.failed(MeasurementResult.Status.ENGINE_UNAVAILABLE, "native lib not loaded");
+        }
+        if (captures == null || captures.isEmpty()) {
+            return MeasurementResult.failed(MeasurementResult.Status.BAD_INPUT, "no captures");
+        }
+        Future<MeasurementResult> f = pool.submit((Callable<MeasurementResult>) () -> measureInternal(captures));
+        try {
+            return f.get(props.getTimeoutMs(), TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            f.cancel(true);
+            return MeasurementResult.failed(MeasurementResult.Status.TIMEOUT, "cv timed out");
+        } catch (Throwable t) {
+            log.warn("Dimension measurement failed", t);
+            return MeasurementResult.failed(MeasurementResult.Status.ERROR, String.valueOf(t.getMessage()));
+        }
+    }
+
+    // ── core ─────────────────────────────────────────────────────────────────
+
+    private MeasurementResult measureInternal(List<Capture> captures) {
+        FaceMeasurement top = null;
+        FaceMeasurement side = null;
+        for (Capture c : captures) {
+            FaceMeasurement fm = measureFace(c.imageBytes());
+            if (fm == null) continue;
+            if (c.view() == DimensionEngine.View.SIDE && side == null) side = fm;
+            else if (top == null) top = fm;   // TOP or UNKNOWN treated as the primary face
+            else if (side == null) side = fm;
+        }
+        if (top == null) {
+            return MeasurementResult.failed(MeasurementResult.Status.NO_MARKER,
+                    "no marker/face resolved in any capture");
+        }
+
+        double length = Math.max(top.a, top.b);
+        double width = Math.min(top.a, top.b);
+        double confidence = top.confidence;
+        Double height = null;
+
+        if (side != null) {
+            // The side face shares one horizontal edge (≈ length or width) with the top; the other
+            // side is the height. Pick the side value closest to a known horizontal edge as the
+            // shared edge, and take the remaining one as height.
+            double[] s = {side.a, side.b};
+            int sharedIdx = closenessToKnown(s[0], length, width) <= closenessToKnown(s[1], length, width) ? 0 : 1;
+            height = s[1 - sharedIdx];
+            confidence = Math.min(confidence, side.confidence);
+        }
+
+        if (confidence < props.getMinConfidence()) {
+            return MeasurementResult.failed(MeasurementResult.Status.LOW_CONFIDENCE,
+                    String.format("confidence %.2f below threshold", confidence));
+        }
+        return MeasurementResult.ok(round1(length), round1(width),
+                height != null ? round1(height) : null, confidence,
+                height != null ? "top+side" : "top-only (no height)");
+    }
+
+    /** Detect the marker + the largest rectangle on its plane; return the two in-plane cm dims. */
+    private FaceMeasurement measureFace(byte[] imageBytes) {
+        if (imageBytes == null || imageBytes.length == 0) return null;
+        Mat encoded = new Mat(1, imageBytes.length, CV_8UC1, new BytePointer(imageBytes));
+        Mat img = imdecode(encoded, IMREAD_COLOR);
+        if (img == null || img.empty()) return null;
+        try {
+            img = downscale(img);
+            Mat markerImgPts = detectFirstMarker(img);   // 4x1 CV_32FC2 (px), or null
+            if (markerImgPts == null) return null;
+
+            Mat markerCmPts = markerSquareCm();          // 4x1 CV_32FC2 (cm)
+            Mat h = getPerspectiveTransform(markerImgPts, markerCmPts);
+
+            Rect markerBox = boundingRect(markerImgPts);
+            Mat parcelImgPts = detectLargestQuad(img, markerBox); // 4x1 CV_32FC2 (px), or null
+            if (parcelImgPts == null) return null;
+
+            Mat parcelCmPts = new Mat();
+            perspectiveTransform(parcelImgPts, parcelCmPts, h);
+
+            double[] sides = quadSideLengths(parcelCmPts);   // [s01, s12, s23, s30]
+            double dimA = (sides[0] + sides[2]) / 2.0;       // one pair of opposite sides
+            double dimB = (sides[1] + sides[3]) / 2.0;       // the other pair
+            double rectness = rectangularity(sides);
+            return new FaceMeasurement(dimA, dimB, rectness);
+        } catch (Throwable t) {
+            log.debug("measureFace failed: {}", t.toString());
+            return null;
+        }
+    }
+
+    private Mat downscale(Mat img) {
+        int longest = Math.max(img.rows(), img.cols());
+        int max = props.getMaxImageEdgePx();
+        if (longest <= max) return img;
+        double f = (double) max / longest;
+        Mat out = new Mat();
+        resize(img, out, new Size((int) Math.round(img.cols() * f), (int) Math.round(img.rows() * f)));
+        return out;
+    }
+
+    /** Returns the first detected marker's 4 corners as a 4x1 CV_32FC2 Mat (px), or null. */
+    private Mat detectFirstMarker(Mat img) {
+        Dictionary dict = org.bytedeco.opencv.global.opencv_objdetect
+                .getPredefinedDictionary(props.getDictionaryId());
+        ArucoDetector detector = new ArucoDetector(dict, new DetectorParameters(), new RefineParameters());
+        MatVector corners = new MatVector();
+        Mat ids = new Mat();
+        detector.detectMarkers(img, corners, ids);
+        if (corners.size() == 0) return null;
+        Mat first = corners.get(0);   // 1x4 CV_32FC2, order TL,TR,BR,BL
+        FloatIndexer in = first.createIndexer();
+        Mat out = new Mat(4, 1, CV_32FC2);
+        FloatIndexer o = out.createIndexer();
+        for (int k = 0; k < 4; k++) {
+            o.put(k, 0, 0, in.get(0, k, 0));
+            o.put(k, 0, 1, in.get(0, k, 1));
+        }
+        o.release();
+        in.release();
+        return out;
+    }
+
+    /** Marker corners in cm-plane coordinates, order TL,TR,BR,BL, side = markerSizeCm. */
+    private Mat markerSquareCm() {
+        float s = (float) props.getMarkerSizeCm();
+        Mat m = new Mat(4, 1, CV_32FC2);
+        FloatIndexer o = m.createIndexer();
+        float[][] pts = {{0, 0}, {s, 0}, {s, s}, {0, s}};
+        for (int k = 0; k < 4; k++) {
+            o.put(k, 0, 0, pts[k][0]);
+            o.put(k, 0, 1, pts[k][1]);
+        }
+        o.release();
+        return m;
+    }
+
+    /** Largest 4-corner contour on the plane, excluding the marker's own box; 4x1 CV_32FC2 px or null. */
+    private Mat detectLargestQuad(Mat img, Rect markerBox) {
+        Mat gray = new Mat();
+        cvtColor(img, gray, COLOR_BGR2GRAY);
+        GaussianBlur(gray, gray, new Size(5, 5), 0);
+        Mat edges = new Mat();
+        Canny(gray, edges, 50, 150);
+        dilate(edges, edges, new Mat());   // close small gaps in the box outline
+
+        MatVector contours = new MatVector();
+        findContours(edges, contours, RETR_EXTERNAL, CHAIN_APPROX_SIMPLE);
+
+        double markerArea = (double) markerBox.width() * markerBox.height();
+        double bestArea = -1;
+        Mat best = null;
+        for (long i = 0; i < contours.size(); i++) {
+            Mat c = contours.get(i);
+            double area = contourArea(c);
+            if (area < Math.max(markerArea * 1.2, 500)) continue;   // must be bigger than the marker
+            Mat approx = new Mat();
+            double peri = arcLength(c, true);
+            approxPolyDP(c, approx, 0.02 * peri, true);
+            if (approx.rows() != 4) continue;
+            Rect box = boundingRect(approx);
+            if (contains(markerBox, center(box)) && box.width() <= markerBox.width() * 1.3) continue; // it's the marker
+            if (area > bestArea) {
+                bestArea = area;
+                best = approx;
+            }
+        }
+        if (best == null) return null;
+        // approxPolyDP gives Nx1 CV_32SC2 (int); convert to 4x1 CV_32FC2.
+        Mat out = new Mat(4, 1, CV_32FC2);
+        FloatIndexer o = out.createIndexer();
+        IntIndexer in = best.createIndexer();
+        for (int k = 0; k < 4; k++) {
+            o.put(k, 0, 0, (float) in.get(k, 0, 0));
+            o.put(k, 0, 1, (float) in.get(k, 0, 1));
+        }
+        o.release();
+        in.release();
+        return out;
+    }
+
+    private static double[] quadSideLengths(Mat quadCm) {
+        FloatIndexer p = quadCm.createIndexer();
+        float[] xs = new float[4];
+        float[] ys = new float[4];
+        for (int k = 0; k < 4; k++) {
+            xs[k] = p.get(k, 0, 0);
+            ys[k] = p.get(k, 0, 1);
+        }
+        p.release();
+        double[] s = new double[4];
+        for (int k = 0; k < 4; k++) {
+            int n = (k + 1) % 4;
+            s[k] = Math.hypot(xs[n] - xs[k], ys[n] - ys[k]);
+        }
+        return s;
+    }
+
+    /** 1.0 = perfect rectangle (opposite sides equal), →0 as opposite sides diverge. */
+    private static double rectangularity(double[] s) {
+        double p1 = ratio(s[0], s[2]);
+        double p2 = ratio(s[1], s[3]);
+        return p1 * p2;
+    }
+
+    private static double ratio(double a, double b) {
+        double lo = Math.min(a, b);
+        double hi = Math.max(a, b);
+        return hi <= 0 ? 0 : lo / hi;
+    }
+
+    private static double closenessToKnown(double v, double length, double width) {
+        return Math.min(Math.abs(v - length), Math.abs(v - width));
+    }
+
+    private static boolean contains(Rect r, Point pt) {
+        return pt.x() >= r.x() && pt.x() <= r.x() + r.width()
+                && pt.y() >= r.y() && pt.y() <= r.y() + r.height();
+    }
+
+    private static Point center(Rect r) {
+        return new Point(r.x() + r.width() / 2, r.y() + r.height() / 2);
+    }
+
+    private static double round1(double v) {
+        return Math.round(v * 10.0) / 10.0;
+    }
+
+    private static ThreadFactory daemon(String prefix) {
+        AtomicInteger n = new AtomicInteger();
+        return r -> {
+            Thread t = new Thread(r, prefix + "-" + n.incrementAndGet());
+            t.setDaemon(true);
+            return t;
+        };
+    }
+
+    /** One face's two in-plane dimensions (cm) + a 0..1 quality score. */
+    private record FaceMeasurement(double a, double b, double confidence) {}
+}

--- a/vision/src/main/java/com/oneday/vision/OpenCvArucoDimensionEngine.java
+++ b/vision/src/main/java/com/oneday/vision/OpenCvArucoDimensionEngine.java
@@ -1,6 +1,7 @@
 package com.oneday.vision;
 
 import org.bytedeco.javacpp.BytePointer;
+import org.bytedeco.javacpp.Loader;
 import org.bytedeco.javacpp.indexer.FloatIndexer;
 import org.bytedeco.javacpp.indexer.IntIndexer;
 import org.bytedeco.opencv.opencv_core.Mat;
@@ -69,8 +70,16 @@ public class OpenCvArucoDimensionEngine implements DimensionEngine {
 
     private static boolean tryLoadNative() {
         try {
-            // Force the javacpp opencv_core preset to load its native library now.
-            org.bytedeco.opencv.global.opencv_core.getBuildInformation();
+            // Force-load EVERY native module the engine actually uses — not just opencv_core. On a
+            // headless runner missing OpenCV's system libs, opencv_objdetect (ArUco) fails to load
+            // even though core loads fine; probing the full chain here means isAvailable() reflects
+            // reality, so callers/tests degrade or skip instead of crashing mid-measurement.
+            Loader.load(org.bytedeco.opencv.global.opencv_core.class);
+            Loader.load(org.bytedeco.opencv.global.opencv_imgproc.class);
+            Loader.load(org.bytedeco.opencv.global.opencv_imgcodecs.class);
+            Loader.load(org.bytedeco.opencv.global.opencv_calib3d.class);
+            Loader.load(org.bytedeco.opencv.global.opencv_objdetect.class); // ArUco — the module that
+            // pulls highgui and fails on a headless runner without OpenCV's GUI/GL system libs.
             return true;
         } catch (Throwable t) { // NOSONAR — native load can throw Error (UnsatisfiedLinkError)
             LoggerFactory.getLogger(OpenCvArucoDimensionEngine.class)

--- a/vision/src/main/java/com/oneday/vision/VisionProperties.java
+++ b/vision/src/main/java/com/oneday/vision/VisionProperties.java
@@ -1,0 +1,43 @@
+package com.oneday.vision;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Tunables for the ArUco dimension engine. The marker's real-world side length is the scale
+ * reference, so it MUST match the printed board exactly.
+ */
+@Component
+@ConfigurationProperties(prefix = "vision")
+public class VisionProperties {
+
+    /** Physical side length of one printed ArUco marker, in cm. Must match the board. */
+    private double markerSizeCm = 5.0;
+
+    /** Predefined ArUco dictionary id (OpenCV DICT_* ordinal). 4 = DICT_5X5_50 (the fleet marker). */
+    private int dictionaryId = 4;
+
+    /** Hard cap on a single measurement (ms); exceeding it aborts to a TIMEOUT result. */
+    private long timeoutMs = 8000;
+
+    /** Longest image edge (px) the engine works at; larger inputs are downscaled first. */
+    private int maxImageEdgePx = 2000;
+
+    /** Below this confidence the result is reported LOW_CONFIDENCE rather than OK. */
+    private double minConfidence = 0.35;
+
+    public double getMarkerSizeCm() { return markerSizeCm; }
+    public void setMarkerSizeCm(double markerSizeCm) { this.markerSizeCm = markerSizeCm; }
+
+    public int getDictionaryId() { return dictionaryId; }
+    public void setDictionaryId(int dictionaryId) { this.dictionaryId = dictionaryId; }
+
+    public long getTimeoutMs() { return timeoutMs; }
+    public void setTimeoutMs(long timeoutMs) { this.timeoutMs = timeoutMs; }
+
+    public int getMaxImageEdgePx() { return maxImageEdgePx; }
+    public void setMaxImageEdgePx(int maxImageEdgePx) { this.maxImageEdgePx = maxImageEdgePx; }
+
+    public double getMinConfidence() { return minConfidence; }
+    public void setMinConfidence(double minConfidence) { this.minConfidence = minConfidence; }
+}

--- a/vision/src/test/java/com/oneday/vision/MarkerBoardGeneratorTest.java
+++ b/vision/src/test/java/com/oneday/vision/MarkerBoardGeneratorTest.java
@@ -1,0 +1,70 @@
+package com.oneday.vision;
+
+import org.bytedeco.opencv.opencv_core.Mat;
+import org.bytedeco.opencv.opencv_core.Point;
+import org.bytedeco.opencv.opencv_core.Rect;
+import org.bytedeco.opencv.opencv_core.Scalar;
+import org.bytedeco.opencv.opencv_core.Size;
+import org.bytedeco.opencv.opencv_objdetect.Dictionary;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import static org.bytedeco.opencv.global.opencv_core.CV_8UC3;
+import static org.bytedeco.opencv.global.opencv_imgcodecs.imwrite;
+import static org.bytedeco.opencv.global.opencv_imgproc.COLOR_GRAY2BGR;
+import static org.bytedeco.opencv.global.opencv_imgproc.FONT_HERSHEY_SIMPLEX;
+import static org.bytedeco.opencv.global.opencv_imgproc.LINE_8;
+import static org.bytedeco.opencv.global.opencv_imgproc.cvtColor;
+import static org.bytedeco.opencv.global.opencv_imgproc.line;
+import static org.bytedeco.opencv.global.opencv_imgproc.putText;
+
+/**
+ * Not a test — a one-off generator for the printable 5cm ArUco reference marker the DA places on the
+ * parcel. Enabled only when {@code -Dmarker.out=<path.png>} is passed, so it never runs in CI.
+ * DICT_4X4_50 id 0 at 300 DPI, with a quiet zone, a caption, and a 5cm scale bar to verify print size.
+ */
+@EnabledIfSystemProperty(named = "marker.out", matches = ".+")
+class MarkerBoardGeneratorTest {
+
+    private static final int DPI = 300;
+    private static final double MARKER_CM = 5.0;
+
+    @Test
+    void generate() {
+        String out = System.getProperty("marker.out");
+        int markerPx = (int) Math.round(MARKER_CM / 2.54 * DPI);   // 5cm @300dpi ≈ 591px
+        int quiet = markerPx / 4;                                   // white quiet zone
+        int w = markerPx + 2 * quiet;
+        int h = markerPx + 2 * quiet + 320;                        // extra space for caption + scale bar
+
+        Mat canvas = new Mat(h, w, CV_8UC3, new Scalar(255, 255, 255, 0));
+
+        Dictionary dict = org.bytedeco.opencv.global.opencv_objdetect.getPredefinedDictionary(4); // DICT_5X5_50
+        Mat gray = new Mat();
+        org.bytedeco.opencv.global.opencv_objdetect.generateImageMarker(dict, 0, markerPx, gray, 1);
+        Mat bgr = new Mat();
+        cvtColor(gray, bgr, COLOR_GRAY2BGR);
+        bgr.copyTo(new Mat(canvas, new Rect(quiet, quiet, markerPx, markerPx)));
+
+        int textY = quiet + markerPx + 70;
+        putText(canvas, "Godspeed - Parcel Dimension Marker (5.0 cm)", new Point(quiet, textY),
+                FONT_HERSHEY_SIMPLEX, 0.9, new Scalar(0, 0, 0, 0), 2, LINE_8, false);
+        putText(canvas, "PRINT AT 100% (no scaling / no fit-to-page).", new Point(quiet, textY + 45),
+                FONT_HERSHEY_SIMPLEX, 0.7, new Scalar(0, 0, 0, 0), 2, LINE_8, false);
+        putText(canvas, "Lay flat on the parcel face; shoot straight on.", new Point(quiet, textY + 85),
+                FONT_HERSHEY_SIMPLEX, 0.7, new Scalar(0, 0, 0, 0), 2, LINE_8, false);
+
+        // 5cm scale bar (should measure exactly 5cm with a ruler after printing).
+        int barY = textY + 150;
+        int barX0 = quiet;
+        int barX1 = quiet + markerPx;   // markerPx == 5cm
+        line(canvas, new Point(barX0, barY), new Point(barX1, barY), new Scalar(0, 0, 0, 0), 3, LINE_8, 0);
+        line(canvas, new Point(barX0, barY - 12), new Point(barX0, barY + 12), new Scalar(0, 0, 0, 0), 3, LINE_8, 0);
+        line(canvas, new Point(barX1, barY - 12), new Point(barX1, barY + 12), new Scalar(0, 0, 0, 0), 3, LINE_8, 0);
+        putText(canvas, "5.0 cm - verify with a ruler", new Point(barX0, barY + 45),
+                FONT_HERSHEY_SIMPLEX, 0.6, new Scalar(0, 0, 0, 0), 1, LINE_8, false);
+
+        Assumptions.assumeTrue(imwrite(out, canvas), "imwrite failed");
+    }
+}

--- a/vision/src/test/java/com/oneday/vision/OpenCvArucoDimensionEngineTest.java
+++ b/vision/src/test/java/com/oneday/vision/OpenCvArucoDimensionEngineTest.java
@@ -1,0 +1,125 @@
+package com.oneday.vision;
+
+import org.bytedeco.javacpp.BytePointer;
+import org.bytedeco.opencv.opencv_core.Mat;
+import org.bytedeco.opencv.opencv_core.Point;
+import org.bytedeco.opencv.opencv_core.Rect;
+import org.bytedeco.opencv.opencv_core.Scalar;
+import org.bytedeco.opencv.opencv_objdetect.Dictionary;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.bytedeco.opencv.global.opencv_core.CV_8UC3;
+import static org.bytedeco.opencv.global.opencv_imgcodecs.imencode;
+import static org.bytedeco.opencv.global.opencv_imgproc.COLOR_GRAY2BGR;
+import static org.bytedeco.opencv.global.opencv_imgproc.FILLED;
+import static org.bytedeco.opencv.global.opencv_imgproc.cvtColor;
+import static org.bytedeco.opencv.global.opencv_imgproc.rectangle;
+
+/**
+ * Validates the measurement math on a synthetic, perspective-free scene: a generated ArUco marker of
+ * known pixel size (= the reference scale) plus a rectangle of known cm dimensions on the same plane.
+ * The engine must recover the rectangle's real size from the marker scale. This exercises marker
+ * detection + homography + contour measurement without needing physical parcel photos (that is the
+ * Phase-0 caliper spike). Skipped automatically if the native OpenCV lib can't load on this host.
+ */
+class OpenCvArucoDimensionEngineTest {
+
+    private static final double PX_PER_CM = 20.0;   // scale of the synthetic scene
+    private OpenCvArucoDimensionEngine engine;
+
+    @BeforeEach
+    void setUp() {
+        engine = new OpenCvArucoDimensionEngine(new VisionProperties()); // markerSizeCm=5, dict=DICT_4X4_50
+        Assumptions.assumeTrue(engine.isAvailable(), "OpenCV native lib not available on this host");
+    }
+
+    @Test
+    void measuresKnownRectangleFromMarkerScale() {
+        // A 30cm x 20cm parcel top face with the 5cm marker placed on it.
+        byte[] png = syntheticTopFace(30, 20);
+        MeasurementResult r = engine.measure(List.of(new DimensionEngine.Capture(png, DimensionEngine.View.TOP)));
+
+        assertThat(r.status()).isEqualTo(MeasurementResult.Status.OK);
+        assertThat(r.lengthCm()).isCloseTo(30.0, org.assertj.core.data.Offset.offset(1.5));
+        assertThat(r.widthCm()).isCloseTo(20.0, org.assertj.core.data.Offset.offset(1.5));
+        assertThat(r.heightCm()).isNull();               // top-only, no side photo
+        assertThat(r.confidence()).isGreaterThan(0.8);
+    }
+
+    @Test
+    void derivesHeightFromTopPlusSide() {
+        byte[] top = syntheticTopFace(30, 20);           // length 30, width 20
+        byte[] side = syntheticTopFace(30, 12);          // side face shares the 30 edge; height 12
+        MeasurementResult r = engine.measure(List.of(
+                new DimensionEngine.Capture(top, DimensionEngine.View.TOP),
+                new DimensionEngine.Capture(side, DimensionEngine.View.SIDE)));
+
+        assertThat(r.status()).isEqualTo(MeasurementResult.Status.OK);
+        assertThat(r.lengthCm()).isCloseTo(30.0, org.assertj.core.data.Offset.offset(1.5));
+        assertThat(r.widthCm()).isCloseTo(20.0, org.assertj.core.data.Offset.offset(1.5));
+        assertThat(r.heightCm()).isCloseTo(12.0, org.assertj.core.data.Offset.offset(1.5));
+    }
+
+    @Test
+    void noMarkerReturnsNoMarker() {
+        byte[] png = blankCanvas();
+        MeasurementResult r = engine.measure(List.of(new DimensionEngine.Capture(png, DimensionEngine.View.TOP)));
+        assertThat(r.status()).isEqualTo(MeasurementResult.Status.NO_MARKER);
+    }
+
+    @Test
+    void emptyInputReturnsBadInput() {
+        assertThat(engine.measure(List.of()).status()).isEqualTo(MeasurementResult.Status.BAD_INPUT);
+    }
+
+    // ── synthetic scene helpers ───────────────────────────────────────────────
+
+    /** White canvas with a gray rectangle of the given cm size (black border) + a 5cm marker on it. */
+    private byte[] syntheticTopFace(int lengthCm, int widthCm) {
+        int margin = 120;
+        int rectW = (int) (lengthCm * PX_PER_CM);
+        int rectH = (int) (widthCm * PX_PER_CM);
+        Mat canvas = new Mat(rectH + 2 * margin, rectW + 2 * margin, CV_8UC3, new Scalar(255, 255, 255, 0));
+
+        // Parcel top face: filled gray rect + a dark border so Canny finds a clean quad.
+        Point tl = new Point(margin, margin);
+        Point br = new Point(margin + rectW, margin + rectH);
+        rectangle(canvas, tl, br, new Scalar(200, 200, 200, 0), FILLED, 8, 0);
+        rectangle(canvas, tl, br, new Scalar(0, 0, 0, 0), 3, 8, 0);
+
+        // 5cm marker placed on the face (inside the rect, so it's excluded from the parcel contour).
+        int side = (int) (5 * PX_PER_CM);
+        Mat marker = markerImage(side);
+        int mx = margin + rectW / 2 - side / 2;
+        int my = margin + rectH / 2 - side / 2;
+        Mat roi = new Mat(canvas, new Rect(mx, my, side, side));
+        marker.copyTo(roi);
+        return encode(canvas);
+    }
+
+    private byte[] blankCanvas() {
+        return encode(new Mat(600, 800, CV_8UC3, new Scalar(255, 255, 255, 0)));
+    }
+
+    private Mat markerImage(int sidePx) {
+        Dictionary dict = org.bytedeco.opencv.global.opencv_objdetect.getPredefinedDictionary(4); // DICT_5X5_50
+        Mat gray = new Mat();
+        org.bytedeco.opencv.global.opencv_objdetect.generateImageMarker(dict, 0, sidePx, gray, 1);
+        Mat bgr = new Mat();
+        cvtColor(gray, bgr, COLOR_GRAY2BGR);
+        return bgr;
+    }
+
+    private byte[] encode(Mat img) {
+        BytePointer buf = new BytePointer();
+        imencode(".png", img, buf);
+        byte[] out = new byte[(int) buf.limit()];
+        buf.get(out);
+        return out;
+    }
+}

--- a/vision/src/test/java/com/oneday/vision/RealPhotoMeasurementTest.java
+++ b/vision/src/test/java/com/oneday/vision/RealPhotoMeasurementTest.java
@@ -1,0 +1,57 @@
+package com.oneday.vision;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Diagnostic run against a REAL photo (e.g. an object beside an ArUco marker on a table, coplanar).
+ * Since a marker's dictionary/size may be unknown, this sweeps the common predefined dictionaries and
+ * prints what each detects/measures (assuming a 5cm marker). Not a strict assertion test — it's the
+ * "does the pipeline work on a real image" check ahead of the physical spike. Run with
+ * {@code -Dphoto.in=/path/to/photo.jpg}; skipped otherwise.
+ */
+@EnabledIfSystemProperty(named = "photo.in", matches = ".+")
+class RealPhotoMeasurementTest {
+
+    private static final Path IMG = Path.of(System.getProperty("photo.in", ""));
+
+    // Common OpenCV predefined dictionary ordinals to try.
+    private static final int[] DICTS = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16, 17, 20};
+    private static final String[] NAMES = {
+            "4X4_50", "4X4_100", "4X4_250", "4X4_1000", "5X5_50", "5X5_100", "5X5_250", "5X5_1000",
+            "6X6_50", "6X6_100", "6X6_250", "6X6_1000", "7X7_50", "ARUCO_ORIGINAL", "APRILTAG_16h5", "APRILTAG_36h11"};
+
+    @Test
+    void sweepDictionariesAndMeasure() throws Exception {
+        Assumptions.assumeTrue(Files.exists(IMG), "real photo not present: " + IMG);
+        byte[] bytes = Files.readAllBytes(IMG);
+
+        VisionProperties baseProps = new VisionProperties();
+        Assumptions.assumeTrue(new OpenCvArucoDimensionEngine(baseProps).isAvailable(),
+                "OpenCV native lib not available");
+
+        System.out.println("\n=== Real-photo dictionary sweep (marker assumed 5.0 cm) ===");
+        for (int i = 0; i < DICTS.length; i++) {
+            VisionProperties props = new VisionProperties();
+            props.setDictionaryId(DICTS[i]);
+            props.setMarkerSizeCm(5.0);
+            props.setMinConfidence(0.0);   // don't filter — we want to see the raw result
+            OpenCvArucoDimensionEngine engine = new OpenCvArucoDimensionEngine(props);
+            MeasurementResult r = engine.measure(List.of(
+                    new DimensionEngine.Capture(bytes, DimensionEngine.View.TOP)));
+            System.out.printf("dict %-16s (id=%2d) -> %-16s L=%s W=%s conf=%.2f  [%s]%n",
+                    NAMES[i], DICTS[i], r.status(),
+                    fmt(r.lengthCm()), fmt(r.widthCm()), r.confidence(), r.detail());
+        }
+        System.out.println("=== end sweep ===\n");
+    }
+
+    private static String fmt(Double d) {
+        return d == null ? "  -  " : String.format("%.1fcm", d);
+    }
+}


### PR DESCRIPTION
## What
Merchants under-declare parcel L×W×H at booking. This adds a **server-authoritative** "scan dimensions" capability: the DA captures photos of the parcel on a 5cm ArUco marker at pickup, the backend measures true dimensions (OpenCV/ArUco), stores the photos in Cloudflare R2 as evidence, and flags over-declaration — **without ever mutating the customer's declared dims** (append-only, source-tagged).

**Evidence-grade only:** the hub stays the billing source of truth. Emits `DIMENSION_DISCREPANCY_FLAGGED` on `oneday.shipments.events` as the hook for a future chargeback flow; never debits the wallet itself.

## Changes
- **`common`** — `ObjectStoragePort` + `R2ObjectStorageAdapter` (AWS SDK v2, presigned PUT/GET, private bucket, transparent per-environment key-prefix). `ParcelMeasuredEvent`.
- **`vision`** (new module) — `OpenCvArucoDimensionEngine` (bytedeco OpenCV/ArUco; same native-in-JVM pattern as OR-Tools). Homography-based metric measurement from a coplanar `DICT_5X5_50` marker. Native-load guard + bounded timeout → graceful degradation (never breaks pickup).
- **`orders`** — `ParcelMeasurement` + Flyway `V4_38` (append-only; source CUSTOMER_DECLARED/DA_PICKUP/HUB), `ParcelMeasurementService`, `DiscrepancyPolicy` (moderate: vol >10% OR any side >2cm), DA endpoints `/internal/v1/shipments/{ref}/measurement`, owner-scoped `/api/v1/shipments/mine/{ref}/measurements`, AFTER_COMMIT event producer.

## Testing
- R2 live round-trip · 4 CV synthetic + real-photo (phone → 16.4×7.9cm) · 5 e2e (real Postgres) · 5 discrepancy unit · `V4_38` applies from scratch.

## Go-live
Set `R2_*` env per environment; migrations apply on boot. Physical caliper spike is the remaining accuracy gate. Docs: `docs/DIMENSION-CHECKER-PLAN.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added parcel dimension capture from ArUco-marked photos, including automated measurements, confidence results, and failure handling.
  * Delivery associates can upload evidence photos and submit pickup measurements.
  * Customers and administrators can view measurement history and supporting evidence.
  * Added discrepancy detection, tolerance-based verdicts, and volumetric weight calculation.
  * Added secure evidence upload and viewing links backed by object storage.
  * Added measurement event reporting for recorded measurements and flagged discrepancies.
* **Documentation**
  * Added a design plan for parcel dimension-checking workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->