### PR TITLE
feat(orders): per-merchant section categories (#1)

### DIFF
--- a/orders/src/main/java/com/oneday/orders/api/MerchantCategoryController.java
+++ b/orders/src/main/java/com/oneday/orders/api/MerchantCategoryController.java
@@ -1,0 +1,74 @@
+package com.oneday.orders.api;
+
+import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.orders.dto.MerchantCategoryRequest;
+import com.oneday.orders.dto.MerchantCategoryResponse;
+import com.oneday.orders.repository.B2bAccountRepository;
+import com.oneday.orders.service.MerchantCategoryService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * A merchant's own section categories. Scoped to the caller's B2B account (resolved from the
+ * principal, never a param), so categories are never visible or mutable across merchants.
+ */
+@RestController
+@RequestMapping("/api/v1/categories")
+class MerchantCategoryController {
+
+    private final MerchantCategoryService categoryService;
+    private final B2bAccountRepository accounts;
+
+    MerchantCategoryController(MerchantCategoryService categoryService, B2bAccountRepository accounts) {
+        this.categoryService = categoryService;
+        this.accounts = accounts;
+    }
+
+    @GetMapping
+    public List<MerchantCategoryResponse> list(@AuthenticationPrincipal AuthUserDetails principal) {
+        return categoryService.list(ownedAccountId(principal));
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public MerchantCategoryResponse create(@AuthenticationPrincipal AuthUserDetails principal,
+                                           @Valid @RequestBody MerchantCategoryRequest request) {
+        return categoryService.create(ownedAccountId(principal), request);
+    }
+
+    @PutMapping("/{id}")
+    public MerchantCategoryResponse rename(@AuthenticationPrincipal AuthUserDetails principal,
+                                           @PathVariable("id") UUID id,
+                                           @Valid @RequestBody MerchantCategoryRequest request) {
+        return categoryService.rename(ownedAccountId(principal), id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@AuthenticationPrincipal AuthUserDetails principal, @PathVariable("id") UUID id) {
+        categoryService.delete(ownedAccountId(principal), id);
+    }
+
+    /** The B2B account owned by the caller, or 404 (also gates the endpoint to B2B users). */
+    private UUID ownedAccountId(AuthUserDetails principal) {
+        Authz.requireRole(principal, "B2B_USER");
+        UUID userId = UUID.fromString(Authz.requireUserId(principal));
+        return accounts.findByOwnerUserId(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No B2B account for this user"))
+                .getId();
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/api/OrdersGlobalExceptionHandler.java
+++ b/orders/src/main/java/com/oneday/orders/api/OrdersGlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import com.oneday.orders.service.BookingService;
 import com.oneday.orders.service.BulkUploadService;
 import com.oneday.orders.service.CancellationService;
 import com.oneday.orders.service.CartService;
+import com.oneday.orders.service.MerchantCategoryService;
 import com.oneday.orders.service.PaymentPort;
 import com.oneday.orders.service.PickupSlotFullException;
 import com.oneday.orders.service.exception.IllegalStateTransitionException;
@@ -130,6 +131,22 @@ class OrdersGlobalExceptionHandler {
     ProblemDetail handlePickupSlotFull(PickupSlotFullException ex) {
         ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.CONFLICT);
         pd.setTitle("Pickup slot full");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    @ExceptionHandler(MerchantCategoryService.CategoryNotFoundException.class)
+    ProblemDetail handleCategoryNotFound(MerchantCategoryService.CategoryNotFoundException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
+        pd.setTitle("Category not found");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    @ExceptionHandler(MerchantCategoryService.DuplicateCategoryException.class)
+    ProblemDetail handleDuplicateCategory(MerchantCategoryService.DuplicateCategoryException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.CONFLICT);
+        pd.setTitle("Duplicate category");
         pd.setDetail(ex.getMessage());
         return pd;
     }

--- a/orders/src/main/java/com/oneday/orders/domain/MerchantCategory.java
+++ b/orders/src/main/java/com/oneday/orders/domain/MerchantCategory.java
@@ -1,0 +1,29 @@
+package com.oneday.orders.domain;
+
+import com.oneday.common.domain.MutableBaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+/**
+ * A merchant-defined section/category ("Electronics", "Apparel"). Account-scoped: the API only ever
+ * reads/writes rows for the authenticated caller's own b2b_account_id.
+ */
+@Entity
+@Table(name = "merchant_category")
+@Getter
+@Setter
+@NoArgsConstructor
+public class MerchantCategory extends MutableBaseEntity {
+
+    @Column(name = "b2b_account_id", nullable = false, updatable = false)
+    private UUID b2bAccountId;
+
+    @Column(name = "name", length = 60, nullable = false)
+    private String name;
+}

--- a/orders/src/main/java/com/oneday/orders/domain/Shipment.java
+++ b/orders/src/main/java/com/oneday/orders/domain/Shipment.java
@@ -50,6 +50,11 @@ public class Shipment extends MutableBaseEntity {
     @Column(name = "order_id", updatable = false)
     private UUID orderId;
 
+    // Merchant's section category for this shipment (null = untagged). Set at booking from the
+    // merchant's own categories; a bare UUID by cross-module convention, not a DB foreign key.
+    @Column(name = "category_id", updatable = false)
+    private UUID categoryId;
+
     // ── Sender ────────────────────────────────────────────────────────────
 
     @Column(name = "sender_name", length = 100, nullable = false, updatable = false)

--- a/orders/src/main/java/com/oneday/orders/dto/B2bBookingRequest.java
+++ b/orders/src/main/java/com/oneday/orders/dto/B2bBookingRequest.java
@@ -23,6 +23,8 @@ public class B2bBookingRequest {
     @NotNull private UUID b2bAccountId;
     @Size(max = 100) private String purchaseOrderRef;  // nullable
 
+    private java.util.UUID categoryId;  // nullable — one of the merchant's own section categories
+
     // ── Sender ────────────────────────────────────────────────────────────────
 
     @NotBlank @Size(max = 100) private String senderName;
@@ -81,6 +83,8 @@ public class B2bBookingRequest {
 
     public String getPurchaseOrderRef()        { return purchaseOrderRef; }
     public void setPurchaseOrderRef(String v)  { this.purchaseOrderRef = v; }
+    public java.util.UUID getCategoryId()      { return categoryId; }
+    public void setCategoryId(java.util.UUID v) { this.categoryId = v; }
 
     public String getSenderName()              { return senderName; }
     public void setSenderName(String v)        { this.senderName = v; }

--- a/orders/src/main/java/com/oneday/orders/dto/MerchantCategoryRequest.java
+++ b/orders/src/main/java/com/oneday/orders/dto/MerchantCategoryRequest.java
@@ -1,0 +1,15 @@
+package com.oneday.orders.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/** Create/rename payload for a merchant category. */
+public class MerchantCategoryRequest {
+
+    @NotBlank
+    @Size(max = 60)
+    private String name;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+}

--- a/orders/src/main/java/com/oneday/orders/dto/MerchantCategoryResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/MerchantCategoryResponse.java
@@ -1,0 +1,12 @@
+package com.oneday.orders.dto;
+
+import com.oneday.orders.domain.MerchantCategory;
+
+import java.util.UUID;
+
+/** Read model for a merchant category. Snake_case on the wire (project-wide Jackson strategy). */
+public record MerchantCategoryResponse(UUID id, String name) {
+    public static MerchantCategoryResponse from(MerchantCategory c) {
+        return new MerchantCategoryResponse(c.getId(), c.getName());
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/dto/MyShipmentSummaryResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/MyShipmentSummaryResponse.java
@@ -4,6 +4,7 @@ import com.oneday.common.domain.enums.CustomerType;
 import com.oneday.common.domain.enums.ShipmentState;
 
 import java.time.Instant;
+import java.util.UUID;
 
 /**
  * One row of a customer's own booking history ({@code GET /api/v1/shipments/mine}). A read-only
@@ -20,6 +21,7 @@ public record MyShipmentSummaryResponse(
         String originCity,
         String destCity,
         Long totalPricePaise,
+        UUID categoryId,
         Instant createdAt,
         Instant cancelledAt) {
 }

--- a/orders/src/main/java/com/oneday/orders/repository/MerchantCategoryRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/MerchantCategoryRepository.java
@@ -1,0 +1,18 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.MerchantCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MerchantCategoryRepository extends JpaRepository<MerchantCategory, UUID> {
+
+    List<MerchantCategory> findByB2bAccountIdOrderByName(UUID b2bAccountId);
+
+    /** Account-scoped fetch so one merchant can never read/edit/tag-with another's category by id. */
+    Optional<MerchantCategory> findByIdAndB2bAccountId(UUID id, UUID b2bAccountId);
+
+    boolean existsByB2bAccountIdAndNameIgnoreCase(UUID b2bAccountId, String name);
+}

--- a/orders/src/main/java/com/oneday/orders/service/MerchantCategoryService.java
+++ b/orders/src/main/java/com/oneday/orders/service/MerchantCategoryService.java
@@ -1,0 +1,32 @@
+package com.oneday.orders.service;
+
+import com.oneday.orders.dto.MerchantCategoryRequest;
+import com.oneday.orders.dto.MerchantCategoryResponse;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Per-merchant section categories. All operations are scoped to the B2B account id supplied by the
+ * controller — one merchant can never see or mutate another's categories.
+ */
+public interface MerchantCategoryService {
+
+    List<MerchantCategoryResponse> list(UUID accountId);
+
+    MerchantCategoryResponse create(UUID accountId, MerchantCategoryRequest request);
+
+    MerchantCategoryResponse rename(UUID accountId, UUID categoryId, MerchantCategoryRequest request);
+
+    void delete(UUID accountId, UUID categoryId);
+
+    /** A category id that does not exist for this merchant → mapped to 404. */
+    class CategoryNotFoundException extends RuntimeException {
+        public CategoryNotFoundException(String message) { super(message); }
+    }
+
+    /** A category name already exists for this merchant → mapped to 409. */
+    class DuplicateCategoryException extends RuntimeException {
+        public DuplicateCategoryException(String message) { super(message); }
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
@@ -24,6 +24,7 @@ import com.oneday.orders.dto.B2bBookingRequest;
 import com.oneday.orders.dto.BookingResponse;
 import com.oneday.orders.repository.B2bAccountRepository;
 import com.oneday.orders.repository.CodCollectionRepository;
+import com.oneday.orders.repository.MerchantCategoryRepository;
 import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.repository.ShipmentStateHistoryRepository;
 import com.oneday.orders.service.B2bBookingService;
@@ -66,6 +67,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
     private final ShipmentRepository shipmentRepository;
     private final ShipmentStateHistoryRepository historyRepository;
     private final CodCollectionRepository codCollectionRepository;
+    private final MerchantCategoryRepository merchantCategoryRepository;
     private final CustomerVisibleStateMapper stateMapper;
     private final WalletService walletService;
     private final PickupSlotCapacity pickupSlotCapacity;
@@ -89,6 +91,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
                           ShipmentRepository shipmentRepository,
                           ShipmentStateHistoryRepository historyRepository,
                           CodCollectionRepository codCollectionRepository,
+                          MerchantCategoryRepository merchantCategoryRepository,
                           CustomerVisibleStateMapper stateMapper,
                           WalletService walletService,
                           PickupSlotCapacity pickupSlotCapacity,
@@ -106,6 +109,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
         this.shipmentRepository   = shipmentRepository;
         this.historyRepository    = historyRepository;
         this.codCollectionRepository = codCollectionRepository;
+        this.merchantCategoryRepository = merchantCategoryRepository;
         this.stateMapper          = stateMapper;
         this.walletService        = walletService;
         this.pickupSlotCapacity   = pickupSlotCapacity;
@@ -139,6 +143,12 @@ class B2bBookingServiceImpl implements B2bBookingService {
         if (account.getOwnerUserId() == null || !account.getOwnerUserId().toString().equals(userId)) {
             throw new AccountAccessException(
                     "Caller is not authorized for B2B account: " + req.getB2bAccountId());
+        }
+        // Category (optional) must be one of THIS merchant's own — never another account's category.
+        if (req.getCategoryId() != null
+                && merchantCategoryRepository.findByIdAndB2bAccountId(req.getCategoryId(), req.getB2bAccountId()).isEmpty()) {
+            throw new BookingService.InvalidBookingRequestException(
+                    "Unknown category for this account: " + req.getCategoryId());
         }
 
         // ── 2. Serviceability (outside TX) ────────────────────────────────────
@@ -244,6 +254,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
         shipment.setOrderId(effectiveOrderId);
         shipment.setCustomerType(CustomerType.B2B);
         shipment.setB2bAccountId(req.getB2bAccountId());
+        shipment.setCategoryId(req.getCategoryId());   // validated same-merchant in book()
         shipment.setDeliveryType(serviceability.deliveryType());
         shipment.setSenderName(req.getSenderName());
         shipment.setSenderPhone(req.getSenderPhone());

--- a/orders/src/main/java/com/oneday/orders/service/impl/CustomerOrderQueryServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/CustomerOrderQueryServiceImpl.java
@@ -223,6 +223,7 @@ class CustomerOrderQueryServiceImpl implements CustomerOrderQueryService {
                 s.getOriginCity(),
                 s.getDestCity(),
                 s.getTotalPricePaise(),
+                s.getCategoryId(),
                 s.getCreatedAt(),
                 s.getCancelledAt());
     }

--- a/orders/src/main/java/com/oneday/orders/service/impl/MerchantCategoryServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/MerchantCategoryServiceImpl.java
@@ -1,0 +1,70 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.domain.MerchantCategory;
+import com.oneday.orders.dto.MerchantCategoryRequest;
+import com.oneday.orders.dto.MerchantCategoryResponse;
+import com.oneday.orders.repository.MerchantCategoryRepository;
+import com.oneday.orders.service.MerchantCategoryService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+class MerchantCategoryServiceImpl implements MerchantCategoryService {
+
+    private final MerchantCategoryRepository repository;
+
+    MerchantCategoryServiceImpl(MerchantCategoryRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MerchantCategoryResponse> list(UUID accountId) {
+        return repository.findByB2bAccountIdOrderByName(accountId).stream()
+                .map(MerchantCategoryResponse::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public MerchantCategoryResponse create(UUID accountId, MerchantCategoryRequest request) {
+        String name = request.getName().trim();
+        requireUnique(accountId, name);
+        MerchantCategory entity = new MerchantCategory();
+        entity.setB2bAccountId(accountId);
+        entity.setName(name);
+        return MerchantCategoryResponse.from(repository.save(entity));
+    }
+
+    @Override
+    @Transactional
+    public MerchantCategoryResponse rename(UUID accountId, UUID categoryId, MerchantCategoryRequest request) {
+        MerchantCategory entity = repository.findByIdAndB2bAccountId(categoryId, accountId)
+                .orElseThrow(() -> new CategoryNotFoundException("Category not found: " + categoryId));
+        String name = request.getName().trim();
+        if (!name.equalsIgnoreCase(entity.getName())) {
+            requireUnique(accountId, name);
+        }
+        entity.setName(name);
+        return MerchantCategoryResponse.from(repository.save(entity));
+    }
+
+    @Override
+    @Transactional
+    public void delete(UUID accountId, UUID categoryId) {
+        MerchantCategory entity = repository.findByIdAndB2bAccountId(categoryId, accountId)
+                .orElseThrow(() -> new CategoryNotFoundException("Category not found: " + categoryId));
+        // Existing shipments keep their category_id (a snapshot of the tag at booking); deleting the
+        // definition just removes it from the pick list. No cascade needed.
+        repository.delete(entity);
+    }
+
+    private void requireUnique(UUID accountId, String name) {
+        if (repository.existsByB2bAccountIdAndNameIgnoreCase(accountId, name)) {
+            throw new DuplicateCategoryException("Category already exists: " + name);
+        }
+    }
+}

--- a/orders/src/main/resources/db/migration/orders/V4_41__create_merchant_category.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_41__create_merchant_category.sql
@@ -1,0 +1,24 @@
+-- M4: per-merchant section categories. A B2B merchant defines their own categories
+-- ("Electronics", "Apparel", …) and tags each shipment with one, for their own filtering/reporting.
+-- Account-scoped: the API only ever reads/writes rows for the caller's own b2b_account_id.
+CREATE TABLE merchant_category (
+  id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- Plain UUID, no FK to b2b_accounts: orders keeps FKs implicit cross-table by convention
+  -- (matches shipments.b2b_account_id / saved_address.user_id).
+  b2b_account_id UUID        NOT NULL,
+  name           VARCHAR(60) NOT NULL,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- One category name per merchant (case-insensitive) — no duplicate "Electronics"/"electronics".
+CREATE UNIQUE INDEX ux_merchant_category_account_name ON merchant_category (b2b_account_id, lower(name));
+
+CREATE TRIGGER trg_merchant_category_updated_at
+  BEFORE UPDATE ON merchant_category
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- Tag a shipment with one of its merchant's categories (null = untagged). FK-by-convention to
+-- merchant_category; set at booking time, so immutable like the other booking facts.
+ALTER TABLE shipments ADD COLUMN category_id UUID;
+CREATE INDEX idx_shipments_category ON shipments (b2b_account_id, category_id);

--- a/orders/src/test/java/com/oneday/orders/service/impl/B2bBookingServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/B2bBookingServiceImplTest.java
@@ -102,7 +102,8 @@ class B2bBookingServiceImplTest {
         service = new B2bBookingServiceImpl(
                 b2bAccountRepository, serviceabilityPort, pricingPort, etaPort,
                 shipmentRefService, orderService, shipmentRepository, historyRepository,
-                codCollectionRepository, stateMapper, walletService, org.mockito.Mockito.mock(PickupSlotCapacity.class), new TransactionTemplate(NO_OP_TX),
+                codCollectionRepository, org.mockito.Mockito.mock(com.oneday.orders.repository.MerchantCategoryRepository.class),
+                stateMapper, walletService, org.mockito.Mockito.mock(PickupSlotCapacity.class), new TransactionTemplate(NO_OP_TX),
                 applicationEventPublisher,
                 CircuitBreakerRegistry.ofDefaults(),
                 TimeLimiterRegistry.ofDefaults(),

--- a/orders/src/test/java/com/oneday/orders/service/impl/MerchantCategoryServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/MerchantCategoryServiceImplTest.java
@@ -1,0 +1,84 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.domain.MerchantCategory;
+import com.oneday.orders.dto.MerchantCategoryRequest;
+import com.oneday.orders.dto.MerchantCategoryResponse;
+import com.oneday.orders.repository.MerchantCategoryRepository;
+import com.oneday.orders.service.MerchantCategoryService;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Categories are per-merchant and must stay that way: create must reject duplicate names, and
+ * rename/delete must look the row up scoped to the caller's account so one merchant can never touch
+ * another's category by id. These pin those guarantees.
+ */
+class MerchantCategoryServiceImplTest {
+
+    private final MerchantCategoryRepository repo = mock(MerchantCategoryRepository.class);
+    private final MerchantCategoryServiceImpl service = new MerchantCategoryServiceImpl(repo);
+
+    private static final UUID ACCOUNT = UUID.randomUUID();
+
+    private static MerchantCategoryRequest req(String name) {
+        MerchantCategoryRequest r = new MerchantCategoryRequest();
+        r.setName(name);
+        return r;
+    }
+
+    @Test
+    void createTrimsNameAndStampsTheCallersAccount() {
+        when(repo.existsByB2bAccountIdAndNameIgnoreCase(ACCOUNT, "Electronics")).thenReturn(false);
+        when(repo.save(any(MerchantCategory.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        MerchantCategoryResponse resp = service.create(ACCOUNT, req("  Electronics  "));
+
+        assertThat(resp.name()).isEqualTo("Electronics");
+        var saved = forClass(MerchantCategory.class);
+        verify(repo).save(saved.capture());
+        assertThat(saved.getValue().getB2bAccountId()).isEqualTo(ACCOUNT);
+        assertThat(saved.getValue().getName()).isEqualTo("Electronics");
+    }
+
+    @Test
+    void createRejectsADuplicateName() {
+        when(repo.existsByB2bAccountIdAndNameIgnoreCase(ACCOUNT, "Apparel")).thenReturn(true);
+
+        assertThatThrownBy(() -> service.create(ACCOUNT, req("Apparel")))
+                .isInstanceOf(MerchantCategoryService.DuplicateCategoryException.class);
+        verify(repo, never()).save(any());
+    }
+
+    @Test
+    void renameOfAnotherMerchantsCategoryIsNotFound() {
+        UUID foreignId = UUID.randomUUID();
+        when(repo.findByIdAndB2bAccountId(foreignId, ACCOUNT)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.rename(ACCOUNT, foreignId, req("Hijack")))
+                .isInstanceOf(MerchantCategoryService.CategoryNotFoundException.class);
+    }
+
+    @Test
+    void deleteIsScopedToTheCallersAccount() {
+        UUID id = UUID.randomUUID();
+        when(repo.findByIdAndB2bAccountId(id, ACCOUNT)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.delete(ACCOUNT, id))
+                .isInstanceOf(MerchantCategoryService.CategoryNotFoundException.class);
+        // Looked up strictly within the caller's account — never a bare findById.
+        verify(repo).findByIdAndB2bAccountId(eq(id), eq(ACCOUNT));
+        verify(repo, never()).delete(any());
+    }
+}


### PR DESCRIPTION
## Feature #1 — Section-based categories per merchant

A B2B merchant defines their own categories (e.g. "Electronics", "Apparel"), tags a shipment with one at booking, and filters/reports by it.

- `merchant_category` table (Flyway `V4_41`) + `shipments.category_id` (nullable, tagged at booking).
- Account-scoped CRUD `/api/v1/categories` (clone of the address-book slice; unique name per merchant, case-insensitive).
- `B2bBookingRequest.categoryId` stamped after **same-merchant validation** (a shipment can only be tagged with one of the booking account's own categories).
- `category_id` surfaced on the customer shipment read model.
- Service test over create/duplicate/rename/delete scoping.

> **Stacked on #148** (base = `feat/pickup-slot-caps`). Merge #147 → #148 → this; the diff shows only the #1 changes.

**Web counterpart:** separate PR in `oneday-web` (Categories management page, nav item, ship-form picker, shipments list column + filter).

Verify: `mvn test -pl orders -Dtest=MerchantCategoryServiceImplTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)