### PR TITLE
fix(app): allow business console origin (localhost:3003) in dev CORS

### DIFF
--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -75,7 +75,7 @@ spring:
 # turns it on. See docs/prod-readiness/PROD-READINESS-NOW.md.
 godspeed:
   cors:
-    allowed-origins: ${GODSPEED_CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:3001,http://localhost:3002,https://*.vercel.app}
+    allowed-origins: ${GODSPEED_CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:3001,http://localhost:3002,http://localhost:3003,https://*.vercel.app}
   ratelimit:
     enabled: ${GODSPEED_RATELIMIT_ENABLED:false}
 


### PR DESCRIPTION
## Problem
The dev/staging CORS default in `app/src/main/resources/application.yml` allowed `localhost:3000` (customer), `3001` (hub), `3002` (station) — but **not `3003`, where the business console runs**. Every business-app → backend request is blocked by CORS in local dev: the login POST fails preflight (403) and the UI shows a generic "Something went wrong."

## Fix
Add `http://localhost:3003` to the `godspeed.cors.allowed-origins` default. One line; no behavior change beyond permitting the business origin in dev.

## Not affected
`application-prod.yml` pins the real Vercel origins via `GODSPEED_CORS_ALLOWED_ORIGINS` and is untouched.

## Verify
Boot the app, then:
```
curl -i -X OPTIONS http://localhost:8080/auth/login \
  -H 'Origin: http://localhost:3003' \
  -H 'Access-Control-Request-Method: POST' \
  -H 'Access-Control-Request-Headers: content-type'
# → 200 with Access-Control-Allow-Origin: http://localhost:3003
```
Found while testing the business console locally (the merchant CSV export, #147).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled local development applications running on port 3003 to access the service through CORS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->