### PR TITLE
feat(orders): merchant self-service CSV export (#6)

### DIFF
--- a/orders/src/main/java/com/oneday/orders/api/B2bShipmentController.java
+++ b/orders/src/main/java/com/oneday/orders/api/B2bShipmentController.java
@@ -4,12 +4,21 @@ import com.oneday.auth.security.AuthUserDetails;
 import com.oneday.orders.dto.B2bBookingRequest;
 import com.oneday.orders.dto.BookingResponse;
 import com.oneday.orders.dto.CancellationResponse;
+import com.oneday.orders.repository.B2bAccountRepository;
+import com.oneday.orders.service.AdminOrderQueryService;
 import com.oneday.orders.service.B2bBookingService;
 import com.oneday.orders.service.CancellationService;
 import jakarta.validation.Valid;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,6 +27,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/v1/b2b/shipments")
@@ -25,10 +39,15 @@ class B2bShipmentController {
 
     private final B2bBookingService b2bBookingService;
     private final CancellationService cancellationService;
+    private final AdminOrderQueryService orderQueryService;
+    private final B2bAccountRepository accounts;
 
-    B2bShipmentController(B2bBookingService b2bBookingService, CancellationService cancellationService) {
+    B2bShipmentController(B2bBookingService b2bBookingService, CancellationService cancellationService,
+                          AdminOrderQueryService orderQueryService, B2bAccountRepository accounts) {
         this.b2bBookingService = b2bBookingService;
         this.cancellationService = cancellationService;
+        this.orderQueryService = orderQueryService;
+        this.accounts = accounts;
     }
 
     @PostMapping
@@ -54,5 +73,31 @@ class B2bShipmentController {
         // reverses the credit (outstanding balance) instead of issuing a Razorpay refund.
         Authz.requireRole(principal, "B2B_USER");
         return cancellationService.cancel(ref, reason, Authz.requireUserId(principal), true);
+    }
+
+    /**
+     * Merchant self-service export: all of the caller's own account's shipments as CSV. Owner-scoped
+     * (never a param — resolved from the caller), reusing the ops CSV layout {@link AdminOrdersController#toCsv}.
+     */
+    @GetMapping(value = "/export", produces = "text/csv")
+    public ResponseEntity<Resource> exportMyShipments(@AuthenticationPrincipal AuthUserDetails principal) {
+        UUID accountId = ownedAccountId(principal);
+        byte[] csv = AdminOrdersController.toCsv(orderQueryService.exportForAccount(accountId))
+                .getBytes(StandardCharsets.UTF_8);
+        String filename = "my-shipments-" + LocalDate.now() + ".csv";
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        ContentDisposition.attachment().filename(filename).build().toString())
+                .contentType(MediaType.parseMediaType("text/csv"))
+                .body(new ByteArrayResource(csv));
+    }
+
+    /** The B2B account owned by the caller, or 404 (also gates the endpoint to B2B users). */
+    private UUID ownedAccountId(AuthUserDetails principal) {
+        Authz.requireRole(principal, "B2B_USER");
+        UUID userId = UUID.fromString(Authz.requireUserId(principal));
+        return accounts.findByOwnerUserId(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No B2B account for this user"))
+                .getId();
     }
 }

--- a/orders/src/main/java/com/oneday/orders/api/B2bShipmentController.java
+++ b/orders/src/main/java/com/oneday/orders/api/B2bShipmentController.java
@@ -88,7 +88,7 @@ class B2bShipmentController {
         return ResponseEntity.ok()
                 .header(HttpHeaders.CONTENT_DISPOSITION,
                         ContentDisposition.attachment().filename(filename).build().toString())
-                .contentType(MediaType.parseMediaType("text/csv"))
+                .contentType(new MediaType("text", "csv", StandardCharsets.UTF_8))
                 .body(new ByteArrayResource(csv));
     }
 

--- a/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
@@ -68,6 +68,10 @@ public interface ShipmentRepository extends JpaRepository<Shipment, UUID> {
     // Customer "my shipments" view: every shipment a given M1 user booked, newest first.
     Page<Shipment> findByBookedByUserId(UUID bookedByUserId, Pageable pageable);
 
+    // Merchant self-service export: every shipment booked against one B2B account (any of the
+    // account's users), newest first. Ownership is enforced by the caller before this runs.
+    Page<Shipment> findByB2bAccountId(UUID b2bAccountId, Pageable pageable);
+
     // Order → N Shipments: the child shipments of one order (booking order preserved).
     List<Shipment> findByOrderIdOrderByCreatedAtAsc(UUID orderId);
 

--- a/orders/src/main/java/com/oneday/orders/service/AdminOrderQueryService.java
+++ b/orders/src/main/java/com/oneday/orders/service/AdminOrderQueryService.java
@@ -34,6 +34,13 @@ public interface AdminOrderQueryService {
     List<ShipmentSummaryResponse> exportShipments(String stateFilter, String cityScope);
 
     /**
+     * Every shipment booked against one B2B account, newest first, without the page cap — backs the
+     * merchant's self-service CSV export. Same row shape as {@link #exportShipments}. The caller
+     * (a B2B controller) resolves and enforces account ownership, so this is not gated here.
+     */
+    List<ShipmentSummaryResponse> exportForAccount(java.util.UUID accountId);
+
+    /**
      * One parcel's full ops timeline by human ref: header + M4 state history merged with the M8 scan
      * trail, oldest first. {@code cityScope} null → any city (ADMIN); otherwise the shipment must touch
      * that city (origin or destination) or it 404s — the same read rule as {@link #listShipments}.

--- a/orders/src/main/java/com/oneday/orders/service/impl/AdminOrderQueryServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/AdminOrderQueryServiceImpl.java
@@ -88,13 +88,26 @@ class AdminOrderQueryServiceImpl implements AdminOrderQueryService {
     public java.util.List<ShipmentSummaryResponse> exportShipments(String stateFilter, String cityScope) {
         ShipmentState state = (stateFilter == null || stateFilter.isBlank())
                 ? null : parseState(stateFilter);
+        return exportPaged(pageable -> fetchPage(state, cityScope, pageable), cityScope);
+    }
 
+    @Override
+    // Same stable-snapshot rationale as exportShipments. Merchant scope: only this account's shipments,
+    // and no custody canAct (null requesterCity — a merchant isn't a city custodian).
+    @Transactional(readOnly = true, isolation = Isolation.REPEATABLE_READ)
+    public java.util.List<ShipmentSummaryResponse> exportForAccount(java.util.UUID accountId) {
+        return exportPaged(pageable -> shipmentRepository.findByB2bAccountId(accountId, pageable), null);
+    }
+
+    /** Shared paged export: walk pages of {@code fetch} until exhausted or the safety ceiling, mapping each. */
+    private java.util.List<ShipmentSummaryResponse> exportPaged(
+            java.util.function.Function<Pageable, Page<Shipment>> fetch, String requesterCity) {
         java.util.List<ShipmentSummaryResponse> out = new java.util.ArrayList<>();
         for (int page = 0; out.size() < EXPORT_MAX_ROWS; page++) {
             Pageable pageable = PageRequest.of(page, EXPORT_PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt").and(Sort.by(Sort.Direction.ASC, "id")));
-            Page<Shipment> batch = fetchPage(state, cityScope, pageable);
+            Page<Shipment> batch = fetch.apply(pageable);
             java.util.Map<java.util.UUID, String> refs = orderRefsFor(batch.getContent());
-            batch.forEach(s -> out.add(toSummary(s, cityScope, orderRefOf(s, refs))));
+            batch.forEach(s -> out.add(toSummary(s, requesterCity, orderRefOf(s, refs))));
             if (!batch.hasNext()) {
                 break;
             }

--- a/orders/src/test/java/com/oneday/orders/service/impl/AdminOrderQueryServiceExportForAccountTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/AdminOrderQueryServiceExportForAccountTest.java
@@ -1,0 +1,58 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.port.ShipmentScanTrailPort;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.dto.ShipmentSummaryResponse;
+import com.oneday.orders.repository.ParcelOrderRepository;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.repository.ShipmentStateHistoryRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The merchant self-service export must read strictly the caller's own account — never a broad scan.
+ * A regression that dropped the account filter (or keyed it on the wrong column) would leak other
+ * merchants' shipments; this pins the query to the passed accountId and checks the row maps cleanly.
+ */
+class AdminOrderQueryServiceExportForAccountTest {
+
+    private final ShipmentRepository shipmentRepo = mock(ShipmentRepository.class);
+    private final ParcelOrderRepository orderRepo = mock(ParcelOrderRepository.class);
+    private final ShipmentStateHistoryRepository historyRepo = mock(ShipmentStateHistoryRepository.class);
+    private final ShipmentScanTrailPort scanTrail = mock(ShipmentScanTrailPort.class);
+
+    private final AdminOrderQueryServiceImpl service =
+            new AdminOrderQueryServiceImpl(shipmentRepo, orderRepo, historyRepo, scanTrail);
+
+    @Test
+    void exportsOnlyTheGivenAccountsShipments() {
+        UUID accountId = UUID.randomUUID();
+        Shipment s = new Shipment();
+        s.setState(ShipmentState.BOOKED);
+        s.setShipmentRef("1DD-SHP-DEL-20260826-00001");
+        s.setOriginCity("DEL");
+        s.setDestCity("BLR");
+        when(shipmentRepo.findByB2bAccountId(eq(accountId), any(Pageable.class)))
+                .thenReturn((Page<Shipment>) new PageImpl<>(List.of(s)));
+
+        List<ShipmentSummaryResponse> rows = service.exportForAccount(accountId);
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).shipmentRef()).isEqualTo("1DD-SHP-DEL-20260826-00001");
+        // Fetched strictly by the caller's account — no cross-account scan.
+        verify(shipmentRepo).findByB2bAccountId(eq(accountId), any(Pageable.class));
+    }
+}


### PR DESCRIPTION
## Feature #6 — Merchant tracking & reports (CSV export)

Adds `GET /api/v1/b2b/shipments/export` so a B2B merchant can download a CSV of **their own** account's shipments.

- Owner-scoped: account resolved from the caller (never a param); 404 if the caller has no B2B account.
- Reuses the existing ops CSV layout (`AdminOrdersController.toCsv` + RFC-4180/CSV-injection guard) and the `toSummary` mapper, via a shared paged-export helper (`AdminOrderQueryServiceImpl.exportPaged`, REPEATABLE_READ).
- New: `ShipmentRepository.findByB2bAccountId`, `AdminOrderQueryService.exportForAccount`, owner-scoping unit test.

**Web counterpart:** separate PR in `oneday-web` (Export CSV button on the business Shipments page).

Verify: `mvn test -pl orders -Dtest=AdminOrderQueryServiceExportForAccountTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * B2B users can export their account’s shipments as a dated, UTF-8 CSV attachment.
  * Exports support large result sets while enforcing a 50,000-row safety limit.

* **Bug Fixes**
  * Improved account scoping to prevent access to shipments belonging to other accounts.
  * Requests without an associated account now receive a not-found response.

* **Tests**
  * Added coverage confirming account-filtered shipment exports return the correct results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->