### PR TITLE
feat(orders): per-slot pickup capacity cap (#11)

### DIFF
--- a/orders/src/main/java/com/oneday/orders/api/OrdersGlobalExceptionHandler.java
+++ b/orders/src/main/java/com/oneday/orders/api/OrdersGlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import com.oneday.orders.service.BulkUploadService;
 import com.oneday.orders.service.CancellationService;
 import com.oneday.orders.service.CartService;
 import com.oneday.orders.service.PaymentPort;
+import com.oneday.orders.service.PickupSlotFullException;
 import com.oneday.orders.service.exception.IllegalStateTransitionException;
 import com.oneday.pricing.service.NoRateConfiguredException;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
@@ -121,6 +122,14 @@ class OrdersGlobalExceptionHandler {
     ProblemDetail handleCancellationNotAllowed(CancellationService.CancellationNotAllowedException ex) {
         ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.CONFLICT);
         pd.setTitle("Cancellation not allowed");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    @ExceptionHandler(PickupSlotFullException.class)
+    ProblemDetail handlePickupSlotFull(PickupSlotFullException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.CONFLICT);
+        pd.setTitle("Pickup slot full");
         pd.setDetail(ex.getMessage());
         return pd;
     }

--- a/orders/src/main/java/com/oneday/orders/config/PickupSlotProperties.java
+++ b/orders/src/main/java/com/oneday/orders/config/PickupSlotProperties.java
@@ -1,0 +1,32 @@
+package com.oneday.orders.config;
+
+import jakarta.validation.constraints.Positive;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Configuration for pickup-slot capacity.
+ *
+ * <pre>{@code
+ * orders:
+ *   pickup-slot:
+ *     max-per-slot: 50
+ * }</pre>
+ */
+@Component
+@ConfigurationProperties(prefix = "orders.pickup-slot")
+@Validated
+public class PickupSlotProperties {
+
+    /**
+     * Max active (non-cancelled) pickups reservable in one (origin city, 2-hour slot) before the slot is
+     * full and further bookings for it are rejected. An ops capacity knob — tune per real DA throughput.
+     * Default: 50.
+     */
+    @Positive
+    private int maxPerSlot = 50;
+
+    public int getMaxPerSlot() { return maxPerSlot; }
+    public void setMaxPerSlot(int maxPerSlot) { this.maxPerSlot = maxPerSlot; }
+}

--- a/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
@@ -72,6 +72,10 @@ public interface ShipmentRepository extends JpaRepository<Shipment, UUID> {
     // account's users), newest first. Ownership is enforced by the caller before this runs.
     Page<Shipment> findByB2bAccountId(UUID b2bAccountId, Pageable pageable);
 
+    // Pickup-slot capacity: how many active (non-cancelled) reservations already hold a given
+    // city's slot (identified by its absolute start instant). Backs the per-slot cap at booking time.
+    int countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(String originCity, Instant scheduledPickupStart);
+
     // Order → N Shipments: the child shipments of one order (booking order preserved).
     List<Shipment> findByOrderIdOrderByCreatedAtAsc(UUID orderId);
 

--- a/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
@@ -1,6 +1,7 @@
 package com.oneday.orders.repository;
 
 import com.oneday.common.domain.enums.CustomerType;
+import com.oneday.common.domain.enums.PickupType;
 import com.oneday.common.domain.enums.ShipmentState;
 import com.oneday.orders.domain.Shipment;
 import jakarta.persistence.LockModeType;
@@ -72,9 +73,11 @@ public interface ShipmentRepository extends JpaRepository<Shipment, UUID> {
     // account's users), newest first. Ownership is enforced by the caller before this runs.
     Page<Shipment> findByB2bAccountId(UUID b2bAccountId, Pageable pageable);
 
-    // Pickup-slot capacity: how many active (non-cancelled) reservations already hold a given
-    // city's slot (identified by its absolute start instant). Backs the per-slot cap at booking time.
-    int countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(String originCity, Instant scheduledPickupStart);
+    // Pickup-slot capacity: how many active (non-cancelled) DA-pickup reservations already hold a
+    // given city's slot (identified by its absolute start instant). Only DA_PICKUP shipments consume
+    // a pickup slot — a SELF_DROP parcel needs no DA. Backs the per-slot cap at booking time.
+    int countByOriginCityAndScheduledPickupStartAndPickupTypeAndCancelledAtIsNull(
+            String originCity, Instant scheduledPickupStart, PickupType pickupType);
 
     // Order → N Shipments: the child shipments of one order (booking order preserved).
     List<Shipment> findByOrderIdOrderByCreatedAtAsc(UUID orderId);

--- a/orders/src/main/java/com/oneday/orders/service/PickupSlotFullException.java
+++ b/orders/src/main/java/com/oneday/orders/service/PickupSlotFullException.java
@@ -1,0 +1,11 @@
+package com.oneday.orders.service;
+
+/**
+ * A booking asked for a pickup slot that is already at capacity for its origin city. Thrown before
+ * payment so a full slot never charges the customer; surfaced as HTTP 409 (see the orders handler).
+ */
+public class PickupSlotFullException extends RuntimeException {
+    public PickupSlotFullException(String message) {
+        super(message);
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
@@ -68,6 +68,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
     private final CodCollectionRepository codCollectionRepository;
     private final CustomerVisibleStateMapper stateMapper;
     private final WalletService walletService;
+    private final PickupSlotCapacity pickupSlotCapacity;
     private final TransactionTemplate tx;
     private final ApplicationEventPublisher applicationEventPublisher;
 
@@ -90,6 +91,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
                           CodCollectionRepository codCollectionRepository,
                           CustomerVisibleStateMapper stateMapper,
                           WalletService walletService,
+                          PickupSlotCapacity pickupSlotCapacity,
                           TransactionTemplate transactionTemplate,
                           ApplicationEventPublisher applicationEventPublisher,
                           CircuitBreakerRegistry circuitBreakerRegistry,
@@ -106,6 +108,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
         this.codCollectionRepository = codCollectionRepository;
         this.stateMapper          = stateMapper;
         this.walletService        = walletService;
+        this.pickupSlotCapacity   = pickupSlotCapacity;
         this.tx                   = transactionTemplate;
         this.applicationEventPublisher = applicationEventPublisher;
         this.serviceabilityCb     = circuitBreakerRegistry.circuitBreaker("serviceability");
@@ -164,6 +167,9 @@ class B2bBookingServiceImpl implements B2bBookingService {
                         req.getDeclaredValuePaise(),
                         account.getRateCardId(),
                         null)));  // B2B is credit-billed — no COD surcharge
+
+        // ── 4b. Pickup-slot capacity (before opening the TX; a full slot rejects cleanly) ──
+        pickupSlotCapacity.ensureRoom(req.getOriginCity(), req.getPickupSlotDate(), req.getPickupSlotStartHour());
 
         // ── 5. DB transaction: credit check → persist → balance increment ──────
         final int finalVolumetric = volumetricWeightGrams;

--- a/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
@@ -169,7 +169,8 @@ class B2bBookingServiceImpl implements B2bBookingService {
                         null)));  // B2B is credit-billed — no COD surcharge
 
         // ── 4b. Pickup-slot capacity (before opening the TX; a full slot rejects cleanly) ──
-        pickupSlotCapacity.ensureRoom(req.getOriginCity(), req.getPickupSlotDate(), req.getPickupSlotStartHour());
+        pickupSlotCapacity.ensureRoom(req.getOriginCity(), req.getPickupSlotDate(),
+                req.getPickupSlotStartHour(), req.getPickupType());
 
         // ── 5. DB transaction: credit check → persist → balance increment ──────
         final int finalVolumetric = volumetricWeightGrams;

--- a/orders/src/main/java/com/oneday/orders/service/impl/BookingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/BookingServiceImpl.java
@@ -68,6 +68,7 @@ class BookingServiceImpl implements BookingService {
     private final PaymentTransactionRepository paymentTransactionRepository;
     private final ShipmentStateHistoryRepository historyRepository;
     private final CustomerVisibleStateMapper stateMapper;
+    private final PickupSlotCapacity pickupSlotCapacity;
     private final TransactionTemplate tx;
 
     private final CircuitBreaker serviceabilityCb;
@@ -91,6 +92,7 @@ class BookingServiceImpl implements BookingService {
                        PaymentTransactionRepository paymentTransactionRepository,
                        ShipmentStateHistoryRepository historyRepository,
                        CustomerVisibleStateMapper stateMapper,
+                       PickupSlotCapacity pickupSlotCapacity,
                        TransactionTemplate transactionTemplate,
                        CircuitBreakerRegistry circuitBreakerRegistry,
                        TimeLimiterRegistry timeLimiterRegistry,
@@ -106,6 +108,7 @@ class BookingServiceImpl implements BookingService {
         this.paymentTransactionRepository = paymentTransactionRepository;
         this.historyRepository = historyRepository;
         this.stateMapper = stateMapper;
+        this.pickupSlotCapacity = pickupSlotCapacity;
         this.tx = transactionTemplate;
         this.serviceabilityCb = circuitBreakerRegistry.circuitBreaker("serviceability");
         this.pricingCb        = circuitBreakerRegistry.circuitBreaker("pricing");
@@ -193,6 +196,9 @@ class BookingServiceImpl implements BookingService {
         int volumetricWeightGrams = priced.volumetricWeightGrams();
         int chargeableWeightGrams = priced.chargeableWeightGrams();
         QuoteResult quote = priced.quote();
+
+        // ── 3b. Pickup-slot capacity (before payment, so a full slot never charges) ──
+        pickupSlotCapacity.ensureRoom(req.getOriginCity(), req.getPickupSlotDate(), req.getPickupSlotStartHour());
 
         // ── 4. Payment verify + capture (PREPAID only, outside DB transaction) ──
         boolean isPrepaid = PaymentMode.PREPAID == req.getPaymentMode();

--- a/orders/src/main/java/com/oneday/orders/service/impl/BookingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/BookingServiceImpl.java
@@ -198,7 +198,8 @@ class BookingServiceImpl implements BookingService {
         QuoteResult quote = priced.quote();
 
         // ── 3b. Pickup-slot capacity (before payment, so a full slot never charges) ──
-        pickupSlotCapacity.ensureRoom(req.getOriginCity(), req.getPickupSlotDate(), req.getPickupSlotStartHour());
+        pickupSlotCapacity.ensureRoom(req.getOriginCity(), req.getPickupSlotDate(),
+                req.getPickupSlotStartHour(), req.getPickupType());
 
         // ── 4. Payment verify + capture (PREPAID only, outside DB transaction) ──
         boolean isPrepaid = PaymentMode.PREPAID == req.getPaymentMode();

--- a/orders/src/main/java/com/oneday/orders/service/impl/PickupSlotCapacity.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/PickupSlotCapacity.java
@@ -1,0 +1,55 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.PickupSlots;
+import com.oneday.orders.config.PickupSlotProperties;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.service.BookingService;
+import com.oneday.orders.service.PickupSlotFullException;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+/**
+ * Enforces the per-slot pickup cap at booking time, shared by the B2C and B2B booking flows.
+ * Called <em>before</em> payment, so a full (or invalid) slot rejects without ever charging.
+ */
+@Component
+class PickupSlotCapacity {
+
+    private final ShipmentRepository shipmentRepository;
+    private final PickupSlotProperties props;
+
+    PickupSlotCapacity(ShipmentRepository shipmentRepository, PickupSlotProperties props) {
+        this.shipmentRepository = shipmentRepository;
+        this.props = props;
+    }
+
+    /**
+     * No-op for an ASAP booking (no slot chosen). Otherwise validate the slot and reject with
+     * {@link PickupSlotFullException} if the (origin city, slot) already holds {@code maxPerSlot} active
+     * reservations.
+     *
+     * <p>ponytail: soft cap — the count-then-book gap lets concurrent writers overbook a slot by up to
+     * (concurrent bookings − 1). A hard cap needs a per-slot counter row + row lock (mirror
+     * {@code VanManifestServiceImpl}); add it only if overbooking actually bites at pilot volume.
+     */
+    void ensureRoom(String originCity, LocalDate slotDate, Integer startHour) {
+        if (slotDate == null && startHour == null) {
+            return;   // ASAP — no slot to cap
+        }
+        // Same rule as applyScheduledPickup, but pre-payment so a bad slot never charges the customer.
+        if (slotDate == null || startHour == null || !PickupSlots.isValidStartHour(startHour)) {
+            throw new BookingService.InvalidBookingRequestException(
+                    "pickupSlotDate and a valid pickupSlotStartHour (7/9/11/13/15/17/19) are both required");
+        }
+        String city = originCity.toUpperCase();
+        Instant slotStart = PickupSlots.resolve(slotDate, startHour).start();
+        int booked = shipmentRepository
+                .countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(city, slotStart);
+        if (booked >= props.getMaxPerSlot()) {
+            throw new PickupSlotFullException(
+                    "The " + startHour + ":00 pickup slot for " + city + " is full. Please choose another slot.");
+        }
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/PickupSlotCapacity.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/PickupSlotCapacity.java
@@ -1,6 +1,7 @@
 package com.oneday.orders.service.impl;
 
 import com.oneday.common.domain.PickupSlots;
+import com.oneday.common.domain.enums.PickupType;
 import com.oneday.orders.config.PickupSlotProperties;
 import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.service.BookingService;
@@ -30,11 +31,14 @@ class PickupSlotCapacity {
      * {@link PickupSlotFullException} if the (origin city, slot) already holds {@code maxPerSlot} active
      * reservations.
      *
+     * <p>Only {@code DA_PICKUP} shipments consume a pickup slot — a {@code SELF_DROP} parcel is dropped
+     * by the customer and needs no DA, so it neither counts against the cap nor is capped.
+     *
      * <p>ponytail: soft cap — the count-then-book gap lets concurrent writers overbook a slot by up to
      * (concurrent bookings − 1). A hard cap needs a per-slot counter row + row lock (mirror
      * {@code VanManifestServiceImpl}); add it only if overbooking actually bites at pilot volume.
      */
-    void ensureRoom(String originCity, LocalDate slotDate, Integer startHour) {
+    void ensureRoom(String originCity, LocalDate slotDate, Integer startHour, PickupType pickupType) {
         if (slotDate == null && startHour == null) {
             return;   // ASAP — no slot to cap
         }
@@ -43,10 +47,14 @@ class PickupSlotCapacity {
             throw new BookingService.InvalidBookingRequestException(
                     "pickupSlotDate and a valid pickupSlotStartHour (7/9/11/13/15/17/19) are both required");
         }
+        if (pickupType != PickupType.DA_PICKUP) {
+            return;   // self-drop consumes no DA pickup slot
+        }
         String city = originCity.toUpperCase();
         Instant slotStart = PickupSlots.resolve(slotDate, startHour).start();
         int booked = shipmentRepository
-                .countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(city, slotStart);
+                .countByOriginCityAndScheduledPickupStartAndPickupTypeAndCancelledAtIsNull(
+                        city, slotStart, PickupType.DA_PICKUP);
         if (booked >= props.getMaxPerSlot()) {
             throw new PickupSlotFullException(
                     "The " + startHour + ":00 pickup slot for " + city + " is full. Please choose another slot.");

--- a/orders/src/test/java/com/oneday/orders/service/impl/B2bBookingServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/B2bBookingServiceImplTest.java
@@ -102,7 +102,7 @@ class B2bBookingServiceImplTest {
         service = new B2bBookingServiceImpl(
                 b2bAccountRepository, serviceabilityPort, pricingPort, etaPort,
                 shipmentRefService, orderService, shipmentRepository, historyRepository,
-                codCollectionRepository, stateMapper, walletService, new TransactionTemplate(NO_OP_TX),
+                codCollectionRepository, stateMapper, walletService, org.mockito.Mockito.mock(PickupSlotCapacity.class), new TransactionTemplate(NO_OP_TX),
                 applicationEventPublisher,
                 CircuitBreakerRegistry.ofDefaults(),
                 TimeLimiterRegistry.ofDefaults(),

--- a/orders/src/test/java/com/oneday/orders/service/impl/BookingServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/BookingServiceImplTest.java
@@ -108,7 +108,7 @@ class BookingServiceImplTest {
         service = new BookingServiceImpl(
                 serviceabilityPort, pricingPort, paymentPort, etaPort,
                 shipmentRefService, orderService, shipmentRepository, paymentTransactionRepository,
-                historyRepository, stateMapper, new TransactionTemplate(NO_OP_TX),
+                historyRepository, stateMapper, org.mockito.Mockito.mock(PickupSlotCapacity.class), new TransactionTemplate(NO_OP_TX),
                 CircuitBreakerRegistry.ofDefaults(),
                 TimeLimiterRegistry.ofDefaults(),
                 scheduler, applicationEventPublisher);

--- a/orders/src/test/java/com/oneday/orders/service/impl/PickupSlotCapacityTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/PickupSlotCapacityTest.java
@@ -1,0 +1,64 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.config.PickupSlotProperties;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.service.BookingService;
+import com.oneday.orders.service.PickupSlotFullException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The per-slot cap is the whole point of the feature: a full slot must be rejected, and it must reject
+ * BEFORE payment (this component runs pre-payment). These pin the four branches so a regression that
+ * dropped the cap, or the ASAP short-circuit, or the pre-charge validation, fails loudly.
+ */
+class PickupSlotCapacityTest {
+
+    private final ShipmentRepository repo = mock(ShipmentRepository.class);
+    private final PickupSlotProperties props = mock(PickupSlotProperties.class);
+    private final PickupSlotCapacity capacity = new PickupSlotCapacity(repo, props);
+
+    private static final LocalDate DATE = LocalDate.of(2026, 8, 27);
+    private static final int VALID_HOUR = 9;
+
+    @Test
+    void asapBookingSkipsTheCapEntirely() {
+        assertThatCode(() -> capacity.ensureRoom("DEL", null, null)).doesNotThrowAnyException();
+        verify(repo, never()).countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(any(), any());
+    }
+
+    @Test
+    void allowsWhenSlotHasRoom() {
+        when(props.getMaxPerSlot()).thenReturn(2);
+        when(repo.countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(eq("DEL"), any(Instant.class)))
+                .thenReturn(1);
+        assertThatCode(() -> capacity.ensureRoom("del", DATE, VALID_HOUR)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsWhenSlotIsFull() {
+        when(props.getMaxPerSlot()).thenReturn(2);
+        when(repo.countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(eq("DEL"), any(Instant.class)))
+                .thenReturn(2);
+        assertThatThrownBy(() -> capacity.ensureRoom("DEL", DATE, VALID_HOUR))
+                .isInstanceOf(PickupSlotFullException.class);
+    }
+
+    @Test
+    void rejectsAnInvalidStartHourBeforeAnyCapLookup() {
+        assertThatThrownBy(() -> capacity.ensureRoom("DEL", DATE, 8))   // 8 is not a valid slot start
+                .isInstanceOf(BookingService.InvalidBookingRequestException.class);
+        verify(repo, never()).countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(any(), any());
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/service/impl/PickupSlotCapacityTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/PickupSlotCapacityTest.java
@@ -1,5 +1,6 @@
 package com.oneday.orders.service.impl;
 
+import com.oneday.common.domain.enums.PickupType;
 import com.oneday.orders.config.PickupSlotProperties;
 import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.service.BookingService;
@@ -34,31 +35,41 @@ class PickupSlotCapacityTest {
 
     @Test
     void asapBookingSkipsTheCapEntirely() {
-        assertThatCode(() -> capacity.ensureRoom("DEL", null, null)).doesNotThrowAnyException();
-        verify(repo, never()).countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(any(), any());
+        assertThatCode(() -> capacity.ensureRoom("DEL", null, null, PickupType.DA_PICKUP))
+                .doesNotThrowAnyException();
+        verify(repo, never()).countByOriginCityAndScheduledPickupStartAndPickupTypeAndCancelledAtIsNull(any(), any(), any());
     }
 
     @Test
     void allowsWhenSlotHasRoom() {
         when(props.getMaxPerSlot()).thenReturn(2);
-        when(repo.countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(eq("DEL"), any(Instant.class)))
-                .thenReturn(1);
-        assertThatCode(() -> capacity.ensureRoom("del", DATE, VALID_HOUR)).doesNotThrowAnyException();
+        when(repo.countByOriginCityAndScheduledPickupStartAndPickupTypeAndCancelledAtIsNull(
+                eq("DEL"), any(Instant.class), eq(PickupType.DA_PICKUP))).thenReturn(1);
+        assertThatCode(() -> capacity.ensureRoom("del", DATE, VALID_HOUR, PickupType.DA_PICKUP))
+                .doesNotThrowAnyException();
     }
 
     @Test
     void rejectsWhenSlotIsFull() {
         when(props.getMaxPerSlot()).thenReturn(2);
-        when(repo.countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(eq("DEL"), any(Instant.class)))
-                .thenReturn(2);
-        assertThatThrownBy(() -> capacity.ensureRoom("DEL", DATE, VALID_HOUR))
+        when(repo.countByOriginCityAndScheduledPickupStartAndPickupTypeAndCancelledAtIsNull(
+                eq("DEL"), any(Instant.class), eq(PickupType.DA_PICKUP))).thenReturn(2);
+        assertThatThrownBy(() -> capacity.ensureRoom("DEL", DATE, VALID_HOUR, PickupType.DA_PICKUP))
                 .isInstanceOf(PickupSlotFullException.class);
     }
 
     @Test
+    void selfDropWithASlotNeverConsumesPickupCapacity() {
+        // A self-drop parcel needs no DA pickup, so it must not count against (or be capped by) the slot.
+        assertThatCode(() -> capacity.ensureRoom("DEL", DATE, VALID_HOUR, PickupType.SELF_DROP))
+                .doesNotThrowAnyException();
+        verify(repo, never()).countByOriginCityAndScheduledPickupStartAndPickupTypeAndCancelledAtIsNull(any(), any(), any());
+    }
+
+    @Test
     void rejectsAnInvalidStartHourBeforeAnyCapLookup() {
-        assertThatThrownBy(() -> capacity.ensureRoom("DEL", DATE, 8))   // 8 is not a valid slot start
+        assertThatThrownBy(() -> capacity.ensureRoom("DEL", DATE, 8, PickupType.DA_PICKUP))   // 8 not a valid slot start
                 .isInstanceOf(BookingService.InvalidBookingRequestException.class);
-        verify(repo, never()).countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(any(), any());
+        verify(repo, never()).countByOriginCityAndScheduledPickupStartAndPickupTypeAndCancelledAtIsNull(any(), any(), any());
     }
 }


### PR DESCRIPTION
## Feature #11 — Pickup slots: per-slot capacity cap

Rejects a booking whose pickup slot is already at capacity, **before payment**, so a full slot never charges the customer.

- Shared `PickupSlotCapacity` enforced in both B2C (`BookingServiceImpl`) and B2B (`B2bBookingServiceImpl`) flows.
- Cap is an ops-tunable property `orders.pickup-slot.max-per-slot` (default 50).
- Full/invalid slot → `PickupSlotFullException` → HTTP 409.
- New: `ShipmentRepository.countBy…ScheduledPickupStartAndCancelledAtIsNull` (excludes cancelled), 4-branch unit test.

> **Stacked on #147** (base = `feat/merchant-csv-export`). Merge #147 first; this diff shows only the #11 changes.

**Deferred (own tickets):** the "ETA slipped → accept/cancel" delay mail depends on the notification foundation; a "hide full slots" availability endpoint is a follow-up. The cap itself is complete (clean pre-charge 409).

`ponytail:` soft cap (count-then-book) — hard-cap upgrade path noted in-code.

Verify: `mvn test -pl orders -Dtest=PickupSlotCapacityTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)