### PR TITLE
feat(dispatch): carry parent order onto DA tasks for stop grouping

### DIFF
--- a/common/src/main/java/com/oneday/common/kafka/events/ShipmentCreatedEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/ShipmentCreatedEvent.java
@@ -48,4 +48,10 @@ public class ShipmentCreatedEvent extends BaseShipmentEvent {
     // Scheduled pickup window (null = ASAP). M5 holds the order until ~60 min before the start.
     private Instant scheduledPickupStart;
     private Instant scheduledPickupEnd;
+
+    // Order grouping (M4 Order → N shipments): the parent order this shipment belongs to. Carried so M5
+    // denormalises it onto dispatch_queue and the DA app can collapse same-order/same-location tasks into
+    // one stop. Null on legacy shipments booked before the Order abstraction.
+    private UUID orderId;
+    private String orderRef;
 }

--- a/common/src/main/java/com/oneday/common/kafka/events/ShipmentStateChangedEvent.java
+++ b/common/src/main/java/com/oneday/common/kafka/events/ShipmentStateChangedEvent.java
@@ -30,4 +30,9 @@ public class ShipmentStateChangedEvent extends BaseShipmentEvent {
     private Double destLon;
     private UUID destTileId;
     private DropType dropType;
+
+    // Order grouping — populated alongside the dest data on HANDED_TO_DROP_VAN so M5 can carry the parent
+    // order onto the DELIVERY dispatch task (lets the DA app collapse same-order/same-location drops).
+    private UUID orderId;
+    private String orderRef;
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/domain/DeferredDispatch.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/domain/DeferredDispatch.java
@@ -27,6 +27,13 @@ public class DeferredDispatch extends MutableBaseEntity {
     @Column(name = "shipment_id", nullable = false, updatable = false)
     private UUID shipmentId;
 
+    // Parent order carried through the defer so a retried pickup still groups with its siblings (M4 Order → N).
+    @Column(name = "order_id", updatable = false)
+    private UUID orderId;
+
+    @Column(name = "order_ref", length = 30, updatable = false)
+    private String orderRef;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "task_type", nullable = false, updatable = false, length = 20)
     private TaskType taskType;

--- a/dispatch/src/main/java/com/oneday/dispatch/domain/DispatchQueue.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/domain/DispatchQueue.java
@@ -35,6 +35,15 @@ public class DispatchQueue extends MutableBaseEntity {
     @Column(name = "shipment_id", nullable = false, updatable = false)
     private UUID shipmentId;
 
+    // Parent order (M4 Order → N shipments), denormalised at assignment. Nullable for legacy/pre-Order
+    // tasks. Lets the DA app collapse same-order tasks at one location into a single stop. order_ref is
+    // display-only. Immutable once assigned, like shipmentId.
+    @Column(name = "order_id", updatable = false)
+    private UUID orderId;
+
+    @Column(name = "order_ref", length = 30, updatable = false)
+    private String orderRef;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "task_type", nullable = false, updatable = false, length = 20)
     private TaskType taskType;

--- a/dispatch/src/main/java/com/oneday/dispatch/domain/ScheduledPickup.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/domain/ScheduledPickup.java
@@ -26,6 +26,13 @@ public class ScheduledPickup extends MutableBaseEntity {
     @Column(name = "shipment_id", nullable = false, updatable = false)
     private UUID shipmentId;
 
+    // Parent order carried through the hold so the released pickup groups with its siblings (M4 Order → N).
+    @Column(name = "order_id", updatable = false)
+    private UUID orderId;
+
+    @Column(name = "order_ref", length = 30, updatable = false)
+    private String orderRef;
+
     @Column(name = "city_id", nullable = false, updatable = false)
     private UUID cityId;
 

--- a/dispatch/src/main/java/com/oneday/dispatch/events/HubDeliveryFeedConsumer.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/events/HubDeliveryFeedConsumer.java
@@ -84,8 +84,11 @@ public class HubDeliveryFeedConsumer {
                     e.parcelId(), e.destinationHexId(), e.validDate());
             return;
         }
+        // Order grouping: the hub event carries no parent order, so HUB_RETURN deliveries assign with a
+        // null order (rendered as singleton stops). The primary VAN_MEETING delivery path groups via the
+        // HANDED_TO_DROP_VAN event; enrich ParcelSortedForDeliveryEvent with the order to group these too.
         AssignmentResult result = dispatchService.assignDelivery(
-                e.parcelId(), e.cityId(), coords[0], coords[1], e.destinationHexId());
+                e.parcelId(), e.cityId(), coords[0], coords[1], e.destinationHexId(), null, null);
         log.debug("HUB_RETURN delivery assignment for parcel {}: {}", e.parcelId(), result.outcome());
     }
 

--- a/dispatch/src/main/java/com/oneday/dispatch/events/ShipmentEventsConsumer.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/events/ShipmentEventsConsumer.java
@@ -124,13 +124,15 @@ public class ShipmentEventsConsumer {
         // Scheduled / off-hours pickups wait out of the queue until ~60 min before their slot; the
         // release job then assigns them. Only assign now if the order is already due.
         if (scheduledPickupService.holdIfNotDue(shipmentId, loc.cityId(), tileId, lat, lon, paymentMode,
-                event.getScheduledPickupStart(), event.getScheduledPickupEnd())) {
+                event.getScheduledPickupStart(), event.getScheduledPickupEnd(),
+                event.getOrderId(), event.getOrderRef())) {
             log.debug("Shipment {} held for scheduled pickup (not yet due)", shipmentId);
             return;
         }
 
         AssignmentResult result = dispatchService.assignPickup(
-                shipmentId, loc.cityId(), lat, lon, tileId, paymentMode);
+                shipmentId, loc.cityId(), lat, lon, tileId, paymentMode,
+                event.getOrderId(), event.getOrderRef());
         log.debug("Pickup assignment for shipment {}: {}", shipmentId, result.outcome());
     }
 
@@ -165,7 +167,8 @@ public class ShipmentEventsConsumer {
             return;
         }
         UUID tileId = event.getDestTileId() != null ? event.getDestTileId() : loc.hexId();
-        AssignmentResult result = dispatchService.assignDelivery(shipmentId, loc.cityId(), lat, lon, tileId);
+        AssignmentResult result = dispatchService.assignDelivery(shipmentId, loc.cityId(), lat, lon, tileId,
+                event.getOrderId(), event.getOrderRef());
         log.debug("Delivery assignment for shipment {}: {}", shipmentId, result.outcome());
     }
 

--- a/dispatch/src/main/java/com/oneday/dispatch/service/DaTaskView.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/DaTaskView.java
@@ -22,6 +22,8 @@ public record DaTaskView(
         UUID taskId,
         UUID shipmentId,
         String shipmentRef,
+        UUID orderId,
+        String orderRef,
         TaskType taskType,
         TaskStatus status,
         int queuePosition,
@@ -41,7 +43,8 @@ public record DaTaskView(
     }
 
     public static DaTaskView of(DispatchQueue row, String shipmentRef) {
-        return new DaTaskView(row.getId(), row.getShipmentId(), shipmentRef, row.getTaskType(),
+        return new DaTaskView(row.getId(), row.getShipmentId(), shipmentRef,
+                row.getOrderId(), row.getOrderRef(), row.getTaskType(),
                 row.getStatus(), row.getQueuePosition(), row.getExpectedEta(),
                 row.getTaskLat(), row.getTaskLon(), row.getPaymentMode(),
                 null, null, null, null, row.isPickedUp());
@@ -54,7 +57,8 @@ public record DaTaskView(
         String phone = c == null ? null : pickup ? c.senderPhone() : c.receiverPhone();
         String addr = c == null ? null : pickup ? c.originAddress() : c.destAddress();
         Long cod = c == null ? null : c.codAmountPaise();
-        return new DaTaskView(row.getId(), row.getShipmentId(), shipmentRef, row.getTaskType(),
+        return new DaTaskView(row.getId(), row.getShipmentId(), shipmentRef,
+                row.getOrderId(), row.getOrderRef(), row.getTaskType(),
                 row.getStatus(), row.getQueuePosition(), row.getExpectedEta(),
                 row.getTaskLat(), row.getTaskLon(), row.getPaymentMode(),
                 name, phone, addr, cod, row.isPickedUp());

--- a/dispatch/src/main/java/com/oneday/dispatch/service/DispatchService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/DispatchService.java
@@ -14,13 +14,19 @@ public interface DispatchService {
 
     /**
      * Assign a first-mile pickup. {@code originTileId} may be null (resolved from {@code lat/lon} via
-     * M3); {@code paymentMode} is stored for COD-aware handling and may be null.
+     * M3); {@code paymentMode} is stored for COD-aware handling and may be null. {@code orderId}/
+     * {@code orderRef} are the parent order (M4 Order → N shipments), denormalised onto the task so the
+     * DA app can group same-order/same-location tasks; both null for legacy/pre-Order shipments.
      */
     AssignmentResult assignPickup(UUID shipmentId, UUID cityId, double lat, double lon,
-                                  UUID originTileId, String paymentMode);
+                                  UUID originTileId, String paymentMode, UUID orderId, String orderRef);
 
-    /** Assign a last-mile delivery. {@code destTileId} may be null (resolved from {@code lat/lon}). */
-    AssignmentResult assignDelivery(UUID shipmentId, UUID cityId, double lat, double lon, UUID destTileId);
+    /**
+     * Assign a last-mile delivery. {@code destTileId} may be null (resolved from {@code lat/lon}).
+     * {@code orderId}/{@code orderRef} carry the parent order for stop grouping (both may be null).
+     */
+    AssignmentResult assignDelivery(UUID shipmentId, UUID cityId, double lat, double lon, UUID destTileId,
+                                    UUID orderId, String orderRef);
 
     /**
      * Cancel a shipment's active task and resequence the DA's queue. A QUEUED task is simply removed.

--- a/dispatch/src/main/java/com/oneday/dispatch/service/ScheduledPickupService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/ScheduledPickupService.java
@@ -10,10 +10,12 @@ public interface ScheduledPickupService {
      * Decide whether an incoming pickup should wait. If it has a future slot (or is an ASAP order booked
      * off-hours) a HELD row is created and {@code true} is returned; otherwise it is due now and
      * {@code false} is returned so the caller assigns immediately. {@code slotStart}/{@code slotEnd} are
-     * null for ASAP orders.
+     * null for ASAP orders. {@code orderId}/{@code orderRef} carry the parent order (M4 Order → N
+     * shipments) so a released bulk pickup still groups with its siblings; both may be null.
      */
     boolean holdIfNotDue(UUID shipmentId, UUID cityId, UUID tileId, double lat, double lon,
-                         String paymentMode, Instant slotStart, Instant slotEnd);
+                         String paymentMode, Instant slotStart, Instant slotEnd,
+                         UUID orderId, String orderRef);
 
     /** Cancel a live HELD hold for a shipment (it was cancelled while waiting). No-op if none. */
     void cancel(UUID shipmentId);

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DispatchServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DispatchServiceImpl.java
@@ -107,16 +107,19 @@ class DispatchServiceImpl implements DispatchService {
     @Override
     @Transactional
     public AssignmentResult assignPickup(UUID shipmentId, UUID cityId, double lat, double lon,
-                                         UUID originTileId, String paymentMode) {
+                                         UUID originTileId, String paymentMode, UUID orderId, String orderRef) {
         return tracked(shipmentId, cityId,
-                () -> assign(new Request(shipmentId, cityId, TaskType.PICKUP, lat, lon, originTileId, paymentMode), true));
+                () -> assign(new Request(shipmentId, cityId, TaskType.PICKUP, lat, lon, originTileId,
+                        paymentMode, orderId, orderRef), true));
     }
 
     @Override
     @Transactional
-    public AssignmentResult assignDelivery(UUID shipmentId, UUID cityId, double lat, double lon, UUID destTileId) {
+    public AssignmentResult assignDelivery(UUID shipmentId, UUID cityId, double lat, double lon, UUID destTileId,
+                                           UUID orderId, String orderRef) {
         return tracked(shipmentId, cityId,
-                () -> assign(new Request(shipmentId, cityId, TaskType.DELIVERY, lat, lon, destTileId, null), true));
+                () -> assign(new Request(shipmentId, cityId, TaskType.DELIVERY, lat, lon, destTileId,
+                        null, orderId, orderRef), true));
     }
 
     /** Wrap an assignment in MDC (shipment/city correlation) + record its outcome (metric + audit line). */
@@ -183,7 +186,7 @@ class DispatchServiceImpl implements DispatchService {
         // paymentMode is not carried on the deferred row → null on retry (COD prioritisation is later).
         AssignmentResult result = assign(new Request(deferred.getShipmentId(), deferred.getCityId(),
                 deferred.getTaskType(), deferred.getTaskLat(), deferred.getTaskLon(),
-                deferred.getTileId(), null), false);
+                deferred.getTileId(), null, deferred.getOrderId(), deferred.getOrderRef()), false);
         if (result.outcome() != com.oneday.dispatch.service.AssignmentOutcome.DEFERRED) {
             deferred.setStatus("ASSIGNED");
             deferred.setAssignedAt(Instant.now());
@@ -342,6 +345,8 @@ class DispatchServiceImpl implements DispatchService {
             DeferredDispatch d = new DeferredDispatch();
             d.setCityId(req.cityId());
             d.setShipmentId(req.shipmentId());
+            d.setOrderId(req.orderId());
+            d.setOrderRef(req.orderRef());
             d.setTaskType(req.taskType());
             d.setTileId(tileId);
             d.setTaskLat(req.lat());
@@ -370,7 +375,8 @@ class DispatchServiceImpl implements DispatchService {
         }
 
         Request req = new Request(deferred.getShipmentId(), deferred.getCityId(), deferred.getTaskType(),
-                deferred.getTaskLat(), deferred.getTaskLon(), deferred.getTileId(), null);
+                deferred.getTaskLat(), deferred.getTaskLon(), deferred.getTileId(), null,
+                deferred.getOrderId(), deferred.getOrderRef());
         Optional<AssignmentResult> result = daStatusService.withDaLock(daId,
                 () -> attemptOnDa(daId, req, deferred.getTileId(), deferred.getOperatingDate(), false, true));
 
@@ -456,6 +462,8 @@ class DispatchServiceImpl implements DispatchService {
         row.setDaId(daId);
         row.setCityId(req.cityId());
         row.setShipmentId(req.shipmentId());
+        row.setOrderId(req.orderId());
+        row.setOrderRef(req.orderRef());
         row.setTaskType(req.taskType());
         row.setTaskLat(req.lat());
         row.setTaskLon(req.lon());
@@ -551,5 +559,5 @@ class DispatchServiceImpl implements DispatchService {
 
     /** Immutable bundle of one assignment request's inputs. */
     private record Request(UUID shipmentId, UUID cityId, TaskType taskType, double lat, double lon,
-                           UUID tileId, String paymentMode) {}
+                           UUID tileId, String paymentMode, UUID orderId, String orderRef) {}
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/ScheduledPickupServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/ScheduledPickupServiceImpl.java
@@ -37,7 +37,8 @@ class ScheduledPickupServiceImpl implements ScheduledPickupService {
     @Override
     @Transactional
     public boolean holdIfNotDue(UUID shipmentId, UUID cityId, UUID tileId, double lat, double lon,
-                                String paymentMode, Instant slotStart, Instant slotEnd) {
+                                String paymentMode, Instant slotStart, Instant slotEnd,
+                                UUID orderId, String orderRef) {
         Instant now = Instant.now();
         Instant releaseAt = slotStart != null
                 ? slotStart.minus(props.getPickup().getReleaseLeadMinutes(), ChronoUnit.MINUTES)
@@ -52,6 +53,8 @@ class ScheduledPickupServiceImpl implements ScheduledPickupService {
         }
         ScheduledPickup sp = new ScheduledPickup();
         sp.setShipmentId(shipmentId);
+        sp.setOrderId(orderId);
+        sp.setOrderRef(orderRef);
         sp.setCityId(cityId);
         sp.setTileId(tileId);
         sp.setPickupLat(lat);
@@ -82,7 +85,8 @@ class ScheduledPickupServiceImpl implements ScheduledPickupService {
         List<ScheduledPickup> due = repository.findByStatusAndReleaseAtLessThanEqual(HELD, now);
         for (ScheduledPickup sp : due) {
             dispatchService.assignPickup(sp.getShipmentId(), sp.getCityId(),
-                    sp.getPickupLat(), sp.getPickupLon(), sp.getTileId(), sp.getPaymentMode());
+                    sp.getPickupLat(), sp.getPickupLon(), sp.getTileId(), sp.getPaymentMode(),
+                    sp.getOrderId(), sp.getOrderRef());
             sp.setStatus("RELEASED");
             sp.setReleasedAt(now);
         }

--- a/dispatch/src/main/resources/db/migration/dispatch/V5_13__add_order_id.sql
+++ b/dispatch/src/main/resources/db/migration/dispatch/V5_13__add_order_id.sql
@@ -1,0 +1,15 @@
+-- M4 Order → N shipments: denormalise the parent order onto every dispatch task so the DA app can
+-- collapse same-order/same-location pickups (or drops) into a single stop card, without dispatch having
+-- to query the orders module. Bare UUID + display ref, cross-module convention (no FK). Both nullable —
+-- legacy tasks and shipments booked before the Order abstraction carry null (rendered as singleton stops).
+ALTER TABLE dispatch_queue  ADD COLUMN order_id UUID;
+ALTER TABLE dispatch_queue  ADD COLUMN order_ref VARCHAR(30);
+CREATE INDEX idx_dispatch_queue_order_id ON dispatch_queue (order_id);
+
+-- Carry the same order through the hold-then-release path so scheduled/off-hours bulk pickups group too.
+ALTER TABLE scheduled_pickup ADD COLUMN order_id UUID;
+ALTER TABLE scheduled_pickup ADD COLUMN order_ref VARCHAR(30);
+
+-- ...and through the defer-then-retry path so a bulk order that briefly defers still groups on assignment.
+ALTER TABLE deferred_dispatch ADD COLUMN order_id UUID;
+ALTER TABLE deferred_dispatch ADD COLUMN order_ref VARCHAR(30);

--- a/dispatch/src/test/java/com/oneday/dispatch/api/DaDispatchControllerTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/api/DaDispatchControllerTest.java
@@ -119,7 +119,8 @@ class DaDispatchControllerTest {
     }
 
     private DaTaskView sampleView() {
-        return new DaTaskView(taskId, UUID.randomUUID(), "1DD-BLR-20260716-00001", TaskType.PICKUP,
+        return new DaTaskView(taskId, UUID.randomUUID(), "1DD-BLR-20260716-00001",
+                UUID.randomUUID(), "1DD-ORD-BLR-20260716-00001", TaskType.PICKUP,
                 TaskStatus.IN_PROGRESS, 0, null, 12.9716, 77.5946, "PREPAID",
                 "Asha Rao", "+919000000001", "12, MG Road, Bengaluru, 560001", null, false);
     }

--- a/dispatch/src/test/java/com/oneday/dispatch/events/ShipmentEventsConsumerTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/events/ShipmentEventsConsumerTest.java
@@ -46,6 +46,8 @@ class ShipmentEventsConsumerTest {
     private final UUID cityId = UUID.randomUUID();
     private final UUID tileId = UUID.randomUUID();
     private final UUID hexFromCoords = UUID.randomUUID();
+    private final UUID orderId = UUID.randomUUID();
+    private final String orderRef = "1DD-ORD-BLR-20260824-00001";
 
     @BeforeEach
     void setUp() {
@@ -59,7 +61,7 @@ class ShipmentEventsConsumerTest {
                 .thenReturn(Optional.empty());
         lenient().when(gridService.serviceableAt(anyDouble(), anyDouble()))
                 .thenReturn(new ServiceableAtResponse(true, "bengaluru", cityId, hexFromCoords, "h3idx"));
-        lenient().when(dispatchService.assignPickup(any(), any(), anyDouble(), anyDouble(), any(), any()))
+        lenient().when(dispatchService.assignPickup(any(), any(), anyDouble(), anyDouble(), any(), any(), any(), any()))
                 .thenReturn(AssignmentResult.assigned(UUID.randomUUID(), 0));
     }
 
@@ -68,19 +70,34 @@ class ShipmentEventsConsumerTest {
         UUID shipment = UUID.randomUUID();
         consumer.onShipmentEvent(created(shipment, PickupType.DA_PICKUP, 12.97, 77.61, tileId, PaymentMode.PREPAID));
 
-        verify(dispatchService).assignPickup(eq(shipment), eq(cityId), eq(12.97), eq(77.61), eq(tileId), eq("PREPAID"));
+        // The parent order (orderId/orderRef) rides through to the assignment so the DA app can group stops.
+        verify(dispatchService).assignPickup(eq(shipment), eq(cityId), eq(12.97), eq(77.61), eq(tileId),
+                eq("PREPAID"), eq(orderId), eq(orderRef));
     }
 
     @Test
     void scheduledPickupIsHeldNotAssigned() {
         UUID shipment = UUID.randomUUID();
         // The hold service parks it (not yet due) → the consumer must NOT assign.
-        when(scheduledPickupService.holdIfNotDue(eq(shipment), any(), any(), anyDouble(), anyDouble(), any(), any(), any()))
+        when(scheduledPickupService.holdIfNotDue(eq(shipment), any(), any(), anyDouble(), anyDouble(), any(), any(), any(), any(), any()))
                 .thenReturn(true);
 
         consumer.onShipmentEvent(created(shipment, PickupType.DA_PICKUP, 12.97, 77.61, tileId, PaymentMode.PREPAID));
 
-        verify(dispatchService, never()).assignPickup(any(), any(), anyDouble(), anyDouble(), any(), any());
+        verify(dispatchService, never()).assignPickup(any(), any(), anyDouble(), anyDouble(), any(), any(), any(), any());
+    }
+
+    @Test
+    void scheduledPickupHoldReceivesParentOrder() {
+        UUID shipment = UUID.randomUUID();
+        when(scheduledPickupService.holdIfNotDue(any(), any(), any(), anyDouble(), anyDouble(), any(), any(), any(), any(), any()))
+                .thenReturn(true);
+
+        consumer.onShipmentEvent(created(shipment, PickupType.DA_PICKUP, 12.97, 77.61, tileId, PaymentMode.PREPAID));
+
+        // A held bulk pickup must carry its order so it still groups with its siblings on release.
+        verify(scheduledPickupService).holdIfNotDue(eq(shipment), eq(cityId), eq(tileId), eq(12.97), eq(77.61),
+                eq("PREPAID"), any(), any(), eq(orderId), eq(orderRef));
     }
 
     @Test
@@ -97,13 +114,13 @@ class ShipmentEventsConsumerTest {
 
         consumer.onShipmentEvent(created(shipment, PickupType.DA_PICKUP, 12.97, 77.61, tileId, PaymentMode.PREPAID));
 
-        verify(dispatchService, never()).assignPickup(any(), any(), anyDouble(), anyDouble(), any(), any());
+        verify(dispatchService, never()).assignPickup(any(), any(), anyDouble(), anyDouble(), any(), any(), any(), any());
     }
 
     @Test
     void missingCoordinatesAreNotAssigned() {
         consumer.onShipmentEvent(created(UUID.randomUUID(), PickupType.DA_PICKUP, null, null, tileId, PaymentMode.COD));
-        verify(dispatchService, never()).assignPickup(any(), any(), anyDouble(), anyDouble(), any(), any());
+        verify(dispatchService, never()).assignPickup(any(), any(), anyDouble(), anyDouble(), any(), any(), any(), any());
     }
 
     @Test
@@ -113,7 +130,7 @@ class ShipmentEventsConsumerTest {
 
         consumer.onShipmentEvent(created(UUID.randomUUID(), PickupType.DA_PICKUP, 0.0, 0.0, tileId, PaymentMode.PREPAID));
 
-        verify(dispatchService, never()).assignPickup(any(), any(), anyDouble(), anyDouble(), any(), any());
+        verify(dispatchService, never()).assignPickup(any(), any(), anyDouble(), anyDouble(), any(), any(), any(), any());
     }
 
     @Test
@@ -121,7 +138,8 @@ class ShipmentEventsConsumerTest {
         UUID shipment = UUID.randomUUID();
         consumer.onShipmentEvent(created(shipment, PickupType.DA_PICKUP, 12.97, 77.61, null, PaymentMode.PREPAID));
 
-        verify(dispatchService).assignPickup(eq(shipment), eq(cityId), eq(12.97), eq(77.61), eq(hexFromCoords), eq("PREPAID"));
+        verify(dispatchService).assignPickup(eq(shipment), eq(cityId), eq(12.97), eq(77.61), eq(hexFromCoords),
+                eq("PREPAID"), eq(orderId), eq(orderRef));
     }
 
     @Test
@@ -157,7 +175,7 @@ class ShipmentEventsConsumerTest {
 
         consumer.onShipmentEvent(e);
 
-        verify(dispatchService, never()).assignDelivery(any(), any(), anyDouble(), anyDouble(), any());
+        verify(dispatchService, never()).assignDelivery(any(), any(), anyDouble(), anyDouble(), any(), any(), any());
     }
 
     private ShipmentCancelledEvent cancelled(UUID shipmentId, ShipmentState at) {
@@ -178,6 +196,8 @@ class ShipmentEventsConsumerTest {
         e.setOriginLon(lon);
         e.setOriginTileId(originTileId);
         e.setPaymentMode(paymentMode);
+        e.setOrderId(orderId);
+        e.setOrderRef(orderRef);
         return e;
     }
 }

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaTaskServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaTaskServiceImplTest.java
@@ -95,6 +95,32 @@ class DaTaskServiceImplTest {
     }
 
     @Test
+    void listTasksSurfacesParentOrder() {
+        // The denormalised order (id + ref) persists on the task and flows onto DaTaskView so the DA app
+        // can collapse same-order/same-location tasks into one stop. V5_13 adds the columns.
+        UUID orderId = UUID.randomUUID();
+        DispatchQueue d = new DispatchQueue();   // order_id is updatable=false → set before first insert
+        d.setDaId(da);
+        d.setCityId(city);
+        d.setShipmentId(UUID.randomUUID());
+        d.setOrderId(orderId);
+        d.setOrderRef("1DD-ORD-BLR-20260824-00001");
+        d.setTaskType(TaskType.PICKUP);
+        d.setTaskLat(12.97);
+        d.setTaskLon(77.61);
+        d.setTileId(tile);
+        d.setQueuePosition(0);
+        d.setStatus(TaskStatus.QUEUED);
+        d.setCronSafe(true);
+        d.setOperatingDate(today);
+        queueRepo.saveAndFlush(d);
+
+        DaTaskView v = service.listTasks(da, today).get(0);
+        assertThat(v.orderId()).isEqualTo(orderId);
+        assertThat(v.orderRef()).isEqualTo("1DD-ORD-BLR-20260824-00001");
+    }
+
+    @Test
     void enRouteOnWrongStatusIs409() {
         DispatchQueue task = persist(TaskType.PICKUP, TaskStatus.IN_PROGRESS);
         assertThatThrownBy(() -> service.markEnRoute(da, task.getId()))

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/DispatchServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/DispatchServiceImplTest.java
@@ -117,7 +117,7 @@ class DispatchServiceImplTest {
         feasibleAt(0);
         UUID shipment = UUID.randomUUID();
 
-        AssignmentResult r = service.assignPickup(shipment, city, 12.98, 77.62, tile, "PREPAID");
+        AssignmentResult r = service.assignPickup(shipment, city, 12.98, 77.62, tile, "PREPAID", null, null);
 
         assertThat(r.outcome()).isEqualTo(AssignmentOutcome.ASSIGNED);
         assertThat(r.daId()).isEqualTo(da);
@@ -132,7 +132,7 @@ class DispatchServiceImplTest {
         UUID idle = readyDa(0);
         feasibleAt(0);
 
-        AssignmentResult r = service.assignPickup(UUID.randomUUID(), city, 12.98, 77.62, tile, null);
+        AssignmentResult r = service.assignPickup(UUID.randomUUID(), city, 12.98, 77.62, tile, null, null, null);
 
         assertThat(r.daId()).isEqualTo(idle);
         assertThat(r.daId()).isNotEqualTo(busy);
@@ -147,7 +147,7 @@ class DispatchServiceImplTest {
         persistCron(da, CronAssignmentStatus.SCHEDULED, Instant.now().plus(3, ChronoUnit.HOURS));
 
         UUID shipment = UUID.randomUUID();
-        AssignmentResult r = service.assignPickup(shipment, city, 12.98, 77.62, tile, null);
+        AssignmentResult r = service.assignPickup(shipment, city, 12.98, 77.62, tile, null, null, null);
 
         assertThat(r.queuePosition()).isEqualTo(1);
         List<DispatchQueue> queue = queueRepo.findByDaIdAndOperatingDateOrderByQueuePosition(da, today);
@@ -158,7 +158,7 @@ class DispatchServiceImplTest {
 
     @Test
     void defersWhenNoDaServesTile() {
-        AssignmentResult r = service.assignPickup(UUID.randomUUID(), city, 12.98, 77.62, tile, null);
+        AssignmentResult r = service.assignPickup(UUID.randomUUID(), city, 12.98, 77.62, tile, null, null, null);
 
         assertThat(r.outcome()).isEqualTo(AssignmentOutcome.DEFERRED);
         assertThat(r.deferReason()).isEqualTo(com.oneday.dispatch.domain.DeferReason.NO_DA_AVAILABLE);
@@ -171,7 +171,7 @@ class DispatchServiceImplTest {
         daStatus.updateStatus(da, DaStatusEnum.CRON_LOCKED);
         persistCron(da, CronAssignmentStatus.SCHEDULED, Instant.now().plus(20, ChronoUnit.MINUTES));
 
-        AssignmentResult r = service.assignPickup(UUID.randomUUID(), city, 12.98, 77.62, tile, null);
+        AssignmentResult r = service.assignPickup(UUID.randomUUID(), city, 12.98, 77.62, tile, null, null, null);
 
         assertThat(r.outcome()).isEqualTo(AssignmentOutcome.DEFERRED);
         assertThat(r.deferReason()).isEqualTo(com.oneday.dispatch.domain.DeferReason.CRON_LOCKED);
@@ -185,7 +185,7 @@ class DispatchServiceImplTest {
         when(feasibility.checkFeasibility(any()))
                 .thenReturn(new FeasibilityResult(false, 0, -100, 9999, false));
 
-        AssignmentResult r = service.assignPickup(UUID.randomUUID(), city, 12.98, 77.62, tile, null);
+        AssignmentResult r = service.assignPickup(UUID.randomUUID(), city, 12.98, 77.62, tile, null, null, null);
 
         assertThat(r.outcome()).isEqualTo(AssignmentOutcome.DEFERRED);
         assertThat(r.deferReason()).isEqualTo(com.oneday.dispatch.domain.DeferReason.CRON_INFEASIBLE);
@@ -196,7 +196,7 @@ class DispatchServiceImplTest {
         UUID da = readyDa(0);
         persistCron(da, CronAssignmentStatus.COMPLETED, Instant.now().minus(1, ChronoUnit.HOURS));
 
-        AssignmentResult r = service.assignPickup(UUID.randomUUID(), city, 12.98, 77.62, tile, null);
+        AssignmentResult r = service.assignPickup(UUID.randomUUID(), city, 12.98, 77.62, tile, null, null, null);
 
         assertThat(r.outcome()).isEqualTo(AssignmentOutcome.ASSIGNED);   // no cron gate post-handoff
     }
@@ -207,8 +207,8 @@ class DispatchServiceImplTest {
         feasibleAt(0);
         UUID keep = UUID.randomUUID();
         UUID drop = UUID.randomUUID();
-        service.assignPickup(keep, city, 12.98, 77.62, tile, null);
-        service.assignPickup(drop, city, 12.99, 77.63, tile, null);
+        service.assignPickup(keep, city, 12.98, 77.62, tile, null, null, null);
+        service.assignPickup(drop, city, 12.99, 77.63, tile, null, null, null);
 
         service.cancelTask(drop, TaskType.PICKUP);
 
@@ -241,7 +241,7 @@ class DispatchServiceImplTest {
         feasibleAt(0);
         // first attempt: no DA serves the tile yet → deferred
         daStatus.setTerritory(da, List.of());   // withdraw territory
-        AssignmentResult deferred = service.assignPickup(UUID.randomUUID(), city, 12.98, 77.62, tile, null);
+        AssignmentResult deferred = service.assignPickup(UUID.randomUUID(), city, 12.98, 77.62, tile, null, null, null);
         assertThat(deferred.outcome()).isEqualTo(AssignmentOutcome.DEFERRED);
 
         // now the DA serves the tile → retry succeeds
@@ -270,7 +270,7 @@ class DispatchServiceImplTest {
         when(adjacent.candidates(eq(city), eq(tile), any()))
                 .thenReturn(List.of(new AdjacentDaProvider.Candidate(neighbourDa, neighbourTile)));
 
-        AssignmentResult r = service.assignPickup(UUID.randomUUID(), city, 12.98, 77.62, tile, null);
+        AssignmentResult r = service.assignPickup(UUID.randomUUID(), city, 12.98, 77.62, tile, null, null, null);
 
         assertThat(r.outcome()).isEqualTo(AssignmentOutcome.CROSS_TERRITORY_ASSIGNED);
         assertThat(r.daId()).isEqualTo(neighbourDa);
@@ -285,7 +285,7 @@ class DispatchServiceImplTest {
         when(feasibility.checkFeasibility(any())).thenReturn(new FeasibilityResult(false, 0, -1, 1, false));
         when(loadScore.getLoadScore(any(), any())).thenThrow(new RuntimeException("M3 down"));
 
-        AssignmentResult r = service.assignPickup(UUID.randomUUID(), city, 12.98, 77.62, tile, null);
+        AssignmentResult r = service.assignPickup(UUID.randomUUID(), city, 12.98, 77.62, tile, null, null, null);
 
         assertThat(r.outcome()).isEqualTo(AssignmentOutcome.DEFERRED);   // skipped spill-over, didn't blow up
         assertThat(r.deferReason()).isEqualTo(com.oneday.dispatch.domain.DeferReason.CRON_INFEASIBLE);
@@ -299,7 +299,7 @@ class DispatchServiceImplTest {
         when(feasibility.checkFeasibility(any())).thenReturn(new FeasibilityResult(false, 0, -1, 1, false));
         when(loadScore.getLoadScore(eq(tile), any())).thenReturn(score(tile, 0.5));   // NOT overloaded
 
-        AssignmentResult r = service.assignPickup(UUID.randomUUID(), city, 12.98, 77.62, tile, null);
+        AssignmentResult r = service.assignPickup(UUID.randomUUID(), city, 12.98, 77.62, tile, null, null, null);
 
         assertThat(r.outcome()).isEqualTo(AssignmentOutcome.DEFERRED);
     }
@@ -314,7 +314,7 @@ class DispatchServiceImplTest {
         try {
             List<Callable<AssignmentResult>> jobs = IntStream.range(0, n)
                     .mapToObj(i -> (Callable<AssignmentResult>) () ->
-                            service.assignPickup(UUID.randomUUID(), city, 12.98, 77.62, tile, null))
+                            service.assignPickup(UUID.randomUUID(), city, 12.98, 77.62, tile, null, null, null))
                     .toList();
             List<Future<AssignmentResult>> done = pool.invokeAll(jobs);
             for (Future<AssignmentResult> f : done) {

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/ScheduledPickupServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/ScheduledPickupServiceImplTest.java
@@ -32,6 +32,8 @@ class ScheduledPickupServiceImplTest {
     private final UUID shipment = UUID.randomUUID();
     private final UUID city = UUID.randomUUID();
     private final UUID tile = UUID.randomUUID();
+    private final UUID orderId = UUID.randomUUID();
+    private final String orderRef = "1DD-ORD-BLR-20260824-00001";
 
     @BeforeEach
     void setUp() {
@@ -45,7 +47,8 @@ class ScheduledPickupServiceImplTest {
         Instant slotStart = Instant.now().plus(3, ChronoUnit.HOURS);
         Instant slotEnd = slotStart.plus(2, ChronoUnit.HOURS);
 
-        boolean held = service.holdIfNotDue(shipment, city, tile, 12.9, 77.6, "PREPAID", slotStart, slotEnd);
+        boolean held = service.holdIfNotDue(shipment, city, tile, 12.9, 77.6, "PREPAID", slotStart, slotEnd,
+                orderId, orderRef);
 
         assertThat(held).isTrue();
         ArgumentCaptor<ScheduledPickup> cap = ArgumentCaptor.forClass(ScheduledPickup.class);
@@ -54,13 +57,17 @@ class ScheduledPickupServiceImplTest {
         assertThat(cap.getValue().getReleaseAt())
                 .isCloseTo(slotStart.minus(60, ChronoUnit.MINUTES), within(1, ChronoUnit.SECONDS));
         assertThat(cap.getValue().getStatus()).isEqualTo("HELD");
+        // The parent order is stored on the hold so the released bulk pickup still groups with its siblings.
+        assertThat(cap.getValue().getOrderId()).isEqualTo(orderId);
+        assertThat(cap.getValue().getOrderRef()).isEqualTo(orderRef);
     }
 
     @Test
     void alreadyDueSlotIsNotHeld() {
         Instant slotStart = Instant.now().minus(1, ChronoUnit.HOURS);   // release_at is in the past
 
-        boolean held = service.holdIfNotDue(shipment, city, tile, 12.9, 77.6, "COD", slotStart, null);
+        boolean held = service.holdIfNotDue(shipment, city, tile, 12.9, 77.6, "COD", slotStart, null,
+                orderId, orderRef);
 
         assertThat(held).isFalse();
         verify(repo, never()).save(any());
@@ -75,13 +82,17 @@ class ScheduledPickupServiceImplTest {
         sp.setPickupLat(12.9);
         sp.setPickupLon(77.6);
         sp.setPaymentMode("PREPAID");
+        sp.setOrderId(orderId);
+        sp.setOrderRef(orderRef);
         sp.setStatus("HELD");
         when(repo.findByStatusAndReleaseAtLessThanEqual(eq("HELD"), any())).thenReturn(List.of(sp));
 
         int n = service.releaseDue();
 
         assertThat(n).isEqualTo(1);
-        verify(dispatchService).assignPickup(eq(shipment), eq(city), eq(12.9), eq(77.6), eq(tile), eq("PREPAID"));
+        // The release carries the held order through so the assigned pickup groups with its siblings.
+        verify(dispatchService).assignPickup(eq(shipment), eq(city), eq(12.9), eq(77.6), eq(tile), eq("PREPAID"),
+                eq(orderId), eq(orderRef));
         assertThat(sp.getStatus()).isEqualTo("RELEASED");
         assertThat(sp.getReleasedAt()).isNotNull();
     }

--- a/orders/src/main/java/com/oneday/orders/events/ShipmentEventProducer.java
+++ b/orders/src/main/java/com/oneday/orders/events/ShipmentEventProducer.java
@@ -8,6 +8,7 @@ import com.oneday.common.kafka.events.ShipmentCreatedEvent;
 import com.oneday.common.kafka.events.ShipmentStateChangedEvent;
 import com.oneday.common.domain.enums.ShipmentState;
 import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.repository.ParcelOrderRepository;
 import com.oneday.orders.repository.ShipmentRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,10 +40,21 @@ public class ShipmentEventProducer {
 
     private final EventPublisher eventPublisher;
     private final ShipmentRepository shipmentRepository;
+    private final ParcelOrderRepository parcelOrderRepository;
 
-    ShipmentEventProducer(EventPublisher eventPublisher, ShipmentRepository shipmentRepository) {
+    ShipmentEventProducer(EventPublisher eventPublisher, ShipmentRepository shipmentRepository,
+                          ParcelOrderRepository parcelOrderRepository) {
         this.eventPublisher = eventPublisher;
         this.shipmentRepository = shipmentRepository;
+        this.parcelOrderRepository = parcelOrderRepository;
+    }
+
+    /** Resolve the display order ref for a parent order id (best-effort; null id or missing order → null). */
+    private String orderRefFor(UUID orderId) {
+        if (orderId == null) {
+            return null;
+        }
+        return parcelOrderRepository.findById(orderId).map(o -> o.getOrderRef()).orElse(null);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -68,6 +80,9 @@ public class ShipmentEventProducer {
                     event.setDestLat(s.getDestAddress().getLatitude());
                     event.setDestLon(s.getDestAddress().getLongitude());
                 }
+                // Carry the parent order so M5 can group same-order/same-location drops into one stop.
+                event.setOrderId(s.getOrderId());
+                event.setOrderRef(orderRefFor(s.getOrderId()));
             });
         }
 
@@ -119,6 +134,9 @@ public class ShipmentEventProducer {
         event.setReceiverAddressLine(s.getDestAddress() != null ? s.getDestAddress().getLine1() : null);
         event.setScheduledPickupStart(s.getScheduledPickupStart());
         event.setScheduledPickupEnd(s.getScheduledPickupEnd());
+        // Parent order (M4 Order → N shipments) so M5 groups same-order/same-location pickups into one stop.
+        event.setOrderId(s.getOrderId());
+        event.setOrderRef(orderRefFor(s.getOrderId()));
 
         log.debug("Publishing CREATED shipmentId={} ref={}", s.getId(), s.getShipmentRef());
         eventPublisher.publish(EventStreams.SHIPMENTS_EVENTS, event);


### PR DESCRIPTION
## What & why
Backend for **task 2** — the driver app's `(order, location)` stop grouping. To collapse a bulk order's parcels that share one pickup/drop location into a single expandable stop, each dispatch task must know its **parent order**. This threads the order (id + display ref) from booking all the way onto the DA task read model.

## Changes
- **Contracts (`common`):** `ShipmentCreatedEvent` + `ShipmentStateChangedEvent` gain `orderId`/`orderRef`. Backward-compatible — `@JsonIgnoreProperties(ignoreUnknown)` + `NON_NULL`, so no existing producer/consumer breaks.
- **Producer (`orders`):** `ShipmentEventProducer` sets them from the shipment's `order_id` (ref resolved via `ParcelOrderRepository`) on CREATED and on the `HANDED_TO_DROP_VAN` transition.
- **Migration `V5_13`:** denormalises `order_id` + `order_ref` onto `dispatch_queue` (+ index), `scheduled_pickup`, and `deferred_dispatch`. Bare UUIDs, **no cross-module FK** (convention).
- **Assignment (`dispatch`):** `DispatchService.assignPickup/assignDelivery` widened; the `Request`/`newRow`, the scheduled-pickup **hold→release** path, and the **defer→retry** path all carry the order, so every bulk-pickup path groups consistently.
- **Read model:** `DaTaskView` exposes `orderId`/`orderRef` to the DA app (flat list preserved — grouping is client-side in the driver app).

## Scope note
`HubDeliveryFeedConsumer` (HUB_RETURN cities, no van) reacts to a hub event that carries no order, so those deliveries assign with a null order (singleton stops). The primary VAN_MEETING delivery path and **all** pickup paths group. Documented inline.

## Tests
- Unit: consumer passes `orderId`/`orderRef` to `assignPickup`; scheduled-pickup hold **stores** and release **carries** the order.
- e2e (real Postgres): `order_id` persists and surfaces on `DaTaskView`; `V5_13` applies and `ddl-auto=validate` passes.
- **94 dispatch + 112 orders** unit tests green; full app assembles.

Companion PRs (same branch name): `oneday-web` (order consoles) and `oneday-driver-app` (stop grouping UI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shipment and dispatch workflows now retain optional parent-order identifiers.
  * Related shipments can be grouped under the same order across pickups, deliveries, scheduled pickups, retries, and deferred dispatches.
  * Dispatch task views now expose parent-order information.
  * Shipment events include parent-order details when available.
* **Bug Fixes**
  * Preserved existing behavior for shipments without parent-order information.
* **Tests**
  * Added coverage confirming order details are persisted, propagated, and displayed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->