### PR TITLE
feat(orders): Order → N Shipments abstraction

### DIFF
--- a/orders/src/main/java/com/oneday/orders/api/AdminOrderGroupsController.java
+++ b/orders/src/main/java/com/oneday/orders/api/AdminOrderGroupsController.java
@@ -1,0 +1,62 @@
+package com.oneday.orders.api;
+
+import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.orders.dto.AdminOrderDetailResponse;
+import com.oneday.orders.dto.OrderPageResponse;
+import com.oneday.orders.service.AdminOrderQueryService;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * The business/admin console's order view (Order → N Shipments) — one card per booking that expands
+ * to its parcels. The order-level counterpart to {@link AdminOrdersController} (which lists individual
+ * shipments). Same visibility model: ADMIN sees every city; a STATION_MANAGER sees orders placed in
+ * their own city.
+ */
+@RestController
+@RequestMapping("/api/v1/admin/orders")
+class AdminOrderGroupsController {
+
+    private static final String STATION_MANAGER = "STATION_MANAGER";
+
+    private final AdminOrderQueryService adminOrderQueryService;
+
+    AdminOrderGroupsController(AdminOrderQueryService adminOrderQueryService) {
+        this.adminOrderQueryService = adminOrderQueryService;
+    }
+
+    @GetMapping
+    public OrderPageResponse listOrders(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "25") int size) {
+        Authz.requireRole(principal, STATION_MANAGER);
+        return adminOrderQueryService.listOrders(cityScope(principal), page, size);
+    }
+
+    @GetMapping("/{orderRef}")
+    public AdminOrderDetailResponse orderDetail(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @PathVariable("orderRef") String orderRef) {
+        Authz.requireRole(principal, STATION_MANAGER);
+        return adminOrderQueryService.orderDetail(orderRef, cityScope(principal));
+    }
+
+    /** Null for ADMIN (all cities); the station manager's own city otherwise (403 if unassigned). */
+    private static String cityScope(AuthUserDetails principal) {
+        if (!STATION_MANAGER.equals(principal.getUser().getRole().getName())) {
+            return null;
+        }
+        String cityScope = principal.getUser().getCityId();
+        if (cityScope == null || cityScope.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Station manager has no city assigned");
+        }
+        return cityScope;
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/api/MyOrdersController.java
+++ b/orders/src/main/java/com/oneday/orders/api/MyOrdersController.java
@@ -1,0 +1,50 @@
+package com.oneday.orders.api;
+
+import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.orders.dto.MyOrderDetailResponse;
+import com.oneday.orders.dto.OrderSummaryResponse;
+import com.oneday.orders.service.CustomerOrderQueryService;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+/**
+ * A customer's own orders (Order → N Shipments). The order-level counterpart to
+ * {@link MyShipmentsController}: a merchant sees one card per booking and expands it to the parcels.
+ * Lane-agnostic — serves every customer role and returns only the orders the caller placed.
+ */
+@RestController
+@RequestMapping("/api/v1/orders")
+class MyOrdersController {
+
+    private final CustomerOrderQueryService customerOrderQueryService;
+
+    MyOrdersController(CustomerOrderQueryService customerOrderQueryService) {
+        this.customerOrderQueryService = customerOrderQueryService;
+    }
+
+    @GetMapping("/mine")
+    public List<OrderSummaryResponse> myOrders(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @RequestParam(value = "limit", defaultValue = "100") int limit) {
+        Authz.requireCustomerRole(principal, "C2C_CUSTOMER", "B2C_CUSTOMER", "B2B_USER");
+        return customerOrderQueryService.myOrders(Authz.requireUserId(principal), limit);
+    }
+
+    @GetMapping("/mine/{orderRef}")
+    public MyOrderDetailResponse myOrderDetail(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @PathVariable("orderRef") String orderRef) {
+        Authz.requireCustomerRole(principal, "C2C_CUSTOMER", "B2C_CUSTOMER", "B2B_USER");
+        return customerOrderQueryService
+                .myOrderDetail(Authz.requireUserId(principal), orderRef)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No such order: " + orderRef));
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/domain/OrderRefCounter.java
+++ b/orders/src/main/java/com/oneday/orders/domain/OrderRefCounter.java
@@ -1,0 +1,24 @@
+package com.oneday.orders.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/** Per-(city, date) sequence backing the order ref. Mirrors {@link ShipmentRefCounter}. */
+@Entity
+@Table(name = "order_ref_counters")
+@Getter
+@Setter
+@NoArgsConstructor
+public class OrderRefCounter {
+
+    @EmbeddedId
+    private OrderRefCounterId id;
+
+    @Column(name = "next_val", nullable = false)
+    private Integer nextVal;
+}

--- a/orders/src/main/java/com/oneday/orders/domain/OrderRefCounterId.java
+++ b/orders/src/main/java/com/oneday/orders/domain/OrderRefCounterId.java
@@ -1,0 +1,25 @@
+package com.oneday.orders.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class OrderRefCounterId implements Serializable {
+
+    @Column(name = "city_code", length = 10, nullable = false)
+    private String cityCode;
+
+    @Column(name = "date_key", nullable = false)
+    private LocalDate dateKey;
+}

--- a/orders/src/main/java/com/oneday/orders/domain/ParcelOrder.java
+++ b/orders/src/main/java/com/oneday/orders/domain/ParcelOrder.java
@@ -1,0 +1,59 @@
+package com.oneday.orders.domain;
+
+import com.oneday.common.domain.MutableBaseEntity;
+import com.oneday.common.domain.enums.CustomerType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnTransformer;
+
+import java.util.UUID;
+
+/**
+ * The durable parent of the Order → N Shipments abstraction. Every booking creates or joins one:
+ * a single booking → an order of one; a cart checkout / bulk upload → one order over all its
+ * shipments. Unlike the transient {@link Cart} (a pre-checkout basket that is emptied at checkout),
+ * a {@code ParcelOrder} survives and each {@link Shipment} carries its {@code order_id}.
+ *
+ * <p>An order is a <em>booking</em> grouping, not a routing unit — its shipments may ride different
+ * flights / delivery DAs. {@code parcelCount} and {@code totalPricePaise} are a denormalized rollup,
+ * advanced atomically as each shipment is booked (see {@code ParcelOrderRepository.addShipment}).</p>
+ */
+@Entity
+@Table(name = "parcel_orders")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ParcelOrder extends MutableBaseEntity {
+
+    @Column(name = "order_ref", length = 30, nullable = false, unique = true, updatable = false)
+    private String orderRef;
+
+    @Enumerated(EnumType.STRING)
+    @ColumnTransformer(read = "customer_type::text", write = "CAST(? AS customer_type)")
+    @Column(name = "customer_type", nullable = false, updatable = false, columnDefinition = "customer_type")
+    private CustomerType customerType;
+
+    @Column(name = "b2b_account_id", updatable = false)
+    private UUID b2bAccountId;
+
+    @Column(name = "booked_by_user_id", updatable = false)
+    private UUID bookedByUserId;
+
+    @Column(name = "purchase_order_ref", length = 100, updatable = false)
+    private String purchaseOrderRef;
+
+    @Column(name = "parcel_count", nullable = false)
+    private int parcelCount;
+
+    @Column(name = "total_price_paise", nullable = false)
+    private long totalPricePaise;
+
+    @Column(name = "city_id", length = 10, nullable = false, updatable = false)
+    private String cityId;
+}

--- a/orders/src/main/java/com/oneday/orders/domain/Shipment.java
+++ b/orders/src/main/java/com/oneday/orders/domain/Shipment.java
@@ -45,6 +45,11 @@ public class Shipment extends MutableBaseEntity {
     @Column(name = "b2b_account_id", updatable = false)
     private UUID b2bAccountId;
 
+    // Parent order (Order → N Shipments). Nullable for rows booked before this feature; a bare
+    // UUID by cross-module convention, not a DB foreign key.
+    @Column(name = "order_id", updatable = false)
+    private UUID orderId;
+
     // ── Sender ────────────────────────────────────────────────────────────
 
     @Column(name = "sender_name", length = 100, nullable = false, updatable = false)

--- a/orders/src/main/java/com/oneday/orders/dto/AdminOrderDetailResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/AdminOrderDetailResponse.java
@@ -1,0 +1,12 @@
+package com.oneday.orders.dto;
+
+import java.util.List;
+
+/**
+ * An order with its shipments expanded for the business/admin console
+ * ({@code GET /api/v1/admin/orders/{orderRef}}) — the "click an order, see its parcels" drill-down.
+ */
+public record AdminOrderDetailResponse(
+        OrderSummaryResponse order,
+        List<ShipmentSummaryResponse> shipments) {
+}

--- a/orders/src/main/java/com/oneday/orders/dto/BookingResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/BookingResponse.java
@@ -12,6 +12,8 @@ import java.util.Map;
 public class BookingResponse {
 
     private String shipmentRef;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String orderRef;                   // parent order (Order → N Shipments); null on cart items
     private CustomerType customerType;         // B2C, C2C, or B2B — what the booker actually is
     private ShipmentState state;               // machine-readable (BOOKED)
     private String stateLabel;                 // human-readable ("Order confirmed")
@@ -76,6 +78,9 @@ public class BookingResponse {
 
     public String getShipmentRef()                     { return shipmentRef; }
     public void setShipmentRef(String v)               { this.shipmentRef = v; }
+
+    public String getOrderRef()                        { return orderRef; }
+    public void setOrderRef(String v)                  { this.orderRef = v; }
 
     public CustomerType getCustomerType()              { return customerType; }
     public void setCustomerType(CustomerType v)        { this.customerType = v; }

--- a/orders/src/main/java/com/oneday/orders/dto/CartCheckoutResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/CartCheckoutResponse.java
@@ -11,6 +11,7 @@ public record CartCheckoutResponse(
         int booked,
         int failed,
         long chargedTotalPaise,
+        String orderRef,          // the single parent order all booked items belong to (null if none booked)
         String cartStatus,
         List<Result> results
 ) {

--- a/orders/src/main/java/com/oneday/orders/dto/MyOrderDetailResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/MyOrderDetailResponse.java
@@ -1,0 +1,12 @@
+package com.oneday.orders.dto;
+
+import java.util.List;
+
+/**
+ * A customer's order with its shipments expanded — the "click an order, see its parcels" drill-down
+ * ({@code GET /api/v1/orders/mine/{orderRef}}). Scoped to the caller.
+ */
+public record MyOrderDetailResponse(
+        OrderSummaryResponse order,
+        List<MyShipmentSummaryResponse> shipments) {
+}

--- a/orders/src/main/java/com/oneday/orders/dto/OrderPageResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/OrderPageResponse.java
@@ -1,0 +1,12 @@
+package com.oneday.orders.dto;
+
+import java.util.List;
+
+/** A page of the admin Order view. Field names serialise to snake_case via the global Jackson config. */
+public record OrderPageResponse(
+        List<OrderSummaryResponse> orders,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages) {
+}

--- a/orders/src/main/java/com/oneday/orders/dto/OrderSummaryResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/OrderSummaryResponse.java
@@ -1,0 +1,25 @@
+package com.oneday.orders.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.oneday.common.domain.enums.CustomerType;
+
+import java.time.Instant;
+
+/**
+ * One row of the Order → N Shipments view — a booking grouping the business and customer consoles
+ * render as a card that expands to its shipments. {@code status} is the rollup over the child
+ * shipments (see {@link com.oneday.orders.service.OrderStatusReducer}). Field names serialise to
+ * snake_case via the global Jackson config.
+ */
+public record OrderSummaryResponse(
+        String orderRef,
+        CustomerType customerType,
+        String status,               // OrderStatusReducer.OrderStatus name
+        String statusLabel,          // human-readable
+        int parcelCount,
+        long totalPricePaise,
+        String originCity,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String purchaseOrderRef,
+        Instant createdAt) {
+}

--- a/orders/src/main/java/com/oneday/orders/repository/OrderRefCounterRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/OrderRefCounterRepository.java
@@ -1,0 +1,29 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.OrderRefCounter;
+import com.oneday.orders.domain.OrderRefCounterId;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+/** @see ShipmentRefCounterRepository — same SELECT FOR UPDATE + insert-if-absent pattern. */
+public interface OrderRefCounterRepository extends JpaRepository<OrderRefCounter, OrderRefCounterId> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM OrderRefCounter r WHERE r.id = :id")
+    Optional<OrderRefCounter> findByIdWithLock(@Param("id") OrderRefCounterId id);
+
+    @Modifying
+    @Transactional
+    @Query(value = "INSERT INTO order_ref_counters (city_code, date_key, next_val) " +
+                   "VALUES (:cityCode, :dateKey, 0) ON CONFLICT (city_code, date_key) DO NOTHING",
+           nativeQuery = true)
+    void insertIfAbsent(@Param("cityCode") String cityCode, @Param("dateKey") LocalDate dateKey);
+}

--- a/orders/src/main/java/com/oneday/orders/repository/ParcelOrderRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ParcelOrderRepository.java
@@ -1,0 +1,36 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.ParcelOrder;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ParcelOrderRepository extends JpaRepository<ParcelOrder, UUID> {
+
+    Optional<ParcelOrder> findByOrderRef(String orderRef);
+
+    /** Customer "my orders" — every order a given M1 user placed, newest first. */
+    Page<ParcelOrder> findByBookedByUserId(UUID bookedByUserId, Pageable pageable);
+
+    /** Admin console — all orders, newest first (ADMIN scope). */
+    Page<ParcelOrder> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    /** Admin console — orders for one origin city (station-manager scope), newest first. */
+    Page<ParcelOrder> findByCityIdOrderByCreatedAtDesc(String cityId, Pageable pageable);
+
+    /**
+     * Advance the denormalized rollup atomically as each shipment is booked. The increment is done
+     * in the WHERE-less UPDATE (not read-modify-write) so N concurrent cart-item transactions each
+     * booking against the same parent order can't lose a count.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE ParcelOrder o SET o.parcelCount = o.parcelCount + 1, "
+            + "o.totalPricePaise = o.totalPricePaise + :amountPaise WHERE o.id = :id")
+    int addShipment(@Param("id") UUID id, @Param("amountPaise") long amountPaise);
+}

--- a/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
@@ -13,6 +13,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -66,6 +67,20 @@ public interface ShipmentRepository extends JpaRepository<Shipment, UUID> {
 
     // Customer "my shipments" view: every shipment a given M1 user booked, newest first.
     Page<Shipment> findByBookedByUserId(UUID bookedByUserId, Pageable pageable);
+
+    // Order → N Shipments: the child shipments of one order (booking order preserved).
+    List<Shipment> findByOrderIdOrderByCreatedAtAsc(UUID orderId);
+
+    // Bulk rollup input: (orderId, state) pairs for a set of orders, to reduce each order's status
+    // in one query instead of N per-order lookups. See OrderStatusReducer.
+    @Query("SELECT s.orderId AS orderId, s.state AS state FROM Shipment s WHERE s.orderId IN :orderIds")
+    List<OrderChildState> findChildStatesByOrderIds(@Param("orderIds") Collection<UUID> orderIds);
+
+    /** Projection for the bulk order-status rollup. */
+    interface OrderChildState {
+        UUID getOrderId();
+        ShipmentState getState();
+    }
 
     // Admin orders-DB view, station-manager scope: every shipment whose origin OR destination
     // is the manager's city (custody model — a city role sees both legs touching its city).

--- a/orders/src/main/java/com/oneday/orders/service/AdminOrderQueryService.java
+++ b/orders/src/main/java/com/oneday/orders/service/AdminOrderQueryService.java
@@ -1,5 +1,7 @@
 package com.oneday.orders.service;
 
+import com.oneday.orders.dto.AdminOrderDetailResponse;
+import com.oneday.orders.dto.OrderPageResponse;
 import com.oneday.orders.dto.ShipmentPageResponse;
 import com.oneday.orders.dto.ShipmentSummaryResponse;
 import com.oneday.orders.dto.ShipmentTimelineResponse;
@@ -38,4 +40,17 @@ public interface AdminOrderQueryService {
      * An unknown ref 404s.
      */
     ShipmentTimelineResponse timeline(String shipmentRef, String cityScope);
+
+    /**
+     * A page of orders (Order → N Shipments), newest first — the business/admin console's order view.
+     * {@code cityScope} null → all cities (ADMIN); otherwise restrict to orders placed in that origin
+     * city (station-manager scope). Each row carries the rollup status over its child shipments.
+     */
+    OrderPageResponse listOrders(String cityScope, int page, int size);
+
+    /**
+     * One order with its shipments expanded, by order ref. {@code cityScope} null → any city (ADMIN);
+     * otherwise the order's origin city must match or it 404s. An unknown ref 404s.
+     */
+    AdminOrderDetailResponse orderDetail(String orderRef, String cityScope);
 }

--- a/orders/src/main/java/com/oneday/orders/service/B2bBookingService.java
+++ b/orders/src/main/java/com/oneday/orders/service/B2bBookingService.java
@@ -5,7 +5,15 @@ import com.oneday.orders.dto.BookingResponse;
 
 public interface B2bBookingService {
 
+    /** Single B2B booking — mints its own parent order of one. */
     BookingResponse book(B2bBookingRequest request, String idempotencyKey, String userId);
+
+    /**
+     * Books a B2B shipment onto an existing parent order (cart checkout — all items share one order).
+     * When {@code orderId} is null this behaves like the single-booking overload.
+     */
+    BookingResponse book(B2bBookingRequest request, String idempotencyKey, String userId,
+                         java.util.UUID orderId);
 
     class AccountNotFoundException extends RuntimeException {
         public AccountNotFoundException(String message) { super(message); }

--- a/orders/src/main/java/com/oneday/orders/service/BookingService.java
+++ b/orders/src/main/java/com/oneday/orders/service/BookingService.java
@@ -44,9 +44,11 @@ public interface BookingService {
      * shipment PREPAID, but writes <b>no</b> per-shipment {@code PaymentTransaction} and performs
      * no gateway call. Used by cart checkout; re-prices the request so cart staleness is caught.
      *
+     * @param orderId the parent order to attach this shipment to (all items of one cart share it)
      * @throws ServiceabilityException if the route is no longer serviceable at checkout time
      */
-    BookingResponse bookSettled(BookingRequest request, String idempotencyKey, String userId, CustomerType customerType);
+    BookingResponse bookSettled(BookingRequest request, String idempotencyKey, String userId,
+                                CustomerType customerType, java.util.UUID orderId);
 
     /**
      * Prices a request without booking or taking payment (serviceability → pricing).

--- a/orders/src/main/java/com/oneday/orders/service/CustomerOrderQueryService.java
+++ b/orders/src/main/java/com/oneday/orders/service/CustomerOrderQueryService.java
@@ -1,7 +1,9 @@
 package com.oneday.orders.service;
 
+import com.oneday.orders.dto.MyOrderDetailResponse;
 import com.oneday.orders.dto.MyShipmentDetailResponse;
 import com.oneday.orders.dto.MyShipmentSummaryResponse;
+import com.oneday.orders.dto.OrderSummaryResponse;
 import com.oneday.orders.dto.ShipmentLabelResponse;
 
 import java.util.List;
@@ -41,4 +43,19 @@ public interface CustomerOrderQueryService {
      * @return the label data, or empty if no such ref exists for this caller
      */
     Optional<ShipmentLabelResponse> shipmentLabel(String userId, String shipmentRef);
+
+    /**
+     * The caller's orders (Order → N Shipments), newest first — each a booking grouping the client
+     * renders as a card that expands to its parcels.
+     *
+     * @param userId the authenticated caller's id (M1 user UUID, as a string)
+     * @param limit  maximum orders to return, newest first (clamped)
+     */
+    List<OrderSummaryResponse> myOrders(String userId, int limit);
+
+    /**
+     * One of the caller's orders with its shipments expanded, by order ref. Scoped to the caller —
+     * an order they did not place is treated as not found.
+     */
+    Optional<MyOrderDetailResponse> myOrderDetail(String userId, String orderRef);
 }

--- a/orders/src/main/java/com/oneday/orders/service/OrderRefService.java
+++ b/orders/src/main/java/com/oneday/orders/service/OrderRefService.java
@@ -1,0 +1,16 @@
+package com.oneday.orders.service;
+
+/**
+ * Generates unique, human-readable order reference numbers — the parent of the shipment refs.
+ *
+ * <p>Format: {@code 1DD-ORD-{CITY}-{YYYYMMDD}-{NNNNN}}
+ * <br>Example: {@code 1DD-ORD-BLR-20260824-00042}
+ *
+ * <p>Mirrors {@link ShipmentRefService}: a per-(city, date) counter serialised with
+ * {@code SELECT FOR UPDATE}, called inside the caller's transaction (MANDATORY).</p>
+ */
+public interface OrderRefService {
+
+    /** Atomically generates the next order ref for the given origin city on today's date (IST). */
+    String generateRef(String originCityCode);
+}

--- a/orders/src/main/java/com/oneday/orders/service/OrderService.java
+++ b/orders/src/main/java/com/oneday/orders/service/OrderService.java
@@ -1,0 +1,31 @@
+package com.oneday.orders.service;
+
+import com.oneday.common.domain.enums.CustomerType;
+
+import java.util.UUID;
+
+/**
+ * Mints and maintains the parent {@link com.oneday.orders.domain.ParcelOrder} of the
+ * Order → N Shipments abstraction. Booking services call {@link #createOrder} once per booking
+ * (or once per cart checkout) and {@link #addShipment} as each child shipment is persisted.
+ */
+public interface OrderService {
+
+    /**
+     * Creates an empty parent order (count 0, total 0) and returns its id + ref.
+     * Must be called inside an active transaction (the ref counter increment is MANDATORY).
+     *
+     * @param customerType     B2C / C2C / B2B
+     * @param b2bAccountId     the B2B account, or null for retail
+     * @param userId           the M1 user placing the order (string; parsed leniently)
+     * @param originCityCode   origin city (drives the ref + the order's city scope)
+     * @param purchaseOrderRef the merchant's own PO ref, or null
+     */
+    CreatedOrder createOrder(CustomerType customerType, UUID b2bAccountId, String userId,
+                             String originCityCode, String purchaseOrderRef);
+
+    /** Atomically folds one booked shipment into the order rollup (count + 1, total += amount). */
+    void addShipment(UUID orderId, long shipmentTotalPaise);
+
+    record CreatedOrder(UUID id, String orderRef) {}
+}

--- a/orders/src/main/java/com/oneday/orders/service/OrderStatusReducer.java
+++ b/orders/src/main/java/com/oneday/orders/service/OrderStatusReducer.java
@@ -1,0 +1,68 @@
+package com.oneday.orders.service;
+
+import com.oneday.common.domain.enums.ShipmentState;
+
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Reduces the states of an order's child shipments into a single order-level status. An order is a
+ * booking grouping whose parcels move independently, so the rollup must express divergence
+ * ("partially delivered", "mixed") rather than pretend the parcels share one state.
+ *
+ * <p>Defined once here and reused by every console so the business and customer views agree.</p>
+ */
+public final class OrderStatusReducer {
+
+    private OrderStatusReducer() {}
+
+    /** Terminal success — the parcel reached the customer. */
+    private static final Set<ShipmentState> DELIVERED =
+            EnumSet.of(ShipmentState.DROPPED, ShipmentState.HUB_COLLECTED);
+
+    /** Terminal returned-to-sender. */
+    private static final Set<ShipmentState> RETURNED =
+            EnumSet.of(ShipmentState.RTO_COMPLETED);
+
+    public enum OrderStatus {
+        EMPTY,                  // no shipments (e.g. a checkout where every item failed)
+        BOOKED,                 // all parcels still at booking
+        IN_PROGRESS,            // parcels moving through the chain
+        PARTIALLY_DELIVERED,    // some delivered, some still active
+        DELIVERED,              // every parcel delivered
+        RETURNED,               // every parcel RTO-completed
+        CANCELLED,              // every parcel cancelled
+        MIXED                   // terminal divergence (e.g. some delivered, some cancelled/returned)
+    }
+
+    /** @return the single order-level status for the given child shipment states. */
+    public static OrderStatus reduce(Collection<ShipmentState> childStates) {
+        if (childStates == null || childStates.isEmpty()) {
+            return OrderStatus.EMPTY;
+        }
+
+        int total = childStates.size();
+        int delivered = 0, returned = 0, cancelled = 0, booked = 0, terminal = 0;
+        for (ShipmentState s : childStates) {
+            if (DELIVERED.contains(s)) { delivered++; terminal++; }
+            else if (RETURNED.contains(s)) { returned++; terminal++; }
+            else if (s == ShipmentState.CANCELLED) { cancelled++; terminal++; }
+            else if (s == ShipmentState.BOOKED) { booked++; }
+        }
+
+        if (delivered == total) return OrderStatus.DELIVERED;
+        if (returned == total)  return OrderStatus.RETURNED;
+        if (cancelled == total) return OrderStatus.CANCELLED;
+        if (booked == total)    return OrderStatus.BOOKED;
+
+        // Some parcels delivered but not all → partial delivery (the headline "mixed" ops care about).
+        if (delivered > 0 && terminal < total) return OrderStatus.PARTIALLY_DELIVERED;
+
+        // More than one distinct terminal outcome, or all terminal but not uniform → mixed.
+        if (terminal == total) return OrderStatus.MIXED;
+
+        // Otherwise parcels are still moving through the chain.
+        return OrderStatus.IN_PROGRESS;
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/AdminOrderQueryServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/AdminOrderQueryServiceImpl.java
@@ -2,12 +2,16 @@ package com.oneday.orders.service.impl;
 
 import com.oneday.common.domain.enums.ShipmentState;
 import com.oneday.common.port.ShipmentScanTrailPort;
+import com.oneday.orders.domain.ParcelOrder;
 import com.oneday.orders.domain.Shipment;
 import com.oneday.orders.domain.ShipmentStateHistory;
+import com.oneday.orders.dto.AdminOrderDetailResponse;
+import com.oneday.orders.dto.OrderPageResponse;
 import com.oneday.orders.dto.ShipmentPageResponse;
 import com.oneday.orders.dto.ShipmentSummaryResponse;
 import com.oneday.orders.dto.ShipmentTimelineResponse;
 import com.oneday.orders.dto.ShipmentTimelineResponse.TimelineEvent;
+import com.oneday.orders.repository.ParcelOrderRepository;
 import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.repository.ShipmentStateHistoryRepository;
 import com.oneday.orders.service.AdminOrderQueryService;
@@ -41,13 +45,16 @@ class AdminOrderQueryServiceImpl implements AdminOrderQueryService {
     private static final int EXPORT_MAX_ROWS = 50_000;
 
     private final ShipmentRepository shipmentRepository;
+    private final ParcelOrderRepository parcelOrderRepository;
     private final ShipmentStateHistoryRepository stateHistoryRepository;
     private final ShipmentScanTrailPort scanTrail;
 
     AdminOrderQueryServiceImpl(ShipmentRepository shipmentRepository,
+                               ParcelOrderRepository parcelOrderRepository,
                                ShipmentStateHistoryRepository stateHistoryRepository,
                                ShipmentScanTrailPort scanTrail) {
         this.shipmentRepository = shipmentRepository;
+        this.parcelOrderRepository = parcelOrderRepository;
         this.stateHistoryRepository = stateHistoryRepository;
         this.scanTrail = scanTrail;
     }
@@ -124,6 +131,57 @@ class AdminOrderQueryServiceImpl implements AdminOrderQueryService {
                 s.getOriginCity(), s.getDestCity(), s.getSenderName(), s.getReceiverName(),
                 s.getChargeableWeightGrams(), s.getEtaPromised(), s.getLastScanAt(), s.getCreatedAt(),
                 events);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public OrderPageResponse listOrders(String cityScope, int page, int size) {
+        int safePage = Math.max(0, page);
+        int safeSize = Math.min(Math.max(1, size), MAX_PAGE_SIZE);
+        Pageable pageable = PageRequest.of(safePage, safeSize);   // repositories sort by createdAt desc
+
+        Page<ParcelOrder> result = (cityScope == null)
+                ? parcelOrderRepository.findAllByOrderByCreatedAtDesc(pageable)
+                : parcelOrderRepository.findByCityIdOrderByCreatedAtDesc(cityScope, pageable);
+
+        java.util.Map<java.util.UUID, List<ShipmentState>> statesByOrder = childStates(result.getContent());
+        return new OrderPageResponse(
+                result.map(o -> OrderSummaries.toSummary(
+                        o, statesByOrder.getOrDefault(o.getId(), List.of()))).getContent(),
+                result.getNumber(),
+                result.getSize(),
+                result.getTotalElements(),
+                result.getTotalPages());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AdminOrderDetailResponse orderDetail(String orderRef, String cityScope) {
+        ParcelOrder order = parcelOrderRepository.findByOrderRef(orderRef)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "Unknown order: " + orderRef));
+        // Station-manager scope: only orders placed in their own city (origin). ADMIN → any.
+        if (cityScope != null && !cityScope.equals(order.getCityId())) {
+            throw new ResponseStatusException(NOT_FOUND, "Unknown order: " + orderRef);
+        }
+        List<Shipment> ships = shipmentRepository.findByOrderIdOrderByCreatedAtAsc(order.getId());
+        List<ShipmentState> states = ships.stream().map(Shipment::getState).toList();
+        var header = OrderSummaries.toSummary(order, states);
+        List<ShipmentSummaryResponse> children = ships.stream().map(s -> toSummary(s, cityScope)).toList();
+        return new AdminOrderDetailResponse(header, children);
+    }
+
+    /** Bulk-fetch child states for a set of orders and group by order id (one query). */
+    private java.util.Map<java.util.UUID, List<ShipmentState>> childStates(List<ParcelOrder> orders) {
+        if (orders.isEmpty()) {
+            return java.util.Map.of();
+        }
+        List<java.util.UUID> ids = orders.stream().map(ParcelOrder::getId).toList();
+        return shipmentRepository.findChildStatesByOrderIds(ids).stream()
+                .collect(java.util.stream.Collectors.groupingBy(
+                        ShipmentRepository.OrderChildState::getOrderId,
+                        java.util.stream.Collectors.mapping(
+                                ShipmentRepository.OrderChildState::getState,
+                                java.util.stream.Collectors.toList())));
     }
 
     private Page<Shipment> fetchPage(ShipmentState state, String cityScope, Pageable pageable) {

--- a/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
@@ -29,6 +29,7 @@ import com.oneday.orders.repository.ShipmentStateHistoryRepository;
 import com.oneday.orders.service.B2bBookingService;
 import com.oneday.orders.service.BookingService;
 import com.oneday.orders.service.CustomerVisibleStateMapper;
+import com.oneday.orders.service.OrderService;
 import com.oneday.orders.service.ShipmentRefService;
 import com.oneday.orders.service.TransitionContext;
 import com.oneday.orders.service.WalletService;
@@ -61,6 +62,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
     private final PricingPort pricingPort;
     private final EtaPort etaPort;
     private final ShipmentRefService shipmentRefService;
+    private final OrderService orderService;
     private final ShipmentRepository shipmentRepository;
     private final ShipmentStateHistoryRepository historyRepository;
     private final CodCollectionRepository codCollectionRepository;
@@ -82,6 +84,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
                           PricingPort pricingPort,
                           EtaPort etaPort,
                           ShipmentRefService shipmentRefService,
+                          OrderService orderService,
                           ShipmentRepository shipmentRepository,
                           ShipmentStateHistoryRepository historyRepository,
                           CodCollectionRepository codCollectionRepository,
@@ -97,6 +100,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
         this.pricingPort          = pricingPort;
         this.etaPort              = etaPort;
         this.shipmentRefService   = shipmentRefService;
+        this.orderService         = orderService;
         this.shipmentRepository   = shipmentRepository;
         this.historyRepository    = historyRepository;
         this.codCollectionRepository = codCollectionRepository;
@@ -113,6 +117,12 @@ class B2bBookingServiceImpl implements B2bBookingService {
 
     @Override
     public BookingResponse book(B2bBookingRequest req, String idempotencyKey, String userId) {
+        return book(req, idempotencyKey, userId, null);
+    }
+
+    @Override
+    public BookingResponse book(B2bBookingRequest req, String idempotencyKey, String userId,
+                                java.util.UUID orderId) {
         // ── 1. Fetch account (outside TX) ─────────────────────────────────────
         B2bAccount account = b2bAccountRepository.findById(req.getB2bAccountId())
                 .orElseThrow(() -> new AccountNotFoundException(
@@ -160,7 +170,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
         final int finalChargeable = chargeableWeightGrams;
         return tx.execute(status ->
                 persistB2b(req, idempotencyKey, userId, account, serviceability,
-                        finalVolumetric, finalChargeable, quote));
+                        finalVolumetric, finalChargeable, quote, orderId));
     }
 
     /** Resolve an optional pickup slot (date + IST start hour) to absolute instants on the shipment. */
@@ -181,8 +191,18 @@ class B2bBookingServiceImpl implements B2bBookingService {
     private BookingResponse persistB2b(B2bBookingRequest req, String idempotencyKey, String userId,
                                        B2bAccount accountSnapshot, ServiceabilityResult serviceability,
                                        int volumetricWeightGrams, int chargeableWeightGrams,
-                                       QuoteResult quote) {
+                                       QuoteResult quote, java.util.UUID orderId) {
         Instant bookedAt = Instant.now();
+
+        // Attach to a parent order. A single B2B booking (orderId == null) mints its own order of one
+        // (carrying the merchant's purchaseOrderRef); a cart checkout passes the shared orderId.
+        OrderService.CreatedOrder createdOrder = null;
+        java.util.UUID effectiveOrderId = orderId;
+        if (effectiveOrderId == null) {
+            createdOrder = orderService.createOrder(CustomerType.B2B, req.getB2bAccountId(), userId,
+                    req.getOriginCity(), req.getPurchaseOrderRef());
+            effectiveOrderId = createdOrder.id();
+        }
 
         // ── 5a. SELECT FOR UPDATE — re-fetch account inside TX ─────────────────
         B2bAccount account = b2bAccountRepository.findByIdForUpdate(req.getB2bAccountId())
@@ -214,6 +234,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
 
         Shipment shipment = new Shipment();
         shipment.setShipmentRef(shipmentRef);
+        shipment.setOrderId(effectiveOrderId);
         shipment.setCustomerType(CustomerType.B2B);
         shipment.setB2bAccountId(req.getB2bAccountId());
         shipment.setDeliveryType(serviceability.deliveryType());
@@ -258,6 +279,9 @@ class B2bBookingServiceImpl implements B2bBookingService {
         shipment.setBookedByUserId(UserIds.parse(userId));
 
         shipment = shipmentRepository.save(shipment);
+
+        // Fold into the parent order rollup (count + 1, total += this shipment's total).
+        orderService.addShipment(effectiveOrderId, quote.totalPricePaise());
 
         // ── 5c-COD. Open the COD collection ledger row (AWAITING_COLLECTION) ────
         // Shipping stays credit-billed above; this is the separate buyer→vendor money we will
@@ -335,6 +359,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
 
         BookingResponse response = new BookingResponse();
         response.setShipmentRef(shipment.getShipmentRef());
+        response.setOrderRef(createdOrder != null ? createdOrder.orderRef() : null);
         response.setCustomerType(CustomerType.B2B);
         response.setState(ShipmentState.BOOKED);
         response.setStateLabel(stateMapper.labelFor(ShipmentState.BOOKED));

--- a/orders/src/main/java/com/oneday/orders/service/impl/BookingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/BookingServiceImpl.java
@@ -27,6 +27,7 @@ import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.repository.ShipmentStateHistoryRepository;
 import com.oneday.orders.service.BookingService;
 import com.oneday.orders.service.CustomerVisibleStateMapper;
+import com.oneday.orders.service.OrderService;
 import com.oneday.orders.service.PaymentPort;
 import com.oneday.orders.service.ShipmentRefService;
 import com.oneday.orders.service.TransitionContext;
@@ -42,6 +43,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.Instant;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.ScheduledExecutorService;
@@ -61,6 +63,7 @@ class BookingServiceImpl implements BookingService {
     private final PaymentPort paymentPort;
     private final EtaPort etaPort;
     private final ShipmentRefService shipmentRefService;
+    private final OrderService orderService;
     private final ShipmentRepository shipmentRepository;
     private final PaymentTransactionRepository paymentTransactionRepository;
     private final ShipmentStateHistoryRepository historyRepository;
@@ -83,6 +86,7 @@ class BookingServiceImpl implements BookingService {
                        PaymentPort paymentPort,
                        EtaPort etaPort,
                        ShipmentRefService shipmentRefService,
+                       OrderService orderService,
                        ShipmentRepository shipmentRepository,
                        PaymentTransactionRepository paymentTransactionRepository,
                        ShipmentStateHistoryRepository historyRepository,
@@ -97,6 +101,7 @@ class BookingServiceImpl implements BookingService {
         this.paymentPort = paymentPort;
         this.etaPort = etaPort;
         this.shipmentRefService = shipmentRefService;
+        this.orderService = orderService;
         this.shipmentRepository = shipmentRepository;
         this.paymentTransactionRepository = paymentTransactionRepository;
         this.historyRepository = historyRepository;
@@ -121,14 +126,15 @@ class BookingServiceImpl implements BookingService {
 
     @Override
     public BookingResponse bookSettled(BookingRequest req, String idempotencyKey, String userId,
-                                       CustomerType customerType) {
+                                       CustomerType customerType, UUID orderId) {
         // Cart checkout already settled payment once for the whole cart, so we re-price (to catch
         // staleness) and persist — but write NO per-shipment PaymentTransaction and take no payment.
+        // The parent order was minted by cart checkout; every item attaches to the same orderId.
         Priced priced = priceRequest(req, customerType);
         return tx.execute(status ->
                 persist(req, idempotencyKey, userId, customerType, priced.serviceability(),
                         priced.volumetricWeightGrams(), priced.chargeableWeightGrams(), priced.quote(),
-                        /* recordPayment */ false));
+                        /* recordPayment */ false, orderId));
     }
 
     // Steps 1-3 of booking, with no payment or DB write — reused by book() and quote()
@@ -213,7 +219,8 @@ class BookingServiceImpl implements BookingService {
         try {
             return tx.execute(status ->
                     persist(req, idempotencyKey, userId, customerType, serviceability,
-                            finalVolumetricWeight, finalChargeableWeight, quote, /* recordPayment */ true));
+                            finalVolumetricWeight, finalChargeableWeight, quote, /* recordPayment */ true,
+                            /* orderId */ null));
         } catch (RuntimeException dbEx) {
             if (isPrepaid) {
                 try {
@@ -249,12 +256,22 @@ class BookingServiceImpl implements BookingService {
     private BookingResponse persist(BookingRequest req, String idempotencyKey, String userId,
                                     CustomerType customerType, ServiceabilityResult serviceability,
                                     int volumetricWeightGrams, int chargeableWeightGrams,
-                                    QuoteResult quote, boolean recordPayment) {
+                                    QuoteResult quote, boolean recordPayment, UUID orderId) {
         Instant bookedAt = Instant.now();
         String shipmentRef = shipmentRefService.generateRef(req.getOriginCity());
 
+        // Attach to a parent order. A single booking (orderId == null) mints its own order of one;
+        // a cart checkout passes the shared orderId so every item joins the same order.
+        OrderService.CreatedOrder createdOrder = null;
+        UUID effectiveOrderId = orderId;
+        if (effectiveOrderId == null) {
+            createdOrder = orderService.createOrder(customerType, null, userId, req.getOriginCity(), null);
+            effectiveOrderId = createdOrder.id();
+        }
+
         Shipment shipment = new Shipment();
         shipment.setShipmentRef(shipmentRef);
+        shipment.setOrderId(effectiveOrderId);
         shipment.setCustomerType(customerType);
         shipment.setDeliveryType(serviceability.deliveryType());
         shipment.setSenderName(req.getSenderName());
@@ -292,6 +309,9 @@ class BookingServiceImpl implements BookingService {
         shipment.setBookedByUserId(UserIds.parse(userId));
 
         shipment = shipmentRepository.save(shipment);
+
+        // Fold this shipment into the parent order rollup (count + 1, total += this shipment's total).
+        orderService.addShipment(effectiveOrderId, quote.totalPricePaise());
 
         if (recordPayment && PaymentMode.PREPAID == req.getPaymentMode()) {
             PaymentTransaction payment = new PaymentTransaction();
@@ -371,6 +391,9 @@ class BookingServiceImpl implements BookingService {
 
         BookingResponse response = new BookingResponse();
         response.setShipmentRef(shipment.getShipmentRef());
+        // Echo the order ref for a single booking; on a cart item it stays null (the cart response
+        // carries the one shared order ref).
+        response.setOrderRef(createdOrder != null ? createdOrder.orderRef() : null);
         response.setCustomerType(customerType);
         response.setState(ShipmentState.BOOKED);
         response.setStateLabel(stateMapper.labelFor(ShipmentState.BOOKED));

--- a/orders/src/main/java/com/oneday/orders/service/impl/CartServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/CartServiceImpl.java
@@ -19,6 +19,7 @@ import com.oneday.orders.repository.CartRepository;
 import com.oneday.orders.service.B2bBookingService;
 import com.oneday.orders.service.BookingService;
 import com.oneday.orders.service.CartService;
+import com.oneday.orders.service.OrderService;
 import com.oneday.orders.service.PaymentPort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,18 +43,20 @@ class CartServiceImpl implements CartService {
     private final CartItemRepository cartItemRepository;
     private final BookingService bookingService;
     private final B2bBookingService b2bBookingService;
+    private final OrderService orderService;
     private final PaymentPort paymentPort;
     private final TransactionTemplate txTemplate;
     private final ExecutorService bulkPricingExecutor;
 
     CartServiceImpl(CartRepository cartRepository, CartItemRepository cartItemRepository,
                     BookingService bookingService, B2bBookingService b2bBookingService,
-                    PaymentPort paymentPort, TransactionTemplate txTemplate,
+                    OrderService orderService, PaymentPort paymentPort, TransactionTemplate txTemplate,
                     @Qualifier("bulkPricingExecutor") ExecutorService bulkPricingExecutor) {
         this.cartRepository = cartRepository;
         this.cartItemRepository = cartItemRepository;
         this.bookingService = bookingService;
         this.b2bBookingService = b2bBookingService;
+        this.orderService = orderService;
         this.paymentPort = paymentPort;
         this.txTemplate = txTemplate;
         this.bulkPricingExecutor = bulkPricingExecutor;
@@ -186,7 +189,7 @@ class CartServiceImpl implements CartService {
             }
         }
         if (payable.isEmpty()) {
-            return finish(cart, items.size(), null, null, 0L, results); // nothing to capture
+            return finish(cart, items.size(), null, null, 0L, null, results); // nothing to capture
         }
 
         // 2. Settle the single aggregate payment for the whole serviceable cart.
@@ -194,11 +197,15 @@ class CartServiceImpl implements CartService {
         paymentPort.verifySignature(req.getRazorpayOrderId(), req.getRazorpayPaymentId(), req.getRazorpaySignature());
         paymentPort.capture(req.getRazorpayPaymentId(), total);
 
-        // 3. Persist each shipment without re-capturing.
+        // 3. Mint the single parent order (committed before the loop so each item's own transaction
+        //    can fold into its rollup), then persist each shipment onto it without re-capturing.
+        OrderService.CreatedOrder order = txTemplate.execute(s -> orderService.createOrder(
+                customerType, null, cart.getUserId().toString(), payable.get(0).getOriginCity(), null));
         for (CartItem item : payable) {
             try {
                 BookingResponse r = bookingService.bookSettled(
-                        toBookingRequest(item), "cart-" + item.getId(), cart.getUserId().toString(), customerType);
+                        toBookingRequest(item), "cart-" + item.getId(), cart.getUserId().toString(),
+                        customerType, order.id());
                 results.add(CartCheckoutResponse.Result.ok(item.getId(), r.getShipmentRef()));
                 cartItemRepository.delete(item);
             } catch (RuntimeException e) {
@@ -208,7 +215,8 @@ class CartServiceImpl implements CartService {
         }
         cart.setCheckoutRazorpayOrderId(req.getRazorpayOrderId());
         cart.setCheckoutRazorpayPaymentId(req.getRazorpayPaymentId());
-        return finish(cart, items.size(), req.getRazorpayOrderId(), req.getRazorpayPaymentId(), total, results);
+        return finish(cart, items.size(), req.getRazorpayOrderId(), req.getRazorpayPaymentId(),
+                total, order.orderRef(), results);
     }
 
     private CartCheckoutResponse checkoutB2b(Cart cart, List<CartItem> items, CartCheckoutRequest req) {
@@ -217,10 +225,15 @@ class CartServiceImpl implements CartService {
         }
         List<CartCheckoutResponse.Result> results = new ArrayList<>();
         long charged = 0L;
+        // Mint the single parent order (committed before the loop so each item folds into its rollup).
+        OrderService.CreatedOrder order = txTemplate.execute(s -> orderService.createOrder(
+                CustomerType.B2B, req.getB2bAccountId(), cart.getUserId().toString(),
+                items.get(0).getOriginCity(), null));
         for (CartItem item : items) {
             try {
                 BookingResponse r = b2bBookingService.book(
-                        toB2bRequest(item, req.getB2bAccountId()), "cart-" + item.getId(), cart.getUserId().toString());
+                        toB2bRequest(item, req.getB2bAccountId()), "cart-" + item.getId(),
+                        cart.getUserId().toString(), order.id());
                 charged += r.getPricing().getTotalPricePaise();
                 results.add(CartCheckoutResponse.Result.ok(item.getId(), r.getShipmentRef()));
                 cartItemRepository.delete(item);
@@ -228,21 +241,22 @@ class CartServiceImpl implements CartService {
                 results.add(CartCheckoutResponse.Result.fail(item.getId(), reasonOf(e)));
             }
         }
-        return finish(cart, items.size(), null, null, charged, results);
+        return finish(cart, items.size(), null, null, charged, order.orderRef(), results);
     }
 
     /** Marks the cart CHECKED_OUT only if every item booked; otherwise it stays OPEN with the failures. */
-    private CartCheckoutResponse finish(Cart cart, int originalCount, String orderId, String paymentId,
-                                        long charged, List<CartCheckoutResponse.Result> results) {
+    private CartCheckoutResponse finish(Cart cart, int originalCount, String razorpayOrderId, String paymentId,
+                                        long charged, String orderRef,
+                                        List<CartCheckoutResponse.Result> results) {
         int booked = (int) results.stream().filter(CartCheckoutResponse.Result::success).count();
         int failed = results.size() - booked;
         cart.setCheckoutTotalPaise(charged);
-        cart.setCheckoutRazorpayOrderId(orderId);
+        cart.setCheckoutRazorpayOrderId(razorpayOrderId);
         cart.setCheckoutRazorpayPaymentId(paymentId);
         boolean allBooked = booked == originalCount && failed == 0;
         cart.setStatus(allBooked ? CartStatus.CHECKED_OUT : CartStatus.OPEN);
         cartRepository.save(cart);
-        return new CartCheckoutResponse(booked, failed, charged, cart.getStatus().name(), results);
+        return new CartCheckoutResponse(booked, failed, charged, orderRef, cart.getStatus().name(), results);
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────────

--- a/orders/src/main/java/com/oneday/orders/service/impl/CustomerOrderQueryServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/CustomerOrderQueryServiceImpl.java
@@ -1,13 +1,18 @@
 package com.oneday.orders.service.impl;
 
 import com.oneday.common.domain.enums.CustomerType;
+import com.oneday.common.domain.enums.ShipmentState;
 import com.oneday.orders.domain.Address;
 import com.oneday.orders.domain.B2bAccount;
+import com.oneday.orders.domain.ParcelOrder;
 import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.dto.MyOrderDetailResponse;
 import com.oneday.orders.dto.MyShipmentDetailResponse;
 import com.oneday.orders.dto.MyShipmentSummaryResponse;
+import com.oneday.orders.dto.OrderSummaryResponse;
 import com.oneday.orders.dto.ShipmentLabelResponse;
 import com.oneday.orders.repository.B2bAccountRepository;
+import com.oneday.orders.repository.ParcelOrderRepository;
 import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.service.CustomerOrderQueryService;
 import com.oneday.orders.service.CustomerVisibleStateMapper;
@@ -19,8 +24,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * @see CustomerOrderQueryService
@@ -31,15 +38,18 @@ class CustomerOrderQueryServiceImpl implements CustomerOrderQueryService {
     private static final int MAX_LIMIT = 200;
 
     private final ShipmentRepository shipmentRepository;
+    private final ParcelOrderRepository parcelOrderRepository;
     private final CustomerVisibleStateMapper stateMapper;
     private final FlightTrackingPort flightTrackingPort;
     private final B2bAccountRepository b2bAccountRepository;
 
     CustomerOrderQueryServiceImpl(ShipmentRepository shipmentRepository,
+                                  ParcelOrderRepository parcelOrderRepository,
                                   CustomerVisibleStateMapper stateMapper,
                                   FlightTrackingPort flightTrackingPort,
                                   B2bAccountRepository b2bAccountRepository) {
         this.shipmentRepository = shipmentRepository;
+        this.parcelOrderRepository = parcelOrderRepository;
         this.stateMapper = stateMapper;
         this.flightTrackingPort = flightTrackingPort;
         this.b2bAccountRepository = b2bAccountRepository;
@@ -57,6 +67,52 @@ class CustomerOrderQueryServiceImpl implements CustomerOrderQueryService {
         return shipmentRepository.findByBookedByUserId(id, pageable)
                 .map(this::toSummary)
                 .getContent();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<OrderSummaryResponse> myOrders(String userId, int limit) {
+        UUID id = UserIds.parse(userId);
+        if (id == null) {
+            return List.of();
+        }
+        int safeLimit = Math.min(Math.max(1, limit), MAX_LIMIT);
+        Pageable pageable = PageRequest.of(0, safeLimit, Sort.by(Sort.Direction.DESC, "createdAt"));
+        List<ParcelOrder> orders = parcelOrderRepository.findByBookedByUserId(id, pageable).getContent();
+        Map<UUID, List<ShipmentState>> statesByOrder = childStates(orders);
+        return orders.stream()
+                .map(o -> OrderSummaries.toSummary(o, statesByOrder.getOrDefault(o.getId(), List.of())))
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<MyOrderDetailResponse> myOrderDetail(String userId, String orderRef) {
+        UUID id = UserIds.parse(userId);
+        if (id == null) {
+            return Optional.empty();
+        }
+        return parcelOrderRepository.findByOrderRef(orderRef)
+                .filter(o -> id.equals(o.getBookedByUserId()))   // ownership scope: not yours → not found
+                .map(o -> {
+                    List<Shipment> ships = shipmentRepository.findByOrderIdOrderByCreatedAtAsc(o.getId());
+                    List<ShipmentState> states = ships.stream().map(Shipment::getState).toList();
+                    OrderSummaryResponse header = OrderSummaries.toSummary(o, states);
+                    List<MyShipmentSummaryResponse> children = ships.stream().map(this::toSummary).toList();
+                    return new MyOrderDetailResponse(header, children);
+                });
+    }
+
+    /** Bulk-fetch the child states for a set of orders and group them by order id (one query). */
+    private Map<UUID, List<ShipmentState>> childStates(List<ParcelOrder> orders) {
+        if (orders.isEmpty()) {
+            return Map.of();
+        }
+        List<UUID> ids = orders.stream().map(ParcelOrder::getId).toList();
+        return shipmentRepository.findChildStatesByOrderIds(ids).stream()
+                .collect(Collectors.groupingBy(
+                        ShipmentRepository.OrderChildState::getOrderId,
+                        Collectors.mapping(ShipmentRepository.OrderChildState::getState, Collectors.toList())));
     }
 
     @Override

--- a/orders/src/main/java/com/oneday/orders/service/impl/OrderRefServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/OrderRefServiceImpl.java
@@ -1,0 +1,55 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.domain.OrderRefCounter;
+import com.oneday.orders.domain.OrderRefCounterId;
+import com.oneday.orders.repository.OrderRefCounterRepository;
+import com.oneday.orders.service.OrderRefService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Generates order refs of the form {@code 1DD-ORD-{CITY}-{YYYYMMDD}-{NNNNN}}.
+ * Same serialisation strategy as {@link ShipmentRefServiceImpl} — a row-level lock on
+ * {@code (city_code, date_key)}. Must run inside the caller's transaction (MANDATORY) so the
+ * counter increment rolls back with a failed booking.
+ */
+@Service
+class OrderRefServiceImpl implements OrderRefService {
+
+    private static final ZoneId IST = ZoneId.of("Asia/Kolkata");
+    private static final String PREFIX = "1DD-ORD";
+
+    private final OrderRefCounterRepository counterRepository;
+
+    OrderRefServiceImpl(OrderRefCounterRepository counterRepository) {
+        this.counterRepository = counterRepository;
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.MANDATORY)
+    public String generateRef(String originCityCode) {
+        String city = originCityCode.toUpperCase();
+        LocalDate today = LocalDate.now(IST);
+
+        OrderRefCounterId id = new OrderRefCounterId(city, today);
+
+        // Ensure the row exists before locking (SELECT FOR UPDATE cannot lock a missing row).
+        counterRepository.insertIfAbsent(city, today);
+
+        OrderRefCounter counter = counterRepository.findByIdWithLock(id)
+                .orElseThrow(() -> new IllegalStateException(
+                        "Order counter must exist after insertIfAbsent for id=" + id));
+
+        int next = counter.getNextVal() + 1;
+        counter.setNextVal(next);
+        counterRepository.save(counter);
+
+        String dateKey = today.format(DateTimeFormatter.BASIC_ISO_DATE); // YYYYMMDD
+        return String.format("%s-%s-%s-%05d", PREFIX, city, dateKey, next);
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/OrderServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/OrderServiceImpl.java
@@ -1,0 +1,48 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.enums.CustomerType;
+import com.oneday.orders.domain.ParcelOrder;
+import com.oneday.orders.repository.ParcelOrderRepository;
+import com.oneday.orders.service.OrderRefService;
+import com.oneday.orders.service.OrderService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+class OrderServiceImpl implements OrderService {
+
+    private final OrderRefService orderRefService;
+    private final ParcelOrderRepository parcelOrderRepository;
+
+    OrderServiceImpl(OrderRefService orderRefService, ParcelOrderRepository parcelOrderRepository) {
+        this.orderRefService = orderRefService;
+        this.parcelOrderRepository = parcelOrderRepository;
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.MANDATORY)
+    public CreatedOrder createOrder(CustomerType customerType, UUID b2bAccountId, String userId,
+                                    String originCityCode, String purchaseOrderRef) {
+        String city = originCityCode.toUpperCase();
+        ParcelOrder order = new ParcelOrder();
+        order.setOrderRef(orderRefService.generateRef(city));
+        order.setCustomerType(customerType);
+        order.setB2bAccountId(b2bAccountId);
+        order.setBookedByUserId(UserIds.parse(userId));
+        order.setPurchaseOrderRef(purchaseOrderRef);
+        order.setParcelCount(0);
+        order.setTotalPricePaise(0L);
+        order.setCityId(city);
+        order = parcelOrderRepository.save(order);
+        return new CreatedOrder(order.getId(), order.getOrderRef());
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void addShipment(UUID orderId, long shipmentTotalPaise) {
+        parcelOrderRepository.addShipment(orderId, shipmentTotalPaise);
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/OrderSummaries.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/OrderSummaries.java
@@ -1,0 +1,42 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.domain.ParcelOrder;
+import com.oneday.orders.dto.OrderSummaryResponse;
+import com.oneday.orders.service.OrderStatusReducer;
+import com.oneday.orders.service.OrderStatusReducer.OrderStatus;
+
+import java.util.Collection;
+
+/** Builds the shared {@link OrderSummaryResponse} card used by both the customer and admin consoles. */
+final class OrderSummaries {
+
+    private OrderSummaries() {}
+
+    static OrderSummaryResponse toSummary(ParcelOrder o, Collection<ShipmentState> childStates) {
+        OrderStatus status = OrderStatusReducer.reduce(childStates);
+        return new OrderSummaryResponse(
+                o.getOrderRef(),
+                o.getCustomerType(),
+                status.name(),
+                label(status),
+                o.getParcelCount(),
+                o.getTotalPricePaise(),
+                o.getCityId(),
+                o.getPurchaseOrderRef(),
+                o.getCreatedAt());
+    }
+
+    static String label(OrderStatus status) {
+        return switch (status) {
+            case EMPTY -> "No parcels";
+            case BOOKED -> "Booked";
+            case IN_PROGRESS -> "In progress";
+            case PARTIALLY_DELIVERED -> "Partially delivered";
+            case DELIVERED -> "Delivered";
+            case RETURNED -> "Returned to sender";
+            case CANCELLED -> "Cancelled";
+            case MIXED -> "Mixed";
+        };
+    }
+}

--- a/orders/src/main/resources/db/migration/orders/V4_40__create_parcel_orders.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_40__create_parcel_orders.sql
@@ -1,0 +1,36 @@
+-- Order → N Shipments abstraction (Feature 1).
+-- A durable parent for every booking. Single bookings get an order of one; a cart checkout /
+-- bulk upload gets one order over all its fanned-out shipments. The transient `cart` remains the
+-- pre-checkout basket; `parcel_orders` is the record that survives checkout and that each shipment
+-- points back to.
+CREATE TABLE parcel_orders (
+  id                  UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+  order_ref           VARCHAR(30)   NOT NULL UNIQUE,
+  customer_type       customer_type NOT NULL,
+  b2b_account_id      UUID,                          -- non-null only for B2B orders
+  booked_by_user_id   UUID,                          -- M1 user who placed the order (powers "my orders")
+  purchase_order_ref  VARCHAR(100),                  -- merchant's own PO ref (B2B); finally has a home
+  parcel_count        INTEGER       NOT NULL DEFAULT 0,
+  total_price_paise   BIGINT        NOT NULL DEFAULT 0,
+  city_id             VARCHAR(10)   NOT NULL,        -- origin city (booking grouping, not a routing unit)
+  created_at          TIMESTAMPTZ   NOT NULL DEFAULT now(),
+  updated_at          TIMESTAMPTZ   NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_parcel_orders_booked_by  ON parcel_orders (booked_by_user_id, created_at DESC);
+CREATE INDEX idx_parcel_orders_b2b_account ON parcel_orders (b2b_account_id);
+CREATE INDEX idx_parcel_orders_city        ON parcel_orders (city_id, created_at DESC);
+
+-- Per-(city, date) order-ref counter — mirrors shipment_ref_counters, serialised via SELECT FOR UPDATE.
+-- Ref format: 1DD-ORD-{CITY}-{YYYYMMDD}-{NNNNN}, e.g. 1DD-ORD-BLR-20260824-00001.
+CREATE TABLE order_ref_counters (
+  city_code VARCHAR(10) NOT NULL,
+  date_key  DATE        NOT NULL,
+  next_val  INTEGER     NOT NULL DEFAULT 1,
+  PRIMARY KEY (city_code, date_key)
+);
+
+-- Link each shipment to its parent order. Nullable: rows booked before this feature have none, and
+-- cross-module convention is a bare UUID, not a DB foreign key.
+ALTER TABLE shipments ADD COLUMN order_id UUID;
+CREATE INDEX idx_shipments_order_id ON shipments (order_id);

--- a/orders/src/test/java/com/oneday/orders/service/OrderStatusReducerTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/OrderStatusReducerTest.java
@@ -1,0 +1,66 @@
+package com.oneday.orders.service;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.service.OrderStatusReducer.OrderStatus;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OrderStatusReducerTest {
+
+    @Test
+    void empty_isEmpty() {
+        assertThat(OrderStatusReducer.reduce(List.of())).isEqualTo(OrderStatus.EMPTY);
+        assertThat(OrderStatusReducer.reduce(null)).isEqualTo(OrderStatus.EMPTY);
+    }
+
+    @Test
+    void allBooked_isBooked() {
+        assertThat(OrderStatusReducer.reduce(List.of(ShipmentState.BOOKED, ShipmentState.BOOKED)))
+                .isEqualTo(OrderStatus.BOOKED);
+    }
+
+    @Test
+    void allDelivered_isDelivered() {
+        assertThat(OrderStatusReducer.reduce(List.of(ShipmentState.DROPPED, ShipmentState.HUB_COLLECTED)))
+                .isEqualTo(OrderStatus.DELIVERED);
+    }
+
+    @Test
+    void allCancelled_isCancelled() {
+        assertThat(OrderStatusReducer.reduce(List.of(ShipmentState.CANCELLED, ShipmentState.CANCELLED)))
+                .isEqualTo(OrderStatus.CANCELLED);
+    }
+
+    @Test
+    void allReturned_isReturned() {
+        assertThat(OrderStatusReducer.reduce(List.of(ShipmentState.RTO_COMPLETED)))
+                .isEqualTo(OrderStatus.RETURNED);
+    }
+
+    @Test
+    void someDeliveredSomeActive_isPartiallyDelivered() {
+        assertThat(OrderStatusReducer.reduce(List.of(ShipmentState.DROPPED, ShipmentState.IN_TAKEOFF_BAG)))
+                .isEqualTo(OrderStatus.PARTIALLY_DELIVERED);
+    }
+
+    @Test
+    void deliveredAndCancelled_allTerminal_isMixed() {
+        assertThat(OrderStatusReducer.reduce(List.of(ShipmentState.DROPPED, ShipmentState.CANCELLED)))
+                .isEqualTo(OrderStatus.MIXED);
+    }
+
+    @Test
+    void movingThroughChain_isInProgress() {
+        assertThat(OrderStatusReducer.reduce(List.of(ShipmentState.BOOKED, ShipmentState.PICKED_UP)))
+                .isEqualTo(OrderStatus.IN_PROGRESS);
+    }
+
+    @Test
+    void cancelledPlusActive_noneDelivered_isInProgress() {
+        assertThat(OrderStatusReducer.reduce(List.of(ShipmentState.CANCELLED, ShipmentState.AT_ORIGIN_HUB)))
+                .isEqualTo(OrderStatus.IN_PROGRESS);
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/service/impl/AdminOrderQueryServiceTimelineTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/AdminOrderQueryServiceTimelineTest.java
@@ -24,10 +24,12 @@ import static org.mockito.Mockito.when;
 class AdminOrderQueryServiceTimelineTest {
 
     private final ShipmentRepository shipmentRepo = mock(ShipmentRepository.class);
+    private final com.oneday.orders.repository.ParcelOrderRepository parcelOrderRepo =
+            mock(com.oneday.orders.repository.ParcelOrderRepository.class);
     private final ShipmentStateHistoryRepository historyRepo = mock(ShipmentStateHistoryRepository.class);
     private final ShipmentScanTrailPort scanTrail = mock(ShipmentScanTrailPort.class);
     private final AdminOrderQueryServiceImpl svc =
-            new AdminOrderQueryServiceImpl(shipmentRepo, historyRepo, scanTrail);
+            new AdminOrderQueryServiceImpl(shipmentRepo, parcelOrderRepo, historyRepo, scanTrail);
 
     private Shipment shipment(UUID id, String ref) {
         Shipment s = mock(Shipment.class);

--- a/orders/src/test/java/com/oneday/orders/service/impl/B2bBookingServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/B2bBookingServiceImplTest.java
@@ -23,6 +23,7 @@ import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.repository.ShipmentStateHistoryRepository;
 import com.oneday.orders.service.B2bBookingService;
 import com.oneday.orders.service.CustomerVisibleStateMapper;
+import com.oneday.orders.service.OrderService;
 import com.oneday.orders.service.ShipmentRefService;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
@@ -50,6 +51,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -62,6 +64,7 @@ class B2bBookingServiceImplTest {
     @Mock private PricingPort pricingPort;
     @Mock private EtaPort etaPort;
     @Mock private ShipmentRefService shipmentRefService;
+    @Mock private OrderService orderService;
     @Mock private ShipmentRepository shipmentRepository;
     @Mock private ShipmentStateHistoryRepository historyRepository;
     @Mock private com.oneday.orders.repository.CodCollectionRepository codCollectionRepository;
@@ -92,9 +95,13 @@ class B2bBookingServiceImplTest {
     @BeforeEach
     void setUp() {
         scheduler = Executors.newSingleThreadScheduledExecutor();
+        // Every B2B booking mints a parent order of one; lenient so failure-path tests that never
+        // reach persist don't trip strict-stub checks.
+        lenient().when(orderService.createOrder(any(), any(), anyString(), anyString(), any()))
+                .thenReturn(new OrderService.CreatedOrder(UUID.randomUUID(), "1DD-ORD-BLR-20260530-00001"));
         service = new B2bBookingServiceImpl(
                 b2bAccountRepository, serviceabilityPort, pricingPort, etaPort,
-                shipmentRefService, shipmentRepository, historyRepository,
+                shipmentRefService, orderService, shipmentRepository, historyRepository,
                 codCollectionRepository, stateMapper, walletService, new TransactionTemplate(NO_OP_TX),
                 applicationEventPublisher,
                 CircuitBreakerRegistry.ofDefaults(),

--- a/orders/src/test/java/com/oneday/orders/service/impl/BookingServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/BookingServiceImplTest.java
@@ -24,6 +24,7 @@ import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.repository.ShipmentStateHistoryRepository;
 import com.oneday.orders.service.BookingService;
 import com.oneday.orders.service.CustomerVisibleStateMapper;
+import com.oneday.orders.service.OrderService;
 import com.oneday.orders.service.PaymentPort;
 import com.oneday.orders.service.ShipmentRefService;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
@@ -54,6 +55,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -66,6 +68,7 @@ class BookingServiceImplTest {
     @Mock private PaymentPort paymentPort;
     @Mock private EtaPort etaPort;
     @Mock private ShipmentRefService shipmentRefService;
+    @Mock private OrderService orderService;
     @Mock private ShipmentRepository shipmentRepository;
     @Mock private PaymentTransactionRepository paymentTransactionRepository;
     @Mock private ShipmentStateHistoryRepository historyRepository;
@@ -97,9 +100,14 @@ class BookingServiceImplTest {
     void setUp() {
         scheduler = Executors.newSingleThreadScheduledExecutor();
 
+        // Every booking mints a parent order of one; lenient so the not-serviceable / bad-request
+        // tests that never reach persist don't trip strict-stub checks.
+        lenient().when(orderService.createOrder(any(), any(), anyString(), anyString(), any()))
+                .thenReturn(new OrderService.CreatedOrder(UUID.randomUUID(), "1DD-ORD-BLR-20260530-00001"));
+
         service = new BookingServiceImpl(
                 serviceabilityPort, pricingPort, paymentPort, etaPort,
-                shipmentRefService, shipmentRepository, paymentTransactionRepository,
+                shipmentRefService, orderService, shipmentRepository, paymentTransactionRepository,
                 historyRepository, stateMapper, new TransactionTemplate(NO_OP_TX),
                 CircuitBreakerRegistry.ofDefaults(),
                 TimeLimiterRegistry.ofDefaults(),
@@ -145,6 +153,61 @@ class BookingServiceImplTest {
         assertThat(resp.getLabelStatus()).isEqualTo("PENDING");
         assertThat(resp.getPayment().getStatus()).isEqualTo("CAPTURED");
         assertThat(resp.getTrackingUrl()).contains(SHIPMENT_REF);
+    }
+
+    // ── book() attaches a parent order (Order → N Shipments) ────────────────
+
+    @Test
+    void book_attachesParentOrder_andRollsUp() {
+        stubServiceability(true, DeliveryType.INTERCITY);
+        stubPricing(4000L, 720L, 4720L);
+        when(shipmentRefService.generateRef(anyString())).thenReturn(SHIPMENT_REF);
+        UUID orderId = UUID.randomUUID();
+        when(orderService.createOrder(any(), any(), anyString(), anyString(), any()))
+                .thenReturn(new OrderService.CreatedOrder(orderId, "1DD-ORD-BLR-20260530-00007"));
+        ArgumentCaptor<Shipment> savedShipment = ArgumentCaptor.forClass(Shipment.class);
+        when(shipmentRepository.save(savedShipment.capture())).thenAnswer(inv -> {
+            Shipment s = inv.getArgument(0);
+            ReflectionTestUtils.setField(s, "id", SHIPMENT_ID);
+            return s;
+        });
+        when(paymentTransactionRepository.save(any())).thenAnswer(inv -> {
+            PaymentTransaction pt = inv.getArgument(0);
+            ReflectionTestUtils.setField(pt, "id", PAYMENT_ID);
+            return pt;
+        });
+        when(historyRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(etaPort.fetchEta(any())).thenReturn(new EtaResult(Instant.now().plusSeconds(86400), 1440));
+
+        BookingResponse resp = service.book(bookingRequest(), IDEMPOTENCY_KEY, USER_ID);
+
+        // A single booking mints its own order of one and echoes the order ref.
+        assertThat(resp.getOrderRef()).isEqualTo("1DD-ORD-BLR-20260530-00007");
+        assertThat(savedShipment.getValue().getOrderId()).isEqualTo(orderId);
+        verify(orderService).addShipment(orderId, 4720L);
+    }
+
+    @Test
+    void bookSettled_attachesToProvidedOrder_withoutCreatingOne() {
+        stubServiceability(true, DeliveryType.INTERCITY);
+        stubPricing(4000L, 720L, 4720L);
+        when(shipmentRefService.generateRef(anyString())).thenReturn(SHIPMENT_REF);
+        UUID cartOrderId = UUID.randomUUID();
+        ArgumentCaptor<Shipment> savedShipment = ArgumentCaptor.forClass(Shipment.class);
+        when(shipmentRepository.save(savedShipment.capture())).thenAnswer(inv -> {
+            Shipment s = inv.getArgument(0);
+            ReflectionTestUtils.setField(s, "id", SHIPMENT_ID);
+            return s;
+        });
+        when(historyRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(etaPort.fetchEta(any())).thenReturn(new EtaResult(Instant.now().plusSeconds(86400), 1440));
+
+        service.bookSettled(bookingRequest(), IDEMPOTENCY_KEY, USER_ID, CustomerType.B2C, cartOrderId);
+
+        // Cart path uses the shared order — no new order minted, shipment attaches to it.
+        verify(orderService, never()).createOrder(any(), any(), anyString(), anyString(), any());
+        assertThat(savedShipment.getValue().getOrderId()).isEqualTo(cartOrderId);
+        verify(orderService).addShipment(cartOrderId, 4720L);
     }
 
     @Test

--- a/orders/src/test/java/com/oneday/orders/service/impl/OrderRefServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/OrderRefServiceImplTest.java
@@ -1,0 +1,42 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.domain.OrderRefCounter;
+import com.oneday.orders.domain.OrderRefCounterId;
+import com.oneday.orders.repository.OrderRefCounterRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OrderRefServiceImplTest {
+
+    @Mock private OrderRefCounterRepository counterRepository;
+
+    @Test
+    void generateRef_formatsAndIncrements() {
+        OrderRefServiceImpl service = new OrderRefServiceImpl(counterRepository);
+        OrderRefCounter counter = new OrderRefCounter();
+        counter.setNextVal(41);
+        when(counterRepository.findByIdWithLock(any(OrderRefCounterId.class))).thenReturn(Optional.of(counter));
+
+        String ref = service.generateRef("blr");   // lower-case in → upper-case out
+
+        String today = LocalDate.now(ZoneId.of("Asia/Kolkata")).format(DateTimeFormatter.BASIC_ISO_DATE);
+        assertThat(ref).isEqualTo("1DD-ORD-BLR-" + today + "-00042");
+        assertThat(counter.getNextVal()).isEqualTo(42);
+        verify(counterRepository).insertIfAbsent(eq("BLR"), any(LocalDate.class));
+        verify(counterRepository).save(counter);
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/service/impl/OrderServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/OrderServiceImplTest.java
@@ -1,0 +1,61 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.enums.CustomerType;
+import com.oneday.orders.domain.ParcelOrder;
+import com.oneday.orders.repository.ParcelOrderRepository;
+import com.oneday.orders.service.OrderRefService;
+import com.oneday.orders.service.OrderService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceImplTest {
+
+    @Mock private OrderRefService orderRefService;
+    @Mock private ParcelOrderRepository parcelOrderRepository;
+
+    @Test
+    void createOrder_mintsRefAndPersistsEmptyOrder() {
+        OrderServiceImpl service = new OrderServiceImpl(orderRefService, parcelOrderRepository);
+        UUID accountId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        when(orderRefService.generateRef("BLR")).thenReturn("1DD-ORD-BLR-20260824-00001");
+        when(parcelOrderRepository.save(any(ParcelOrder.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        OrderService.CreatedOrder created = service.createOrder(
+                CustomerType.B2B, accountId, userId.toString(), "blr", "PO-42");
+
+        ArgumentCaptor<ParcelOrder> captor = ArgumentCaptor.forClass(ParcelOrder.class);
+        verify(parcelOrderRepository).save(captor.capture());
+        ParcelOrder saved = captor.getValue();
+        assertThat(saved.getOrderRef()).isEqualTo("1DD-ORD-BLR-20260824-00001");
+        assertThat(saved.getCustomerType()).isEqualTo(CustomerType.B2B);
+        assertThat(saved.getB2bAccountId()).isEqualTo(accountId);
+        assertThat(saved.getBookedByUserId()).isEqualTo(userId);
+        assertThat(saved.getPurchaseOrderRef()).isEqualTo("PO-42");
+        assertThat(saved.getParcelCount()).isZero();
+        assertThat(saved.getTotalPricePaise()).isZero();
+        assertThat(saved.getCityId()).isEqualTo("BLR");
+        assertThat(created.orderRef()).isEqualTo("1DD-ORD-BLR-20260824-00001");
+    }
+
+    @Test
+    void addShipment_delegatesAtomicIncrement() {
+        OrderServiceImpl service = new OrderServiceImpl(orderRefService, parcelOrderRepository);
+        UUID orderId = UUID.randomUUID();
+
+        service.addShipment(orderId, 4720L);
+
+        verify(parcelOrderRepository).addShipment(orderId, 4720L);
+    }
+}


### PR DESCRIPTION
## What & why

A merchant's bulk booking should be **one order of many parcels**, not N unrelated shipments. Today the platform's atomic unit is `Shipment` (= one parcel) everywhere, and the only "bulk" mechanism is a **transient cart** that fans out to N independent shipments at checkout and is then **deleted** — the shipments carry no grouping, and there's no order entity, order ref, or `order_id`. (`B2bBookingRequest.purchaseOrderRef` was even accepted over the wire and silently dropped.)

This PR adds a durable **Order → N Shipments** parent and surfaces the grouping on the backend + both consoles.

## Changes

**Model**
- New `parcel_orders` table + `ParcelOrder` entity; nullable `shipments.order_id` (bare UUID, cross-module convention — no cross-module FK). Migration `V4_40`.
- `OrderRefService` / `OrderRefCounter` mint `1DD-ORD-{CITY}-{YYYYMMDD}-{NNNNN}`, mirroring the proven shipment-ref counter (`SELECT FOR UPDATE` per city+date).
- `OrderService.createOrder` + an **atomic** `addShipment` rollup (`parcel_count`, `total_price_paise`).

**Booking — every booking becomes an order**
- Single B2C/C2C and B2B bookings mint their own order of one.
- Cart checkout mints **one** order and attaches every fanned-out shipment to it (order committed before the fan-out loop, so each item's own transaction folds into the rollup atomically).
- B2B order finally persists the merchant's `purchaseOrderRef`.
- `BookingResponse.orderRef` + `CartCheckoutResponse.orderRef` echo the parent.

**Read side — "one order, click to expand N shipments"**
- Customer: `GET /api/v1/orders/mine`, `GET /api/v1/orders/mine/{orderRef}`.
- Business/admin: `GET /api/v1/admin/orders`, `GET /api/v1/admin/orders/{orderRef}` (ADMIN → all cities; STATION_MANAGER → their origin city).
- `OrderStatusReducer` reduces child shipment states to one order status (`BOOKED` / `IN_PROGRESS` / `PARTIALLY_DELIVERED` / `DELIVERED` / `RETURNED` / `CANCELLED` / `MIXED`), reused by every console. Child states fetched in **one** bulk query per page (no N+1).

## Design notes
- An order is a **booking grouping, not a routing unit** — its parcels may ride different flights / delivery DAs. `parcel_count` / `total` are a denormalized rollup.
- Billing unchanged (still per-shipment); the order is a display + grouping layer in v1.

## Testing
- New unit tests: `OrderStatusReducerTest`, `OrderRefServiceImplTest`, `OrderServiceImplTest`, plus booking attach/rollup + cart-shared-order behaviour in the existing booking tests.
- **Full non-e2e orders suite green (112 tests).** `@Tag("e2e")` tests need a real Postgres and are excluded in CI (they currently can't run on the local DB due to a pre-existing `V4_37` Flyway-history inconsistency, unrelated to this PR).
- `V4_40` validated against real Postgres 16 (applies cleanly; `customer_type` enum + `order_id` column verified in a rolled-back transaction).
- Full reactor assembles (`mvn clean install`).

## Follow-up (separate PR)
Driver-app **dispatch queue grouping by (order, location)** — the "one order card → N parcels, grouped per stop" view for the DA app. Deferred because it needs a `ShipmentCreatedEvent` contract change (add order id/ref) + a `dispatch_queue` migration + the dispatch lifecycle to E2E, which is a cohesive second slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added order tracking with human-readable order references.
  * Customers can view their orders and detailed shipment information.
  * Administrators and station managers can browse paginated orders and view details with appropriate city access.
  * Cart checkout now groups shipments under a single order and returns its reference.
  * Booking responses include the associated order reference when applicable.
  * Order summaries show shipment-based statuses, pricing, parcel counts, and purchase-order details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->