### PR TITLE
feat(exceptions): M11 Increment 1 — MISSING + batch + reassign + ops-analytics columns

### DIFF
--- a/common/src/main/java/com/oneday/common/kafka/enums/ExceptionsEventType.java
+++ b/common/src/main/java/com/oneday/common/kafka/enums/ExceptionsEventType.java
@@ -4,5 +4,8 @@ public enum ExceptionsEventType {
     RTO_INITIATED,
     PICKUP_RESCHEDULED,
     DELIVERY_RESCHEDULED,
+    /** Re-run M5 delivery assignment (re-drives HANDED_TO_DROP_VAN) — unlike RESCHEDULE which only flips
+     *  M4 to DROP_ASSIGNED (van-meeting redelivery, same DA). */
+    DELIVERY_REASSIGNED,
     RTO_COMPLETED
 }

--- a/exceptions/src/main/java/com/oneday/exceptions/api/ExceptionController.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/api/ExceptionController.java
@@ -76,7 +76,7 @@ public class ExceptionController {
         return ResponseEntity.noContent().build();
     }
 
-    /** Apply one action to many cases (manage-packages batch ops). Returns a per-case outcome — a closed
+    /** Apply one action to many cases at once (e.g. a whole missed-flight bag). Returns a per-case outcome — a closed
      *  or missing case in the batch is reported, not fatal — so this is 200, not 204. */
     @PostMapping("/resolve")
     public BatchResolveResponse batchResolve(

--- a/exceptions/src/main/java/com/oneday/exceptions/api/ExceptionController.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/api/ExceptionController.java
@@ -2,6 +2,8 @@ package com.oneday.exceptions.api;
 
 import com.oneday.auth.security.AuthUserDetails;
 import com.oneday.exceptions.domain.ExceptionType;
+import com.oneday.exceptions.dto.BatchResolveRequest;
+import com.oneday.exceptions.dto.BatchResolveResponse;
 import com.oneday.exceptions.dto.ExceptionCaseDetail;
 import com.oneday.exceptions.dto.ExceptionQueueResponse;
 import com.oneday.exceptions.dto.ExceptionSummaryResponse;
@@ -72,5 +74,16 @@ public class ExceptionController {
         service.resolve(id, body.action(), Authz.cityScope(principal),
                 Authz.requireUserId(principal), Authz.role(principal), body.notes());
         return ResponseEntity.noContent().build();
+    }
+
+    /** Apply one action to many cases (manage-packages batch ops). Returns a per-case outcome — a closed
+     *  or missing case in the batch is reported, not fatal — so this is 200, not 204. */
+    @PostMapping("/resolve")
+    public BatchResolveResponse batchResolve(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @Valid @RequestBody BatchResolveRequest body) {
+        Authz.requireRole(principal, Authz.STATION_MANAGER, Authz.SUPERVISOR, Authz.CALL_CENTER_AGENT);
+        return service.batchResolve(body, Authz.cityScope(principal),
+                Authz.requireUserId(principal), Authz.role(principal));
     }
 }

--- a/exceptions/src/main/java/com/oneday/exceptions/domain/Disposition.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/domain/Disposition.java
@@ -8,6 +8,8 @@ public enum Disposition {
     UNDELIVERABLE,
     /** RTO in flight or done. */
     RETURNED,
+    /** Parcel can't be physically located (lost in the network) — stays live so ops keep chasing it. */
+    MISSING,
     /** Case closed successfully. */
     RESOLVED
 }

--- a/exceptions/src/main/java/com/oneday/exceptions/domain/ResolveAction.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/domain/ResolveAction.java
@@ -10,6 +10,8 @@ import com.oneday.common.kafka.enums.ExceptionsEventType;
 public enum ResolveAction {
     RESCHEDULE_PICKUP(ExceptionsEventType.PICKUP_RESCHEDULED),
     RESCHEDULE_DELIVERY(ExceptionsEventType.DELIVERY_RESCHEDULED),
+    /** Re-dispatch to a (fresh-scored, usually different) DA — re-runs M5 assignment. */
+    REASSIGN_DELIVERY(ExceptionsEventType.DELIVERY_REASSIGNED),
     INITIATE_RTO(ExceptionsEventType.RTO_INITIATED),
     COMPLETE_RTO(ExceptionsEventType.RTO_COMPLETED),
     /** Close the case without moving the shipment — the issue was handled offline. */

--- a/exceptions/src/main/java/com/oneday/exceptions/domain/ResolveAction.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/domain/ResolveAction.java
@@ -13,7 +13,10 @@ public enum ResolveAction {
     INITIATE_RTO(ExceptionsEventType.RTO_INITIATED),
     COMPLETE_RTO(ExceptionsEventType.RTO_COMPLETED),
     /** Close the case without moving the shipment — the issue was handled offline. */
-    MARK_RESOLVED(null);
+    MARK_RESOLVED(null),
+    /** Flag the parcel as lost in the network. Publishes no M4 event and stays live (unresolved) so it
+     *  keeps rolling up in the header cards and ops keep chasing it. */
+    MARK_MISSING(null);
 
     private final ExceptionsEventType event;
 

--- a/exceptions/src/main/java/com/oneday/exceptions/dto/BatchResolveRequest.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/dto/BatchResolveRequest.java
@@ -14,6 +14,6 @@ import java.util.UUID;
  */
 public record BatchResolveRequest(
         @NotNull ResolveAction action,
-        @NotEmpty List<UUID> caseIds,
+        @NotEmpty List<@NotNull UUID> caseIds,
         String notes) {
 }

--- a/exceptions/src/main/java/com/oneday/exceptions/dto/BatchResolveRequest.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/dto/BatchResolveRequest.java
@@ -1,0 +1,18 @@
+package com.oneday.exceptions.dto;
+
+import com.oneday.exceptions.domain.ResolveAction;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Apply one problem-solve action to many cases at once (Amazon's manage-packages batch ops). v1 keys on
+ * case-ids (the queue UI already carries them); tracking-id entry is a follow-up (see issue #128).
+ */
+public record BatchResolveRequest(
+        @NotNull ResolveAction action,
+        @NotEmpty List<UUID> caseIds,
+        String notes) {
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/dto/BatchResolveRequest.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/dto/BatchResolveRequest.java
@@ -8,8 +8,9 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * Apply one problem-solve action to many cases at once (Amazon's manage-packages batch ops). v1 keys on
- * case-ids (the queue UI already carries them); tracking-id entry is a follow-up (see issue #128).
+ * Apply one problem-solve action to many cases at once — a DA no-show or a missed-flight bag lands many
+ * failures together, so ops act on them in one go. v1 keys on case-ids (the queue UI already carries
+ * them); tracking-id entry is a follow-up (see issue #128).
  */
 public record BatchResolveRequest(
         @NotNull ResolveAction action,

--- a/exceptions/src/main/java/com/oneday/exceptions/dto/BatchResolveResponse.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/dto/BatchResolveResponse.java
@@ -1,0 +1,16 @@
+package com.oneday.exceptions.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Per-case outcome of a batch resolve. Each case is applied in its own transaction, so a partial failure
+ * (a closed or missing case) doesn't roll back the rest — hence a per-id result list rather than 204.
+ */
+public record BatchResolveResponse(List<Item> results) {
+
+    public enum Status { OK, ALREADY_CLOSED, NOT_FOUND, ERROR }
+
+    public record Item(UUID caseId, Status status, String message) {
+    }
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/dto/ExceptionSummaryResponse.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/dto/ExceptionSummaryResponse.java
@@ -5,5 +5,6 @@ public record ExceptionSummaryResponse(
         long open,
         long reattemptable,
         long undeliverable,
-        long returned) {
+        long returned,
+        long missing) {
 }

--- a/exceptions/src/main/java/com/oneday/exceptions/service/ExceptionCaseService.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/service/ExceptionCaseService.java
@@ -4,6 +4,8 @@ import com.oneday.common.domain.enums.ShipmentState;
 import com.oneday.exceptions.domain.ExceptionReason;
 import com.oneday.exceptions.domain.ExceptionType;
 import com.oneday.exceptions.domain.ResolveAction;
+import com.oneday.exceptions.dto.BatchResolveRequest;
+import com.oneday.exceptions.dto.BatchResolveResponse;
 import com.oneday.exceptions.dto.ExceptionCaseDetail;
 import com.oneday.exceptions.dto.ExceptionQueueResponse;
 import com.oneday.exceptions.dto.ExceptionSummaryResponse;
@@ -35,4 +37,7 @@ public interface ExceptionCaseService {
 
     /** Take a problem-solve action — publishes the M4-driving event and records the action. */
     void resolve(UUID caseId, ResolveAction action, String cityScope, String userId, String role, String notes);
+
+    /** Apply one action to many cases, each in its own transaction; returns a per-case outcome. */
+    BatchResolveResponse batchResolve(BatchResolveRequest request, String cityScope, String userId, String role);
 }

--- a/exceptions/src/main/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImpl.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImpl.java
@@ -251,7 +251,7 @@ class ExceptionCaseServiceImpl implements ExceptionCaseService {
             c.setNotes(notes);
         }
         switch (action) {
-            case RESCHEDULE_PICKUP, RESCHEDULE_DELIVERY -> {
+            case RESCHEDULE_PICKUP, RESCHEDULE_DELIVERY, REASSIGN_DELIVERY -> {
                 c.setStatus(ExceptionStatus.RESCHEDULED);
                 caseRepo.save(c);
             }

--- a/exceptions/src/main/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImpl.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImpl.java
@@ -9,6 +9,8 @@ import com.oneday.exceptions.domain.ExceptionReason;
 import com.oneday.exceptions.domain.ExceptionStatus;
 import com.oneday.exceptions.domain.ExceptionType;
 import com.oneday.exceptions.domain.ResolveAction;
+import com.oneday.exceptions.dto.BatchResolveRequest;
+import com.oneday.exceptions.dto.BatchResolveResponse;
 import com.oneday.exceptions.dto.ExceptionActionView;
 import com.oneday.exceptions.dto.ExceptionCaseDetail;
 import com.oneday.exceptions.dto.ExceptionCaseSummary;
@@ -22,6 +24,7 @@ import com.oneday.exceptions.repository.ExceptionCaseRepository;
 import com.oneday.exceptions.service.ExceptionCaseService;
 import com.oneday.orders.service.ShipmentJourneyService;
 import com.oneday.orders.service.ShipmentLookupService;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -32,6 +35,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -49,11 +53,16 @@ class ExceptionCaseServiceImpl implements ExceptionCaseService {
     private final ShipmentContactPort contactPort;
     private final ExceptionEventProducer producer;
     private final ExceptionProperties props;
+    /** Self-proxy so batchResolve's per-id resolve() calls cross the @Transactional boundary (a direct
+     *  this.resolve() would bypass the proxy → no per-case transaction). @Lazy breaks the self-cycle. */
+    private final ExceptionCaseService self;
 
     public ExceptionCaseServiceImpl(ExceptionCaseRepository caseRepo, ExceptionActionRepository actionRepo,
                                     ShipmentLookupService shipmentLookup, ShipmentJourneyService journeyService,
                                     CourierOnShipmentPort courierPort, ShipmentContactPort contactPort,
-                                    ExceptionEventProducer producer, ExceptionProperties props) {
+                                    ExceptionEventProducer producer, ExceptionProperties props,
+                                    @Lazy ExceptionCaseService self) {
+        this.self = self;
         this.caseRepo = caseRepo;
         this.actionRepo = actionRepo;
         this.shipmentLookup = shipmentLookup;
@@ -175,7 +184,7 @@ class ExceptionCaseServiceImpl implements ExceptionCaseService {
     @Override
     @Transactional(readOnly = true)
     public ExceptionSummaryResponse summary(String cityScope) {
-        long open = 0, reattemptable = 0, undeliverable = 0, returned = 0;
+        long open = 0, reattemptable = 0, undeliverable = 0, returned = 0, missing = 0;
         for (Object[] row : caseRepo.countOpenByDisposition(cityScope)) {
             Disposition d = (Disposition) row[0];
             long n = (Long) row[1];
@@ -184,10 +193,11 @@ class ExceptionCaseServiceImpl implements ExceptionCaseService {
                 case REATTEMPTABLE -> reattemptable += n;
                 case UNDELIVERABLE -> undeliverable += n;
                 case RETURNED -> returned += n;
+                case MISSING -> missing += n;
                 case RESOLVED -> { /* resolved cases aren't in the live set */ }
             }
         }
-        return new ExceptionSummaryResponse(open, reattemptable, undeliverable, returned);
+        return new ExceptionSummaryResponse(open, reattemptable, undeliverable, returned, missing);
     }
 
     @Override
@@ -252,8 +262,38 @@ class ExceptionCaseServiceImpl implements ExceptionCaseService {
             }
             case COMPLETE_RTO -> close(c, ExceptionStatus.RTO, Disposition.RETURNED);
             case MARK_RESOLVED -> close(c, ExceptionStatus.RESOLVED, Disposition.RESOLVED);
+            case MARK_MISSING -> {
+                // Lost in the network: keep the case live (no resolvedAt) so it stays in the queue/rollups.
+                c.setStatus(ExceptionStatus.IN_PROGRESS);
+                c.setDisposition(Disposition.MISSING);
+                caseRepo.save(c);
+            }
         }
         logAction(c.getId(), action.name(), userId, role, notes);
+    }
+
+    /** Not @Transactional: each per-id {@code self.resolve()} opens its own (REQUIRED) transaction, so one
+     *  bad case (closed / not found / not visible) is isolated and the rest still apply. */
+    @Override
+    public BatchResolveResponse batchResolve(BatchResolveRequest request, String cityScope,
+                                             String userId, String role) {
+        List<BatchResolveResponse.Item> results = new ArrayList<>();
+        for (UUID caseId : request.caseIds()) {
+            try {
+                self.resolve(caseId, request.action(), cityScope, userId, role, request.notes());
+                results.add(new BatchResolveResponse.Item(caseId, BatchResolveResponse.Status.OK, null));
+            } catch (ResponseStatusException e) {
+                BatchResolveResponse.Status status = switch (e.getStatusCode().value()) {
+                    case 404 -> BatchResolveResponse.Status.NOT_FOUND;
+                    case 409 -> BatchResolveResponse.Status.ALREADY_CLOSED;
+                    default -> BatchResolveResponse.Status.ERROR;
+                };
+                results.add(new BatchResolveResponse.Item(caseId, status, e.getReason()));
+            } catch (Exception e) {
+                results.add(new BatchResolveResponse.Item(caseId, BatchResolveResponse.Status.ERROR, e.getMessage()));
+            }
+        }
+        return new BatchResolveResponse(results);
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────────────────────────

--- a/exceptions/src/main/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImpl.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImpl.java
@@ -233,18 +233,19 @@ class ExceptionCaseServiceImpl implements ExceptionCaseService {
     @Transactional
     public void resolve(UUID caseId, ResolveAction action, String cityScope,
                         String userId, String role, String notes) {
+        // Authorize the restricted action BEFORE any lookup, so an unauthorized caller can't probe case
+        // existence/state (404/409) through this endpoint. Reassigning to a new DA re-runs M5 dispatch —
+        // an intraday change that needs ops (station-manager) approval, not a call-centre action.
+        if (action == ResolveAction.REASSIGN_DELIVERY
+                && !ADMIN.equals(role) && !STATION_MANAGER.equals(role) && !SUPERVISOR.equals(role)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                    "REASSIGN_DELIVERY requires station-manager approval");
+        }
         ExceptionCase c = caseRepo.findById(caseId)
                 .filter(x -> visible(x, cityScope))
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Case not found"));
         if (c.getResolvedAt() != null) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Case is already closed");
-        }
-        // Reassigning to a new DA re-runs M5 dispatch — an intraday operational change that needs ops
-        // (station-manager) approval, not a call-centre action (CLAUDE.md nightly-stability invariant).
-        if (action == ResolveAction.REASSIGN_DELIVERY
-                && !ADMIN.equals(role) && !STATION_MANAGER.equals(role) && !SUPERVISOR.equals(role)) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
-                    "REASSIGN_DELIVERY requires station-manager approval");
         }
 
         // Drive M4 (and, downstream, M10) by publishing the matching event — the orders consumer transitions.

--- a/exceptions/src/main/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImpl.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImpl.java
@@ -24,6 +24,8 @@ import com.oneday.exceptions.repository.ExceptionCaseRepository;
 import com.oneday.exceptions.service.ExceptionCaseService;
 import com.oneday.orders.service.ShipmentJourneyService;
 import com.oneday.orders.service.ShipmentLookupService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -43,7 +45,13 @@ import java.util.UUID;
 @Service
 class ExceptionCaseServiceImpl implements ExceptionCaseService {
 
+    private static final Logger log = LoggerFactory.getLogger(ExceptionCaseServiceImpl.class);
+
     private static final int MAX_PAGE_SIZE = 100;
+    // Roles allowed to trigger an intraday dispatch change (REASSIGN) — ops desk, not call-centre.
+    private static final String ADMIN = "ADMIN";
+    private static final String STATION_MANAGER = "STATION_MANAGER";
+    private static final String SUPERVISOR = "SUPERVISOR";
 
     private final ExceptionCaseRepository caseRepo;
     private final ExceptionActionRepository actionRepo;
@@ -231,6 +239,13 @@ class ExceptionCaseServiceImpl implements ExceptionCaseService {
         if (c.getResolvedAt() != null) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Case is already closed");
         }
+        // Reassigning to a new DA re-runs M5 dispatch — an intraday operational change that needs ops
+        // (station-manager) approval, not a call-centre action (CLAUDE.md nightly-stability invariant).
+        if (action == ResolveAction.REASSIGN_DELIVERY
+                && !ADMIN.equals(role) && !STATION_MANAGER.equals(role) && !SUPERVISOR.equals(role)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                    "REASSIGN_DELIVERY requires station-manager approval");
+        }
 
         // Drive M4 (and, downstream, M10) by publishing the matching event — the orders consumer transitions.
         // Publish only AFTER this tx commits (matches orders' ShipmentEventProducer): the broker send is
@@ -290,7 +305,9 @@ class ExceptionCaseServiceImpl implements ExceptionCaseService {
                 };
                 results.add(new BatchResolveResponse.Item(caseId, status, e.getReason()));
             } catch (Exception e) {
-                results.add(new BatchResolveResponse.Item(caseId, BatchResolveResponse.Status.ERROR, e.getMessage()));
+                // Don't leak DB/broker/framework internals to the caller — log server-side, return generic.
+                log.error("Batch resolve failed for case {}", caseId, e);
+                results.add(new BatchResolveResponse.Item(caseId, BatchResolveResponse.Status.ERROR, "Resolution failed"));
             }
         }
         return new BatchResolveResponse(results);

--- a/exceptions/src/test/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImplTest.java
+++ b/exceptions/src/test/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImplTest.java
@@ -19,6 +19,7 @@ import com.oneday.orders.service.ShipmentLookupService;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Instant;
 import java.util.List;
@@ -26,6 +27,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -161,6 +163,21 @@ class ExceptionCaseServiceImplTest {
 
         verify(producer).publish(shipmentId, ExceptionsEventType.DELIVERY_REASSIGNED);
         assertThat(c.getStatus()).isEqualTo(ExceptionStatus.RESCHEDULED);
+    }
+
+    @Test
+    void reassignDeliveryRejectsCallCentreAgent() {
+        UUID caseId = UUID.randomUUID();
+        ExceptionCase c = new ExceptionCase();
+        c.setShipmentId(shipmentId);
+        when(caseRepo.findById(caseId)).thenReturn(Optional.of(c));
+
+        // Reassigning a DA is an intraday dispatch change — a call-centre agent must not trigger it.
+        assertThatThrownBy(() ->
+                svc.resolve(caseId, ResolveAction.REASSIGN_DELIVERY, null, "u1", "CALL_CENTER_AGENT", null))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(403));
+        verify(producer, never()).publish(any(), any());
     }
 
     @Test

--- a/exceptions/src/test/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImplTest.java
+++ b/exceptions/src/test/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImplTest.java
@@ -166,17 +166,16 @@ class ExceptionCaseServiceImplTest {
     }
 
     @Test
-    void reassignDeliveryRejectsCallCentreAgent() {
+    void reassignDeliveryRejectsCallCentreAgentBeforeAnyLookup() {
         UUID caseId = UUID.randomUUID();
-        ExceptionCase c = new ExceptionCase();
-        c.setShipmentId(shipmentId);
-        when(caseRepo.findById(caseId)).thenReturn(Optional.of(c));
 
-        // Reassigning a DA is an intraday dispatch change — a call-centre agent must not trigger it.
+        // Reassigning a DA is an intraday dispatch change — a call-centre agent must not trigger it, and
+        // the 403 must come BEFORE the case lookup so it can't probe existence/state via this endpoint.
         assertThatThrownBy(() ->
                 svc.resolve(caseId, ResolveAction.REASSIGN_DELIVERY, null, "u1", "CALL_CENTER_AGENT", null))
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(403));
+        verify(caseRepo, never()).findById(any());
         verify(producer, never()).publish(any(), any());
     }
 

--- a/exceptions/src/test/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImplTest.java
+++ b/exceptions/src/test/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImplTest.java
@@ -9,19 +9,25 @@ import com.oneday.exceptions.domain.ExceptionReason;
 import com.oneday.exceptions.domain.ExceptionStatus;
 import com.oneday.exceptions.domain.ExceptionType;
 import com.oneday.exceptions.domain.ResolveAction;
+import com.oneday.exceptions.dto.BatchResolveRequest;
+import com.oneday.exceptions.dto.BatchResolveResponse;
 import com.oneday.exceptions.events.ExceptionEventProducer;
 import com.oneday.exceptions.repository.ExceptionActionRepository;
 import com.oneday.exceptions.repository.ExceptionCaseRepository;
+import com.oneday.exceptions.service.ExceptionCaseService;
 import com.oneday.orders.service.ShipmentLookupService;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -41,9 +47,11 @@ class ExceptionCaseServiceImplTest {
             mock(com.oneday.common.port.ShipmentContactPort.class);
     private final ExceptionEventProducer producer = mock(ExceptionEventProducer.class);
     private final ExceptionProperties props = new ExceptionProperties(); // maxReattempts = 2
+    // Self-proxy is a mock; the batch test stubs it to delegate to the real svc.resolve.
+    private final ExceptionCaseService self = mock(ExceptionCaseService.class);
 
     private final ExceptionCaseServiceImpl svc =
-            new ExceptionCaseServiceImpl(caseRepo, actionRepo, lookup, journey, courier, contact, producer, props);
+            new ExceptionCaseServiceImpl(caseRepo, actionRepo, lookup, journey, courier, contact, producer, props, self);
 
     private final UUID shipmentId = UUID.randomUUID();
 
@@ -154,6 +162,53 @@ class ExceptionCaseServiceImplTest {
         verify(producer, never()).publish(any(), any());
         assertThat(c.getResolvedAt()).isNotNull();
         assertThat(c.getStatus()).isEqualTo(ExceptionStatus.RESOLVED);
+    }
+
+    @Test
+    void markMissingKeepsCaseLiveWithMissingDisposition() {
+        UUID caseId = UUID.randomUUID();
+        ExceptionCase c = new ExceptionCase();
+        c.setShipmentId(shipmentId);
+        when(caseRepo.findById(caseId)).thenReturn(Optional.of(c));
+        when(caseRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        svc.resolve(caseId, ResolveAction.MARK_MISSING, null, "u1", "STATION_MANAGER", "not on the van");
+
+        verify(producer, never()).publish(any(), any());       // no M4 event
+        assertThat(c.getResolvedAt()).isNull();                // stays live in the queue
+        assertThat(c.getStatus()).isEqualTo(ExceptionStatus.IN_PROGRESS);
+        assertThat(c.getDisposition()).isEqualTo(Disposition.MISSING);
+    }
+
+    @Test
+    void batchResolveReportsPerCaseOutcome() {
+        UUID ok = UUID.randomUUID(), closed = UUID.randomUUID(), gone = UUID.randomUUID();
+        ExceptionCase okCase = new ExceptionCase();
+        okCase.setShipmentId(shipmentId);
+        ExceptionCase closedCase = new ExceptionCase();
+        closedCase.setResolvedAt(Instant.now());               // already closed → 409
+        when(caseRepo.findById(ok)).thenReturn(Optional.of(okCase));
+        when(caseRepo.findById(closed)).thenReturn(Optional.of(closedCase));
+        when(caseRepo.findById(gone)).thenReturn(Optional.empty()); // not found → 404
+        when(caseRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+        // The self-proxy delegates to the real resolve (MARK_RESOLVED → no publish, so no tx needed).
+        doAnswer(inv -> {
+            svc.resolve(inv.getArgument(0), inv.getArgument(1), inv.getArgument(2),
+                    inv.getArgument(3), inv.getArgument(4), inv.getArgument(5));
+            return null;
+        }).when(self).resolve(any(), any(), any(), any(), any(), any());
+
+        BatchResolveRequest req = new BatchResolveRequest(ResolveAction.MARK_RESOLVED, List.of(ok, closed, gone), null);
+        BatchResolveResponse resp = svc.batchResolve(req, null, "u1", "STATION_MANAGER");
+
+        assertThat(resp.results()).hasSize(3);
+        assertThat(statusOf(resp, ok)).isEqualTo(BatchResolveResponse.Status.OK);
+        assertThat(statusOf(resp, closed)).isEqualTo(BatchResolveResponse.Status.ALREADY_CLOSED);
+        assertThat(statusOf(resp, gone)).isEqualTo(BatchResolveResponse.Status.NOT_FOUND);
+    }
+
+    private static BatchResolveResponse.Status statusOf(BatchResolveResponse r, UUID id) {
+        return r.results().stream().filter(i -> i.caseId().equals(id)).findFirst().orElseThrow().status();
     }
 
     @Test

--- a/exceptions/src/test/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImplTest.java
+++ b/exceptions/src/test/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImplTest.java
@@ -150,6 +150,20 @@ class ExceptionCaseServiceImplTest {
     }
 
     @Test
+    void resolveReassignDeliveryPublishesTheReassignEvent() {
+        UUID caseId = UUID.randomUUID();
+        ExceptionCase c = new ExceptionCase();
+        c.setShipmentId(shipmentId);
+        when(caseRepo.findById(caseId)).thenReturn(Optional.of(c));
+        when(caseRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        resolveInTx(() -> svc.resolve(caseId, ResolveAction.REASSIGN_DELIVERY, null, "u1", "STATION_MANAGER", null));
+
+        verify(producer).publish(shipmentId, ExceptionsEventType.DELIVERY_REASSIGNED);
+        assertThat(c.getStatus()).isEqualTo(ExceptionStatus.RESCHEDULED);
+    }
+
+    @Test
     void markResolvedClosesWithoutPublishing() {
         UUID caseId = UUID.randomUUID();
         ExceptionCase c = new ExceptionCase();

--- a/orders/src/main/java/com/oneday/orders/domain/Shipment.java
+++ b/orders/src/main/java/com/oneday/orders/domain/Shipment.java
@@ -158,6 +158,14 @@ public class Shipment extends MutableBaseEntity {
     @Column(name = "eta_updated")
     private Instant etaUpdated;
 
+    // ── Dwell / ageing primitive (V4_39; nullable, mutable) ───────────────
+    /** Denormalized latest scan (populated by the M8-scan writer, issue #124). Dwell = now − lastScanAt. */
+    @Column(name = "last_scan_at")
+    private Instant lastScanAt;
+
+    @Column(name = "last_scan_type", length = 30)
+    private String lastScanType;
+
     // ── Scheduled pickup (nullable = ASAP) ────────────────────────────────
     @Column(name = "scheduled_pickup_start")
     private Instant scheduledPickupStart;

--- a/orders/src/main/java/com/oneday/orders/events/ExceptionsEventsConsumer.java
+++ b/orders/src/main/java/com/oneday/orders/events/ExceptionsEventsConsumer.java
@@ -29,6 +29,9 @@ public class ExceptionsEventsConsumer {
             case RTO_INITIATED        -> ShipmentState.RTO_INITIATED;
             case PICKUP_RESCHEDULED   -> ShipmentState.PICKUP_ASSIGNED;
             case DELIVERY_RESCHEDULED -> ShipmentState.DROP_ASSIGNED;
+            // Reassign re-drives the M5 assignment trigger (the failed DELIVERY task is already terminal,
+            // so dispatch assigns a fresh DA); reschedule above only flips M4 state (van-meeting redelivery).
+            case DELIVERY_REASSIGNED  -> ShipmentState.HANDED_TO_DROP_VAN;
             case RTO_COMPLETED        -> ShipmentState.RTO_COMPLETED;
         };
         stateMachine.transition(event.shipmentId(), target,

--- a/orders/src/main/java/com/oneday/orders/service/TransitionRegistry.java
+++ b/orders/src/main/java/com/oneday/orders/service/TransitionRegistry.java
@@ -100,6 +100,7 @@ public class TransitionRegistry {
         register(ShipmentState.DELIVERY_FAILED,       ShipmentState.RTO_INITIATED);
         register(ShipmentState.DELIVERY_FAILED,       ShipmentState.DROP_ASSIGNED);          // VAN_MEETING redelivery
         register(ShipmentState.DELIVERY_FAILED,       ShipmentState.HUB_DELIVERY_ASSIGNED);  // HUB_RETURN redelivery
+        register(ShipmentState.DELIVERY_FAILED,       ShipmentState.HANDED_TO_DROP_VAN);     // M11 reassign → re-run M5
 
         // ── RTO path (delivery_type branching at RTO_INITIATED) ──────────────
         // Both targets registered; impl filters to one at runtime.

--- a/orders/src/main/resources/db/migration/orders/V4_39__enrich_shipment_ops_analytics.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_39__enrich_shipment_ops_analytics.sql
@@ -1,0 +1,13 @@
+-- Dwell / ageing primitive on shipments — the one Amazon PackageResults field that maps to Godspeed's
+-- model. Both nullable and set AFTER booking (by the M8-scan writer, issue #124), so they don't touch
+-- the immutable booking facts. Plain VARCHAR for last_scan_type (churns; avoids enum CAST ceremony).
+--
+-- Dwell (minutes-since-last-scan) is DERIVED at read (now - last_scan_at), never stored — it powers the
+-- ageing report and flags parcels stuck before a hub/flight cutoff.
+--
+-- The rest of Amazon's PackageResults schema was intentionally dropped: cluster ≈ dest_tile_id + van
+-- route, sort_zone/aisle don't fit Godspeed's bag+stand sortation, service_type/rdd are already covered
+-- by delivery_type + customer_type + sla_commitment_minutes + eta_promised.
+ALTER TABLE shipments
+    ADD COLUMN last_scan_at    TIMESTAMPTZ,    -- denormalized latest-scan time (powers dwell/ageing)
+    ADD COLUMN last_scan_type  VARCHAR(30);

--- a/orders/src/test/java/com/oneday/orders/events/ExceptionsEventsConsumerTest.java
+++ b/orders/src/test/java/com/oneday/orders/events/ExceptionsEventsConsumerTest.java
@@ -1,0 +1,36 @@
+package com.oneday.orders.events;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.kafka.enums.ExceptionsEventType;
+import com.oneday.common.kafka.events.ExceptionsEvent;
+import com.oneday.orders.service.ShipmentStateMachine;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/** M11 exception events → M4 state transitions. Guards the reschedule-vs-reassign distinction. */
+class ExceptionsEventsConsumerTest {
+
+    private final ShipmentStateMachine sm = mock(ShipmentStateMachine.class);
+    private final ExceptionsEventsConsumer consumer = new ExceptionsEventsConsumer(sm);
+
+    @Test
+    void reassignReDrivesHandedToDropVan() {
+        UUID id = UUID.randomUUID();
+        consumer.onExceptionsEvent(new ExceptionsEvent(id, ExceptionsEventType.DELIVERY_REASSIGNED));
+        // HANDED_TO_DROP_VAN is M5's assignment trigger → dispatch scores a fresh DA.
+        verify(sm).transition(eq(id), eq(ShipmentState.HANDED_TO_DROP_VAN), any());
+    }
+
+    @Test
+    void rescheduleOnlyFlipsToDropAssigned() {
+        UUID id = UUID.randomUUID();
+        consumer.onExceptionsEvent(new ExceptionsEvent(id, ExceptionsEventType.DELIVERY_RESCHEDULED));
+        verify(sm).transition(eq(id), eq(ShipmentState.DROP_ASSIGNED), any());
+    }
+}


### PR DESCRIPTION
## What
Increment 1 of the Amazon-parity roadmap — finishes M11 to true problem-solve parity and lands the one shipment data-model field the ops-analytics layer needs.

Plan: `~/.claude/plans/update-the-memory-and-dazzling-sifakis.md`

## Changes
1. **MISSING disposition** (`MARK_MISSING`) — flags a parcel lost in the network. No M4 event; stays **live** (resolvedAt null) so it keeps rolling up in the header cards. New `Disposition.MISSING` + summary bucket.
2. **Batch resolve** — `POST /api/v1/exceptions/resolve` applies one action to N case-ids (manage-packages parity). Reuses single `resolve()` per id, each in its own tx via an `@Lazy` self-proxy → a closed/missing case is reported (200 + per-id results), not fatal.
3. **REASSIGN_DELIVERY** — re-dispatches a failed delivery to a fresh-scored DA. **Key seam finding: reschedule ≠ reassign** — `RESCHEDULE_DELIVERY` only flips M4 to `DROP_ASSIGNED` (van-meeting, same DA); reassign publishes a new `DELIVERY_REASSIGNED` → orders re-drives `HANDED_TO_DROP_VAN` (M5's assignment trigger). No dispatch change needed: the failed DELIVERY task is already terminal, so `handleStateChanged` assigns fresh.
4. **V4_39 — dwell/ageing primitive** — `last_scan_at` + `last_scan_type` on `shipments`. **Trimmed from the original Amazon schema after a Godspeed reality-check**: dropped `service_type`/`sort_zone`/`cluster`/`aisle`/`rdd` — `cluster` ≈ `dest_tile_id` + van route, `sort_zone`/`aisle` don't fit Godspeed's bag+stand sortation, `service_type`/`rdd` are covered by `delivery_type` + `customer_type` + `sla_commitment_minutes`/`eta_promised`. Kept only the dwell primitive, which maps to Godspeed's hard flight/cron cutoff (a parcel stuck since its last scan is a real ageing signal).

## Verified
- exceptions suite green (15); orders consumer + state-machine green (11). App assembles with V4_39.

## Follow-ups filed
- #122 guarantee a different DA on reassign (excludeDaId)
- #124 M8-scan writer for `last_scan_at` (powers dwell/ageing)
- #128 tracking-id batch entry · #129 on-road override
- (#123 ship_method closed — N/A to Godspeed)

## Note for the web repo
`GET /api/v1/exceptions/summary` gains a `missing` count; resolve accepts `MARK_MISSING` and `REASSIGN_DELIVERY`. The station console needs the MISSING card + the two actions in the dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added batch resolution for multiple exception cases with individual results.
  - Added options to reassign deliveries or mark parcels as missing.
  - Added missing-parcel counts and latest scan details, including scan age, to operations analytics.

- **Bug Fixes**
  - Improved handling of reassigned and rescheduled deliveries across shipment workflows.
  - Improved reporting for missing, closed, unavailable, and failed resolutions.
  - Added clearer outcomes for cases that are not found or already closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->