### PR TITLE
fix(orders): ageing endpoint 500s — Hibernate mis-parses ::text cast

### DIFF
--- a/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
@@ -91,10 +91,11 @@ public interface ShipmentRepository extends JpaRepository<Shipment, UUID> {
      * Ageing rollup: live (non-terminal) shipments grouped by state and a dwell band. Dwell is
      * {@code now() − COALESCE(last_scan_at, created_at)} (a never-scanned parcel ages from booking).
      * Bands: 0 = {@code < t1}s, 1 = {@code < t2}s, 2 = {@code < t3}s, 3 = older. {@code city} null → all.
-     * Native (Postgres) — the enum column is compared as text and the interval math is DB-side.
+     * Native (Postgres). Uses {@code cast(state as text)} not {@code state::text} — Hibernate mis-parses
+     * the {@code ::} cast as a {@code :}-named parameter in native queries (verified failing at runtime).
      */
     @Query(value = """
-            SELECT s.state::text AS state,
+            SELECT cast(s.state as text) AS state,
                    CASE
                        WHEN EXTRACT(EPOCH FROM now() - COALESCE(s.last_scan_at, s.created_at)) < :t1 THEN 0
                        WHEN EXTRACT(EPOCH FROM now() - COALESCE(s.last_scan_at, s.created_at)) < :t2 THEN 1
@@ -103,7 +104,7 @@ public interface ShipmentRepository extends JpaRepository<Shipment, UUID> {
                    END AS band,
                    COUNT(*) AS cnt
             FROM shipments s
-            WHERE s.state::text NOT IN ('DROPPED', 'HUB_COLLECTED', 'RTO_COMPLETED', 'CANCELLED')
+            WHERE cast(s.state as text) NOT IN ('DROPPED', 'HUB_COLLECTED', 'RTO_COMPLETED', 'CANCELLED')
               AND (:city IS NULL OR s.origin_city = :city OR s.dest_city = :city)
             GROUP BY s.state, band
             """, nativeQuery = true)


### PR DESCRIPTION
## Bug
`GET /api/v1/admin/shipments/ageing` **returns 500** on `main`. The ageing rollup query (merged in #134) uses PostgreSQL's `::text` cast, which **Hibernate mis-parses as a `:`-named parameter** in native queries — `s.state::text` becomes `s.state:text` → `ERROR: syntax error at or near ":"` (SQLState 42601).

## Why #134 didn't catch it
- The raw-psql validation passed (psql doesn't go through Hibernate's parameter parser).
- The service unit test passed (it mocks the repository).
- Only **running the endpoint live** surfaces it — which is how it was found.

## Fix
Both occurrences `s.state::text` → `cast(s.state as text)` (Hibernate-safe, same result). No behaviour change.

## Verified
Ran the endpoint live against local Postgres: now **200** with the bucket × band matrix (`{total:16, bands:["<2h","2-4h","4-8h","8h+"], by_bucket, band_totals}`). `orders` compiles.

Targets `main` because #134 already merged the buggy version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shipment ageing queries to improve compatibility when filtering and displaying shipment states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->