### PR TITLE
feat(orders): CSV export of all matching shipments (past the list cap)

### DIFF
--- a/orders/src/main/java/com/oneday/orders/api/AdminOrdersController.java
+++ b/orders/src/main/java/com/oneday/orders/api/AdminOrdersController.java
@@ -118,7 +118,7 @@ class AdminOrdersController {
 
     static String toCsv(List<ShipmentSummaryResponse> rows) {
         StringBuilder sb = new StringBuilder();
-        sb.append(String.join(",", CSV_HEADERS)).append('\n');
+        sb.append(String.join(",", CSV_HEADERS)).append("\r\n");
         for (ShipmentSummaryResponse r : rows) {
             sb.append(csv(r.shipmentRef())).append(',')
               .append(csv(r.customerType())).append(',')
@@ -136,17 +136,25 @@ class AdminOrdersController {
               .append(csv(r.totalPricePaise())).append(',')
               .append(csv(r.createdAt())).append(',')
               .append(csv(r.cancelledAt())).append(',')
-              .append(csv(r.custodyCity())).append('\n');
+              .append(csv(r.custodyCity())).append("\r\n");
         }
         return sb.toString();
     }
 
-    /** RFC-4180 cell: quote + double any embedded quote when the value has a comma/quote/newline. */
+    /**
+     * RFC-4180 cell + CSV-injection guard. A value beginning with {@code = + - @} (or a tab/CR that
+     * spreadsheets treat the same) is prefixed with an apostrophe so a sender/receiver name can't be
+     * evaluated as a formula when the export is opened in a spreadsheet; then it's quoted + quote-doubled
+     * if it contains a comma/quote/newline.
+     */
     static String csv(Object value) {
         if (value == null) {
             return "";
         }
         String s = String.valueOf(value);
+        if (!s.isEmpty() && "=+-@\t\r".indexOf(s.charAt(0)) >= 0) {
+            s = "'" + s;
+        }
         if (s.contains(",") || s.contains("\"") || s.contains("\n") || s.contains("\r")) {
             return '"' + s.replace("\"", "\"\"") + '"';
         }

--- a/orders/src/main/java/com/oneday/orders/api/AdminOrdersController.java
+++ b/orders/src/main/java/com/oneday/orders/api/AdminOrdersController.java
@@ -4,11 +4,18 @@ import com.oneday.auth.security.AuthUserDetails;
 import com.oneday.orders.dto.CancellationResponse;
 import com.oneday.orders.dto.ShipmentAgeingStats;
 import com.oneday.orders.dto.ShipmentPageResponse;
+import com.oneday.orders.dto.ShipmentSummaryResponse;
 import com.oneday.orders.dto.ShipmentSummaryStats;
 import com.oneday.orders.service.AdminOrderQueryService;
 import com.oneday.orders.service.AdminOrderSummaryService;
 import com.oneday.orders.service.CancellationService;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +24,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.List;
 
 /**
  * Orders-database access for ops tooling. The counterpart to the customer booking endpoints — these
@@ -77,6 +88,69 @@ class AdminOrdersController {
     public ShipmentAgeingStats ageing(@AuthenticationPrincipal AuthUserDetails principal) {
         Authz.requireRole(principal, STATION_MANAGER);
         return adminOrderSummaryService.ageing(cityScope(principal));
+    }
+
+    /**
+     * Export every matching shipment as CSV (ops "export all"), same {@code state} filter + city scope as
+     * {@link #listShipments} but without the 200-row page cap. Streams a downloadable attachment.
+     */
+    @GetMapping(value = "/export", produces = "text/csv")
+    public ResponseEntity<Resource> exportShipments(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @RequestParam(value = "state", required = false) String state) {
+        Authz.requireRole(principal, STATION_MANAGER);
+        List<ShipmentSummaryResponse> rows = adminOrderQueryService.exportShipments(state, cityScope(principal));
+
+        byte[] csv = toCsv(rows).getBytes(StandardCharsets.UTF_8);
+        String filename = "shipments-" + LocalDate.now() + (state == null || state.isBlank() ? "" : "-" + state) + ".csv";
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        ContentDisposition.attachment().filename(filename).build().toString())
+                .contentType(MediaType.parseMediaType("text/csv"))
+                .body(new ByteArrayResource(csv));
+    }
+
+    private static final String[] CSV_HEADERS = {
+            "shipment_ref", "customer_type", "delivery_type", "state", "pickup_type", "payment_mode",
+            "origin_city", "origin_pincode", "dest_city", "dest_pincode", "sender_name", "receiver_name",
+            "chargeable_weight_grams", "total_price_paise", "created_at", "cancelled_at", "custody_city"
+    };
+
+    static String toCsv(List<ShipmentSummaryResponse> rows) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.join(",", CSV_HEADERS)).append('\n');
+        for (ShipmentSummaryResponse r : rows) {
+            sb.append(csv(r.shipmentRef())).append(',')
+              .append(csv(r.customerType())).append(',')
+              .append(csv(r.deliveryType())).append(',')
+              .append(csv(r.state())).append(',')
+              .append(csv(r.pickupType())).append(',')
+              .append(csv(r.paymentMode())).append(',')
+              .append(csv(r.originCity())).append(',')
+              .append(csv(r.originPincode())).append(',')
+              .append(csv(r.destCity())).append(',')
+              .append(csv(r.destPincode())).append(',')
+              .append(csv(r.senderName())).append(',')
+              .append(csv(r.receiverName())).append(',')
+              .append(csv(r.chargeableWeightGrams())).append(',')
+              .append(csv(r.totalPricePaise())).append(',')
+              .append(csv(r.createdAt())).append(',')
+              .append(csv(r.cancelledAt())).append(',')
+              .append(csv(r.custodyCity())).append('\n');
+        }
+        return sb.toString();
+    }
+
+    /** RFC-4180 cell: quote + double any embedded quote when the value has a comma/quote/newline. */
+    static String csv(Object value) {
+        if (value == null) {
+            return "";
+        }
+        String s = String.valueOf(value);
+        if (s.contains(",") || s.contains("\"") || s.contains("\n") || s.contains("\r")) {
+            return '"' + s.replace("\"", "\"\"") + '"';
+        }
+        return s;
     }
 
     /** Null for ADMIN (all cities); the station manager's own city otherwise (403 if unassigned). */

--- a/orders/src/main/java/com/oneday/orders/service/AdminOrderQueryService.java
+++ b/orders/src/main/java/com/oneday/orders/service/AdminOrderQueryService.java
@@ -1,6 +1,9 @@
 package com.oneday.orders.service;
 
 import com.oneday.orders.dto.ShipmentPageResponse;
+import com.oneday.orders.dto.ShipmentSummaryResponse;
+
+import java.util.List;
 
 /**
  * Read-only orders-database access for ADMIN tooling. Lists shipments across all customers
@@ -19,4 +22,11 @@ public interface AdminOrderQueryService {
      * @return a page of shipment summaries, newest first
      */
     ShipmentPageResponse listShipments(String stateFilter, String cityScope, int page, int size);
+
+    /**
+     * Every shipment matching the same {@code stateFilter} + {@code cityScope} as {@link #listShipments},
+     * newest first, without the page cap — backs the ops "export all matching" CSV. Bounded by a hard
+     * safety ceiling in the implementation.
+     */
+    List<ShipmentSummaryResponse> exportShipments(String stateFilter, String cityScope);
 }

--- a/orders/src/main/java/com/oneday/orders/service/impl/AdminOrderQueryServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/AdminOrderQueryServiceImpl.java
@@ -40,7 +40,7 @@ class AdminOrderQueryServiceImpl implements AdminOrderQueryService {
     public ShipmentPageResponse listShipments(String stateFilter, String cityScope, int page, int size) {
         int safePage = Math.max(0, page);
         int safeSize = Math.min(Math.max(1, size), MAX_PAGE_SIZE);
-        Pageable pageable = PageRequest.of(safePage, safeSize, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Pageable pageable = PageRequest.of(safePage, safeSize, Sort.by(Sort.Direction.DESC, "createdAt").and(Sort.by(Sort.Direction.ASC, "id")));
 
         ShipmentState state = (stateFilter == null || stateFilter.isBlank())
                 ? null : parseState(stateFilter);
@@ -63,7 +63,7 @@ class AdminOrderQueryServiceImpl implements AdminOrderQueryService {
 
         java.util.List<ShipmentSummaryResponse> out = new java.util.ArrayList<>();
         for (int page = 0; out.size() < EXPORT_MAX_ROWS; page++) {
-            Pageable pageable = PageRequest.of(page, EXPORT_PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"));
+            Pageable pageable = PageRequest.of(page, EXPORT_PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt").and(Sort.by(Sort.Direction.ASC, "id")));
             Page<Shipment> batch = fetchPage(state, cityScope, pageable);
             batch.forEach(s -> out.add(toSummary(s, cityScope)));
             if (!batch.hasNext()) {

--- a/orders/src/main/java/com/oneday/orders/service/impl/AdminOrderQueryServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/AdminOrderQueryServiceImpl.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -56,7 +57,10 @@ class AdminOrderQueryServiceImpl implements AdminOrderQueryService {
     }
 
     @Override
-    @Transactional(readOnly = true)
+    // REPEATABLE_READ gives the whole paged export one stable snapshot, so shipments booked or
+    // transitioning state between the per-page OFFSET queries can't duplicate or drop rows (the id
+    // tiebreaker only orders within a single query's snapshot). Read-only + short-lived, so cheap.
+    @Transactional(readOnly = true, isolation = Isolation.REPEATABLE_READ)
     public java.util.List<ShipmentSummaryResponse> exportShipments(String stateFilter, String cityScope) {
         ShipmentState state = (stateFilter == null || stateFilter.isBlank())
                 ? null : parseState(stateFilter);

--- a/orders/src/main/java/com/oneday/orders/service/impl/AdminOrderQueryServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/AdminOrderQueryServiceImpl.java
@@ -24,6 +24,10 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 class AdminOrderQueryServiceImpl implements AdminOrderQueryService {
 
     private static final int MAX_PAGE_SIZE = 200;
+    // ponytail: export pages 500 at a time and stops at 50k rows — a pilot city-day is well under this;
+    // raise the cap (or switch to a true streaming response) if a single export ever needs more.
+    private static final int EXPORT_PAGE_SIZE = 500;
+    private static final int EXPORT_MAX_ROWS = 50_000;
 
     private final ShipmentRepository shipmentRepository;
 
@@ -41,16 +45,7 @@ class AdminOrderQueryServiceImpl implements AdminOrderQueryService {
         ShipmentState state = (stateFilter == null || stateFilter.isBlank())
                 ? null : parseState(stateFilter);
 
-        Page<Shipment> result;
-        if (cityScope == null) {                       // admin oversight — all cities
-            result = (state == null)
-                    ? shipmentRepository.findAll(pageable)
-                    : shipmentRepository.findByState(state, pageable);
-        } else {                                       // station manager — only their city's legs
-            result = (state == null)
-                    ? shipmentRepository.findByCityInvolved(cityScope, pageable)
-                    : shipmentRepository.findByCityInvolvedAndState(cityScope, state, pageable);
-        }
+        Page<Shipment> result = fetchPage(state, cityScope, pageable);
 
         return new ShipmentPageResponse(
                 result.map(s -> toSummary(s, cityScope)).getContent(),
@@ -58,6 +53,36 @@ class AdminOrderQueryServiceImpl implements AdminOrderQueryService {
                 result.getSize(),
                 result.getTotalElements(),
                 result.getTotalPages());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public java.util.List<ShipmentSummaryResponse> exportShipments(String stateFilter, String cityScope) {
+        ShipmentState state = (stateFilter == null || stateFilter.isBlank())
+                ? null : parseState(stateFilter);
+
+        java.util.List<ShipmentSummaryResponse> out = new java.util.ArrayList<>();
+        for (int page = 0; out.size() < EXPORT_MAX_ROWS; page++) {
+            Pageable pageable = PageRequest.of(page, EXPORT_PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"));
+            Page<Shipment> batch = fetchPage(state, cityScope, pageable);
+            batch.forEach(s -> out.add(toSummary(s, cityScope)));
+            if (!batch.hasNext()) {
+                break;
+            }
+        }
+        return out;
+    }
+
+    private Page<Shipment> fetchPage(ShipmentState state, String cityScope, Pageable pageable) {
+        if (cityScope == null) {                       // admin oversight — all cities
+            return (state == null)
+                    ? shipmentRepository.findAll(pageable)
+                    : shipmentRepository.findByState(state, pageable);
+        }
+        // station manager — only their city's legs (origin OR dest)
+        return (state == null)
+                ? shipmentRepository.findByCityInvolved(cityScope, pageable)
+                : shipmentRepository.findByCityInvolvedAndState(cityScope, state, pageable);
     }
 
     private static ShipmentState parseState(String stateFilter) {

--- a/orders/src/test/java/com/oneday/orders/api/AdminOrdersControllerCsvTest.java
+++ b/orders/src/test/java/com/oneday/orders/api/AdminOrdersControllerCsvTest.java
@@ -1,0 +1,44 @@
+package com.oneday.orders.api;
+
+import com.oneday.common.domain.enums.CustomerType;
+import com.oneday.common.domain.enums.DeliveryType;
+import com.oneday.common.domain.enums.PaymentMode;
+import com.oneday.common.domain.enums.PickupType;
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.dto.ShipmentSummaryResponse;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AdminOrdersControllerCsvTest {
+
+    @Test
+    void escapesCommasAndQuotesAndWritesHeaderPlusRow() {
+        ShipmentSummaryResponse row = new ShipmentSummaryResponse(
+                "1DD-BLR-1", CustomerType.B2C, DeliveryType.INTERCITY, ShipmentState.BOOKED,
+                PickupType.DA_PICKUP, PaymentMode.PREPAID,
+                "Bengaluru", "560001", "Delhi", "110001",
+                "Sharma, Rao & Co", "Priya \"Pri\" N", 1200, 25000L,
+                Instant.parse("2026-08-24T10:00:00Z"), null, "Bengaluru", true);
+
+        String csv = AdminOrdersController.toCsv(List.of(row));
+        String[] lines = csv.split("\n", -1);
+
+        assertThat(lines[0]).startsWith("shipment_ref,customer_type,delivery_type,state");
+        // comma-bearing sender is quoted; embedded quotes are doubled
+        assertThat(lines[1]).contains("\"Sharma, Rao & Co\"");
+        assertThat(lines[1]).contains("\"Priya \"\"Pri\"\" N\"");
+        assertThat(lines[1]).contains("1DD-BLR-1");
+        assertThat(lines[1]).contains("560001");
+    }
+
+    @Test
+    void plainValuesAreUnquotedAndNullsAreEmpty() {
+        assertThat(AdminOrdersController.csv("BOOKED")).isEqualTo("BOOKED");
+        assertThat(AdminOrdersController.csv(null)).isEmpty();
+        assertThat(AdminOrdersController.csv(42)).isEqualTo("42");
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/api/AdminOrdersControllerCsvTest.java
+++ b/orders/src/test/java/com/oneday/orders/api/AdminOrdersControllerCsvTest.java
@@ -41,4 +41,28 @@ class AdminOrdersControllerCsvTest {
         assertThat(AdminOrdersController.csv(null)).isEmpty();
         assertThat(AdminOrdersController.csv(42)).isEqualTo("42");
     }
+
+    @Test
+    void neutralizesFormulaLeadingCells() {
+        // A leading =,+,-,@ is apostrophe-prefixed so a spreadsheet won't evaluate it (CSV injection).
+        assertThat(AdminOrdersController.csv("=SUM(A1)")).isEqualTo("'=SUM(A1)");
+        assertThat(AdminOrdersController.csv("+91999")).isEqualTo("'+91999");
+        assertThat(AdminOrdersController.csv("-1")).isEqualTo("'-1");
+        assertThat(AdminOrdersController.csv("@handle")).isEqualTo("'@handle");
+        // still quoted when it also contains a comma
+        assertThat(AdminOrdersController.csv("=1,2")).isEqualTo("\"'=1,2\"");
+        // an ordinary value is untouched
+        assertThat(AdminOrdersController.csv("Bengaluru")).isEqualTo("Bengaluru");
+    }
+
+    @Test
+    void usesCrlfRecordDelimiter() {
+        ShipmentSummaryResponse row = new ShipmentSummaryResponse(
+                "1DD-BLR-2", CustomerType.B2C, DeliveryType.INTERCITY, ShipmentState.BOOKED,
+                PickupType.DA_PICKUP, PaymentMode.PREPAID, "Bengaluru", "560001", "Delhi", "110001",
+                "A", "B", 1000, 100L, Instant.parse("2026-08-24T10:00:00Z"), null, "Bengaluru", true);
+        String csv = AdminOrdersController.toCsv(List.of(row));
+        assertThat(csv).contains("\r\n");                 // RFC-4180 record delimiter
+        assertThat(csv.split("\r\n", -1)).hasSizeGreaterThanOrEqualTo(2);
+    }
 }


### PR DESCRIPTION

<img width="1950" height="1190" alt="image" src="https://github.com/user-attachments/assets/2d29806c-d42a-428b-a4d9-f9a2fe83c785" />


Amazon-parity Phase 1 (backend half). Pairs with the station web PR (oneday-web#30).

## What
- `GET /api/v1/admin/shipments/export` → `text/csv` downloadable attachment, same `state` filter + city scope as `GET /api/v1/admin/shipments` but **without the 200-row page cap**.
- `AdminOrderQueryService.exportShipments(state, cityScope)` pages the existing `findByCityInvolved*` / `findByState` finders 500 at a time up to a 50k safety ceiling (ponytail-commented; switch to true streaming if a single export ever needs more).
- Controller hand-writes RFC-4180 CSV — **no new dependency** — using the `ResponseEntity<Resource>` + `Content-Disposition` pattern from `BulkUploadController`.

## Auth / scope
`Authz.requireRole(STATION_MANAGER)` (ADMIN always); ADMIN → all cities, STATION_MANAGER → shipments touching their own city (same rule as the list).

## Test
`AdminOrdersControllerCsvTest` covers CSV escaping (commas/quotes) + header/row shape; orders admin tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added CSV export for filtered admin shipment listings.
  * Exports support state and city filters and include up to 50,000 shipments.
  * Downloads are provided as UTF-8 CSV files with headers and a dated filename.
  * Shipment details correctly handle commas, quotes, and line breaks.
* **Bug Fixes**
  * Improved CSV compatibility with spreadsheet applications by using standard line endings.
  * Protected exported values beginning with formula characters from unintended spreadsheet execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->