### PR TITLE
feat(dispatch): real M10 SLA colour + parcel ref on DA tasks; station…

### DIFF
--- a/common/src/main/java/com/oneday/common/port/ShipmentSlaPort.java
+++ b/common/src/main/java/com/oneday/common/port/ShipmentSlaPort.java
@@ -1,0 +1,33 @@
+package com.oneday.common.port;
+
+import com.oneday.common.domain.enums.SlaState;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Read shipments' authoritative M10 SLA status in bulk, without importing the sla module. Implemented in
+ * sla (M10); consumed in dispatch (M5) so the DA control-tower can colour a DA's tasks by the real
+ * per-shipment SLA state instead of a dispatch-local ETA heuristic. Batch (one {@code findByShipmentIdIn})
+ * to avoid an N+1 over a DA's task list. Same cross-module pattern as {@link ShipmentRefPort}.
+ */
+public interface ShipmentSlaPort {
+
+    /** SLA status per shipment id; ids without an SLA row yet (e.g. pre-pickup) are absent from the map. */
+    Map<UUID, SlaStatus> slaFor(Collection<UUID> shipmentIds);
+
+    /**
+     * The cross-module SLA snapshot the control tower needs. Only {@code common}-safe types — the sla-only
+     * {@code PriorityBand} is deliberately not exposed; the RAG needs the colour, not the triage band.
+     *
+     * @param state          overall SLA colour (GREEN/AMBER/RED/BREACHED/CLOSED)
+     * @param breached        target actually passed
+     * @param urgencyMinutes minutes projected (or already) past target; negative = slack; null before the
+     *                        SLA clock starts
+     * @param actByAt        soonest hard window the manager is racing; null before the clock starts
+     */
+    record SlaStatus(SlaState state, boolean breached, Integer urgencyMinutes, Instant actByAt) {
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/api/StationDispatchController.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/api/StationDispatchController.java
@@ -7,6 +7,7 @@ import com.oneday.dispatch.dto.response.DeferredAssignResponse;
 import com.oneday.dispatch.dto.response.DispatchExecutionStats;
 import com.oneday.dispatch.dto.response.TileQueueResponse;
 import com.oneday.dispatch.service.DispatchMetricsService;
+import com.oneday.dispatch.service.GpsFixView;
 import com.oneday.dispatch.service.StationDispatchService;
 import com.oneday.grid.service.GridService;
 import jakarta.validation.Valid;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -71,6 +73,21 @@ public class StationDispatchController {
         Authz.requireRole(principal, Authz.STATION_MANAGER);
         UUID scopeCityId = Authz.isAdmin(principal) ? null : managerCity(principal);
         return dispatchMetricsService.daDetail(daId, date != null ? date : LocalDate.now(), scopeCityId);
+    }
+
+    /**
+     * A DA's GPS breadcrumb trail for a date (the station map on the DA-detail page), oldest first. Same
+     * city scope as {@link #daDetail} — a STATION_MANAGER can only see a DA with tasks in their city that
+     * day (else 404); ADMIN any. Distinct from the DA-self {@code /dispatch/da/{daId}/track}.
+     */
+    @GetMapping("/dispatch/da/{daId}/trail")
+    public List<GpsFixView> daTrail(
+            @PathVariable UUID daId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireRole(principal, Authz.STATION_MANAGER);
+        UUID scopeCityId = Authz.isAdmin(principal) ? null : managerCity(principal);
+        return dispatchMetricsService.daTrail(daId, date != null ? date : LocalDate.now(), scopeCityId);
     }
 
     @GetMapping("/dispatch/tiles/{tileId}/queue")

--- a/dispatch/src/main/java/com/oneday/dispatch/dto/response/DaDetailResponse.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/dto/response/DaDetailResponse.java
@@ -29,16 +29,22 @@ public record DaDetailResponse(
         List<DayStops> history) {
 
     /**
-     * @param urgency RED (failed / past-ETA active) · AMBER (in-progress on-track) · GREEN (queued
-     *                on-track) · DONE (completed) — derived from status + expectedEta vs now.
+     * @param shipmentRef    human ref (e.g. {@code 1DD-BLR-…}) for the parcel-detail link; null if unresolved
+     * @param urgency        RED · AMBER · GREEN · DONE — from the real M10 SLA colour when the shipment has an
+     *                       SLA row, else a dispatch-local expectedEta fallback (see {@code DispatchMetricsServiceImpl})
+     * @param actByAt        soonest SLA hard window (from M10); null when no SLA row / clock not started
+     * @param urgencyMinutes minutes past target (from M10); negative = slack; null when no SLA row
      */
     public record DaTaskItem(
             UUID taskId,
             UUID shipmentId,
+            String shipmentRef,
             String taskType,
             String status,
             Instant expectedEta,
-            String urgency) {
+            String urgency,
+            Instant actByAt,
+            Integer urgencyMinutes) {
     }
 
     public record DayStops(LocalDate date, long done, long failed) {

--- a/dispatch/src/main/java/com/oneday/dispatch/dto/response/DaDetailResponse.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/dto/response/DaDetailResponse.java
@@ -35,6 +35,11 @@ public record DaDetailResponse(
      * @param actByAt        soonest SLA hard window (from M10); null when no SLA row / clock not started
      * @param urgencyMinutes minutes past target (from M10); negative = slack; null when no SLA row
      */
+    /**
+     * The lifecycle timestamps ({@code assignedAt}/{@code startedAt}/{@code arrivedAt}/{@code completedAt})
+     * let the client reconstruct what the DA was doing at any moment on the GPS-trail scrubber — which
+     * parcels were assigned-but-open, in progress, on-site, or already done at a given fix time.
+     */
     public record DaTaskItem(
             UUID taskId,
             UUID shipmentId,
@@ -44,7 +49,11 @@ public record DaDetailResponse(
             Instant expectedEta,
             String urgency,
             Instant actByAt,
-            Integer urgencyMinutes) {
+            Integer urgencyMinutes,
+            Instant assignedAt,
+            Instant startedAt,
+            Instant arrivedAt,
+            Instant completedAt) {
     }
 
     public record DayStops(LocalDate date, long done, long failed) {

--- a/dispatch/src/main/java/com/oneday/dispatch/service/DispatchMetricsService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/DispatchMetricsService.java
@@ -4,6 +4,7 @@ import com.oneday.dispatch.dto.response.DaDetailResponse;
 import com.oneday.dispatch.dto.response.DispatchExecutionStats;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -22,4 +23,11 @@ public interface DispatchMetricsService {
      * {@code date} (else 404) and only that city's tasks/history are returned.
      */
     DaDetailResponse daDetail(UUID daId, LocalDate date, UUID scopeCityId);
+
+    /**
+     * A DA's GPS breadcrumb trail for a date (station map), oldest first. Same city scope as
+     * {@link #daDetail}: a STATION_MANAGER can only inspect a DA with tasks in their city that day
+     * (else 404); {@code scopeCityId} null → any city (ADMIN).
+     */
+    List<GpsFixView> daTrail(UUID daId, LocalDate date, UUID scopeCityId);
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImpl.java
@@ -109,7 +109,8 @@ class DispatchMetricsServiceImpl implements DispatchMetricsService {
                             t.getTaskType().name(), t.getStatus().name(), t.getExpectedEta(),
                             urgency(t, sla, now),
                             sla != null ? sla.actByAt() : null,
-                            sla != null ? sla.urgencyMinutes() : null);
+                            sla != null ? sla.urgencyMinutes() : null,
+                            t.getAssignedAt(), t.getStartedAt(), t.getArrivedAt(), t.getCompletedAt());
                 })
                 .sorted(Comparator.comparingInt(i -> urgencyRank(i.urgency())))
                 .toList();

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImpl.java
@@ -2,6 +2,9 @@ package com.oneday.dispatch.service.impl;
 
 import com.oneday.common.port.DaDirectoryPort;
 import com.oneday.common.port.DaDirectoryPort.DaContact;
+import com.oneday.common.port.ShipmentRefPort;
+import com.oneday.common.port.ShipmentSlaPort;
+import com.oneday.common.port.ShipmentSlaPort.SlaStatus;
 import com.oneday.dispatch.domain.DispatchQueue;
 import com.oneday.dispatch.domain.TaskStatus;
 import com.oneday.dispatch.dto.response.DaDetailResponse;
@@ -13,7 +16,9 @@ import com.oneday.dispatch.repository.DaDayStopsRow;
 import com.oneday.dispatch.repository.DaPaceRow;
 import com.oneday.dispatch.repository.DeliveryOutcome;
 import com.oneday.dispatch.repository.DispatchQueueRepository;
+import com.oneday.dispatch.service.DaStatusService;
 import com.oneday.dispatch.service.DispatchMetricsService;
+import com.oneday.dispatch.service.GpsFixView;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +27,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -33,13 +39,22 @@ import java.util.stream.IntStream;
 class DispatchMetricsServiceImpl implements DispatchMetricsService {
 
     private static final int HISTORY_DAYS = 7;
+    private static final ZoneId IST = ZoneId.of("Asia/Kolkata");
 
     private final DispatchQueueRepository queueRepository;
     private final DaDirectoryPort daDirectory;
+    private final ShipmentSlaPort shipmentSla;
+    private final ShipmentRefPort shipmentRef;
+    private final DaStatusService daStatus;
 
-    DispatchMetricsServiceImpl(DispatchQueueRepository queueRepository, DaDirectoryPort daDirectory) {
+    DispatchMetricsServiceImpl(DispatchQueueRepository queueRepository, DaDirectoryPort daDirectory,
+                               ShipmentSlaPort shipmentSla, ShipmentRefPort shipmentRef,
+                               DaStatusService daStatus) {
         this.queueRepository = queueRepository;
         this.daDirectory = daDirectory;
+        this.shipmentSla = shipmentSla;
+        this.shipmentRef = shipmentRef;
+        this.daStatus = daStatus;
     }
 
     @Override
@@ -66,13 +81,7 @@ class DispatchMetricsServiceImpl implements DispatchMetricsService {
     @Override
     @Transactional(readOnly = true)
     public DaDetailResponse daDetail(UUID daId, LocalDate date, UUID scopeCityId) {
-        List<DispatchQueue> all = queueRepository.findByDaIdAndOperatingDateOrderByQueuePosition(daId, date);
-        // City scope: a station manager only inspects a DA operating in their city today.
-        List<DispatchQueue> tasks = scopeCityId == null ? all
-                : all.stream().filter(t -> scopeCityId.equals(t.getCityId())).toList();
-        if (scopeCityId != null && tasks.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No tasks for this DA in your city today");
-        }
+        List<DispatchQueue> tasks = scopedTasks(daId, date, scopeCityId);
 
         DaContact contact = daDirectory.contactsFor(List.of(daId)).get(daId);
         String name = contact != null ? contact.name() : null;
@@ -89,9 +98,19 @@ class DispatchMetricsServiceImpl implements DispatchMetricsService {
         long completed = tasks.stream().filter(t -> t.getStatus() == TaskStatus.COMPLETED).count();
         long failed = tasks.stream().filter(t -> t.getStatus() == TaskStatus.FAILED).count();
 
+        List<UUID> shipmentIds = tasks.stream().map(DispatchQueue::getShipmentId).toList();
+        Map<UUID, SlaStatus> slaByShipment = shipmentSla.slaFor(shipmentIds);
+        Map<UUID, String> refByShipment = shipmentRef.refsFor(shipmentIds);
+
         List<DaTaskItem> items = tasks.stream()
-                .map(t -> new DaTaskItem(t.getId(), t.getShipmentId(), t.getTaskType().name(),
-                        t.getStatus().name(), t.getExpectedEta(), urgency(t, now)))
+                .map(t -> {
+                    SlaStatus sla = slaByShipment.get(t.getShipmentId());
+                    return new DaTaskItem(t.getId(), t.getShipmentId(), refByShipment.get(t.getShipmentId()),
+                            t.getTaskType().name(), t.getStatus().name(), t.getExpectedEta(),
+                            urgency(t, sla, now),
+                            sla != null ? sla.actByAt() : null,
+                            sla != null ? sla.urgencyMinutes() : null);
+                })
                 .sorted(Comparator.comparingInt(i -> urgencyRank(i.urgency())))
                 .toList();
 
@@ -100,9 +119,51 @@ class DispatchMetricsServiceImpl implements DispatchMetricsService {
         return new DaDetailResponse(daId, name, phone, cityId, date, pace, completed, failed, items, history);
     }
 
-    /** RED = failed or an active task already past its ETA; AMBER = in-progress on-track; GREEN = queued
-     *  on-track; DONE = completed/cancelled. Uses expectedEta as the on-time signal dispatch owns. */
-    private static String urgency(DispatchQueue t, Instant now) {
+    @Override
+    @Transactional(readOnly = true)
+    public List<GpsFixView> daTrail(UUID daId, LocalDate date, UUID scopeCityId) {
+        scopedTasks(daId, date, scopeCityId); // same city guard as daDetail (da_gps_ping has no city column)
+        Instant from = date.atStartOfDay(IST).toInstant();
+        Instant to = date.plusDays(1).atStartOfDay(IST).toInstant();
+        return daStatus.listTrack(daId, from, to);
+    }
+
+    /**
+     * The DA's tasks for the date, city-scoped. {@code scopeCityId} null → all cities (ADMIN); otherwise
+     * only that city's rows — and a station manager inspecting a DA with no task in their city that day
+     * gets 404. The single scope authority both {@link #daDetail} and {@link #daTrail} route through.
+     */
+    private List<DispatchQueue> scopedTasks(UUID daId, LocalDate date, UUID scopeCityId) {
+        List<DispatchQueue> all = queueRepository.findByDaIdAndOperatingDateOrderByQueuePosition(daId, date);
+        List<DispatchQueue> tasks = scopeCityId == null ? all
+                : all.stream().filter(t -> scopeCityId.equals(t.getCityId())).toList();
+        if (scopeCityId != null && tasks.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No tasks for this DA in your city today");
+        }
+        return tasks;
+    }
+
+    /** Task RAG colour. Terminal tasks are DONE. Otherwise the authoritative M10 SLA colour drives it when
+     *  the shipment has an SLA row; before the SLA clock exists (e.g. pre-pickup) we fall back to the
+     *  dispatch-local expectedEta heuristic. */
+    private static String urgency(DispatchQueue t, SlaStatus sla, Instant now) {
+        if (t.getStatus() == TaskStatus.COMPLETED || t.getStatus() == TaskStatus.CANCELLED) {
+            return "DONE";
+        }
+        if (sla != null) {
+            return switch (sla.state()) {
+                case BREACHED, RED -> "RED";
+                case AMBER -> "AMBER";
+                case GREEN -> "GREEN";
+                case CLOSED -> "DONE";
+            };
+        }
+        return urgencyFromEta(t, now);
+    }
+
+    /** Fallback when M10 has no row yet: RED = failed or active-past-ETA; AMBER = in-progress on-track;
+     *  GREEN = queued on-track; DONE = completed/cancelled. */
+    private static String urgencyFromEta(DispatchQueue t, Instant now) {
         boolean pastEta = t.getExpectedEta() != null && now.isAfter(t.getExpectedEta());
         return switch (t.getStatus()) {
             case COMPLETED, CANCELLED -> "DONE";

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImplTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.within;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -30,7 +31,14 @@ class DispatchMetricsServiceImplTest {
     private final DispatchQueueRepository repo = mock(DispatchQueueRepository.class);
     private final com.oneday.common.port.DaDirectoryPort directory =
             mock(com.oneday.common.port.DaDirectoryPort.class);
-    private final DispatchMetricsServiceImpl svc = new DispatchMetricsServiceImpl(repo, directory);
+    private final com.oneday.common.port.ShipmentSlaPort slaPort =
+            mock(com.oneday.common.port.ShipmentSlaPort.class);
+    private final com.oneday.common.port.ShipmentRefPort refPort =
+            mock(com.oneday.common.port.ShipmentRefPort.class);
+    private final com.oneday.dispatch.service.DaStatusService daStatus =
+            mock(com.oneday.dispatch.service.DaStatusService.class);
+    private final DispatchMetricsServiceImpl svc =
+            new DispatchMetricsServiceImpl(repo, directory, slaPort, refPort, daStatus);
     private final LocalDate date = LocalDate.now();
 
     private record Outcome(long completed, long failed) implements DeliveryOutcome {
@@ -117,6 +125,53 @@ class DispatchMetricsServiceImplTest {
         DaDetailResponse.DayStops empty = h.stream()
                 .filter(x -> x.date().equals(date.minusDays(5))).findFirst().orElseThrow();
         assertThat(empty.done()).isZero();                              // zero-filled, not missing
+    }
+
+    @Test
+    void daDetailUsesRealSlaColourOverEtaHeuristic() {
+        UUID da = UUID.randomUUID();
+        UUID city = UUID.randomUUID();
+        Instant now = Instant.now();
+        DispatchQueue breaching = task(city, TaskStatus.IN_PROGRESS, now.plusSeconds(3600)); // ETA on-track → AMBER
+        DispatchQueue noSla = task(city, TaskStatus.QUEUED, now.plusSeconds(3600));          // ETA on-track → GREEN
+        when(repo.findByDaIdAndOperatingDateOrderByQueuePosition(da, date))
+                .thenReturn(List.of(breaching, noSla));
+        when(repo.paceByDa(null, date)).thenReturn(List.of());
+        when(repo.paceByDaOverDays(eq(da), any(), eq(null))).thenReturn(List.of());
+        when(directory.contactsFor(List.of(da))).thenReturn(Map.of());
+        // Only the in-progress task has an SLA row, and it is BREACHED → RED, overriding the on-track ETA.
+        when(slaPort.slaFor(any())).thenReturn(Map.of(breaching.getShipmentId(),
+                new com.oneday.common.port.ShipmentSlaPort.SlaStatus(
+                        com.oneday.common.domain.enums.SlaState.BREACHED, true, 22, now.plusSeconds(600))));
+        when(refPort.refsFor(any())).thenReturn(Map.of(breaching.getShipmentId(), "1DD-BLR-1"));
+
+        DaDetailResponse d = svc.daDetail(da, date, null);
+
+        // BREACHED in-progress sorts RED (ahead of the no-SLA GREEN task, which falls back to the heuristic).
+        assertThat(d.tasks()).extracting(DaDetailResponse.DaTaskItem::urgency)
+                .containsExactly("RED", "GREEN");
+        DaDetailResponse.DaTaskItem top = d.tasks().get(0);
+        assertThat(top.shipmentRef()).isEqualTo("1DD-BLR-1");
+        assertThat(top.urgencyMinutes()).isEqualTo(22);
+        assertThat(top.actByAt()).isNotNull();
+    }
+
+    @Test
+    void daTrailGuardsCityAndDelegates() {
+        UUID da = UUID.randomUUID();
+        UUID city = UUID.randomUUID();
+        UUID otherCity = UUID.randomUUID();
+        when(repo.findByDaIdAndOperatingDateOrderByQueuePosition(da, date))
+                .thenReturn(List.of(task(city, TaskStatus.IN_PROGRESS, null)));
+        when(daStatus.listTrack(eq(da), any(), any()))
+                .thenReturn(List.of(new com.oneday.dispatch.service.GpsFixView(12.9, 77.6, Instant.now())));
+
+        // A manager scoped to another city can't see this DA's trail.
+        assertThatThrownBy(() -> svc.daTrail(da, date, otherCity))
+                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
+        // In-scope, and admin (null scope), both delegate to listTrack.
+        assertThat(svc.daTrail(da, date, city)).hasSize(1);
+        assertThat(svc.daTrail(da, date, null)).hasSize(1);
     }
 
     @Test

--- a/sla/src/main/java/com/oneday/sla/repository/SlaShipmentRepository.java
+++ b/sla/src/main/java/com/oneday/sla/repository/SlaShipmentRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -16,6 +17,9 @@ import java.util.UUID;
 public interface SlaShipmentRepository extends JpaRepository<SlaShipment, UUID> {
 
     Optional<SlaShipment> findByShipmentId(UUID shipmentId);
+
+    /** Bulk SLA rows for a set of shipments — backs the {@code ShipmentSlaPort} batch read. */
+    List<SlaShipment> findByShipmentIdIn(Collection<UUID> shipmentIds);
 
     Optional<SlaShipment> findByShipmentRef(String shipmentRef);
 

--- a/sla/src/main/java/com/oneday/sla/service/impl/ShipmentSlaPortAdapter.java
+++ b/sla/src/main/java/com/oneday/sla/service/impl/ShipmentSlaPortAdapter.java
@@ -1,0 +1,35 @@
+package com.oneday.sla.service.impl;
+
+import com.oneday.common.port.ShipmentSlaPort;
+import com.oneday.sla.repository.SlaShipmentRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/** The single {@link ShipmentSlaPort} implementation — reads the live M10 SLA rollup by shipment id. */
+@Component
+class ShipmentSlaPortAdapter implements ShipmentSlaPort {
+
+    private final SlaShipmentRepository slaShipmentRepository;
+
+    ShipmentSlaPortAdapter(SlaShipmentRepository slaShipmentRepository) {
+        this.slaShipmentRepository = slaShipmentRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<UUID, SlaStatus> slaFor(Collection<UUID> shipmentIds) {
+        if (shipmentIds.isEmpty()) {
+            return Map.of();
+        }
+        return slaShipmentRepository.findByShipmentIdIn(shipmentIds).stream()
+                .collect(Collectors.toMap(
+                        s -> s.getShipmentId(),
+                        s -> new SlaStatus(s.getOverallState(), s.isBreached(),
+                                s.getUrgencyMinutes(), s.getActByAt())));
+    }
+}


### PR DESCRIPTION
<img width="2428" height="1328" alt="image" src="https://github.com/user-attachments/assets/a6a172d0-a200-4d4b-9c4e-3a1a315a8993" />

<img width="2412" height="1470" alt="image" src="https://github.com/user-attachments/assets/ef20253c-ddcd-4af2-b895-47e374988008" />


- Task RAG now reflects the authoritative M10 per-shipment SLA state (via a new common ShipmentSlaPort, implemented in sla over SlaShipmentRepository) instead of dispatch's local expectedEta heuristic; the heuristic stays as a fallback for tasks with no SLA row yet (pre-pickup). DaTaskItem gains shipmentRef (via the existing ShipmentRefPort) for a parcel-detail link plus actByAt/urgencyMinutes.
- New station-scoped GET /dispatch/da/{daId}/trail returns the DA's GPS breadcrumb for a date, reusing the daDetail city guard (da_gps_ping has no city column) and delegating to the existing DaStatusService.listTrack. Distinct path from the DA-self /track.

Tests: SLA colour overrides the ETA heuristic; trail city guard + delegation.

# Pull Request

## Summary
<!-- REQUIRED: One or two sentences describing what this PR does. Must not be left blank. -->


---

## What Changed
<!-- REQUIRED: At least one meaningful bullet. Replace the placeholder lines. -->
- 
- 

---

## Why This Change?
<!-- REQUIRED: Describe the problem this solves or the goal it achieves. -->


---

## Testing
- [ ] Tested locally
- [ ] Edge cases considered
- [ ] No breaking changes introduced

### Test Evidence
<!-- REQUIRED: Attach at minimum one screenshot, log snippet, or test output.
     Drag-and-drop images here or paste log excerpts in a code block. 
     Do NOT leave this section blank or with only this comment. -->


---

## Impact

### Areas Affected
<!-- Check every area this PR touches. At least one must be checked. -->
- [ ] Backend
- [ ] Frontend
- [ ] Routing
- [ ] Infra
- [ ] Database
- [ ] NA

### Modules Affected
<!-- Check every module this PR touches. At least one must be checked. -->
- [ ] M1 — Auth
- [ ] M2 — Pricing
- [ ] M3 — Grid
- [ ] M4 — Orders
- [ ] M5 — Dispatch
- [ ] M6 — Routing
- [ ] M7 — Hub
- [ ] M8 — Barcode
- [ ] M9 — Airline
- [ ] M10 — SLA
- [ ] M11 — Exceptions
- [ ] NA

---

## Risks / Concerns
<!-- REQUIRED: Describe known risks, or write "None" with a brief justification. -->
- 

---

## Checklist
- [ ] Code follows project conventions (package layout, no cross-module internal imports)
- [ ] Self-review completed
- [ ] Append-only audit trail preserved (no mutations to scan/manifest/role-change records)
- [ ] No sensitive data or credentials exposed
- [ ] Documentation updated if behaviour changed
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Station managers can view a delivery associate’s GPS breadcrumb trail for a selected date, subject to access permissions.
* Delivery task details now include shipment references, lifecycle timestamps, SLA deadlines, breach status, and urgency information.
* Added delivery associate scorecards with pace, success rate, on-time rate, and activity-based ordering.

## Bug Fixes
* Improved city-based access controls for delivery associate details and GPS trails.

## Tests
* Added coverage for scorecard calculations, ordering, date boundaries, and SLA-related task insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->