### PR TITLE
feat(orders): order back-reference across internal ops consoles (M4/M5/M10/M11)

### DIFF
--- a/dispatch/src/main/java/com/oneday/dispatch/dto/response/DaDetailResponse.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/dto/response/DaDetailResponse.java
@@ -44,6 +44,7 @@ public record DaDetailResponse(
             UUID taskId,
             UUID shipmentId,
             String shipmentRef,
+            String orderRef,          // parent order back-ref (null for legacy/pre-order tasks)
             String taskType,
             String status,
             Instant expectedEta,

--- a/dispatch/src/main/java/com/oneday/dispatch/dto/response/TileQueueResponse.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/dto/response/TileQueueResponse.java
@@ -27,6 +27,7 @@ public record TileQueueResponse(
     public record TaskView(
             UUID taskId,
             UUID shipmentId,
+            String orderRef,          // parent order back-ref (null for legacy/pre-order tasks)
             int queuePosition,
             String status,
             Instant expectedEta,
@@ -38,6 +39,7 @@ public record TileQueueResponse(
     public record DeferredTaskView(
             UUID deferredId,
             UUID shipmentId,
+            String orderRef,          // parent order back-ref (null for legacy/pre-order tasks)
             String taskType,
             String deferReason,
             Instant deferredAt,

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DispatchMetricsServiceImpl.java
@@ -108,6 +108,7 @@ class DispatchMetricsServiceImpl implements DispatchMetricsService {
                 .map(t -> {
                     SlaStatus sla = slaByShipment.get(t.getShipmentId());
                     return new DaTaskItem(t.getId(), t.getShipmentId(), refByShipment.get(t.getShipmentId()),
+                            t.getOrderRef(),
                             t.getTaskType().name(), t.getStatus().name(), t.getExpectedEta(),
                             urgency(t, sla, now),
                             sla != null ? sla.actByAt() : null,

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/StationDispatchServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/StationDispatchServiceImpl.java
@@ -82,7 +82,7 @@ class StationDispatchServiceImpl implements StationDispatchService {
         }
         List<DeferredTaskView> deferredTasks = deferredRepository
                 .findByTileIdAndOperatingDateAndStatus(tileId, date, PENDING).stream()
-                .map(d -> new DeferredTaskView(d.getId(), d.getShipmentId(), d.getTaskType().name(),
+                .map(d -> new DeferredTaskView(d.getId(), d.getShipmentId(), d.getOrderRef(), d.getTaskType().name(),
                         d.getDeferReason().name(), d.getDeferredAt(), d.getRetryAfter(), d.getRetryCount()))
                 .toList();
         return new TileQueueResponse(tileId, date, das, deferredTasks.size(), deferredTasks);
@@ -138,7 +138,7 @@ class StationDispatchServiceImpl implements StationDispatchService {
                 .orElse(null);
 
         List<TaskView> queue = rows.stream()
-                .map(r -> new TaskView(r.getId(), r.getShipmentId(), r.getQueuePosition(),
+                .map(r -> new TaskView(r.getId(), r.getShipmentId(), r.getOrderRef(), r.getQueuePosition(),
                         r.getStatus().name(), r.getExpectedEta(), r.isCrossTerritory(), r.getTaskType().name()))
                 .toList();
         return new DaQueueView(daId, status, queue.size(), cronSlack, queue);

--- a/exceptions/src/main/java/com/oneday/exceptions/api/ExceptionController.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/api/ExceptionController.java
@@ -86,4 +86,16 @@ public class ExceptionController {
         return service.batchResolve(body, Authz.cityScope(principal),
                 Authz.requireUserId(principal), Authz.role(principal));
     }
+
+    /** Apply one action to every live case of a parent order — the "RTO the whole failed order" shortcut.
+     *  Returns the same per-case outcome as {@link #batchResolve}; an order with no live cases is 200 + empty. */
+    @PostMapping("/orders/{orderRef}/resolve")
+    public BatchResolveResponse resolveByOrder(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @PathVariable String orderRef,
+            @Valid @RequestBody ResolveRequest body) {
+        Authz.requireRole(principal, Authz.STATION_MANAGER, Authz.SUPERVISOR, Authz.CALL_CENTER_AGENT);
+        return service.resolveByOrder(orderRef, body.action(), Authz.cityScope(principal),
+                Authz.requireUserId(principal), Authz.role(principal), body.notes());
+    }
 }

--- a/exceptions/src/main/java/com/oneday/exceptions/domain/ExceptionCase.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/domain/ExceptionCase.java
@@ -28,6 +28,13 @@ public class ExceptionCase extends MutableBaseEntity {
     @Column(name = "shipment_ref")
     private String shipmentRef;
 
+    // Order back-reference (Order → N shipments) — null for legacy/pre-order cases.
+    @Column(name = "order_id")
+    private UUID orderId;
+
+    @Column(name = "order_ref")
+    private String orderRef;
+
     @Column(name = "origin_city")
     private String originCity;
 

--- a/exceptions/src/main/java/com/oneday/exceptions/dto/ExceptionCaseDetail.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/dto/ExceptionCaseDetail.java
@@ -14,7 +14,10 @@ public record ExceptionCaseDetail(
         List<ExceptionActionView> actions,
         List<JourneyStep> journey,
         Contact handler,
-        Contact receiver) {
+        Contact receiver,
+        // Live cases in the same parent order (this one included) — powers the "N open in this order"
+        // badge and the batch-RTO-by-order action. 0 when the case carries no order back-ref.
+        long openOrderSiblings) {
 
     /** A callable person: name + phone (+ role for the handler). */
     public record Contact(String name, String phone, String role) {}

--- a/exceptions/src/main/java/com/oneday/exceptions/dto/ExceptionCaseSummary.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/dto/ExceptionCaseSummary.java
@@ -15,6 +15,8 @@ public record ExceptionCaseSummary(
         UUID id,
         UUID shipmentId,
         String shipmentRef,
+        // Parent order back-ref (null for legacy/pre-order cases) — lets the queue chip a parcel to its order.
+        String orderRef,
         String originCity,
         String destCity,
         DeliveryType deliveryType,
@@ -29,7 +31,8 @@ public record ExceptionCaseSummary(
 
     public static ExceptionCaseSummary from(ExceptionCase c) {
         return new ExceptionCaseSummary(
-                c.getId(), c.getShipmentId(), c.getShipmentRef(), c.getOriginCity(), c.getDestCity(),
+                c.getId(), c.getShipmentId(), c.getShipmentRef(), c.getOrderRef(),
+                c.getOriginCity(), c.getDestCity(),
                 c.getDeliveryType(), c.getType(), c.getReasonCode(), c.getStatus(), c.getDisposition(),
                 c.getAttemptNo(), c.isDaAttributable(), c.getAssignedTo(), c.getOpenedAt());
     }

--- a/exceptions/src/main/java/com/oneday/exceptions/repository/ExceptionCaseRepository.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/repository/ExceptionCaseRepository.java
@@ -16,6 +16,12 @@ public interface ExceptionCaseRepository extends JpaRepository<ExceptionCase, UU
     /** The one live (unresolved) case for a shipment, if any — the idempotency key for open/bump. */
     Optional<ExceptionCase> findFirstByShipmentIdAndResolvedAtIsNull(UUID shipmentId);
 
+    /** All live cases belonging to one parent order — sibling view + batch-RTO-by-order. */
+    List<ExceptionCase> findByOrderRefAndResolvedAtIsNull(String orderRef);
+
+    /** How many live cases the order still has — the "N open in this order" badge on the detail. */
+    long countByOrderRefAndResolvedAtIsNull(String orderRef);
+
     /**
      * The problem-solve queue: live cases, city-scoped (origin or dest matches), optional type filter,
      * freshest first. {@code city == null} = admin (all cities).

--- a/exceptions/src/main/java/com/oneday/exceptions/service/ExceptionCaseService.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/service/ExceptionCaseService.java
@@ -40,4 +40,11 @@ public interface ExceptionCaseService {
 
     /** Apply one action to many cases, each in its own transaction; returns a per-case outcome. */
     BatchResolveResponse batchResolve(BatchResolveRequest request, String cityScope, String userId, String role);
+
+    /**
+     * Apply one action to every live case of one parent order — the batch-RTO-a-whole-failed-order path.
+     * Resolves each visible sibling in its own transaction (same isolation as {@link #batchResolve}).
+     */
+    BatchResolveResponse resolveByOrder(String orderRef, ResolveAction action, String cityScope,
+                                        String userId, String role, String notes);
 }

--- a/exceptions/src/main/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImpl.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImpl.java
@@ -131,6 +131,8 @@ class ExceptionCaseServiceImpl implements ExceptionCaseService {
                 c.setOriginCity(info.originCity());
                 c.setDestCity(info.destCity());
                 c.setDeliveryType(info.deliveryType());
+                c.setOrderId(info.orderId());
+                c.setOrderRef(info.orderRef());
             });
         }
         return c;
@@ -224,7 +226,9 @@ class ExceptionCaseServiceImpl implements ExceptionCaseService {
                 contactPort.contactsFor(List.of(c.getShipmentId())).get(c.getShipmentId());
         ExceptionCaseDetail.Contact receiver = contact == null ? null
                 : new ExceptionCaseDetail.Contact(contact.receiverName(), contact.receiverPhone(), "CUSTOMER");
-        return new ExceptionCaseDetail(ExceptionCaseSummary.from(c), actions, journey, handler, receiver);
+        long siblings = c.getOrderRef() == null ? 0
+                : caseRepo.countByOrderRefAndResolvedAtIsNull(c.getOrderRef());
+        return new ExceptionCaseDetail(ExceptionCaseSummary.from(c), actions, journey, handler, receiver, siblings);
     }
 
     // ── Resolve ───────────────────────────────────────────────────────────────────────────────────
@@ -312,6 +316,22 @@ class ExceptionCaseServiceImpl implements ExceptionCaseService {
             }
         }
         return new BatchResolveResponse(results);
+    }
+
+    /** Not @Transactional for the same reason as {@link #batchResolve} — each sibling resolves in its own tx. */
+    @Override
+    public BatchResolveResponse resolveByOrder(String orderRef, ResolveAction action, String cityScope,
+                                               String userId, String role, String notes) {
+        // Only the caller's visible siblings (own-city for a station manager; all for admin) are acted on,
+        // so a cross-city sibling isn't silently RTO'd nor reported as NOT_FOUND noise.
+        List<UUID> ids = caseRepo.findByOrderRefAndResolvedAtIsNull(orderRef).stream()
+                .filter(c -> visible(c, cityScope))
+                .map(ExceptionCase::getId)
+                .toList();
+        if (ids.isEmpty()) {
+            return new BatchResolveResponse(List.of());
+        }
+        return self.batchResolve(new BatchResolveRequest(action, ids, notes), cityScope, userId, role);
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────────────────────────

--- a/exceptions/src/main/resources/db/migration/exceptions/V11_3__add_order_ref.sql
+++ b/exceptions/src/main/resources/db/migration/exceptions/V11_3__add_order_ref.sql
@@ -1,0 +1,9 @@
+-- Order back-reference on a case: which parent Order (Order → N shipments) the failed parcel belongs
+-- to. Lets the problem-solve console group a parcel with its order siblings and RTO a whole failed
+-- order in one action. Populated at open time from M4's ShipmentInfo; null for legacy/pre-order cases.
+ALTER TABLE exception_case ADD COLUMN order_id  UUID;
+ALTER TABLE exception_case ADD COLUMN order_ref VARCHAR(30);
+
+-- Live-siblings lookup + batch-RTO-by-order both query the live cases of one order, so index the
+-- order_ref over just the unresolved set (mirrors idx_exception_case_open's partial-index shape).
+CREATE INDEX idx_exception_case_open_order ON exception_case (order_ref) WHERE resolved_at IS NULL;

--- a/exceptions/src/test/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImplTest.java
+++ b/exceptions/src/test/java/com/oneday/exceptions/service/impl/ExceptionCaseServiceImplTest.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -257,6 +258,74 @@ class ExceptionCaseServiceImplTest {
         assertThat(live.getDisposition()).isEqualTo(Disposition.RETURNED);
         assertThat(live.getAttemptNo()).isEqualTo(3);
         verify(caseRepo, never()).save(any()); // trail-only; no mutation of the case
+    }
+
+    @Test
+    void openCaseStampsTheOrderBackRefFromShipmentInfo() {
+        UUID orderId = UUID.randomUUID();
+        when(caseRepo.findFirstByShipmentIdAndResolvedAtIsNull(shipmentId)).thenReturn(Optional.empty());
+        when(caseRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+        when(lookup.findByRef("1DD-BLR-1")).thenReturn(Optional.of(new com.oneday.orders.dto.ShipmentInfo(
+                shipmentId, "1DD-BLR-1", ShipmentState.PICKED_UP, 1000, null,
+                com.oneday.common.domain.enums.DeliveryType.INTERCITY, "BLR", "DEL", "110001", null, null,
+                orderId, "1DD-ORD-BLR-20260824-00001")));
+
+        svc.captureDaFailure(shipmentId, "1DD-BLR-1", ExceptionType.DELIVERY_FAILED, ExceptionReason.UNKNOWN, false);
+
+        ExceptionCase c = saved();
+        assertThat(c.getOrderId()).isEqualTo(orderId);
+        assertThat(c.getOrderRef()).isEqualTo("1DD-ORD-BLR-20260824-00001");
+    }
+
+    @Test
+    void resolveByOrderBatchesEveryVisibleLiveSibling() {
+        UUID id1 = UUID.randomUUID(), id2 = UUID.randomUUID();
+        ExceptionCase c1 = mock(ExceptionCase.class);
+        when(c1.getId()).thenReturn(id1);
+        when(c1.getOriginCity()).thenReturn("BLR");
+        ExceptionCase c2 = mock(ExceptionCase.class);
+        when(c2.getId()).thenReturn(id2);
+        when(c2.getOriginCity()).thenReturn("BLR");
+        when(caseRepo.findByOrderRefAndResolvedAtIsNull("1DD-ORD-1")).thenReturn(List.of(c1, c2));
+        when(self.batchResolve(any(), any(), any(), any())).thenReturn(new BatchResolveResponse(List.of()));
+
+        svc.resolveByOrder("1DD-ORD-1", ResolveAction.INITIATE_RTO, null, "u1", "STATION_MANAGER", "bulk rto");
+
+        ArgumentCaptor<BatchResolveRequest> cap = ArgumentCaptor.forClass(BatchResolveRequest.class);
+        verify(self).batchResolve(cap.capture(), eq(null), eq("u1"), eq("STATION_MANAGER"));
+        assertThat(cap.getValue().action()).isEqualTo(ResolveAction.INITIATE_RTO);
+        assertThat(cap.getValue().caseIds()).containsExactlyInAnyOrder(id1, id2);
+    }
+
+    @Test
+    void resolveByOrderSkipsSiblingsOutsideTheCallersCity() {
+        UUID inCity = UUID.randomUUID(), otherCity = UUID.randomUUID();
+        ExceptionCase mine = mock(ExceptionCase.class);
+        when(mine.getId()).thenReturn(inCity);
+        when(mine.getOriginCity()).thenReturn("BLR");
+        when(mine.getDestCity()).thenReturn("DEL");
+        ExceptionCase foreign = mock(ExceptionCase.class);
+        when(foreign.getOriginCity()).thenReturn("HYD");
+        when(foreign.getDestCity()).thenReturn("MAA");
+        when(caseRepo.findByOrderRefAndResolvedAtIsNull("1DD-ORD-1")).thenReturn(List.of(mine, foreign));
+        when(self.batchResolve(any(), any(), any(), any())).thenReturn(new BatchResolveResponse(List.of()));
+
+        svc.resolveByOrder("1DD-ORD-1", ResolveAction.INITIATE_RTO, "BLR", "u1", "STATION_MANAGER", null);
+
+        ArgumentCaptor<BatchResolveRequest> cap = ArgumentCaptor.forClass(BatchResolveRequest.class);
+        verify(self).batchResolve(cap.capture(), eq("BLR"), eq("u1"), eq("STATION_MANAGER"));
+        assertThat(cap.getValue().caseIds()).containsExactly(inCity); // the HYD→MAA sibling is not this SM's
+    }
+
+    @Test
+    void resolveByOrderWithNoLiveCasesReturnsEmptyWithoutBatching() {
+        when(caseRepo.findByOrderRefAndResolvedAtIsNull("1DD-ORD-EMPTY")).thenReturn(List.of());
+
+        BatchResolveResponse resp = svc.resolveByOrder("1DD-ORD-EMPTY", ResolveAction.INITIATE_RTO,
+                null, "u1", "STATION_MANAGER", null);
+
+        assertThat(resp.results()).isEmpty();
+        verify(self, never()).batchResolve(any(), any(), any(), any());
     }
 
     @Test

--- a/orders/src/main/java/com/oneday/orders/api/AdminOrdersController.java
+++ b/orders/src/main/java/com/oneday/orders/api/AdminOrdersController.java
@@ -125,7 +125,7 @@ class AdminOrdersController {
     }
 
     private static final String[] CSV_HEADERS = {
-            "shipment_ref", "customer_type", "delivery_type", "state", "pickup_type", "payment_mode",
+            "shipment_ref", "order_ref", "customer_type", "delivery_type", "state", "pickup_type", "payment_mode",
             "origin_city", "origin_pincode", "dest_city", "dest_pincode", "sender_name", "receiver_name",
             "chargeable_weight_grams", "total_price_paise", "created_at", "cancelled_at", "custody_city"
     };
@@ -135,6 +135,7 @@ class AdminOrdersController {
         sb.append(String.join(",", CSV_HEADERS)).append("\r\n");
         for (ShipmentSummaryResponse r : rows) {
             sb.append(csv(r.shipmentRef())).append(',')
+              .append(csv(r.orderRef())).append(',')
               .append(csv(r.customerType())).append(',')
               .append(csv(r.deliveryType())).append(',')
               .append(csv(r.state())).append(',')

--- a/orders/src/main/java/com/oneday/orders/dto/ShipmentInfo.java
+++ b/orders/src/main/java/com/oneday/orders/dto/ShipmentInfo.java
@@ -26,5 +26,9 @@ public record ShipmentInfo(
         String destCity,
         String destPincode,
         UUID destTileId,
-        Instant slaDeadline) {
+        Instant slaDeadline,
+        // Order back-reference (null for legacy shipments booked before the Order → N abstraction).
+        // Lets downstream ops modules (M11 exceptions/RTO) group a parcel with its order siblings.
+        UUID orderId,
+        String orderRef) {
 }

--- a/orders/src/main/java/com/oneday/orders/dto/ShipmentSummaryResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/ShipmentSummaryResponse.java
@@ -15,6 +15,8 @@ import java.time.Instant;
  */
 public record ShipmentSummaryResponse(
         String shipmentRef,
+        // Parent order back-ref (null for legacy/pre-order shipments) — the sibling-order link in ops views.
+        String orderRef,
         CustomerType customerType,
         DeliveryType deliveryType,
         ShipmentState state,

--- a/orders/src/main/java/com/oneday/orders/dto/ShipmentTimelineResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/ShipmentTimelineResponse.java
@@ -15,6 +15,8 @@ import java.util.UUID;
  */
 public record ShipmentTimelineResponse(
         String shipmentRef,
+        // Parent order back-ref (null for legacy/pre-order shipments) — powers the "view order siblings" link.
+        String orderRef,
         UUID shipmentId,
         ShipmentState state,
         CustomerType customerType,

--- a/orders/src/main/java/com/oneday/orders/repository/ParcelOrderRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ParcelOrderRepository.java
@@ -15,6 +15,20 @@ public interface ParcelOrderRepository extends JpaRepository<ParcelOrder, UUID> 
 
     Optional<ParcelOrder> findByOrderRef(String orderRef);
 
+    /** Cheap order-ref lookup by id (no entity load) for read projections that carry an order back-ref. */
+    @Query("SELECT o.orderRef FROM ParcelOrder o WHERE o.id = :id")
+    Optional<String> findOrderRefById(@Param("id") UUID id);
+
+    /** Batched (id → order_ref) resolve for a page of shipments — avoids N+1 when a list carries order refs. */
+    @Query("SELECT o.id AS id, o.orderRef AS orderRef FROM ParcelOrder o WHERE o.id IN :ids")
+    java.util.List<OrderRefRow> findOrderRefsByIds(@Param("ids") java.util.Collection<UUID> ids);
+
+    /** Projection for {@link #findOrderRefsByIds}. */
+    interface OrderRefRow {
+        UUID getId();
+        String getOrderRef();
+    }
+
     /** Customer "my orders" — every order a given M1 user placed, newest first. */
     Page<ParcelOrder> findByBookedByUserId(UUID bookedByUserId, Pageable pageable);
 

--- a/orders/src/main/java/com/oneday/orders/service/impl/AdminOrderQueryServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/AdminOrderQueryServiceImpl.java
@@ -70,9 +70,10 @@ class AdminOrderQueryServiceImpl implements AdminOrderQueryService {
                 ? null : parseState(stateFilter);
 
         Page<Shipment> result = fetchPage(state, cityScope, pageable);
+        java.util.Map<java.util.UUID, String> refs = orderRefsFor(result.getContent());
 
         return new ShipmentPageResponse(
-                result.map(s -> toSummary(s, cityScope)).getContent(),
+                result.map(s -> toSummary(s, cityScope, orderRefOf(s, refs))).getContent(),
                 result.getNumber(),
                 result.getSize(),
                 result.getTotalElements(),
@@ -92,7 +93,8 @@ class AdminOrderQueryServiceImpl implements AdminOrderQueryService {
         for (int page = 0; out.size() < EXPORT_MAX_ROWS; page++) {
             Pageable pageable = PageRequest.of(page, EXPORT_PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt").and(Sort.by(Sort.Direction.ASC, "id")));
             Page<Shipment> batch = fetchPage(state, cityScope, pageable);
-            batch.forEach(s -> out.add(toSummary(s, cityScope)));
+            java.util.Map<java.util.UUID, String> refs = orderRefsFor(batch.getContent());
+            batch.forEach(s -> out.add(toSummary(s, cityScope, orderRefOf(s, refs))));
             if (!batch.hasNext()) {
                 break;
             }
@@ -126,8 +128,10 @@ class AdminOrderQueryServiceImpl implements AdminOrderQueryService {
         events.sort(Comparator.comparing(TimelineEvent::at,
                 Comparator.nullsLast(Comparator.naturalOrder())));
 
+        String orderRef = s.getOrderId() == null ? null
+                : parcelOrderRepository.findOrderRefById(s.getOrderId()).orElse(null);
         return new ShipmentTimelineResponse(
-                s.getShipmentRef(), s.getId(), s.getState(), s.getCustomerType(), s.getDeliveryType(),
+                s.getShipmentRef(), orderRef, s.getId(), s.getState(), s.getCustomerType(), s.getDeliveryType(),
                 s.getOriginCity(), s.getDestCity(), s.getSenderName(), s.getReceiverName(),
                 s.getChargeableWeightGrams(), s.getEtaPromised(), s.getLastScanAt(), s.getCreatedAt(),
                 events);
@@ -166,8 +170,30 @@ class AdminOrderQueryServiceImpl implements AdminOrderQueryService {
         List<Shipment> ships = shipmentRepository.findByOrderIdOrderByCreatedAtAsc(order.getId());
         List<ShipmentState> states = ships.stream().map(Shipment::getState).toList();
         var header = OrderSummaries.toSummary(order, states);
-        List<ShipmentSummaryResponse> children = ships.stream().map(s -> toSummary(s, cityScope)).toList();
+        // Children all share this order's ref — no lookup needed.
+        List<ShipmentSummaryResponse> children =
+                ships.stream().map(s -> toSummary(s, cityScope, order.getOrderRef())).toList();
         return new AdminOrderDetailResponse(header, children);
+    }
+
+    /** Batched (order_id → order_ref) map for the orders referenced by a page of shipments (one query). */
+    private java.util.Map<java.util.UUID, String> orderRefsFor(List<Shipment> ships) {
+        List<java.util.UUID> ids = ships.stream()
+                .map(Shipment::getOrderId)
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .toList();
+        if (ids.isEmpty()) {
+            return java.util.Map.of();
+        }
+        return parcelOrderRepository.findOrderRefsByIds(ids).stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        ParcelOrderRepository.OrderRefRow::getId,
+                        ParcelOrderRepository.OrderRefRow::getOrderRef));
+    }
+
+    private static String orderRefOf(Shipment s, java.util.Map<java.util.UUID, String> refs) {
+        return s.getOrderId() == null ? null : refs.get(s.getOrderId());
     }
 
     /** Bulk-fetch child states for a set of orders and group by order id (one query). */
@@ -204,7 +230,7 @@ class AdminOrderQueryServiceImpl implements AdminOrderQueryService {
         }
     }
 
-    private static ShipmentSummaryResponse toSummary(Shipment s, String requesterCity) {
+    private static ShipmentSummaryResponse toSummary(Shipment s, String requesterCity, String orderRef) {
         // Custody city = origin or dest depending on the parcel's current phase (ShipmentCustody).
         String custodyCity = ShipmentCustody.custodian(s.getState()) == ShipmentCustody.Custodian.ORIGIN
                 ? s.getOriginCity()
@@ -213,6 +239,7 @@ class AdminOrderQueryServiceImpl implements AdminOrderQueryService {
         boolean canAct = requesterCity != null && requesterCity.equals(custodyCity);
         return new ShipmentSummaryResponse(
                 s.getShipmentRef(),
+                orderRef,
                 s.getCustomerType(),
                 s.getDeliveryType(),
                 s.getState(),

--- a/orders/src/main/java/com/oneday/orders/service/impl/ShipmentLookupServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/ShipmentLookupServiceImpl.java
@@ -2,6 +2,7 @@ package com.oneday.orders.service.impl;
 
 import com.oneday.orders.domain.Shipment;
 import com.oneday.orders.dto.ShipmentInfo;
+import com.oneday.orders.repository.ParcelOrderRepository;
 import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.service.ShipmentLookupService;
 import org.springframework.stereotype.Service;
@@ -14,18 +15,25 @@ import java.util.Optional;
 class ShipmentLookupServiceImpl implements ShipmentLookupService {
 
     private final ShipmentRepository shipmentRepository;
+    private final ParcelOrderRepository parcelOrderRepository;
 
-    ShipmentLookupServiceImpl(ShipmentRepository shipmentRepository) {
+    ShipmentLookupServiceImpl(ShipmentRepository shipmentRepository,
+                              ParcelOrderRepository parcelOrderRepository) {
         this.shipmentRepository = shipmentRepository;
+        this.parcelOrderRepository = parcelOrderRepository;
     }
 
     @Override
     @Transactional(readOnly = true)
     public Optional<ShipmentInfo> findByRef(String shipmentRef) {
-        return shipmentRepository.findByShipmentRef(shipmentRef).map(ShipmentLookupServiceImpl::toInfo);
+        return shipmentRepository.findByShipmentRef(shipmentRef).map(this::toInfo);
     }
 
-    private static ShipmentInfo toInfo(Shipment s) {
+    private ShipmentInfo toInfo(Shipment s) {
+        // Resolve the order back-ref lazily — only shipments that carry an order_id hit parcel_orders.
+        String orderRef = s.getOrderId() == null
+                ? null
+                : parcelOrderRepository.findOrderRefById(s.getOrderId()).orElse(null);
         return new ShipmentInfo(
                 s.getId(),
                 s.getShipmentRef(),
@@ -37,6 +45,8 @@ class ShipmentLookupServiceImpl implements ShipmentLookupService {
                 s.getDestCity(),
                 s.getDestPincode(),
                 s.getDestTileId(),
-                null); // slaDeadline wired when M10's commitment timestamp lands
+                null, // slaDeadline wired when M10's commitment timestamp lands
+                s.getOrderId(),
+                orderRef);
     }
 }

--- a/orders/src/test/java/com/oneday/orders/api/AdminOrdersControllerCsvTest.java
+++ b/orders/src/test/java/com/oneday/orders/api/AdminOrdersControllerCsvTest.java
@@ -18,8 +18,8 @@ class AdminOrdersControllerCsvTest {
     @Test
     void escapesCommasAndQuotesAndWritesHeaderPlusRow() {
         ShipmentSummaryResponse row = new ShipmentSummaryResponse(
-                "1DD-BLR-1", CustomerType.B2C, DeliveryType.INTERCITY, ShipmentState.BOOKED,
-                PickupType.DA_PICKUP, PaymentMode.PREPAID,
+                "1DD-BLR-1", "1DD-ORD-BLR-20260824-00001", CustomerType.B2C, DeliveryType.INTERCITY,
+                ShipmentState.BOOKED, PickupType.DA_PICKUP, PaymentMode.PREPAID,
                 "Bengaluru", "560001", "Delhi", "110001",
                 "Sharma, Rao & Co", "Priya \"Pri\" N", 1200, 25000L,
                 Instant.parse("2026-08-24T10:00:00Z"), null, "Bengaluru", true);
@@ -27,11 +27,12 @@ class AdminOrdersControllerCsvTest {
         String csv = AdminOrdersController.toCsv(List.of(row));
         String[] lines = csv.split("\n", -1);
 
-        assertThat(lines[0]).startsWith("shipment_ref,customer_type,delivery_type,state");
+        assertThat(lines[0]).startsWith("shipment_ref,order_ref,customer_type,delivery_type,state");
         // comma-bearing sender is quoted; embedded quotes are doubled
         assertThat(lines[1]).contains("\"Sharma, Rao & Co\"");
         assertThat(lines[1]).contains("\"Priya \"\"Pri\"\" N\"");
         assertThat(lines[1]).contains("1DD-BLR-1");
+        assertThat(lines[1]).contains("1DD-ORD-BLR-20260824-00001");
         assertThat(lines[1]).contains("560001");
     }
 
@@ -58,7 +59,7 @@ class AdminOrdersControllerCsvTest {
     @Test
     void usesCrlfRecordDelimiter() {
         ShipmentSummaryResponse row = new ShipmentSummaryResponse(
-                "1DD-BLR-2", CustomerType.B2C, DeliveryType.INTERCITY, ShipmentState.BOOKED,
+                "1DD-BLR-2", null, CustomerType.B2C, DeliveryType.INTERCITY, ShipmentState.BOOKED,
                 PickupType.DA_PICKUP, PaymentMode.PREPAID, "Bengaluru", "560001", "Delhi", "110001",
                 "A", "B", 1000, 100L, Instant.parse("2026-08-24T10:00:00Z"), null, "Bengaluru", true);
         String csv = AdminOrdersController.toCsv(List.of(row));

--- a/sla/src/main/java/com/oneday/sla/domain/SlaShipment.java
+++ b/sla/src/main/java/com/oneday/sla/domain/SlaShipment.java
@@ -30,6 +30,13 @@ public class SlaShipment extends MutableBaseEntity {
     @Column(name = "shipment_ref")
     private String shipmentRef;
 
+    // Order back-reference (Order → N shipments) — null for legacy/pre-order rows.
+    @Column(name = "order_id")
+    private UUID orderId;
+
+    @Column(name = "order_ref")
+    private String orderRef;
+
     @Column(name = "origin_city")
     private String originCity;
 

--- a/sla/src/main/java/com/oneday/sla/dto/SlaClusterResponse.java
+++ b/sla/src/main/java/com/oneday/sla/dto/SlaClusterResponse.java
@@ -10,8 +10,14 @@ import java.util.List;
  * At 1000/day the failures correlate (one late flight puts a dozen parcels RED); ranking the causes
  * instead of the individual cards turns ~200 rows into ~10 calls. Clusters are ordered worst-band
  * first (never a band-jump), then by size (12 affected beats 1), then soonest act-by.
+ *
+ * <p>{@code orderClusters} is a parallel correlation axis: the same at-risk set re-grouped by parent
+ * order, keeping only orders with 2+ parcels at risk. When a whole B2B booking breaches together, that
+ * is one merchant call rather than one-per-parcel — {@code stage = "ORDER"}, {@code scope} = the order
+ * ref. It overlaps the stage/geo clusters by design (a different lens on the same rows), never replaces
+ * them.</p>
  */
-public record SlaClusterResponse(List<Cluster> clusters) {
+public record SlaClusterResponse(List<Cluster> clusters, List<Cluster> orderClusters) {
 
     public record Cluster(
             String stage,                       // PICKUP | HUB | AIR | DELIVERY

--- a/sla/src/main/java/com/oneday/sla/dto/SlaShipmentSummary.java
+++ b/sla/src/main/java/com/oneday/sla/dto/SlaShipmentSummary.java
@@ -14,6 +14,8 @@ import java.util.UUID;
 public record SlaShipmentSummary(
         UUID shipmentId,
         String shipmentRef,
+        // Parent order back-ref (null for legacy/pre-order rows) — lets the tower group order siblings.
+        String orderRef,
         String originCity,
         String destCity,
         String lane,
@@ -57,7 +59,8 @@ public record SlaShipmentSummary(
                                           ShipmentContactPort.ShipmentContact contact,
                                           boolean weatherExposed) {
         return new SlaShipmentSummary(
-                s.getShipmentId(), s.getShipmentRef(), s.getOriginCity(), s.getDestCity(), s.getLane(),
+                s.getShipmentId(), s.getShipmentRef(), s.getOrderRef(),
+                s.getOriginCity(), s.getDestCity(), s.getLane(),
                 s.getDeliveryType(), s.getOverallState(), s.getCurrentLeg(), s.isBreached(),
                 s.getBookedAt(), s.getInternalTargetAt(), s.getPublicPromiseAt(),
                 s.getProjectedFinishAt(), s.getDeliveredAt(),

--- a/sla/src/main/java/com/oneday/sla/service/SlaLifecycleService.java
+++ b/sla/src/main/java/com/oneday/sla/service/SlaLifecycleService.java
@@ -68,6 +68,8 @@ public class SlaLifecycleService {
         SlaShipment ss = new SlaShipment();
         ss.setShipmentId(e.getShipmentId());
         ss.setShipmentRef(e.getShipmentRef());
+        ss.setOrderId(e.getOrderId());
+        ss.setOrderRef(e.getOrderRef());
         ss.setOriginCity(e.getOriginCity());
         ss.setDestCity(e.getDestCity());
         ss.setLane(lane(e.getOriginCity(), e.getDestCity()));

--- a/sla/src/main/java/com/oneday/sla/service/impl/SlaQueryServiceImpl.java
+++ b/sla/src/main/java/com/oneday/sla/service/impl/SlaQueryServiceImpl.java
@@ -152,34 +152,58 @@ public class SlaQueryServiceImpl implements SlaQueryService {
         // The actionable set = the fire bands (CRITICAL/HIGH). WATCH is "keep an eye, no fire" — and this
         // is the band, not the colour: a parcel that's colour-GREEN but racing a 60-min flight cutoff is
         // a HIGH-band fire and belongs here, while a slack AMBER (WATCH band) does not.
-        Map<Cause, List<SlaShipment>> grouped = shipmentRepo.findByClosedAtIsNull().stream()
+        List<SlaShipment> atRisk = shipmentRepo.findByClosedAtIsNull().stream()
                 .filter(ss -> visible(ss, cityScope))
                 .filter(ss -> ss.getBand() != null && ss.getBand() != PriorityBand.WATCH)
-                .collect(Collectors.groupingBy(SlaQueryServiceImpl::causeOf));
-
-        List<SlaClusterResponse.Cluster> clusters = grouped.entrySet().stream()
-                .map(e -> {
-                    Cause c = e.getKey();
-                    List<SlaShipment> members = e.getValue().stream()
-                            .sorted(Comparator.comparingDouble(SlaShipment::getPriorityScore).reversed())
-                            .toList();
-                    PriorityBand band = members.stream()
-                            .map(SlaShipment::getBand).filter(java.util.Objects::nonNull)
-                            .max(Comparator.comparingInt(PriorityBand::rank)).orElse(PriorityBand.WATCH);
-                    int breached = (int) members.stream().filter(SlaShipment::isBreached).count();
-                    Instant earliestActBy = members.stream()
-                            .map(SlaShipment::getActByAt).filter(java.util.Objects::nonNull)
-                            .min(Comparator.naturalOrder()).orElse(null);
-                    List<String> refs = members.stream().map(SlaShipment::getShipmentRef).limit(50).toList();
-                    return new SlaClusterResponse.Cluster(c.stage(), c.scope(), c.label(), band,
-                            members.size(), breached, earliestActBy, refs, deskFor(c));
-                })
-                // Worst band first (never a band-jump), then bigger cluster, then soonest deadline.
-                .sorted(Comparator.comparingInt((SlaClusterResponse.Cluster cl) -> cl.band().rank()).reversed()
-                        .thenComparing(Comparator.comparingInt(SlaClusterResponse.Cluster::size).reversed())
-                        .thenComparing(cl -> cl.earliestActBy() == null ? Instant.MAX : cl.earliestActBy()))
                 .toList();
-        return new SlaClusterResponse(clusters);
+
+        // Primary axis: the operational cause (stage + city/lane).
+        List<SlaClusterResponse.Cluster> clusters = atRisk.stream()
+                .collect(Collectors.groupingBy(SlaQueryServiceImpl::causeOf))
+                .entrySet().stream()
+                .map(e -> toCluster(e.getKey().stage(), e.getKey().scope(), e.getKey().label(),
+                        e.getValue(), deskFor(e.getKey())))
+                .sorted(clusterOrder())
+                .toList();
+
+        // Parallel axis: same rows re-grouped by parent order — only orders with 2+ at-risk parcels
+        // (a single-parcel "order cluster" is just that parcel's row, no correlation value).
+        List<SlaClusterResponse.Cluster> orderClusters = atRisk.stream()
+                .filter(ss -> ss.getOrderRef() != null)
+                .collect(Collectors.groupingBy(SlaShipment::getOrderRef))
+                .entrySet().stream()
+                .filter(e -> e.getValue().size() >= 2)
+                // No single desk owns a whole order (it spans cities) — the merchant is the callee, so contact=null.
+                .map(e -> toCluster("ORDER", e.getKey(), "Order " + e.getKey(), e.getValue(), null))
+                .sorted(clusterOrder())
+                .toList();
+
+        return new SlaClusterResponse(clusters, orderClusters);
+    }
+
+    /** Fold a set of at-risk members into one cluster card (worst band, breach count, soonest act-by, refs). */
+    private static SlaClusterResponse.Cluster toCluster(String stage, String scope, String label,
+                                                        List<SlaShipment> group, SlaShipmentSummary.Handler desk) {
+        List<SlaShipment> members = group.stream()
+                .sorted(Comparator.comparingDouble(SlaShipment::getPriorityScore).reversed())
+                .toList();
+        PriorityBand band = members.stream()
+                .map(SlaShipment::getBand).filter(java.util.Objects::nonNull)
+                .max(Comparator.comparingInt(PriorityBand::rank)).orElse(PriorityBand.WATCH);
+        int breached = (int) members.stream().filter(SlaShipment::isBreached).count();
+        Instant earliestActBy = members.stream()
+                .map(SlaShipment::getActByAt).filter(java.util.Objects::nonNull)
+                .min(Comparator.naturalOrder()).orElse(null);
+        List<String> refs = members.stream().map(SlaShipment::getShipmentRef).limit(50).toList();
+        return new SlaClusterResponse.Cluster(stage, scope, label, band,
+                members.size(), breached, earliestActBy, refs, desk);
+    }
+
+    /** Worst band first (never a band-jump), then bigger cluster, then soonest deadline. */
+    private static Comparator<SlaClusterResponse.Cluster> clusterOrder() {
+        return Comparator.comparingInt((SlaClusterResponse.Cluster cl) -> cl.band().rank()).reversed()
+                .thenComparing(Comparator.comparingInt(SlaClusterResponse.Cluster::size).reversed())
+                .thenComparing(cl -> cl.earliestActBy() == null ? Instant.MAX : cl.earliestActBy());
     }
 
     @Override

--- a/sla/src/main/resources/db/migration/sla/V10_5__add_order_ref.sql
+++ b/sla/src/main/resources/db/migration/sla/V10_5__add_order_ref.sql
@@ -1,0 +1,8 @@
+-- Order back-reference on the per-shipment SLA row. The ShipmentCreatedEvent already carries the
+-- parent order (Order → N shipments) but M10 was discarding it; persist it so the control tower can
+-- correlate the N parcels of one breaching booking into a single merchant call. Null for legacy rows.
+ALTER TABLE sla_shipment ADD COLUMN order_id  UUID;
+ALTER TABLE sla_shipment ADD COLUMN order_ref VARCHAR(30);
+
+-- The order-correlation cluster groups the live at-risk set by order_ref; index over the open set.
+CREATE INDEX idx_sla_shipment_open_order ON sla_shipment (order_ref) WHERE closed_at IS NULL;

--- a/sla/src/test/java/com/oneday/sla/service/impl/SlaClusterTest.java
+++ b/sla/src/test/java/com/oneday/sla/service/impl/SlaClusterTest.java
@@ -87,4 +87,34 @@ class SlaClusterTest {
         assertThat(hub.size()).isEqualTo(3);
         assertThat(hub.contact().role()).isEqualTo("HUB_OPERATOR");
     }
+
+    @Test
+    void orderClustersGroupBreachingSiblingsOfTheSameBooking() {
+        when(stageContactPort.hubDesk(any())).thenReturn(Optional.empty());
+        when(stageContactPort.ghaDesk()).thenReturn(Optional.empty());
+
+        // Booking ORD-1 has three at-risk parcels spread across stages/cities; a lone parcel of ORD-2.
+        SlaShipment o1a = ship("O1A", "BLR", "DEL", SlaLegType.LAST_MILE, SlaState.BREACHED, PriorityBand.CRITICAL, true, 3_000_100);
+        SlaShipment o1b = ship("O1B", "HYD", "MAA", SlaLegType.ORIGIN_HUB, SlaState.RED, PriorityBand.HIGH, false, 2_000_050);
+        SlaShipment o1c = ship("O1C", "BLR", "DEL", SlaLegType.AIR, SlaState.RED, PriorityBand.HIGH, false, 2_000_010);
+        SlaShipment o2 = ship("O2A", "BLR", "DEL", SlaLegType.LAST_MILE, SlaState.RED, PriorityBand.HIGH, false, 2_000_000);
+        o1a.setOrderRef("1DD-ORD-1");
+        o1b.setOrderRef("1DD-ORD-1");
+        o1c.setOrderRef("1DD-ORD-1");
+        o2.setOrderRef("1DD-ORD-2");
+        when(shipmentRepo.findByClosedAtIsNull()).thenReturn(List.of(o1a, o1b, o1c, o2));
+
+        List<SlaClusterResponse.Cluster> orderClusters = svc.clusters(null).orderClusters();
+
+        // Only ORD-1 qualifies (2+ at-risk parcels); ORD-2's single parcel is not an order cluster.
+        assertThat(orderClusters).hasSize(1);
+        SlaClusterResponse.Cluster ord = orderClusters.get(0);
+        assertThat(ord.stage()).isEqualTo("ORDER");
+        assertThat(ord.scope()).isEqualTo("1DD-ORD-1");
+        assertThat(ord.size()).isEqualTo(3);
+        assertThat(ord.band()).isEqualTo(PriorityBand.CRITICAL); // worst member floats up
+        assertThat(ord.breachedCount()).isEqualTo(1);
+        assertThat(ord.refs()).containsExactly("O1A", "O1B", "O1C"); // worst score first
+        assertThat(ord.contact()).isNull(); // an order spans cities — no single desk; call the merchant
+    }
 }


### PR DESCRIPTION
## Why

Follow-up to the Order → N Shipments abstraction. A codebase-wide audit (all six web consoles, all backend modules, the driver app's three personas) asked: *where else does this abstraction actually belong internally?*

**Finding:** full order-*list* views are a booking-owner concept (business portal only) — they don't belong in the internal ops consoles. But a lightweight order *back-reference* on a parcel ("this parcel is 1 of N in order X → view siblings / act on the whole order") is genuinely load-bearing, most of all for **Exceptions/RTO (M11)**, and cheaply useful on the station + SLA parcel views because `order_id` already sits on `shipments` and `dispatch_queue`.

Deliberately untouched (order grouping is noise there — bag/flight/stop grain, parcels of one order diverge): **hub (M7), airline (M9), van & shuttle** personas.

## What

- **M4 (`orders`)** — `ShipmentInfo` carries `orderId`/`orderRef` (shared enabler for M11); admin/station shipment grid + CSV export + timeline expose `order_ref` (batched resolve, no N+1). No migration (column pre-existed).
- **M5 (`dispatch`)** — `TileQueue` `TaskView`/`DeferredTaskView` + `DaDetail` `DaTaskItem` expose `order_ref` (columns already on `dispatch_queue`/`deferred_dispatch` from V5_13). No migration.
- **M11 (`exceptions`)** — `exception_case` gains `order_id`/`order_ref` (**V11_3**), stamped at `openCase`; case detail returns the open-order-sibling count; new `POST /api/v1/exceptions/orders/{orderRef}/resolve` batch-RTOs a whole failed booking (city-scoped; reuses the per-case batch path).
- **M10 (`sla`)** — `sla_shipment` gains `order_id`/`order_ref` (**V10_5**), now persisted from `ShipmentCreatedEvent` (previously discarded); control-tower rows + detail expose `order_ref`; `clusters` gains a parallel **order-correlation axis** (`order_clusters`) so N parcels of one booking breaching together = one merchant call.

## Tests

- `ExceptionCaseServiceImplTest` +4 (order stamp on open; `resolveByOrder` batches visible siblings; skips cross-city siblings; empty order → no batch).
- `SlaClusterTest` +1 (order clusters group 2+ at-risk siblings, worst band floats up, no single desk).
- `AdminOrdersControllerCsvTest` updated for the new `order_ref` column.
- Affected modules compile; full app assembles (JDK 21). Unit tests green; the pre-existing e2e failures are an unrelated dirty-test-DB issue (`V4_37 wallet_recharge_order already exists`).

## Paired web PR

Sidarthapati/oneday-web `feat/order-backref-internal-consoles` (admin Orders removal + station UI + `packages/api` types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added parent order references to shipment, dispatch, exception, and SLA details, summaries, timelines, and exports.
  * Added order-level exception resolution for all visible unresolved cases.
  * Exception details now show the number of open sibling cases in the same order.
  * SLA monitoring now groups at-risk shipments by parent order when multiple shipments are affected.
* **Bug Fixes**
  * Improved traceability for legacy and pre-order shipments while preserving support for records without an order reference.
* **Tests**
  * Added coverage for order linking, order-level resolution, filtering, exports, and SLA grouping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->