### PR TITLE
feat(orders): unified per-parcel event timeline

### DIFF
--- a/barcode/src/main/java/com/oneday/barcode/adapter/ShipmentScanTrailPortAdapter.java
+++ b/barcode/src/main/java/com/oneday/barcode/adapter/ShipmentScanTrailPortAdapter.java
@@ -1,0 +1,29 @@
+package com.oneday.barcode.adapter;
+
+import com.oneday.barcode.repository.ScanLedgerRepository;
+import com.oneday.common.port.ShipmentScanTrailPort;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+/** The single {@link ShipmentScanTrailPort} implementation — reads the append-only M8 scan ledger. */
+@Component
+class ShipmentScanTrailPortAdapter implements ShipmentScanTrailPort {
+
+    private final ScanLedgerRepository scanLedgerRepository;
+
+    ShipmentScanTrailPortAdapter(ScanLedgerRepository scanLedgerRepository) {
+        this.scanLedgerRepository = scanLedgerRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ScanTrailEntry> trailFor(UUID shipmentId) {
+        return scanLedgerRepository.findByShipmentIdOrderByScannedAtAsc(shipmentId).stream()
+                .map(e -> new ScanTrailEntry(
+                        e.getScanType(), e.getLocationType(), e.getLocationId(), e.getActorId(), e.getScannedAt()))
+                .toList();
+    }
+}

--- a/common/src/main/java/com/oneday/common/port/ShipmentScanTrailPort.java
+++ b/common/src/main/java/com/oneday/common/port/ShipmentScanTrailPort.java
@@ -1,0 +1,28 @@
+package com.oneday.common.port;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Read a shipment's append-only scan trail, time-ordered, without importing the barcode module.
+ * Implemented in barcode (M8, over the immutable scan ledger); consumed in orders (M4) to weave scans
+ * into the unified per-parcel event timeline. Same cross-module read pattern as {@link ShipmentRefPort}.
+ */
+public interface ShipmentScanTrailPort {
+
+    /** The shipment's scans, oldest first; empty if none. */
+    List<ScanTrailEntry> trailFor(UUID shipmentId);
+
+    /**
+     * One scan on the trail — only {@code common}-safe types.
+     *
+     * @param scanType     the scan kind (a {@code ScanEventType} or van scan name, kept as text)
+     * @param locationType where it happened (hub / van / DA / …), or null
+     * @param locationId   the node id, or null
+     * @param actorId      who scanned, or null
+     * @param scannedAt    device fix time
+     */
+    record ScanTrailEntry(String scanType, String locationType, UUID locationId, UUID actorId, Instant scannedAt) {
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/api/AdminOrdersController.java
+++ b/orders/src/main/java/com/oneday/orders/api/AdminOrdersController.java
@@ -5,6 +5,7 @@ import com.oneday.orders.dto.CancellationResponse;
 import com.oneday.orders.dto.ShipmentAgeingStats;
 import com.oneday.orders.dto.ShipmentPageResponse;
 import com.oneday.orders.dto.ShipmentSummaryStats;
+import com.oneday.orders.dto.ShipmentTimelineResponse;
 import com.oneday.orders.service.AdminOrderQueryService;
 import com.oneday.orders.service.AdminOrderSummaryService;
 import com.oneday.orders.service.CancellationService;
@@ -77,6 +78,19 @@ class AdminOrdersController {
     public ShipmentAgeingStats ageing(@AuthenticationPrincipal AuthUserDetails principal) {
         Authz.requireRole(principal, STATION_MANAGER);
         return adminOrderSummaryService.ageing(cityScope(principal));
+    }
+
+    /**
+     * One parcel's full ops timeline by ref — header + M4 state history merged with the M8 scan trail,
+     * oldest first (the "search → timeline" drill-down). Same visibility as {@link #listShipments}: a
+     * shipment outside a station manager's city 404s (matching the read rule), as does an unknown ref.
+     */
+    @GetMapping("/{ref}/timeline")
+    public ShipmentTimelineResponse timeline(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @PathVariable("ref") String ref) {
+        Authz.requireRole(principal, STATION_MANAGER);
+        return adminOrderQueryService.timeline(ref, cityScope(principal));
     }
 
     /** Null for ADMIN (all cities); the station manager's own city otherwise (403 if unassigned). */

--- a/orders/src/main/java/com/oneday/orders/dto/ShipmentTimelineResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/ShipmentTimelineResponse.java
@@ -1,0 +1,39 @@
+package com.oneday.orders.dto;
+
+import com.oneday.common.domain.enums.CustomerType;
+import com.oneday.common.domain.enums.DeliveryType;
+import com.oneday.common.domain.enums.ShipmentState;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * A parcel's full ops picture ({@code GET /api/v1/admin/shipments/{ref}/timeline}): the header (identity +
+ * the already-stored data-model fields ops asks for) plus one merged, time-ordered event stream weaving
+ * M4 state transitions and M8 scans together — the "search → timeline" drill-down.
+ */
+public record ShipmentTimelineResponse(
+        String shipmentRef,
+        UUID shipmentId,
+        ShipmentState state,
+        CustomerType customerType,
+        DeliveryType deliveryType,
+        String originCity,
+        String destCity,
+        String senderName,
+        String receiverName,
+        Integer chargeableWeightGrams,
+        Instant etaPromised,
+        Instant lastScanAt,
+        Instant createdAt,
+        List<TimelineEvent> events) {
+
+    /**
+     * @param kind   {@code STATE} (a shipment state transition) or {@code SCAN} (a ledger scan)
+     * @param label  the headline — the new state, or the scan type
+     * @param detail supporting context — actor / trigger / node, or null
+     */
+    public record TimelineEvent(Instant at, String kind, String label, String detail) {
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/AdminOrderQueryService.java
+++ b/orders/src/main/java/com/oneday/orders/service/AdminOrderQueryService.java
@@ -1,6 +1,7 @@
 package com.oneday.orders.service;
 
 import com.oneday.orders.dto.ShipmentPageResponse;
+import com.oneday.orders.dto.ShipmentTimelineResponse;
 
 /**
  * Read-only orders-database access for ADMIN tooling. Lists shipments across all customers
@@ -19,4 +20,12 @@ public interface AdminOrderQueryService {
      * @return a page of shipment summaries, newest first
      */
     ShipmentPageResponse listShipments(String stateFilter, String cityScope, int page, int size);
+
+    /**
+     * One parcel's full ops timeline by human ref: header + M4 state history merged with the M8 scan
+     * trail, oldest first. {@code cityScope} null → any city (ADMIN); otherwise the shipment must touch
+     * that city (origin or destination) or it 404s — the same read rule as {@link #listShipments}.
+     * An unknown ref 404s.
+     */
+    ShipmentTimelineResponse timeline(String shipmentRef, String cityScope);
 }

--- a/orders/src/main/java/com/oneday/orders/service/impl/AdminOrderQueryServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/AdminOrderQueryServiceImpl.java
@@ -1,10 +1,15 @@
 package com.oneday.orders.service.impl;
 
 import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.port.ShipmentScanTrailPort;
 import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.domain.ShipmentStateHistory;
 import com.oneday.orders.dto.ShipmentPageResponse;
 import com.oneday.orders.dto.ShipmentSummaryResponse;
+import com.oneday.orders.dto.ShipmentTimelineResponse;
+import com.oneday.orders.dto.ShipmentTimelineResponse.TimelineEvent;
 import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.repository.ShipmentStateHistoryRepository;
 import com.oneday.orders.service.AdminOrderQueryService;
 import com.oneday.orders.service.ShipmentCustody;
 import org.springframework.data.domain.Page;
@@ -15,7 +20,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 /**
  * @see AdminOrderQueryService
@@ -26,9 +36,15 @@ class AdminOrderQueryServiceImpl implements AdminOrderQueryService {
     private static final int MAX_PAGE_SIZE = 200;
 
     private final ShipmentRepository shipmentRepository;
+    private final ShipmentStateHistoryRepository stateHistoryRepository;
+    private final ShipmentScanTrailPort scanTrail;
 
-    AdminOrderQueryServiceImpl(ShipmentRepository shipmentRepository) {
+    AdminOrderQueryServiceImpl(ShipmentRepository shipmentRepository,
+                               ShipmentStateHistoryRepository stateHistoryRepository,
+                               ShipmentScanTrailPort scanTrail) {
         this.shipmentRepository = shipmentRepository;
+        this.stateHistoryRepository = stateHistoryRepository;
+        this.scanTrail = scanTrail;
     }
 
     @Override
@@ -58,6 +74,39 @@ class AdminOrderQueryServiceImpl implements AdminOrderQueryService {
                 result.getSize(),
                 result.getTotalElements(),
                 result.getTotalPages());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ShipmentTimelineResponse timeline(String shipmentRef, String cityScope) {
+        Shipment s = shipmentRepository.findByShipmentRef(shipmentRef)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "Unknown shipment: " + shipmentRef));
+        // Same read rule as the list: a station manager only sees a shipment touching their city.
+        if (cityScope != null
+                && !cityScope.equals(s.getOriginCity()) && !cityScope.equals(s.getDestCity())) {
+            throw new ResponseStatusException(NOT_FOUND, "Unknown shipment: " + shipmentRef);
+        }
+
+        List<TimelineEvent> events = new ArrayList<>();
+        for (ShipmentStateHistory h : stateHistoryRepository.findByShipmentIdOrderByOccurredAtAsc(s.getId())) {
+            String detail = h.getTriggerSource() != null ? "via " + h.getTriggerSource() : null;
+            if (h.getNotes() != null && !h.getNotes().isBlank()) {
+                detail = detail == null ? h.getNotes() : detail + " · " + h.getNotes();
+            }
+            events.add(new TimelineEvent(h.getOccurredAt(), "STATE", h.getToState().name(), detail));
+        }
+        for (ShipmentScanTrailPort.ScanTrailEntry scan : scanTrail.trailFor(s.getId())) {
+            String detail = scan.locationType() != null ? "at " + scan.locationType() : null;
+            events.add(new TimelineEvent(scan.scannedAt(), "SCAN", scan.scanType(), detail));
+        }
+        events.sort(Comparator.comparing(TimelineEvent::at,
+                Comparator.nullsLast(Comparator.naturalOrder())));
+
+        return new ShipmentTimelineResponse(
+                s.getShipmentRef(), s.getId(), s.getState(), s.getCustomerType(), s.getDeliveryType(),
+                s.getOriginCity(), s.getDestCity(), s.getSenderName(), s.getReceiverName(),
+                s.getChargeableWeightGrams(), s.getEtaPromised(), s.getLastScanAt(), s.getCreatedAt(),
+                events);
     }
 
     private static ShipmentState parseState(String stateFilter) {

--- a/orders/src/test/java/com/oneday/orders/service/impl/AdminOrderQueryServiceTimelineTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/AdminOrderQueryServiceTimelineTest.java
@@ -1,0 +1,85 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.port.ShipmentScanTrailPort;
+import com.oneday.common.port.ShipmentScanTrailPort.ScanTrailEntry;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.domain.ShipmentStateHistory;
+import com.oneday.orders.dto.ShipmentTimelineResponse;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.repository.ShipmentStateHistoryRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AdminOrderQueryServiceTimelineTest {
+
+    private final ShipmentRepository shipmentRepo = mock(ShipmentRepository.class);
+    private final ShipmentStateHistoryRepository historyRepo = mock(ShipmentStateHistoryRepository.class);
+    private final ShipmentScanTrailPort scanTrail = mock(ShipmentScanTrailPort.class);
+    private final AdminOrderQueryServiceImpl svc =
+            new AdminOrderQueryServiceImpl(shipmentRepo, historyRepo, scanTrail);
+
+    private Shipment shipment(UUID id, String ref) {
+        Shipment s = mock(Shipment.class);
+        when(s.getId()).thenReturn(id);
+        when(s.getShipmentRef()).thenReturn(ref);
+        when(s.getState()).thenReturn(ShipmentState.PICKED_UP);
+        when(s.getOriginCity()).thenReturn("BLR");
+        when(s.getDestCity()).thenReturn("DEL");
+        return s;
+    }
+
+    private ShipmentStateHistory hist(ShipmentState to, Instant at) {
+        ShipmentStateHistory h = mock(ShipmentStateHistory.class);
+        when(h.getToState()).thenReturn(to);
+        when(h.getOccurredAt()).thenReturn(at);
+        return h;
+    }
+
+    @Test
+    void mergesStateHistoryAndScansInTimeOrder() {
+        UUID id = UUID.randomUUID();
+        Instant t0 = Instant.parse("2026-08-24T09:00:00Z");
+        Shipment s = shipment(id, "1DD-1");
+        ShipmentStateHistory booked = hist(ShipmentState.BOOKED, t0);
+        ShipmentStateHistory pickedUp = hist(ShipmentState.PICKED_UP, t0.plusSeconds(1200));
+        when(shipmentRepo.findByShipmentRef("1DD-1")).thenReturn(Optional.of(s));
+        when(historyRepo.findByShipmentIdOrderByOccurredAtAsc(id)).thenReturn(List.of(booked, pickedUp));
+        when(scanTrail.trailFor(id)).thenReturn(List.of(
+                new ScanTrailEntry("PICKUP_SCAN", "DA", UUID.randomUUID(), UUID.randomUUID(), t0.plusSeconds(600))));
+
+        ShipmentTimelineResponse r = svc.timeline("1DD-1", null);
+
+        // interleaved by time: BOOKED (state) → PICKUP_SCAN (scan) → PICKED_UP (state)
+        assertThat(r.events()).extracting(ShipmentTimelineResponse.TimelineEvent::label)
+                .containsExactly("BOOKED", "PICKUP_SCAN", "PICKED_UP");
+        assertThat(r.events()).extracting(ShipmentTimelineResponse.TimelineEvent::kind)
+                .containsExactly("STATE", "SCAN", "STATE");
+        assertThat(r.shipmentRef()).isEqualTo("1DD-1");
+    }
+
+    @Test
+    void unknownRef404s() {
+        when(shipmentRepo.findByShipmentRef("nope")).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> svc.timeline("nope", null)).isInstanceOf(ResponseStatusException.class);
+    }
+
+    @Test
+    void shipmentOutsideManagerCity404s() {
+        UUID id = UUID.randomUUID();
+        Shipment s = shipment(id, "1DD-1");
+        when(shipmentRepo.findByShipmentRef("1DD-1")).thenReturn(Optional.of(s));
+        // BLR↔DEL shipment; a HYD manager can't see it.
+        assertThatThrownBy(() -> svc.timeline("1DD-1", "HYD")).isInstanceOf(ResponseStatusException.class);
+    }
+}


### PR DESCRIPTION

<img width="2558" height="1120" alt="image" src="https://github.com/user-attachments/assets/4d71c026-dbf0-42f9-b51d-30e4e1934361" />

<img width="1106" height="1534" alt="image" src="https://github.com/user-attachments/assets/5f05a39c-7290-44c1-b302-3a162580e133" />

<img width="2430" height="1330" alt="image" src="https://github.com/user-attachments/assets/661c6781-14d7-48c0-9419-f8a3b4cf3cf8" />


Amazon-parity Phase 3 (backend half). Pairs with the station web PR (oneday-web#32). Closes teardown gap C; folds in Phase 5.

## What
- `GET /api/v1/admin/shipments/{ref}/timeline` → parcel header (identity + delivery type, promised ETA, last-scan, chargeable weight) plus one **time-ordered event stream merging M4 `ShipmentStateHistory` with the M8 scan trail**.
- New `common` read port **`ShipmentScanTrailPort`** (impl in barcode over `ScanLedgerRepository`) bridges the shipment-id-keyed ledger without importing barcode internals — same pattern as `ShipmentRefPort`.
- Same city-scope read rule as the shipment list (shipment must touch the manager's city, else 404; unknown ref 404s).

## Test
`AdminOrderQueryServiceTimelineTest` — merge + time-order + kind tagging, unknown-ref 404, out-of-city 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated admin view for shipment timelines by shipment reference.
  * Timelines include shipment details, status changes, and scan activity merged chronologically.
  * Added shipment scan history with scan type, location, actor, and timestamp information.
  * Added downloadable CSV exports for filtered shipment listings.
  * Access is restricted according to the administrator’s permitted city scope.

* **Bug Fixes**
  * Unknown shipments and shipments outside the permitted scope now return a not-found response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->