### PR TITLE
feat(dispatch): per-DA delivery scorecards endpoint

### DIFF
--- a/dispatch/src/main/java/com/oneday/dispatch/api/StationDispatchController.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/api/StationDispatchController.java
@@ -3,6 +3,7 @@ package com.oneday.dispatch.api;
 import com.oneday.auth.security.AuthUserDetails;
 import com.oneday.dispatch.dto.request.AssignDeferredRequest;
 import com.oneday.dispatch.dto.response.DaDetailResponse;
+import com.oneday.dispatch.dto.response.DaScorecard;
 import com.oneday.dispatch.dto.response.DeferredAssignResponse;
 import com.oneday.dispatch.dto.response.DispatchExecutionStats;
 import com.oneday.dispatch.dto.response.TileQueueResponse;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -56,6 +58,19 @@ public class StationDispatchController {
         Authz.requireRole(principal, Authz.STATION_MANAGER);
         UUID scopeCityId = Authz.isAdmin(principal) ? null : managerCity(principal);
         return dispatchMetricsService.execution(date != null ? date : LocalDate.now(), scopeCityId);
+    }
+
+    /**
+     * Per-DA delivery scorecards for a date (defaults to today): stops, stops/hr, attempt-success % and
+     * on-time %. Same city scope as {@link #execution} — STATION_MANAGER their own city, ADMIN all.
+     */
+    @GetMapping("/dispatch/scorecards")
+    public List<DaScorecard> scorecards(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireRole(principal, Authz.STATION_MANAGER);
+        UUID scopeCityId = Authz.isAdmin(principal) ? null : managerCity(principal);
+        return dispatchMetricsService.scorecards(date != null ? date : LocalDate.now(), scopeCityId);
     }
 
     /**

--- a/dispatch/src/main/java/com/oneday/dispatch/dto/response/DaScorecard.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/dto/response/DaScorecard.java
@@ -1,0 +1,25 @@
+package com.oneday.dispatch.dto.response;
+
+import java.util.UUID;
+
+/**
+ * One DA's delivery performance for a date — the control-tower scorecard row.
+ *
+ * @param stopsDone         completed delivery stops
+ * @param stopsFailed       failed delivery attempts
+ * @param stopsPending      still-open delivery tasks
+ * @param stopsPerHour      completed stops ÷ hours on shift (since first assignment); 0 for a fresh DA
+ * @param attemptSuccessPct completed ÷ (completed + failed) attempts, 0..1; null when no attempts yet
+ * @param onTimePct         completed on/before ETA ÷ completed, 0..1; null when nothing completed
+ */
+public record DaScorecard(
+        UUID daId,
+        String daName,
+        String daPhone,
+        long stopsDone,
+        long stopsFailed,
+        long stopsPending,
+        double stopsPerHour,
+        Double attemptSuccessPct,
+        Double onTimePct) {
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/repository/DaScorecardRow.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/repository/DaScorecardRow.java
@@ -1,0 +1,20 @@
+package com.oneday.dispatch.repository;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Per-DA scorecard projection for a date: stops completed ({@code done}), failed attempts ({@code failed}),
+ * completed on or before their ETA ({@code onTime}), still-open tasks ({@code pending}), and the DA's first
+ * assignment time ({@code firstAssigned}, for stops-per-hour). Native-query aliases are camelCase
+ * ({@code AS daId / done / failed / onTime / pending / firstAssigned}) so Postgres's lowercase fold matches
+ * these getters — same pattern as {@link DaPaceRow}.
+ */
+public interface DaScorecardRow {
+    UUID getDaId();
+    long getDone();
+    long getFailed();
+    long getOnTime();
+    long getPending();
+    Instant getFirstAssigned();
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/repository/DispatchQueueRepository.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/repository/DispatchQueueRepository.java
@@ -115,4 +115,26 @@ public interface DispatchQueueRepository extends JpaRepository<DispatchQueue, UU
     List<DaDayStopsRow> paceByDaOverDays(@Param("daId") UUID daId,
                                          @Param("fromDate") LocalDate fromDate,
                                          @Param("city") UUID city);
+
+    /**
+     * Per-DA scorecard for a city/date: delivery stops done, failed, done on/before ETA (on-time), open
+     * tasks, and the DA's first assignment (for stops-per-hour). Delivery attempts only ({@code
+     * task_type='DELIVERY'}) so attempt-success/on-time are last-mile metrics. Native (Postgres FILTER);
+     * {@code city} null → all cities. camelCase aliases bind to {@link DaScorecardRow}.
+     */
+    @Query(value = """
+            SELECT da_id AS daId,
+                   COUNT(*) FILTER (WHERE status = 'COMPLETED') AS done,
+                   COUNT(*) FILTER (WHERE status = 'FAILED')    AS failed,
+                   COUNT(*) FILTER (WHERE status = 'COMPLETED'
+                                      AND expected_eta IS NOT NULL
+                                      AND completed_at <= expected_eta) AS onTime,
+                   COUNT(*) FILTER (WHERE status IN ('QUEUED', 'IN_PROGRESS')) AS pending,
+                   MIN(assigned_at) AS firstAssigned
+            FROM dispatch_queue
+            WHERE task_type = 'DELIVERY' AND operating_date = :date
+              AND (:city IS NULL OR city_id = :city)
+            GROUP BY da_id
+            """, nativeQuery = true)
+    List<DaScorecardRow> scorecardByDa(@Param("city") UUID city, @Param("date") LocalDate date);
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/repository/DispatchQueueRepository.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/repository/DispatchQueueRepository.java
@@ -129,7 +129,7 @@ public interface DispatchQueueRepository extends JpaRepository<DispatchQueue, UU
                    COUNT(*) FILTER (WHERE status = 'COMPLETED'
                                       AND expected_eta IS NOT NULL
                                       AND completed_at <= expected_eta) AS onTime,
-                   COUNT(*) FILTER (WHERE status IN ('QUEUED', 'IN_PROGRESS')) AS pending,
+                   COUNT(*) FILTER (WHERE status IN ('QUEUED', 'IN_PROGRESS', 'DEFERRED')) AS pending,
                    MIN(assigned_at) AS firstAssigned
             FROM dispatch_queue
             WHERE task_type = 'DELIVERY' AND operating_date = :date

--- a/dispatch/src/main/java/com/oneday/dispatch/service/DispatchMetricsService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/DispatchMetricsService.java
@@ -1,9 +1,11 @@
 package com.oneday.dispatch.service;
 
 import com.oneday.dispatch.dto.response.DaDetailResponse;
+import com.oneday.dispatch.dto.response.DaScorecard;
 import com.oneday.dispatch.dto.response.DispatchExecutionStats;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -22,4 +24,10 @@ public interface DispatchMetricsService {
      * {@code date} (else 404) and only that city's tasks/history are returned.
      */
     DaDetailResponse daDetail(UUID daId, LocalDate date, UUID scopeCityId);
+
+    /**
+     * Per-DA delivery scorecards for a date: stops, stops/hr, attempt-success % and on-time %, most-active
+     * first. {@code scopeCityId} null → all cities (ADMIN); otherwise restrict to that city.
+     */
+    List<DaScorecard> scorecards(LocalDate date, UUID scopeCityId);
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImpl.java
@@ -24,6 +24,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +36,7 @@ import java.util.stream.IntStream;
 class DispatchMetricsServiceImpl implements DispatchMetricsService {
 
     private static final int HISTORY_DAYS = 7;
+    private static final ZoneId IST = ZoneId.of("Asia/Kolkata");
 
     private final DispatchQueueRepository queueRepository;
     private final DaDirectoryPort daDirectory;
@@ -105,11 +107,15 @@ class DispatchMetricsServiceImpl implements DispatchMetricsService {
     @Override
     @Transactional(readOnly = true)
     public List<DaScorecard> scorecards(LocalDate date, UUID scopeCityId) {
+        // For a past date, stops/hr must measure that day's shift, not every hour since — cap the clock
+        // at the end of the operating date (IST); for today, that end is in the future, so `now` wins.
+        Instant dayEnd = date.plusDays(1).atStartOfDay(IST).toInstant();
         Instant now = Instant.now();
+        Instant cutoff = now.isBefore(dayEnd) ? now : dayEnd;
         List<DaScorecardRow> rows = queueRepository.scorecardByDa(scopeCityId, date);
         Map<UUID, DaContact> contacts = daDirectory.contactsFor(rows.stream().map(DaScorecardRow::getDaId).toList());
         return rows.stream()
-                .map(r -> toScorecard(r, now, contacts.get(r.getDaId())))
+                .map(r -> toScorecard(r, cutoff, contacts.get(r.getDaId())))
                 // busiest first: most stops done, then most still pending
                 .sorted(Comparator.comparingLong(DaScorecard::stopsDone).reversed()
                         .thenComparing(Comparator.comparingLong(DaScorecard::stopsPending).reversed()))

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImpl.java
@@ -7,10 +7,12 @@ import com.oneday.dispatch.domain.TaskStatus;
 import com.oneday.dispatch.dto.response.DaDetailResponse;
 import com.oneday.dispatch.dto.response.DaDetailResponse.DaTaskItem;
 import com.oneday.dispatch.dto.response.DaDetailResponse.DayStops;
+import com.oneday.dispatch.dto.response.DaScorecard;
 import com.oneday.dispatch.dto.response.DispatchExecutionStats;
 import com.oneday.dispatch.dto.response.DispatchExecutionStats.DaPace;
 import com.oneday.dispatch.repository.DaDayStopsRow;
 import com.oneday.dispatch.repository.DaPaceRow;
+import com.oneday.dispatch.repository.DaScorecardRow;
 import com.oneday.dispatch.repository.DeliveryOutcome;
 import com.oneday.dispatch.repository.DispatchQueueRepository;
 import com.oneday.dispatch.service.DispatchMetricsService;
@@ -98,6 +100,32 @@ class DispatchMetricsServiceImpl implements DispatchMetricsService {
         List<DayStops> history = buildHistory(daId, date, scopeCityId);
 
         return new DaDetailResponse(daId, name, phone, cityId, date, pace, completed, failed, items, history);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<DaScorecard> scorecards(LocalDate date, UUID scopeCityId) {
+        Instant now = Instant.now();
+        List<DaScorecardRow> rows = queueRepository.scorecardByDa(scopeCityId, date);
+        Map<UUID, DaContact> contacts = daDirectory.contactsFor(rows.stream().map(DaScorecardRow::getDaId).toList());
+        return rows.stream()
+                .map(r -> toScorecard(r, now, contacts.get(r.getDaId())))
+                // busiest first: most stops done, then most still pending
+                .sorted(Comparator.comparingLong(DaScorecard::stopsDone).reversed()
+                        .thenComparing(Comparator.comparingLong(DaScorecard::stopsPending).reversed()))
+                .toList();
+    }
+
+    private static DaScorecard toScorecard(DaScorecardRow r, Instant now, DaContact contact) {
+        long attempts = r.getDone() + r.getFailed();
+        Double attemptSuccess = attempts == 0 ? null : (double) r.getDone() / attempts;
+        Double onTime = r.getDone() == 0 ? null : (double) r.getOnTime() / r.getDone();
+        return new DaScorecard(r.getDaId(),
+                contact != null ? contact.name() : null,
+                contact != null ? contact.phone() : null,
+                r.getDone(), r.getFailed(), r.getPending(),
+                avgPerHour(r.getDone(), r.getFirstAssigned(), now),
+                attemptSuccess, onTime);
     }
 
     /** RED = failed or an active task already past its ETA; AMBER = in-progress on-track; GREEN = queued

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImplTest.java
@@ -201,4 +201,21 @@ class DispatchMetricsServiceImplTest {
         assertThat(cards.get(1).attemptSuccessPct()).isNull();        // no attempts → null, not 0
         assertThat(cards.get(1).onTimePct()).isNull();
     }
+
+    @Test
+    void scorecardsBoundStopsPerHourToPastOperatingDate() {
+        java.time.ZoneId ist = java.time.ZoneId.of("Asia/Kolkata");
+        LocalDate pastDate = LocalDate.now(ist).minusDays(2);
+        UUID da = UUID.randomUUID();
+        // 8 stops, first assigned 09:00 IST on that past date → clock caps at that day's 00:00 next-day
+        // (~15h), so ~0.53/hr; a now-based clock (2 days later) would read ~0.15/hr.
+        Instant firstAssigned = pastDate.atStartOfDay(ist).plusHours(9).toInstant();
+        when(repo.scorecardByDa(null, pastDate)).thenReturn(List.of(new Score(da, 8, 0, 8, 0, firstAssigned)));
+        when(directory.contactsFor(List.of(da))).thenReturn(Map.of());
+
+        double perHour = svc.scorecards(pastDate, null).get(0).stopsPerHour();
+
+        assertThat(perHour).isGreaterThan(0.4);            // day-bounded, not spread across 2 days
+        assertThat(perHour).isCloseTo(8.0 / 15.0, within(0.05));
+    }
 }

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImplTest.java
@@ -181,8 +181,11 @@ class DispatchMetricsServiceImplTest {
     @Test
     void scorecardsComputeSuccessOnTimeAndSortBusiestFirst() {
         Instant now = Instant.now();
+        // stops/hr is clock-bounded at the IST end of the operating day, so "today" must be today in
+        // IST for that end to still be in the future (else a UTC-evening CI run clamps the 4h window).
+        LocalDate today = LocalDate.now(java.time.ZoneId.of("Asia/Kolkata"));
         UUID busy = UUID.randomUUID(), idle = UUID.randomUUID();
-        when(repo.scorecardByDa(null, date)).thenReturn(List.of(
+        when(repo.scorecardByDa(null, today)).thenReturn(List.of(
                 // 8 done / 2 failed → success 0.8; 6 on-time of 8 → 0.75; 8 stops over 4h → 2/hr
                 new Score(busy, 8, 2, 6, 1, now.minus(4, ChronoUnit.HOURS)),
                 // no attempts → both pcts null (not 0), stays visible
@@ -190,7 +193,7 @@ class DispatchMetricsServiceImplTest {
         when(directory.contactsFor(List.of(busy, idle)))
                 .thenReturn(Map.of(busy, new DaContact("Ravi", "+9111")));
 
-        List<com.oneday.dispatch.dto.response.DaScorecard> cards = svc.scorecards(date, null);
+        List<com.oneday.dispatch.dto.response.DaScorecard> cards = svc.scorecards(today, null);
 
         assertThat(cards).hasSize(2);
         assertThat(cards.get(0).daId()).isEqualTo(busy);              // most done sorts first

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImplTest.java
@@ -47,6 +47,16 @@ class DispatchMetricsServiceImplTest {
         @Override public Instant getFirstAssigned() { return firstAssigned; }
     }
 
+    private record Score(UUID daId, long done, long failed, long onTime, long pending, Instant firstAssigned)
+            implements com.oneday.dispatch.repository.DaScorecardRow {
+        @Override public UUID getDaId() { return daId; }
+        @Override public long getDone() { return done; }
+        @Override public long getFailed() { return failed; }
+        @Override public long getOnTime() { return onTime; }
+        @Override public long getPending() { return pending; }
+        @Override public Instant getFirstAssigned() { return firstAssigned; }
+    }
+
     private record Day(LocalDate day, long done, long failed)
             implements com.oneday.dispatch.repository.DaDayStopsRow {
         @Override public LocalDate getDay() { return day; }
@@ -166,5 +176,29 @@ class DispatchMetricsServiceImplTest {
                 new Pace(UUID.randomUUID(), 1, 1, 3, now.minus(60, ChronoUnit.SECONDS)))); // <6min
 
         assertThat(svc.execution(date, null).das().get(0).avgPerHour()).isEqualTo(0.0);
+    }
+
+    @Test
+    void scorecardsComputeSuccessOnTimeAndSortBusiestFirst() {
+        Instant now = Instant.now();
+        UUID busy = UUID.randomUUID(), idle = UUID.randomUUID();
+        when(repo.scorecardByDa(null, date)).thenReturn(List.of(
+                // 8 done / 2 failed → success 0.8; 6 on-time of 8 → 0.75; 8 stops over 4h → 2/hr
+                new Score(busy, 8, 2, 6, 1, now.minus(4, ChronoUnit.HOURS)),
+                // no attempts → both pcts null (not 0), stays visible
+                new Score(idle, 0, 0, 0, 3, now.minus(1, ChronoUnit.HOURS))));
+        when(directory.contactsFor(List.of(busy, idle)))
+                .thenReturn(Map.of(busy, new DaContact("Ravi", "+9111")));
+
+        List<com.oneday.dispatch.dto.response.DaScorecard> cards = svc.scorecards(date, null);
+
+        assertThat(cards).hasSize(2);
+        assertThat(cards.get(0).daId()).isEqualTo(busy);              // most done sorts first
+        assertThat(cards.get(0).daName()).isEqualTo("Ravi");
+        assertThat(cards.get(0).attemptSuccessPct()).isEqualTo(0.8);
+        assertThat(cards.get(0).onTimePct()).isEqualTo(0.75);
+        assertThat(cards.get(0).stopsPerHour()).isCloseTo(2.0, within(0.05));
+        assertThat(cards.get(1).attemptSuccessPct()).isNull();        // no attempts → null, not 0
+        assertThat(cards.get(1).onTimePct()).isNull();
     }
 }


### PR DESCRIPTION

<img width="2930" height="970" alt="image" src="https://github.com/user-attachments/assets/a1d85eb3-6491-4c31-8cd6-54a3c00484a1" />

Amazon-parity Phase 2 (backend half). Pairs with the station web PR (oneday-web#31). Closes teardown gap N.

## What
- `GET /dispatch/scorecards?date=` on `StationDispatchController` (same `STATION_MANAGER` + city-scope idiom as `/dispatch/execution`).
- New native `scorecardByDa(city, date)` query — the same `COUNT(*) FILTER` idiom as `paceByDa`, over DELIVERY tasks, adding `failed` and `onTime` (`completed_at <= expected_eta`).
- Service computes per DA: attempt-success % (completed/attempts, null when no attempts), on-time % (on-time/completed, null when nothing completed), stops/hr (reusing `avgPerHour`), enriched with name/phone via `DaDirectoryPort`, busiest-first.

## Test
`scorecardsComputeSuccessOnTimeAndSortBusiestFirst` — the pct math, null-on-no-attempts, and sort. dispatch suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added station-manager scorecards for delivery agents by date.
  * Scorecards show completed, failed, pending, and deferred stops, productivity, attempt success, on-time performance, and contact details.
  * Results are city-scoped for non-admin users and sorted by completed stops.
  * The date defaults to today when omitted.

* **Bug Fixes**
  * Improved productivity calculations for past operating dates to use only that day’s elapsed time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->