### PR TITLE
feat(dispatch): DA name/phone in control tower + per-DA detail endpoint

### DIFF
--- a/dispatch/src/main/java/com/oneday/dispatch/api/StationDispatchController.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/api/StationDispatchController.java
@@ -2,6 +2,7 @@ package com.oneday.dispatch.api;
 
 import com.oneday.auth.security.AuthUserDetails;
 import com.oneday.dispatch.dto.request.AssignDeferredRequest;
+import com.oneday.dispatch.dto.response.DaDetailResponse;
 import com.oneday.dispatch.dto.response.DeferredAssignResponse;
 import com.oneday.dispatch.dto.response.DispatchExecutionStats;
 import com.oneday.dispatch.dto.response.TileQueueResponse;
@@ -55,6 +56,21 @@ public class StationDispatchController {
         Authz.requireRole(principal, Authz.STATION_MANAGER);
         UUID scopeCityId = Authz.isAdmin(principal) ? null : managerCity(principal);
         return dispatchMetricsService.execution(date != null ? date : LocalDate.now(), scopeCityId);
+    }
+
+    /**
+     * One DA's detail (click-through from the control tower): identity + phone, today's pace, today's
+     * tasks urgency-sorted, and a short history. Same city scope — a STATION_MANAGER can only inspect a
+     * DA operating in their own city today (else 404); ADMIN any.
+     */
+    @GetMapping("/dispatch/da/{daId}")
+    public DaDetailResponse daDetail(
+            @PathVariable UUID daId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireRole(principal, Authz.STATION_MANAGER);
+        UUID scopeCityId = Authz.isAdmin(principal) ? null : managerCity(principal);
+        return dispatchMetricsService.daDetail(daId, date != null ? date : LocalDate.now(), scopeCityId);
     }
 
     @GetMapping("/dispatch/tiles/{tileId}/queue")

--- a/dispatch/src/main/java/com/oneday/dispatch/dto/response/DaDetailResponse.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/dto/response/DaDetailResponse.java
@@ -1,0 +1,46 @@
+package com.oneday.dispatch.dto.response;
+
+import com.oneday.dispatch.dto.response.DispatchExecutionStats.DaPace;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * A single DA's control-tower detail for a date: who they are, how they're pacing, today's tasks ordered
+ * by urgency (RED → IN_PROGRESS → QUEUED → DONE), and a short per-day history for the trend.
+ *
+ * @param pace      today's pace (done / last-hour / pending / avg-per-hour), name+phone included
+ * @param completed today's completed tasks · @param failed today's failed attempts
+ * @param tasks     today's tasks, most-urgent first
+ * @param history   per-day stops (done/failed), oldest first — the mini-trend
+ */
+public record DaDetailResponse(
+        UUID daId,
+        String name,
+        String phone,
+        UUID cityId,
+        LocalDate date,
+        DaPace pace,
+        long completed,
+        long failed,
+        List<DaTaskItem> tasks,
+        List<DayStops> history) {
+
+    /**
+     * @param urgency RED (failed / past-ETA active) · AMBER (in-progress on-track) · GREEN (queued
+     *                on-track) · DONE (completed) — derived from status + expectedEta vs now.
+     */
+    public record DaTaskItem(
+            UUID taskId,
+            UUID shipmentId,
+            String taskType,
+            String status,
+            Instant expectedEta,
+            String urgency) {
+    }
+
+    public record DayStops(LocalDate date, long done, long failed) {
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/dto/response/DispatchExecutionStats.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/dto/response/DispatchExecutionStats.java
@@ -21,6 +21,9 @@ public record DispatchExecutionStats(
         List<DaPace> das) {
 
     /**
+     * @param daId           the DA
+     * @param daName         DA name (null if not in the directory) — so the console shows a person, not a UUID
+     * @param daPhone        DA phone for a one-tap call (nullable)
      * @param stopsDone      tasks completed today
      * @param stopsLastHour  completed in the last hour — the current pace
      * @param stopsPending   still-open tasks (queued or in progress)
@@ -28,6 +31,8 @@ public record DispatchExecutionStats(
      */
     public record DaPace(
             UUID daId,
+            String daName,
+            String daPhone,
             long stopsDone,
             long stopsLastHour,
             long stopsPending,

--- a/dispatch/src/main/java/com/oneday/dispatch/repository/DaDayStopsRow.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/repository/DaDayStopsRow.java
@@ -1,0 +1,13 @@
+package com.oneday.dispatch.repository;
+
+import java.time.LocalDate;
+
+/**
+ * Per-day stops for one DA — the mini history/trend. Native aliases {@code AS day / done / failed} map
+ * to these getters (camelCase, so Postgres's lowercase fold binds — same pattern as {@link DaPaceRow}).
+ */
+public interface DaDayStopsRow {
+    LocalDate getDay();
+    long getDone();
+    long getFailed();
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/repository/DispatchQueueRepository.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/repository/DispatchQueueRepository.java
@@ -97,4 +97,22 @@ public interface DispatchQueueRepository extends JpaRepository<DispatchQueue, UU
             GROUP BY da_id
             """, nativeQuery = true)
     List<DaPaceRow> paceByDa(@Param("city") UUID city, @Param("date") LocalDate date);
+
+    /**
+     * Per-day stops (done/failed) for one DA from {@code fromDate} onward — the DA-detail mini history.
+     * {@code city} null → all cities. Native (Postgres FILTER); camelCase aliases bind to {@link DaDayStopsRow}.
+     */
+    @Query(value = """
+            SELECT operating_date AS day,
+                   COUNT(*) FILTER (WHERE status = 'COMPLETED') AS done,
+                   COUNT(*) FILTER (WHERE status = 'FAILED')    AS failed
+            FROM dispatch_queue
+            WHERE da_id = :daId AND operating_date >= :fromDate
+              AND (:city IS NULL OR city_id = :city)
+            GROUP BY operating_date
+            ORDER BY operating_date
+            """, nativeQuery = true)
+    List<DaDayStopsRow> paceByDaOverDays(@Param("daId") UUID daId,
+                                         @Param("fromDate") LocalDate fromDate,
+                                         @Param("city") UUID city);
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/service/DispatchMetricsService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/DispatchMetricsService.java
@@ -1,5 +1,6 @@
 package com.oneday.dispatch.service;
 
+import com.oneday.dispatch.dto.response.DaDetailResponse;
 import com.oneday.dispatch.dto.response.DispatchExecutionStats;
 
 import java.time.LocalDate;
@@ -14,4 +15,11 @@ public interface DispatchMetricsService {
 
     /** @param scopeCityId null → all cities (ADMIN); otherwise restrict to that city. */
     DispatchExecutionStats execution(LocalDate date, UUID scopeCityId);
+
+    /**
+     * One DA's detail for a date: identity + pace + today's tasks (urgency-sorted) + a short history.
+     * {@code scopeCityId} null → any city (ADMIN); otherwise the DA must have a task in that city on
+     * {@code date} (else 404) and only that city's tasks/history are returned.
+     */
+    DaDetailResponse daDetail(UUID daId, LocalDate date, UUID scopeCityId);
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImpl.java
@@ -9,6 +9,7 @@ import com.oneday.dispatch.dto.response.DaDetailResponse.DaTaskItem;
 import com.oneday.dispatch.dto.response.DaDetailResponse.DayStops;
 import com.oneday.dispatch.dto.response.DispatchExecutionStats;
 import com.oneday.dispatch.dto.response.DispatchExecutionStats.DaPace;
+import com.oneday.dispatch.repository.DaDayStopsRow;
 import com.oneday.dispatch.repository.DaPaceRow;
 import com.oneday.dispatch.repository.DeliveryOutcome;
 import com.oneday.dispatch.repository.DispatchQueueRepository;
@@ -25,6 +26,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Service
 class DispatchMetricsServiceImpl implements DispatchMetricsService {
@@ -92,10 +95,7 @@ class DispatchMetricsServiceImpl implements DispatchMetricsService {
                 .sorted(Comparator.comparingInt(i -> urgencyRank(i.urgency())))
                 .toList();
 
-        List<DayStops> history = queueRepository
-                .paceByDaOverDays(daId, date.minusDays(HISTORY_DAYS - 1L), scopeCityId).stream()
-                .map(h -> new DayStops(h.getDay(), h.getDone(), h.getFailed()))
-                .toList();
+        List<DayStops> history = buildHistory(daId, date, scopeCityId);
 
         return new DaDetailResponse(daId, name, phone, cityId, date, pace, completed, failed, items, history);
     }
@@ -110,6 +110,25 @@ class DispatchMetricsServiceImpl implements DispatchMetricsService {
             case IN_PROGRESS -> pastEta ? "RED" : "AMBER";
             case QUEUED, DEFERRED -> pastEta ? "RED" : "GREEN";
         };
+    }
+
+    /**
+     * Exactly {@code HISTORY_DAYS} entries, from {@code date.minusDays(HISTORY_DAYS-1)} through
+     * {@code date}, oldest first: days a DA ran no tasks are filled with zeroes (so the trend chart
+     * has one bar per day), and the upper bound keeps a request for a past date from leaking later days.
+     */
+    private List<DayStops> buildHistory(UUID daId, LocalDate date, UUID scopeCityId) {
+        LocalDate from = date.minusDays(HISTORY_DAYS - 1L);
+        Map<LocalDate, DaDayStopsRow> byDay = queueRepository.paceByDaOverDays(daId, from, scopeCityId).stream()
+                .filter(r -> !r.getDay().isAfter(date))
+                .collect(Collectors.toMap(DaDayStopsRow::getDay, r -> r, (a, b) -> a));
+        return IntStream.range(0, HISTORY_DAYS)
+                .mapToObj(from::plusDays)
+                .map(d -> {
+                    DaDayStopsRow r = byDay.get(d);
+                    return r == null ? new DayStops(d, 0, 0) : new DayStops(d, r.getDone(), r.getFailed());
+                })
+                .toList();
     }
 
     private static int urgencyRank(String urgency) {

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImpl.java
@@ -1,28 +1,42 @@
 package com.oneday.dispatch.service.impl;
 
+import com.oneday.common.port.DaDirectoryPort;
+import com.oneday.common.port.DaDirectoryPort.DaContact;
+import com.oneday.dispatch.domain.DispatchQueue;
+import com.oneday.dispatch.domain.TaskStatus;
+import com.oneday.dispatch.dto.response.DaDetailResponse;
+import com.oneday.dispatch.dto.response.DaDetailResponse.DaTaskItem;
+import com.oneday.dispatch.dto.response.DaDetailResponse.DayStops;
 import com.oneday.dispatch.dto.response.DispatchExecutionStats;
 import com.oneday.dispatch.dto.response.DispatchExecutionStats.DaPace;
 import com.oneday.dispatch.repository.DaPaceRow;
 import com.oneday.dispatch.repository.DeliveryOutcome;
 import com.oneday.dispatch.repository.DispatchQueueRepository;
 import com.oneday.dispatch.service.DispatchMetricsService;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Service
 class DispatchMetricsServiceImpl implements DispatchMetricsService {
 
-    private final DispatchQueueRepository queueRepository;
+    private static final int HISTORY_DAYS = 7;
 
-    DispatchMetricsServiceImpl(DispatchQueueRepository queueRepository) {
+    private final DispatchQueueRepository queueRepository;
+    private final DaDirectoryPort daDirectory;
+
+    DispatchMetricsServiceImpl(DispatchQueueRepository queueRepository, DaDirectoryPort daDirectory) {
         this.queueRepository = queueRepository;
+        this.daDirectory = daDirectory;
     }
 
     @Override
@@ -35,8 +49,10 @@ class DispatchMetricsServiceImpl implements DispatchMetricsService {
         Double successPct = attempts == 0 ? null : (double) completed / attempts;
 
         Instant now = Instant.now();
-        List<DaPace> das = queueRepository.paceByDa(scopeCityId, date).stream()
-                .map(r -> toPace(r, now))
+        List<DaPaceRow> rows = queueRepository.paceByDa(scopeCityId, date);
+        Map<UUID, DaContact> contacts = daDirectory.contactsFor(rows.stream().map(DaPaceRow::getDaId).toList());
+        List<DaPace> das = rows.stream()
+                .map(r -> toPace(r, now, contacts.get(r.getDaId())))
                 .sorted(Comparator.comparingLong(DaPace::stopsPending).reversed()
                         .thenComparing(Comparator.comparingLong(DaPace::stopsDone).reversed()))
                 .toList();
@@ -44,8 +60,72 @@ class DispatchMetricsServiceImpl implements DispatchMetricsService {
         return new DispatchExecutionStats(date, successPct, completed, failed, das);
     }
 
-    private static DaPace toPace(DaPaceRow r, Instant now) {
-        return new DaPace(r.getDaId(), r.getDone(), r.getLastHour(), r.getPending(),
+    @Override
+    @Transactional(readOnly = true)
+    public DaDetailResponse daDetail(UUID daId, LocalDate date, UUID scopeCityId) {
+        List<DispatchQueue> all = queueRepository.findByDaIdAndOperatingDateOrderByQueuePosition(daId, date);
+        // City scope: a station manager only inspects a DA operating in their city today.
+        List<DispatchQueue> tasks = scopeCityId == null ? all
+                : all.stream().filter(t -> scopeCityId.equals(t.getCityId())).toList();
+        if (scopeCityId != null && tasks.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No tasks for this DA in your city today");
+        }
+
+        DaContact contact = daDirectory.contactsFor(List.of(daId)).get(daId);
+        String name = contact != null ? contact.name() : null;
+        String phone = contact != null ? contact.phone() : null;
+        UUID cityId = tasks.isEmpty() ? scopeCityId : tasks.get(0).getCityId();
+
+        Instant now = Instant.now();
+        DaPace pace = queueRepository.paceByDa(scopeCityId, date).stream()
+                .filter(r -> r.getDaId().equals(daId))
+                .findFirst()
+                .map(r -> toPace(r, now, contact))
+                .orElse(new DaPace(daId, name, phone, 0, 0, 0, 0.0));
+
+        long completed = tasks.stream().filter(t -> t.getStatus() == TaskStatus.COMPLETED).count();
+        long failed = tasks.stream().filter(t -> t.getStatus() == TaskStatus.FAILED).count();
+
+        List<DaTaskItem> items = tasks.stream()
+                .map(t -> new DaTaskItem(t.getId(), t.getShipmentId(), t.getTaskType().name(),
+                        t.getStatus().name(), t.getExpectedEta(), urgency(t, now)))
+                .sorted(Comparator.comparingInt(i -> urgencyRank(i.urgency())))
+                .toList();
+
+        List<DayStops> history = queueRepository
+                .paceByDaOverDays(daId, date.minusDays(HISTORY_DAYS - 1L), scopeCityId).stream()
+                .map(h -> new DayStops(h.getDay(), h.getDone(), h.getFailed()))
+                .toList();
+
+        return new DaDetailResponse(daId, name, phone, cityId, date, pace, completed, failed, items, history);
+    }
+
+    /** RED = failed or an active task already past its ETA; AMBER = in-progress on-track; GREEN = queued
+     *  on-track; DONE = completed/cancelled. Uses expectedEta as the on-time signal dispatch owns. */
+    private static String urgency(DispatchQueue t, Instant now) {
+        boolean pastEta = t.getExpectedEta() != null && now.isAfter(t.getExpectedEta());
+        return switch (t.getStatus()) {
+            case COMPLETED, CANCELLED -> "DONE";
+            case FAILED -> "RED";
+            case IN_PROGRESS -> pastEta ? "RED" : "AMBER";
+            case QUEUED, DEFERRED -> pastEta ? "RED" : "GREEN";
+        };
+    }
+
+    private static int urgencyRank(String urgency) {
+        return switch (urgency) {
+            case "RED" -> 0;
+            case "AMBER" -> 1;
+            case "GREEN" -> 2;
+            default -> 3; // DONE
+        };
+    }
+
+    private static DaPace toPace(DaPaceRow r, Instant now, DaContact contact) {
+        return new DaPace(r.getDaId(),
+                contact != null ? contact.name() : null,
+                contact != null ? contact.phone() : null,
+                r.getDone(), r.getLastHour(), r.getPending(),
                 avgPerHour(r.getDone(), r.getFirstAssigned(), now));
     }
 

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImplTest.java
@@ -1,5 +1,10 @@
 package com.oneday.dispatch.service.impl;
 
+import com.oneday.common.port.DaDirectoryPort.DaContact;
+import com.oneday.dispatch.domain.DispatchQueue;
+import com.oneday.dispatch.domain.TaskStatus;
+import com.oneday.dispatch.domain.TaskType;
+import com.oneday.dispatch.dto.response.DaDetailResponse;
 import com.oneday.dispatch.dto.response.DispatchExecutionStats;
 import com.oneday.dispatch.repository.DaPaceRow;
 import com.oneday.dispatch.repository.DeliveryOutcome;
@@ -10,6 +15,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,7 +28,9 @@ import static org.mockito.Mockito.when;
 class DispatchMetricsServiceImplTest {
 
     private final DispatchQueueRepository repo = mock(DispatchQueueRepository.class);
-    private final DispatchMetricsServiceImpl svc = new DispatchMetricsServiceImpl(repo);
+    private final com.oneday.common.port.DaDirectoryPort directory =
+            mock(com.oneday.common.port.DaDirectoryPort.class);
+    private final DispatchMetricsServiceImpl svc = new DispatchMetricsServiceImpl(repo, directory);
     private final LocalDate date = LocalDate.now();
 
     private record Outcome(long completed, long failed) implements DeliveryOutcome {
@@ -37,6 +45,45 @@ class DispatchMetricsServiceImplTest {
         @Override public long getLastHour() { return lastHour; }
         @Override public long getPending() { return pending; }
         @Override public Instant getFirstAssigned() { return firstAssigned; }
+    }
+
+    private DispatchQueue task(UUID cityId, TaskStatus status, Instant eta) {
+        DispatchQueue t = new DispatchQueue();
+        t.setDaId(UUID.randomUUID());
+        t.setCityId(cityId);
+        t.setShipmentId(UUID.randomUUID());
+        t.setTaskType(TaskType.DELIVERY);
+        t.setStatus(status);
+        t.setExpectedEta(eta);
+        t.setQueuePosition(0);
+        t.setOperatingDate(date);
+        return t;
+    }
+
+    @Test
+    void daDetailSortsByUrgencyAndAttachesIdentity() {
+        UUID da = UUID.randomUUID();
+        UUID city = UUID.randomUUID();
+        Instant now = Instant.now();
+        when(repo.findByDaIdAndOperatingDateOrderByQueuePosition(da, date)).thenReturn(List.of(
+                task(city, TaskStatus.COMPLETED, null),                       // DONE
+                task(city, TaskStatus.FAILED, null),                          // RED
+                task(city, TaskStatus.IN_PROGRESS, now.plusSeconds(3600)),    // AMBER (on-track)
+                task(city, TaskStatus.QUEUED, now.minusSeconds(3600))));      // RED (past ETA)
+        when(repo.paceByDa(null, date)).thenReturn(List.of());
+        when(repo.paceByDaOverDays(eq(da), any(), eq(null))).thenReturn(List.of());
+        when(directory.contactsFor(List.of(da)))
+                .thenReturn(Map.of(da, new DaContact("Ravi Kumar", "+919000000000")));
+
+        DaDetailResponse d = svc.daDetail(da, date, null);
+
+        assertThat(d.name()).isEqualTo("Ravi Kumar");
+        assertThat(d.phone()).isEqualTo("+919000000000");
+        assertThat(d.completed()).isEqualTo(1);
+        assertThat(d.failed()).isEqualTo(1);
+        // stable sort: FAILED then past-ETA QUEUED (both RED), then AMBER, then DONE
+        assertThat(d.tasks()).extracting(DaDetailResponse.DaTaskItem::urgency)
+                .containsExactly("RED", "RED", "AMBER", "DONE");
     }
 
     @Test

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImplTest.java
@@ -47,6 +47,13 @@ class DispatchMetricsServiceImplTest {
         @Override public Instant getFirstAssigned() { return firstAssigned; }
     }
 
+    private record Day(LocalDate day, long done, long failed)
+            implements com.oneday.dispatch.repository.DaDayStopsRow {
+        @Override public LocalDate getDay() { return day; }
+        @Override public long getDone() { return done; }
+        @Override public long getFailed() { return failed; }
+    }
+
     private DispatchQueue task(UUID cityId, TaskStatus status, Instant eta) {
         DispatchQueue t = new DispatchQueue();
         t.setDaId(UUID.randomUUID());
@@ -84,6 +91,32 @@ class DispatchMetricsServiceImplTest {
         // stable sort: FAILED then past-ETA QUEUED (both RED), then AMBER, then DONE
         assertThat(d.tasks()).extracting(DaDetailResponse.DaTaskItem::urgency)
                 .containsExactly("RED", "RED", "AMBER", "DONE");
+    }
+
+    @Test
+    void historyIsSevenDaysZeroFilledAndBounded() {
+        UUID da = UUID.randomUUID();
+        when(repo.findByDaIdAndOperatingDateOrderByQueuePosition(da, date)).thenReturn(List.of());
+        when(repo.paceByDa(null, date)).thenReturn(List.of());
+        when(directory.contactsFor(List.of(da))).thenReturn(Map.of());
+        // one in-range day with data + a later day the upper bound must exclude
+        when(repo.paceByDaOverDays(eq(da), any(), eq(null))).thenReturn(List.of(
+                new Day(date.minusDays(2), 4, 1),
+                new Day(date.plusDays(1), 9, 9)));
+
+        List<DaDetailResponse.DayStops> h = svc.daDetail(da, date, null).history();
+
+        assertThat(h).hasSize(7);
+        assertThat(h.get(0).date()).isEqualTo(date.minusDays(6));
+        assertThat(h.get(6).date()).isEqualTo(date);
+        assertThat(h).noneMatch(x -> x.date().isAfter(date));           // upper bound
+        DaDetailResponse.DayStops filled = h.stream()
+                .filter(x -> x.date().equals(date.minusDays(2))).findFirst().orElseThrow();
+        assertThat(filled.done()).isEqualTo(4);
+        assertThat(filled.failed()).isEqualTo(1);
+        DaDetailResponse.DayStops empty = h.stream()
+                .filter(x -> x.date().equals(date.minusDays(5))).findFirst().orElseThrow();
+        assertThat(empty.done()).isZero();                              // zero-filled, not missing
     }
 
     @Test


### PR DESCRIPTION
## What
Turns the control-tower DA rows from raw ids into people you can identify, call, and drill into.

- **DA identity in the tower**: `DaPace` now carries `da_name` + `da_phone`, enriched via the existing `common` `DaDirectoryPort.contactsFor(daIds)` in `DispatchMetricsServiceImpl` (batch, no N+1). `GET /dispatch/execution` shows a name, not a UUID.
- **New `GET /dispatch/da/{daId}?date=`** (STATION_MANAGER, city-scoped; ADMIN any) → `DaDetailResponse`:
  - **identity** (name / phone / city),
  - **today's pace** (done / last-hr / avg-hr / pending, delivered / failed),
  - **today's tasks urgency-sorted** — `RED` (failed or active past its `expectedEta`) → `AMBER` (in-progress on-track) → `GREEN` (queued on-track) → `DONE`,
  - **7-day per-day stops history** (new native `paceByDaOverDays`).
  - **City guard**: a manager can only inspect a DA operating in their city today (else 404).

## Reuse / new
Reuses `DaDirectoryPort`, `findByDaIdAndOperatingDateOrderByQueuePosition`, `paceByDa`. New: one native history query + the detail composition. No new persistence.

## Verified
`DispatchMetricsServiceImplTest` 5 green (+1: urgency sort + identity); history native query validated against real Postgres; app assembles.

## Flagged follow-up
Task urgency is derived from dispatch's own `expectedEta`; the **real M10 per-shipment SLA band/breach** is a cleaner signal but needs a new `common` `ShipmentSlaStatusPort` (sla→common→dispatch) — deferred. Also: a station-scoped DA GPS-trail endpoint (the DA-self one exists) and deeper multi-week trends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a station-dispatch detail view for delivery agents, including identity, contact details, pace, completed and failed stops, prioritized tasks, and seven-day history.
  * Added date-based detail views, defaulting to the current day when no date is specified.
  * Added access controls and city-based data scoping for station managers and administrators.
  * Dispatch performance statistics now include agent names and phone numbers.
* **Bug Fixes**
  * Improved task prioritization based on status and expected delivery timing.
  * History now consistently displays seven days, including days with no activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->