### PR TITLE
feat(orders): ageing report — live shipments by ops-stage x dwell band

### DIFF
--- a/orders/src/main/java/com/oneday/orders/api/AdminOrdersController.java
+++ b/orders/src/main/java/com/oneday/orders/api/AdminOrdersController.java
@@ -2,6 +2,7 @@ package com.oneday.orders.api;
 
 import com.oneday.auth.security.AuthUserDetails;
 import com.oneday.orders.dto.CancellationResponse;
+import com.oneday.orders.dto.ShipmentAgeingStats;
 import com.oneday.orders.dto.ShipmentPageResponse;
 import com.oneday.orders.dto.ShipmentSummaryStats;
 import com.oneday.orders.service.AdminOrderQueryService;
@@ -66,6 +67,16 @@ class AdminOrdersController {
     public ShipmentSummaryStats summary(@AuthenticationPrincipal AuthUserDetails principal) {
         Authz.requireRole(principal, STATION_MANAGER);
         return adminOrderSummaryService.summary(cityScope(principal));
+    }
+
+    /**
+     * Ageing rollup — live shipments grouped by ops stage and how long since their last scan, so ops
+     * catch parcels stuck before a flight/cron cutoff. Same visibility as {@link #summary}.
+     */
+    @GetMapping("/ageing")
+    public ShipmentAgeingStats ageing(@AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireRole(principal, STATION_MANAGER);
+        return adminOrderSummaryService.ageing(cityScope(principal));
     }
 
     /** Null for ADMIN (all cities); the station manager's own city otherwise (403 if unassigned). */

--- a/orders/src/main/java/com/oneday/orders/dto/ShipmentAgeingStats.java
+++ b/orders/src/main/java/com/oneday/orders/dto/ShipmentAgeingStats.java
@@ -1,0 +1,22 @@
+package com.oneday.orders.dto;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Ageing rollup for the ops dashboard — live shipments grouped by {@code OpsBucket} stage and dwell band
+ * (time since last scan). {@code bands} names the columns in order (e.g. {@code ["<2h","2-4h","4-8h",">8h"]});
+ * every list in {@code byBucket} and {@code bandTotals} is aligned to that order. Serialises snake_case
+ * ({@code byBucket} → {@code by_bucket}); map keys pass through verbatim ({@code OpsBucket} names).
+ *
+ * @param total       live shipments in scope
+ * @param bands       ordered band labels (the columns)
+ * @param byBucket    OpsBucket name → per-band counts (aligned to {@code bands})
+ * @param bandTotals  per-band totals across all buckets (aligned to {@code bands})
+ */
+public record ShipmentAgeingStats(
+        long total,
+        List<String> bands,
+        Map<String, List<Long>> byBucket,
+        List<Long> bandTotals) {
+}

--- a/orders/src/main/java/com/oneday/orders/repository/AgeingBandCount.java
+++ b/orders/src/main/java/com/oneday/orders/repository/AgeingBandCount.java
@@ -1,0 +1,13 @@
+package com.oneday.orders.repository;
+
+/**
+ * Spring Data projection for the ageing query — one row per {@code (state, dwell-band)} with the number
+ * of live shipments in it. {@code band} is 0..3 (fresh → critical), computed in SQL from
+ * {@code now() − COALESCE(last_scan_at, created_at)}. Native-query column aliases ({@code AS state},
+ * {@code AS band}, {@code AS cnt}) must match these getters.
+ */
+public interface AgeingBandCount {
+    String getState();
+    int getBand();
+    long getCnt();
+}

--- a/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
@@ -86,4 +86,29 @@ public interface ShipmentRepository extends JpaRepository<Shipment, UUID> {
     @Query("SELECT s.state AS state, COUNT(s) AS count FROM Shipment s "
             + "WHERE s.originCity = :city OR s.destCity = :city GROUP BY s.state")
     List<StateCount> countByStateForCity(@Param("city") String city);
+
+    /**
+     * Ageing rollup: live (non-terminal) shipments grouped by state and a dwell band. Dwell is
+     * {@code now() − COALESCE(last_scan_at, created_at)} (a never-scanned parcel ages from booking).
+     * Bands: 0 = {@code < t1}s, 1 = {@code < t2}s, 2 = {@code < t3}s, 3 = older. {@code city} null → all.
+     * Native (Postgres) — the enum column is compared as text and the interval math is DB-side.
+     */
+    @Query(value = """
+            SELECT s.state::text AS state,
+                   CASE
+                       WHEN EXTRACT(EPOCH FROM now() - COALESCE(s.last_scan_at, s.created_at)) < :t1 THEN 0
+                       WHEN EXTRACT(EPOCH FROM now() - COALESCE(s.last_scan_at, s.created_at)) < :t2 THEN 1
+                       WHEN EXTRACT(EPOCH FROM now() - COALESCE(s.last_scan_at, s.created_at)) < :t3 THEN 2
+                       ELSE 3
+                   END AS band,
+                   COUNT(*) AS cnt
+            FROM shipments s
+            WHERE s.state::text NOT IN ('DROPPED', 'HUB_COLLECTED', 'RTO_COMPLETED', 'CANCELLED')
+              AND (:city IS NULL OR s.origin_city = :city OR s.dest_city = :city)
+            GROUP BY s.state, band
+            """, nativeQuery = true)
+    List<AgeingBandCount> ageingByStateAndBand(@Param("city") String city,
+                                               @Param("t1") long t1Seconds,
+                                               @Param("t2") long t2Seconds,
+                                               @Param("t3") long t3Seconds);
 }

--- a/orders/src/main/java/com/oneday/orders/service/AdminOrderSummaryService.java
+++ b/orders/src/main/java/com/oneday/orders/service/AdminOrderSummaryService.java
@@ -1,5 +1,6 @@
 package com.oneday.orders.service;
 
+import com.oneday.orders.dto.ShipmentAgeingStats;
 import com.oneday.orders.dto.ShipmentSummaryStats;
 
 /**
@@ -16,4 +17,11 @@ public interface AdminOrderSummaryService {
      * @return per-bucket and per-state counts plus the in-scope total
      */
     ShipmentSummaryStats summary(String cityScope);
+
+    /**
+     * Ageing rollup: live (non-terminal) shipments grouped by {@code OpsBucket} stage and dwell band
+     * (time since last scan), so ops can spot parcels stuck before a flight/cron cutoff. Same city-scope
+     * rule as {@link #summary}.
+     */
+    ShipmentAgeingStats ageing(String cityScope);
 }

--- a/orders/src/main/java/com/oneday/orders/service/impl/AdminOrderSummaryServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/AdminOrderSummaryServiceImpl.java
@@ -28,7 +28,8 @@ class AdminOrderSummaryServiceImpl implements AdminOrderSummaryService {
 
     // ponytail: hour bands for a one-day product (SLA is intraday). Constants for now; make them
     // config-driven only if ops want to tune the thresholds.
-    private static final List<String> BANDS = List.of("<2h", "2-4h", "4-8h", ">8h");
+    // "8h+" (not ">8h") because band 3 is inclusive of exactly 8h — the CASE assigns band 3 at age >= t3.
+    private static final List<String> BANDS = List.of("<2h", "2-4h", "4-8h", "8h+");
     private static final long BAND_T1_SECONDS = 2 * 3600L;
     private static final long BAND_T2_SECONDS = 4 * 3600L;
     private static final long BAND_T3_SECONDS = 8 * 3600L;
@@ -48,9 +49,15 @@ class AdminOrderSummaryServiceImpl implements AdminOrderSummaryService {
         this.shipmentRepository = shipmentRepository;
     }
 
+    /** City keys are prefixed so no cityId value (which {@code User.cityId} allows to be any string) can
+     *  ever collide with the all-cities sentinel and leak another scope's cached stats. */
+    private static String cacheKey(String cityScope) {
+        return cityScope == null ? ALL_CITIES_KEY : "city:" + cityScope;
+    }
+
     @Override
     public ShipmentSummaryStats summary(String cityScope) {
-        String key = (cityScope == null) ? ALL_CITIES_KEY : cityScope;
+        String key = cacheKey(cityScope);
         Cached hit = cache.get(key);
         long now = System.currentTimeMillis();
         if (hit != null && now - hit.at() < TTL_MILLIS) {
@@ -86,7 +93,7 @@ class AdminOrderSummaryServiceImpl implements AdminOrderSummaryService {
 
     @Override
     public ShipmentAgeingStats ageing(String cityScope) {
-        String key = (cityScope == null) ? ALL_CITIES_KEY : cityScope;
+        String key = cacheKey(cityScope);
         CachedAgeing hit = ageingCache.get(key);
         long now = System.currentTimeMillis();
         if (hit != null && now - hit.at() < TTL_MILLIS) {

--- a/orders/src/main/java/com/oneday/orders/service/impl/AdminOrderSummaryServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/AdminOrderSummaryServiceImpl.java
@@ -1,12 +1,16 @@
 package com.oneday.orders.service.impl;
 
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.dto.ShipmentAgeingStats;
 import com.oneday.orders.dto.ShipmentSummaryStats;
+import com.oneday.orders.repository.AgeingBandCount;
 import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.repository.StateCount;
 import com.oneday.orders.service.AdminOrderSummaryService;
 import com.oneday.orders.service.OpsBucket;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.LinkedHashMap;
@@ -22,14 +26,23 @@ class AdminOrderSummaryServiceImpl implements AdminOrderSummaryService {
     private static final long TTL_MILLIS = 30_000L;
     private static final String ALL_CITIES_KEY = "__all__";
 
+    // ponytail: hour bands for a one-day product (SLA is intraday). Constants for now; make them
+    // config-driven only if ops want to tune the thresholds.
+    private static final List<String> BANDS = List.of("<2h", "2-4h", "4-8h", ">8h");
+    private static final long BAND_T1_SECONDS = 2 * 3600L;
+    private static final long BAND_T2_SECONDS = 4 * 3600L;
+    private static final long BAND_T3_SECONDS = 8 * 3600L;
+
     private final ShipmentRepository shipmentRepository;
 
     // ponytail: 30s per-instance memo, keyed by city scope. Protects the (remote) DB from
     // GROUP-BY on every ops poll; on one app node it's enough. Reach for a shared cache only if
     // we scale out and cross-node staleness actually diverges.
     private final Map<String, Cached> cache = new ConcurrentHashMap<>();
+    private final Map<String, CachedAgeing> ageingCache = new ConcurrentHashMap<>();
 
     private record Cached(long at, ShipmentSummaryStats value) {}
+    private record CachedAgeing(long at, ShipmentAgeingStats value) {}
 
     AdminOrderSummaryServiceImpl(ShipmentRepository shipmentRepository) {
         this.shipmentRepository = shipmentRepository;
@@ -69,5 +82,46 @@ class AdminOrderSummaryServiceImpl implements AdminOrderSummaryService {
         Map<String, Long> bucketsByName = new LinkedHashMap<>();
         buckets.forEach((b, n) -> bucketsByName.put(b.name(), n));
         return new ShipmentSummaryStats(total, bucketsByName, byState);
+    }
+
+    @Override
+    public ShipmentAgeingStats ageing(String cityScope) {
+        String key = (cityScope == null) ? ALL_CITIES_KEY : cityScope;
+        CachedAgeing hit = ageingCache.get(key);
+        long now = System.currentTimeMillis();
+        if (hit != null && now - hit.at() < TTL_MILLIS) {
+            return hit.value();
+        }
+        ShipmentAgeingStats fresh = computeAgeing(cityScope);
+        ageingCache.put(key, new CachedAgeing(now, fresh));
+        return fresh;
+    }
+
+    private ShipmentAgeingStats computeAgeing(String cityScope) {
+        List<AgeingBandCount> rows = shipmentRepository.ageingByStateAndBand(
+                cityScope, BAND_T1_SECONDS, BAND_T2_SECONDS, BAND_T3_SECONDS);
+
+        int n = BANDS.size();
+        Map<OpsBucket, long[]> byBucket = new EnumMap<>(OpsBucket.class);
+        long[] bandTotals = new long[n];
+        long total = 0L;
+        for (AgeingBandCount r : rows) {
+            OpsBucket bucket = OpsBucket.of(ShipmentState.valueOf(r.getState()));
+            byBucket.computeIfAbsent(bucket, b -> new long[n])[r.getBand()] += r.getCnt();
+            bandTotals[r.getBand()] += r.getCnt();
+            total += r.getCnt();
+        }
+
+        Map<String, List<Long>> byBucketOut = new LinkedHashMap<>();
+        byBucket.forEach((b, counts) -> byBucketOut.put(b.name(), boxed(counts)));
+        return new ShipmentAgeingStats(total, BANDS, byBucketOut, boxed(bandTotals));
+    }
+
+    private static List<Long> boxed(long[] a) {
+        List<Long> out = new ArrayList<>(a.length);
+        for (long v : a) {
+            out.add(v);
+        }
+        return out;
     }
 }

--- a/orders/src/test/java/com/oneday/orders/service/impl/AdminOrderSummaryServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/AdminOrderSummaryServiceImplTest.java
@@ -1,7 +1,9 @@
 package com.oneday.orders.service.impl;
 
 import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.dto.ShipmentAgeingStats;
 import com.oneday.orders.dto.ShipmentSummaryStats;
+import com.oneday.orders.repository.AgeingBandCount;
 import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.repository.StateCount;
 import com.oneday.orders.service.OpsBucket;
@@ -73,6 +75,33 @@ class AdminOrderSummaryServiceImplTest {
         svc.summary(null);
 
         verify(shipmentRepository, times(1)).countByState();
+    }
+
+    private record Band(String state, int band, long cnt) implements AgeingBandCount {
+        @Override public String getState() { return state; }
+        @Override public int getBand() { return band; }
+        @Override public long getCnt() { return cnt; }
+    }
+
+    @Test
+    void ageingRollsStatesIntoOpsBucketsAndBands() {
+        when(shipmentRepository.ageingByStateAndBand(null, 7200L, 14400L, 28800L)).thenReturn(List.of(
+                new Band("AT_AIRPORT", 0, 3),           // IN_TRANSIT, <2h
+                new Band("DEST_HUB_PROCESSING", 3, 2),  // IN_TRANSIT, >8h
+                new Band("DROP_ASSIGNED", 1, 4),        // OUT_FOR_DELIVERY, 2-4h
+                new Band("DELIVERY_FAILED", 3, 1)));    // EXCEPTIONS, >8h
+
+        AdminOrderSummaryServiceImpl svc = new AdminOrderSummaryServiceImpl(shipmentRepository);
+        ShipmentAgeingStats stats = svc.ageing(null);
+
+        assertThat(stats.total()).isEqualTo(10);
+        assertThat(stats.bands()).containsExactly("<2h", "2-4h", "4-8h", ">8h");
+        assertThat(stats.byBucket().get("IN_TRANSIT")).containsExactly(3L, 0L, 0L, 2L);
+        assertThat(stats.byBucket().get("OUT_FOR_DELIVERY")).containsExactly(0L, 4L, 0L, 0L);
+        assertThat(stats.byBucket().get("EXCEPTIONS")).containsExactly(0L, 0L, 0L, 1L);
+        // Terminal states are excluded by the query, so DELIVERED never appears.
+        assertThat(stats.byBucket()).doesNotContainKey("DELIVERED");
+        assertThat(stats.bandTotals()).containsExactly(3L, 4L, 0L, 3L);
     }
 
     @Test

--- a/orders/src/test/java/com/oneday/orders/service/impl/AdminOrderSummaryServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/AdminOrderSummaryServiceImplTest.java
@@ -95,7 +95,7 @@ class AdminOrderSummaryServiceImplTest {
         ShipmentAgeingStats stats = svc.ageing(null);
 
         assertThat(stats.total()).isEqualTo(10);
-        assertThat(stats.bands()).containsExactly("<2h", "2-4h", "4-8h", ">8h");
+        assertThat(stats.bands()).containsExactly("<2h", "2-4h", "4-8h", "8h+");
         assertThat(stats.byBucket().get("IN_TRANSIT")).containsExactly(3L, 0L, 0L, 2L);
         assertThat(stats.byBucket().get("OUT_FOR_DELIVERY")).containsExactly(0L, 4L, 0L, 0L);
         assertThat(stats.byBucket().get("EXCEPTIONS")).containsExactly(0L, 0L, 0L, 1L);


### PR DESCRIPTION
## What
Roadmap **step 2c** — the ageing report, the first analytics the `last_scan_at` dwell primitive (PR #132) powers.

`GET /api/v1/admin/shipments/ageing` (STATION_MANAGER, city-scoped) returns **live shipments grouped by ops stage × dwell band**, so a manager sees "3 parcels stuck IN_TRANSIT for >8h" and acts before they breach the flight/cron cutoff.

## Design (mirrors the existing `/summary`)
- **Dwell = `now − COALESCE(last_scan_at, created_at)`** — a never-scanned parcel ages from booking, so a booked-but-not-picked-up parcel still shows as stuck.
- **Bands (hour-based, one-day product):** `<2h` / `2-4h` / `4-8h` / `>8h`. Service constants (`ponytail:` — config-driven only if ops want to tune).
- **Terminal states excluded** (`DROPPED`/`HUB_COLLECTED`/`RTO_COMPLETED`/`CANCELLED`); active failures (`PICKUP_FAILED`, `RTO_INITIATED`, …) are kept — they're exactly what's stuck.
- One native Postgres `GROUP BY state × band`, rolled into `OpsBucket` in Java (reuses `OpsBucket.of`), 30s memo like `/summary`.

## Response shape
```json
{ "total": 10,
  "bands": ["<2h","2-4h","4-8h",">8h"],
  "by_bucket": { "IN_TRANSIT": [3,0,0,2], "OUT_FOR_DELIVERY": [0,4,0,0], "EXCEPTIONS": [0,0,0,1] },
  "band_totals": [3,4,0,3] }
```

## Verified
- orders summary-service test 5 green (+2: rollup + terminal-state exclusion).
- **Native query run against a real Postgres** (enum `::text` cast, `EXTRACT`/`COALESCE`, `GROUP BY state,band` alias all valid).
- App assembles.

## Follow-ups (rest of step 2c)
Per-DA pace / projected-RTS / attempt-success dashboards, DA scorecards, CSV export; config-driven band thresholds if ops want them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shipment ageing statistics for live shipments.
  * Added an admin endpoint showing shipment counts across operational stages and ageing bands.
  * Statistics can be scoped to the caller’s city and exclude completed shipments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->