### PR TITLE
feat(dispatch): execution metrics — attempt-success % + per-DA pace

### DIFF
--- a/dispatch/src/main/java/com/oneday/dispatch/api/StationDispatchController.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/api/StationDispatchController.java
@@ -3,7 +3,9 @@ package com.oneday.dispatch.api;
 import com.oneday.auth.security.AuthUserDetails;
 import com.oneday.dispatch.dto.request.AssignDeferredRequest;
 import com.oneday.dispatch.dto.response.DeferredAssignResponse;
+import com.oneday.dispatch.dto.response.DispatchExecutionStats;
 import com.oneday.dispatch.dto.response.TileQueueResponse;
+import com.oneday.dispatch.service.DispatchMetricsService;
 import com.oneday.dispatch.service.StationDispatchService;
 import com.oneday.grid.service.GridService;
 import jakarta.validation.Valid;
@@ -30,11 +32,29 @@ import java.util.UUID;
 public class StationDispatchController {
 
     private final StationDispatchService stationDispatchService;
+    private final DispatchMetricsService dispatchMetricsService;
     private final GridService gridService;
 
-    public StationDispatchController(StationDispatchService stationDispatchService, GridService gridService) {
+    public StationDispatchController(StationDispatchService stationDispatchService,
+                                     DispatchMetricsService dispatchMetricsService,
+                                     GridService gridService) {
         this.stationDispatchService = stationDispatchService;
+        this.dispatchMetricsService = dispatchMetricsService;
         this.gridService = gridService;
+    }
+
+    /**
+     * Control-tower execution view — the delivery attempt-success gauge and per-DA pace for a date
+     * (defaults to today). Same city scope as the tile views: STATION_MANAGER sees their own city,
+     * ADMIN all cities.
+     */
+    @GetMapping("/dispatch/execution")
+    public DispatchExecutionStats execution(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireRole(principal, Authz.STATION_MANAGER);
+        UUID scopeCityId = Authz.isAdmin(principal) ? null : managerCity(principal);
+        return dispatchMetricsService.execution(date != null ? date : LocalDate.now(), scopeCityId);
     }
 
     @GetMapping("/dispatch/tiles/{tileId}/queue")

--- a/dispatch/src/main/java/com/oneday/dispatch/dto/response/DispatchExecutionStats.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/dto/response/DispatchExecutionStats.java
@@ -1,0 +1,36 @@
+package com.oneday.dispatch.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Control-tower execution view for a city/date: the delivery attempt-success gauge and per-DA pace.
+ *
+ * @param date               operating date the figures are for
+ * @param attemptSuccessPct  delivered / (delivered + failed) delivery attempts, 0..1; null if no attempts
+ * @param deliveriesCompleted successful delivery tasks
+ * @param deliveriesFailed    failed delivery attempts
+ * @param das                per-DA pace, busiest (most pending) first
+ */
+public record DispatchExecutionStats(
+        LocalDate date,
+        Double attemptSuccessPct,
+        long deliveriesCompleted,
+        long deliveriesFailed,
+        List<DaPace> das) {
+
+    /**
+     * @param stopsDone      tasks completed today
+     * @param stopsLastHour  completed in the last hour — the current pace
+     * @param stopsPending   still-open tasks (queued or in progress)
+     * @param avgPerHour     stopsDone over hours since the DA's first assignment (0 if not started)
+     */
+    public record DaPace(
+            UUID daId,
+            long stopsDone,
+            long stopsLastHour,
+            long stopsPending,
+            double avgPerHour) {
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/repository/DaPaceRow.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/repository/DaPaceRow.java
@@ -1,0 +1,19 @@
+package com.oneday.dispatch.repository;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Per-DA pace projection for the execution view: stops completed today ({@code done}), completed in the
+ * last hour ({@code lastHour} — the current pace), still-open tasks ({@code pending}), and when the DA's
+ * first task was assigned ({@code firstAssigned}, for the average-per-hour). Native-query aliases are
+ * camelCase ({@code AS daId}, {@code done}, {@code lastHour}, {@code pending}, {@code firstAssigned}) so
+ * Postgres's lowercase fold matches these getters — the pattern the auth DA-summary projections use.
+ */
+public interface DaPaceRow {
+    UUID getDaId();
+    long getDone();
+    long getLastHour();
+    long getPending();
+    Instant getFirstAssigned();
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/repository/DeliveryOutcome.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/repository/DeliveryOutcome.java
@@ -1,0 +1,11 @@
+package com.oneday.dispatch.repository;
+
+/**
+ * Delivery attempt outcome for a city/date: how many DELIVERY tasks were COMPLETED vs FAILED. Feeds the
+ * attempt-success gauge ({@code completed / (completed + failed)}). Native aliases {@code AS completed},
+ * {@code AS failed} map here.
+ */
+public interface DeliveryOutcome {
+    long getCompleted();
+    long getFailed();
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/repository/DispatchQueueRepository.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/repository/DispatchQueueRepository.java
@@ -65,4 +65,36 @@ public interface DispatchQueueRepository extends JpaRepository<DispatchQueue, UU
             order by d.assignedAt desc
             """)
     List<DispatchQueue> findActiveByShipmentId(@Param("shipmentId") UUID shipmentId);
+
+    /**
+     * Delivery attempt outcome for a city/date — COMPLETED vs FAILED DELIVERY tasks (attempt-success
+     * gauge). Native (Postgres FILTER); status/task_type are EnumType.STRING so they compare as text.
+     * {@code city} null → all cities.
+     */
+    @Query(value = """
+            SELECT COUNT(*) FILTER (WHERE status = 'COMPLETED') AS completed,
+                   COUNT(*) FILTER (WHERE status = 'FAILED')    AS failed
+            FROM dispatch_queue
+            WHERE task_type = 'DELIVERY' AND operating_date = :date
+              AND (:city IS NULL OR city_id = :city)
+            """, nativeQuery = true)
+    DeliveryOutcome deliveryOutcome(@Param("city") UUID city, @Param("date") LocalDate date);
+
+    /**
+     * Per-DA pace for a city/date: stops done, stops in the last hour (current pace), open tasks, and the
+     * DA's first assignment time (for average-per-hour). Native (Postgres FILTER + interval).
+     * {@code city} null → all cities.
+     */
+    @Query(value = """
+            SELECT da_id AS daId,
+                   COUNT(*) FILTER (WHERE status = 'COMPLETED') AS done,
+                   COUNT(*) FILTER (WHERE status = 'COMPLETED'
+                                      AND completed_at >= now() - interval '1 hour') AS lastHour,
+                   COUNT(*) FILTER (WHERE status IN ('QUEUED', 'IN_PROGRESS')) AS pending,
+                   MIN(assigned_at) AS firstAssigned
+            FROM dispatch_queue
+            WHERE operating_date = :date AND (:city IS NULL OR city_id = :city)
+            GROUP BY da_id
+            """, nativeQuery = true)
+    List<DaPaceRow> paceByDa(@Param("city") UUID city, @Param("date") LocalDate date);
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/service/DispatchMetricsService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/DispatchMetricsService.java
@@ -1,0 +1,17 @@
+package com.oneday.dispatch.service;
+
+import com.oneday.dispatch.dto.response.DispatchExecutionStats;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * Read-only control-tower metrics over the dispatch queue: delivery attempt-success and per-DA pace.
+ * Purely DB-aggregated (the queue rows carry {@code completed_at}), so it's independent of the live
+ * in-memory tile authority that {@link StationDispatchService} uses.
+ */
+public interface DispatchMetricsService {
+
+    /** @param scopeCityId null → all cities (ADMIN); otherwise restrict to that city. */
+    DispatchExecutionStats execution(LocalDate date, UUID scopeCityId);
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImpl.java
@@ -1,0 +1,64 @@
+package com.oneday.dispatch.service.impl;
+
+import com.oneday.dispatch.dto.response.DispatchExecutionStats;
+import com.oneday.dispatch.dto.response.DispatchExecutionStats.DaPace;
+import com.oneday.dispatch.repository.DaPaceRow;
+import com.oneday.dispatch.repository.DeliveryOutcome;
+import com.oneday.dispatch.repository.DispatchQueueRepository;
+import com.oneday.dispatch.service.DispatchMetricsService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+class DispatchMetricsServiceImpl implements DispatchMetricsService {
+
+    private final DispatchQueueRepository queueRepository;
+
+    DispatchMetricsServiceImpl(DispatchQueueRepository queueRepository) {
+        this.queueRepository = queueRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public DispatchExecutionStats execution(LocalDate date, UUID scopeCityId) {
+        DeliveryOutcome outcome = queueRepository.deliveryOutcome(scopeCityId, date);
+        long completed = outcome != null ? outcome.getCompleted() : 0;
+        long failed = outcome != null ? outcome.getFailed() : 0;
+        long attempts = completed + failed;
+        Double successPct = attempts == 0 ? null : (double) completed / attempts;
+
+        Instant now = Instant.now();
+        List<DaPace> das = queueRepository.paceByDa(scopeCityId, date).stream()
+                .map(r -> toPace(r, now))
+                .sorted(Comparator.comparingLong(DaPace::stopsPending).reversed()
+                        .thenComparing(Comparator.comparingLong(DaPace::stopsDone).reversed()))
+                .toList();
+
+        return new DispatchExecutionStats(date, successPct, completed, failed, das);
+    }
+
+    private static DaPace toPace(DaPaceRow r, Instant now) {
+        return new DaPace(r.getDaId(), r.getDone(), r.getLastHour(), r.getPending(),
+                avgPerHour(r.getDone(), r.getFirstAssigned(), now));
+    }
+
+    /** Stops done over hours on shift (since first assignment). Guards a fresh DA: &lt;6 min elapsed → 0,
+     *  so one early stop doesn't read as an implausible 60/hr. */
+    private static double avgPerHour(long done, Instant firstAssigned, Instant now) {
+        if (done == 0 || firstAssigned == null) {
+            return 0.0;
+        }
+        double hours = Duration.between(firstAssigned, now).toSeconds() / 3600.0;
+        if (hours < 0.1) {
+            return 0.0;
+        }
+        return done / hours;
+    }
+}

--- a/dispatch/src/test/java/com/oneday/dispatch/api/StationDispatchControllerTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/api/StationDispatchControllerTest.java
@@ -4,6 +4,7 @@ import com.oneday.auth.security.AuthUserDetails;
 import com.oneday.dispatch.dto.request.AssignDeferredRequest;
 import com.oneday.dispatch.dto.response.TileQueueResponse;
 import com.oneday.dispatch.service.AssignmentResult;
+import com.oneday.dispatch.service.DispatchMetricsService;
 import com.oneday.dispatch.service.StationDispatchService;
 import com.oneday.grid.service.GridService;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +28,7 @@ import static org.mockito.Mockito.when;
 class StationDispatchControllerTest {
 
     private StationDispatchService stationDispatchService;
+    private DispatchMetricsService dispatchMetricsService;
     private GridService gridService;
     private StationDispatchController controller;
 
@@ -36,8 +38,9 @@ class StationDispatchControllerTest {
     @BeforeEach
     void setUp() {
         stationDispatchService = mock(StationDispatchService.class);
+        dispatchMetricsService = mock(DispatchMetricsService.class);
         gridService = mock(GridService.class);
-        controller = new StationDispatchController(stationDispatchService, gridService);
+        controller = new StationDispatchController(stationDispatchService, dispatchMetricsService, gridService);
         when(stationDispatchService.tileQueue(any(), any(), any()))
                 .thenReturn(new TileQueueResponse(tile, date, List.of(), 0, List.of()));
     }

--- a/dispatch/src/test/java/com/oneday/dispatch/repository/DispatchQueueRepositoryTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/repository/DispatchQueueRepositoryTest.java
@@ -10,7 +10,10 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.dao.DataIntegrityViolationException;
 
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -72,6 +75,42 @@ class DispatchQueueRepositoryTest {
 
         var queue = repo.findByDaIdAndOperatingDateOrderByQueuePosition(da, today);
         assertThat(queue).extracting(DispatchQueue::getQueuePosition).containsExactly(1, 2);
+    }
+
+    @Test
+    void executionProjectionsBindAgainstRealPostgres() {
+        UUID da = UUID.randomUUID();
+        UUID city = UUID.randomUUID();
+        LocalDate today = LocalDate.now();
+        Instant now = Instant.now();
+
+        repo.saveAndFlush(delivery(da, city, today, TaskStatus.COMPLETED, now));                       // done + last hour
+        repo.saveAndFlush(delivery(da, city, today, TaskStatus.COMPLETED, now.minus(3, ChronoUnit.HOURS))); // done, not last hour
+        repo.saveAndFlush(delivery(da, city, today, TaskStatus.FAILED, null));                          // failed attempt
+        repo.saveAndFlush(delivery(da, city, today, TaskStatus.QUEUED, null));                          // pending
+
+        // paceByDa — the real test: proves the unquoted camelCase native aliases (daId / lastHour /
+        // firstAssigned) bind to DaPaceRow's getters under real Postgres (the auth DA-summary pattern).
+        List<DaPaceRow> rows = repo.paceByDa(city, today);
+        assertThat(rows).hasSize(1);
+        DaPaceRow r = rows.get(0);
+        assertThat(r.getDaId()).isEqualTo(da);
+        assertThat(r.getDone()).isEqualTo(2);
+        assertThat(r.getLastHour()).isEqualTo(1);
+        assertThat(r.getPending()).isEqualTo(1);
+        assertThat(r.getFirstAssigned()).isNotNull();
+
+        DeliveryOutcome outcome = repo.deliveryOutcome(city, today);
+        assertThat(outcome.getCompleted()).isEqualTo(2);
+        assertThat(outcome.getFailed()).isEqualTo(1);
+    }
+
+    private DispatchQueue delivery(UUID daId, UUID cityId, LocalDate date, TaskStatus status, Instant completedAt) {
+        DispatchQueue d = task(daId, UUID.randomUUID(), date, status, 0);
+        d.setCityId(cityId);
+        d.setTaskType(TaskType.DELIVERY);
+        d.setCompletedAt(completedAt);
+        return d;
     }
 
     private DispatchQueue task(UUID daId, UUID shipmentId, LocalDate date, TaskStatus status, int pos) {

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImplTest.java
@@ -1,0 +1,90 @@
+package com.oneday.dispatch.service.impl;
+
+import com.oneday.dispatch.dto.response.DispatchExecutionStats;
+import com.oneday.dispatch.repository.DaPaceRow;
+import com.oneday.dispatch.repository.DeliveryOutcome;
+import com.oneday.dispatch.repository.DispatchQueueRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DispatchMetricsServiceImplTest {
+
+    private final DispatchQueueRepository repo = mock(DispatchQueueRepository.class);
+    private final DispatchMetricsServiceImpl svc = new DispatchMetricsServiceImpl(repo);
+    private final LocalDate date = LocalDate.now();
+
+    private record Outcome(long completed, long failed) implements DeliveryOutcome {
+        @Override public long getCompleted() { return completed; }
+        @Override public long getFailed() { return failed; }
+    }
+
+    private record Pace(UUID daId, long done, long lastHour, long pending, Instant firstAssigned)
+            implements DaPaceRow {
+        @Override public UUID getDaId() { return daId; }
+        @Override public long getDone() { return done; }
+        @Override public long getLastHour() { return lastHour; }
+        @Override public long getPending() { return pending; }
+        @Override public Instant getFirstAssigned() { return firstAssigned; }
+    }
+
+    @Test
+    void attemptSuccessIsCompletedOverAttempts() {
+        when(repo.deliveryOutcome(null, date)).thenReturn(new Outcome(18, 2));
+        when(repo.paceByDa(null, date)).thenReturn(List.of());
+
+        DispatchExecutionStats stats = svc.execution(date, null);
+
+        assertThat(stats.deliveriesCompleted()).isEqualTo(18);
+        assertThat(stats.deliveriesFailed()).isEqualTo(2);
+        assertThat(stats.attemptSuccessPct()).isEqualTo(0.9); // 18 / 20
+    }
+
+    @Test
+    void attemptSuccessNullWhenNoAttempts() {
+        when(repo.deliveryOutcome(null, date)).thenReturn(new Outcome(0, 0));
+        when(repo.paceByDa(null, date)).thenReturn(List.of());
+
+        assertThat(svc.execution(date, null).attemptSuccessPct()).isNull();
+    }
+
+    @Test
+    void avgPerHourAndPendingSortComputed() {
+        Instant now = Instant.now();
+        UUID busy = UUID.randomUUID(), light = UUID.randomUUID();
+        when(repo.deliveryOutcome(any(), any())).thenReturn(new Outcome(0, 0));
+        when(repo.paceByDa(eq(null), eq(date))).thenReturn(List.of(
+                // 8 stops over 4h → 2/hr; 1 pending
+                new Pace(light, 8, 1, 1, now.minus(4, ChronoUnit.HOURS)),
+                // 5 stops over 5h → 1/hr; 6 pending (busiest → sorts first)
+                new Pace(busy, 5, 2, 6, now.minus(5, ChronoUnit.HOURS))));
+
+        List<DispatchExecutionStats.DaPace> das = svc.execution(date, null).das();
+
+        assertThat(das).hasSize(2);
+        assertThat(das.get(0).daId()).isEqualTo(busy);           // most pending first
+        assertThat(das.get(0).avgPerHour()).isCloseTo(1.0, within(0.05));
+        assertThat(das.get(1).avgPerHour()).isCloseTo(2.0, within(0.05));
+    }
+
+    @Test
+    void freshDaWithTinyElapsedReadsZeroAvg() {
+        Instant now = Instant.now();
+        when(repo.deliveryOutcome(any(), any())).thenReturn(new Outcome(0, 0));
+        when(repo.paceByDa(any(), any())).thenReturn(List.of(
+                new Pace(UUID.randomUUID(), 1, 1, 3, now.minus(60, ChronoUnit.SECONDS)))); // <6min
+
+        assertThat(svc.execution(date, null).das().get(0).avgPerHour()).isEqualTo(0.0);
+    }
+}


### PR DESCRIPTION
## What
Roadmap **step 2c** control-tower core — the delivery **attempt-success gauge** and **per-DA pace**, the two things Amazon's Route Execution console leads with.

`GET /dispatch/execution?date=` (STATION_MANAGER, city-scoped; ADMIN all cities; date defaults to today):

```json
{ "date": "2026-08-24",
  "attempt_success_pct": 0.9, "deliveries_completed": 18, "deliveries_failed": 2,
  "das": [
    { "da_id": "…", "stops_done": 5, "stops_last_hour": 2, "stops_pending": 6, "avg_per_hour": 1.0 },
    { "da_id": "…", "stops_done": 8, "stops_last_hour": 1, "stops_pending": 1, "avg_per_hour": 2.0 } ] }
```

## Design
- **Attempt-success** = `COMPLETED / (COMPLETED + FAILED)` DELIVERY tasks (null if no attempts).
- **Per-DA pace**: `stops_done` today, `stops_last_hour` (current pace), `stops_pending` (open), and `avg_per_hour` since first assignment — guarded so a fresh DA's single stop doesn't read as 60/hr. Busiest (most pending) first.
- **Pure DB aggregation** over `dispatch_queue` (`completed_at` is set on completion), so it's independent of the live in-memory tile authority — a new `DispatchMetricsService`, not coupled to `StationDispatchService`.
- Two native Postgres queries (FILTER + interval) via interface projections with **camelCase aliases** (matches the auth DA-summary pattern, so Postgres's lowercase fold binds to the getters).

## Verified
- dispatch metrics test 4 green (attempt-success, null-when-no-attempts, avg/hr + pending-sort, fresh-DA guard); controller test updated (7 green). App assembles.
- **Both native queries run against a real Postgres** (FILTER, interval, GROUP BY all valid).

## Follow-ups (rest of step 2c)
Projected-RTS (needs an ETA model per DA queue), DA scorecards over a window, CSV export. Web control-tower cards to render this are a separate frontend slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dispatch execution statistics for a selected date, defaulting to today.
  * Displayed delivery attempt success rates, completed and failed deliveries, and per-agent pacing metrics.
  * Added access-controlled city or administrator scope to execution statistics.
  * Included pending stops, recent completions, and average hourly throughput for each delivery agent.

* **Tests**
  * Added coverage for metric calculations, sorting, edge cases, and database-backed execution reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->