### PR TITLE
Feat/pickup slot caps

### DIFF
--- a/orders/src/main/java/com/oneday/orders/api/MerchantCategoryController.java
+++ b/orders/src/main/java/com/oneday/orders/api/MerchantCategoryController.java
@@ -1,0 +1,74 @@
+package com.oneday.orders.api;
+
+import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.orders.dto.MerchantCategoryRequest;
+import com.oneday.orders.dto.MerchantCategoryResponse;
+import com.oneday.orders.repository.B2bAccountRepository;
+import com.oneday.orders.service.MerchantCategoryService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * A merchant's own section categories. Scoped to the caller's B2B account (resolved from the
+ * principal, never a param), so categories are never visible or mutable across merchants.
+ */
+@RestController
+@RequestMapping("/api/v1/categories")
+class MerchantCategoryController {
+
+    private final MerchantCategoryService categoryService;
+    private final B2bAccountRepository accounts;
+
+    MerchantCategoryController(MerchantCategoryService categoryService, B2bAccountRepository accounts) {
+        this.categoryService = categoryService;
+        this.accounts = accounts;
+    }
+
+    @GetMapping
+    public List<MerchantCategoryResponse> list(@AuthenticationPrincipal AuthUserDetails principal) {
+        return categoryService.list(ownedAccountId(principal));
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public MerchantCategoryResponse create(@AuthenticationPrincipal AuthUserDetails principal,
+                                           @Valid @RequestBody MerchantCategoryRequest request) {
+        return categoryService.create(ownedAccountId(principal), request);
+    }
+
+    @PutMapping("/{id}")
+    public MerchantCategoryResponse rename(@AuthenticationPrincipal AuthUserDetails principal,
+                                           @PathVariable("id") UUID id,
+                                           @Valid @RequestBody MerchantCategoryRequest request) {
+        return categoryService.rename(ownedAccountId(principal), id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@AuthenticationPrincipal AuthUserDetails principal, @PathVariable("id") UUID id) {
+        categoryService.delete(ownedAccountId(principal), id);
+    }
+
+    /** The B2B account owned by the caller, or 404 (also gates the endpoint to B2B users). */
+    private UUID ownedAccountId(AuthUserDetails principal) {
+        Authz.requireRole(principal, "B2B_USER");
+        UUID userId = UUID.fromString(Authz.requireUserId(principal));
+        return accounts.findByOwnerUserId(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No B2B account for this user"))
+                .getId();
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/api/OrdersGlobalExceptionHandler.java
+++ b/orders/src/main/java/com/oneday/orders/api/OrdersGlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import com.oneday.orders.service.BulkUploadService;
 import com.oneday.orders.service.CancellationService;
 import com.oneday.orders.service.CartService;
 import com.oneday.orders.service.PaymentPort;
+import com.oneday.orders.service.PickupSlotFullException;
 import com.oneday.orders.service.exception.IllegalStateTransitionException;
 import com.oneday.pricing.service.NoRateConfiguredException;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
@@ -121,6 +122,14 @@ class OrdersGlobalExceptionHandler {
     ProblemDetail handleCancellationNotAllowed(CancellationService.CancellationNotAllowedException ex) {
         ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.CONFLICT);
         pd.setTitle("Cancellation not allowed");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    @ExceptionHandler(PickupSlotFullException.class)
+    ProblemDetail handlePickupSlotFull(PickupSlotFullException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.CONFLICT);
+        pd.setTitle("Pickup slot full");
         pd.setDetail(ex.getMessage());
         return pd;
     }

--- a/orders/src/main/java/com/oneday/orders/api/OrdersGlobalExceptionHandler.java
+++ b/orders/src/main/java/com/oneday/orders/api/OrdersGlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import com.oneday.orders.service.BookingService;
 import com.oneday.orders.service.BulkUploadService;
 import com.oneday.orders.service.CancellationService;
 import com.oneday.orders.service.CartService;
+import com.oneday.orders.service.MerchantCategoryService;
 import com.oneday.orders.service.PaymentPort;
 import com.oneday.orders.service.PickupSlotFullException;
 import com.oneday.orders.service.exception.IllegalStateTransitionException;
@@ -130,6 +131,22 @@ class OrdersGlobalExceptionHandler {
     ProblemDetail handlePickupSlotFull(PickupSlotFullException ex) {
         ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.CONFLICT);
         pd.setTitle("Pickup slot full");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    @ExceptionHandler(MerchantCategoryService.CategoryNotFoundException.class)
+    ProblemDetail handleCategoryNotFound(MerchantCategoryService.CategoryNotFoundException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
+        pd.setTitle("Category not found");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    @ExceptionHandler(MerchantCategoryService.DuplicateCategoryException.class)
+    ProblemDetail handleDuplicateCategory(MerchantCategoryService.DuplicateCategoryException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.CONFLICT);
+        pd.setTitle("Duplicate category");
         pd.setDetail(ex.getMessage());
         return pd;
     }

--- a/orders/src/main/java/com/oneday/orders/config/PickupSlotProperties.java
+++ b/orders/src/main/java/com/oneday/orders/config/PickupSlotProperties.java
@@ -1,0 +1,32 @@
+package com.oneday.orders.config;
+
+import jakarta.validation.constraints.Positive;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Configuration for pickup-slot capacity.
+ *
+ * <pre>{@code
+ * orders:
+ *   pickup-slot:
+ *     max-per-slot: 50
+ * }</pre>
+ */
+@Component
+@ConfigurationProperties(prefix = "orders.pickup-slot")
+@Validated
+public class PickupSlotProperties {
+
+    /**
+     * Max active (non-cancelled) pickups reservable in one (origin city, 2-hour slot) before the slot is
+     * full and further bookings for it are rejected. An ops capacity knob — tune per real DA throughput.
+     * Default: 50.
+     */
+    @Positive
+    private int maxPerSlot = 50;
+
+    public int getMaxPerSlot() { return maxPerSlot; }
+    public void setMaxPerSlot(int maxPerSlot) { this.maxPerSlot = maxPerSlot; }
+}

--- a/orders/src/main/java/com/oneday/orders/domain/MerchantCategory.java
+++ b/orders/src/main/java/com/oneday/orders/domain/MerchantCategory.java
@@ -1,0 +1,29 @@
+package com.oneday.orders.domain;
+
+import com.oneday.common.domain.MutableBaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+/**
+ * A merchant-defined section/category ("Electronics", "Apparel"). Account-scoped: the API only ever
+ * reads/writes rows for the authenticated caller's own b2b_account_id.
+ */
+@Entity
+@Table(name = "merchant_category")
+@Getter
+@Setter
+@NoArgsConstructor
+public class MerchantCategory extends MutableBaseEntity {
+
+    @Column(name = "b2b_account_id", nullable = false, updatable = false)
+    private UUID b2bAccountId;
+
+    @Column(name = "name", length = 60, nullable = false)
+    private String name;
+}

--- a/orders/src/main/java/com/oneday/orders/domain/Shipment.java
+++ b/orders/src/main/java/com/oneday/orders/domain/Shipment.java
@@ -50,6 +50,11 @@ public class Shipment extends MutableBaseEntity {
     @Column(name = "order_id", updatable = false)
     private UUID orderId;
 
+    // Merchant's section category for this shipment (null = untagged). Set at booking from the
+    // merchant's own categories; a bare UUID by cross-module convention, not a DB foreign key.
+    @Column(name = "category_id", updatable = false)
+    private UUID categoryId;
+
     // ── Sender ────────────────────────────────────────────────────────────
 
     @Column(name = "sender_name", length = 100, nullable = false, updatable = false)

--- a/orders/src/main/java/com/oneday/orders/dto/B2bBookingRequest.java
+++ b/orders/src/main/java/com/oneday/orders/dto/B2bBookingRequest.java
@@ -23,6 +23,8 @@ public class B2bBookingRequest {
     @NotNull private UUID b2bAccountId;
     @Size(max = 100) private String purchaseOrderRef;  // nullable
 
+    private java.util.UUID categoryId;  // nullable — one of the merchant's own section categories
+
     // ── Sender ────────────────────────────────────────────────────────────────
 
     @NotBlank @Size(max = 100) private String senderName;
@@ -81,6 +83,8 @@ public class B2bBookingRequest {
 
     public String getPurchaseOrderRef()        { return purchaseOrderRef; }
     public void setPurchaseOrderRef(String v)  { this.purchaseOrderRef = v; }
+    public java.util.UUID getCategoryId()      { return categoryId; }
+    public void setCategoryId(java.util.UUID v) { this.categoryId = v; }
 
     public String getSenderName()              { return senderName; }
     public void setSenderName(String v)        { this.senderName = v; }

--- a/orders/src/main/java/com/oneday/orders/dto/MerchantCategoryRequest.java
+++ b/orders/src/main/java/com/oneday/orders/dto/MerchantCategoryRequest.java
@@ -1,0 +1,15 @@
+package com.oneday.orders.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/** Create/rename payload for a merchant category. */
+public class MerchantCategoryRequest {
+
+    @NotBlank
+    @Size(max = 60)
+    private String name;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+}

--- a/orders/src/main/java/com/oneday/orders/dto/MerchantCategoryResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/MerchantCategoryResponse.java
@@ -1,0 +1,12 @@
+package com.oneday.orders.dto;
+
+import com.oneday.orders.domain.MerchantCategory;
+
+import java.util.UUID;
+
+/** Read model for a merchant category. Snake_case on the wire (project-wide Jackson strategy). */
+public record MerchantCategoryResponse(UUID id, String name) {
+    public static MerchantCategoryResponse from(MerchantCategory c) {
+        return new MerchantCategoryResponse(c.getId(), c.getName());
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/dto/MyShipmentSummaryResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/MyShipmentSummaryResponse.java
@@ -4,6 +4,7 @@ import com.oneday.common.domain.enums.CustomerType;
 import com.oneday.common.domain.enums.ShipmentState;
 
 import java.time.Instant;
+import java.util.UUID;
 
 /**
  * One row of a customer's own booking history ({@code GET /api/v1/shipments/mine}). A read-only
@@ -20,6 +21,7 @@ public record MyShipmentSummaryResponse(
         String originCity,
         String destCity,
         Long totalPricePaise,
+        UUID categoryId,
         Instant createdAt,
         Instant cancelledAt) {
 }

--- a/orders/src/main/java/com/oneday/orders/repository/MerchantCategoryRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/MerchantCategoryRepository.java
@@ -1,0 +1,18 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.MerchantCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MerchantCategoryRepository extends JpaRepository<MerchantCategory, UUID> {
+
+    List<MerchantCategory> findByB2bAccountIdOrderByName(UUID b2bAccountId);
+
+    /** Account-scoped fetch so one merchant can never read/edit/tag-with another's category by id. */
+    Optional<MerchantCategory> findByIdAndB2bAccountId(UUID id, UUID b2bAccountId);
+
+    boolean existsByB2bAccountIdAndNameIgnoreCase(UUID b2bAccountId, String name);
+}

--- a/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
@@ -72,6 +72,10 @@ public interface ShipmentRepository extends JpaRepository<Shipment, UUID> {
     // account's users), newest first. Ownership is enforced by the caller before this runs.
     Page<Shipment> findByB2bAccountId(UUID b2bAccountId, Pageable pageable);
 
+    // Pickup-slot capacity: how many active (non-cancelled) reservations already hold a given
+    // city's slot (identified by its absolute start instant). Backs the per-slot cap at booking time.
+    int countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(String originCity, Instant scheduledPickupStart);
+
     // Order → N Shipments: the child shipments of one order (booking order preserved).
     List<Shipment> findByOrderIdOrderByCreatedAtAsc(UUID orderId);
 

--- a/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
@@ -1,6 +1,7 @@
 package com.oneday.orders.repository;
 
 import com.oneday.common.domain.enums.CustomerType;
+import com.oneday.common.domain.enums.PickupType;
 import com.oneday.common.domain.enums.ShipmentState;
 import com.oneday.orders.domain.Shipment;
 import jakarta.persistence.LockModeType;
@@ -72,9 +73,11 @@ public interface ShipmentRepository extends JpaRepository<Shipment, UUID> {
     // account's users), newest first. Ownership is enforced by the caller before this runs.
     Page<Shipment> findByB2bAccountId(UUID b2bAccountId, Pageable pageable);
 
-    // Pickup-slot capacity: how many active (non-cancelled) reservations already hold a given
-    // city's slot (identified by its absolute start instant). Backs the per-slot cap at booking time.
-    int countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(String originCity, Instant scheduledPickupStart);
+    // Pickup-slot capacity: how many active (non-cancelled) DA-pickup reservations already hold a
+    // given city's slot (identified by its absolute start instant). Only DA_PICKUP shipments consume
+    // a pickup slot — a SELF_DROP parcel needs no DA. Backs the per-slot cap at booking time.
+    int countByOriginCityAndScheduledPickupStartAndPickupTypeAndCancelledAtIsNull(
+            String originCity, Instant scheduledPickupStart, PickupType pickupType);
 
     // Order → N Shipments: the child shipments of one order (booking order preserved).
     List<Shipment> findByOrderIdOrderByCreatedAtAsc(UUID orderId);

--- a/orders/src/main/java/com/oneday/orders/service/MerchantCategoryService.java
+++ b/orders/src/main/java/com/oneday/orders/service/MerchantCategoryService.java
@@ -1,0 +1,32 @@
+package com.oneday.orders.service;
+
+import com.oneday.orders.dto.MerchantCategoryRequest;
+import com.oneday.orders.dto.MerchantCategoryResponse;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Per-merchant section categories. All operations are scoped to the B2B account id supplied by the
+ * controller — one merchant can never see or mutate another's categories.
+ */
+public interface MerchantCategoryService {
+
+    List<MerchantCategoryResponse> list(UUID accountId);
+
+    MerchantCategoryResponse create(UUID accountId, MerchantCategoryRequest request);
+
+    MerchantCategoryResponse rename(UUID accountId, UUID categoryId, MerchantCategoryRequest request);
+
+    void delete(UUID accountId, UUID categoryId);
+
+    /** A category id that does not exist for this merchant → mapped to 404. */
+    class CategoryNotFoundException extends RuntimeException {
+        public CategoryNotFoundException(String message) { super(message); }
+    }
+
+    /** A category name already exists for this merchant → mapped to 409. */
+    class DuplicateCategoryException extends RuntimeException {
+        public DuplicateCategoryException(String message) { super(message); }
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/PickupSlotFullException.java
+++ b/orders/src/main/java/com/oneday/orders/service/PickupSlotFullException.java
@@ -1,0 +1,11 @@
+package com.oneday.orders.service;
+
+/**
+ * A booking asked for a pickup slot that is already at capacity for its origin city. Thrown before
+ * payment so a full slot never charges the customer; surfaced as HTTP 409 (see the orders handler).
+ */
+public class PickupSlotFullException extends RuntimeException {
+    public PickupSlotFullException(String message) {
+        super(message);
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
@@ -68,6 +68,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
     private final CodCollectionRepository codCollectionRepository;
     private final CustomerVisibleStateMapper stateMapper;
     private final WalletService walletService;
+    private final PickupSlotCapacity pickupSlotCapacity;
     private final TransactionTemplate tx;
     private final ApplicationEventPublisher applicationEventPublisher;
 
@@ -90,6 +91,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
                           CodCollectionRepository codCollectionRepository,
                           CustomerVisibleStateMapper stateMapper,
                           WalletService walletService,
+                          PickupSlotCapacity pickupSlotCapacity,
                           TransactionTemplate transactionTemplate,
                           ApplicationEventPublisher applicationEventPublisher,
                           CircuitBreakerRegistry circuitBreakerRegistry,
@@ -106,6 +108,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
         this.codCollectionRepository = codCollectionRepository;
         this.stateMapper          = stateMapper;
         this.walletService        = walletService;
+        this.pickupSlotCapacity   = pickupSlotCapacity;
         this.tx                   = transactionTemplate;
         this.applicationEventPublisher = applicationEventPublisher;
         this.serviceabilityCb     = circuitBreakerRegistry.circuitBreaker("serviceability");
@@ -164,6 +167,9 @@ class B2bBookingServiceImpl implements B2bBookingService {
                         req.getDeclaredValuePaise(),
                         account.getRateCardId(),
                         null)));  // B2B is credit-billed — no COD surcharge
+
+        // ── 4b. Pickup-slot capacity (before opening the TX; a full slot rejects cleanly) ──
+        pickupSlotCapacity.ensureRoom(req.getOriginCity(), req.getPickupSlotDate(), req.getPickupSlotStartHour());
 
         // ── 5. DB transaction: credit check → persist → balance increment ──────
         final int finalVolumetric = volumetricWeightGrams;

--- a/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
@@ -169,7 +169,8 @@ class B2bBookingServiceImpl implements B2bBookingService {
                         null)));  // B2B is credit-billed — no COD surcharge
 
         // ── 4b. Pickup-slot capacity (before opening the TX; a full slot rejects cleanly) ──
-        pickupSlotCapacity.ensureRoom(req.getOriginCity(), req.getPickupSlotDate(), req.getPickupSlotStartHour());
+        pickupSlotCapacity.ensureRoom(req.getOriginCity(), req.getPickupSlotDate(),
+                req.getPickupSlotStartHour(), req.getPickupType());
 
         // ── 5. DB transaction: credit check → persist → balance increment ──────
         final int finalVolumetric = volumetricWeightGrams;

--- a/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
@@ -24,6 +24,7 @@ import com.oneday.orders.dto.B2bBookingRequest;
 import com.oneday.orders.dto.BookingResponse;
 import com.oneday.orders.repository.B2bAccountRepository;
 import com.oneday.orders.repository.CodCollectionRepository;
+import com.oneday.orders.repository.MerchantCategoryRepository;
 import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.repository.ShipmentStateHistoryRepository;
 import com.oneday.orders.service.B2bBookingService;
@@ -66,6 +67,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
     private final ShipmentRepository shipmentRepository;
     private final ShipmentStateHistoryRepository historyRepository;
     private final CodCollectionRepository codCollectionRepository;
+    private final MerchantCategoryRepository merchantCategoryRepository;
     private final CustomerVisibleStateMapper stateMapper;
     private final WalletService walletService;
     private final PickupSlotCapacity pickupSlotCapacity;
@@ -89,6 +91,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
                           ShipmentRepository shipmentRepository,
                           ShipmentStateHistoryRepository historyRepository,
                           CodCollectionRepository codCollectionRepository,
+                          MerchantCategoryRepository merchantCategoryRepository,
                           CustomerVisibleStateMapper stateMapper,
                           WalletService walletService,
                           PickupSlotCapacity pickupSlotCapacity,
@@ -106,6 +109,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
         this.shipmentRepository   = shipmentRepository;
         this.historyRepository    = historyRepository;
         this.codCollectionRepository = codCollectionRepository;
+        this.merchantCategoryRepository = merchantCategoryRepository;
         this.stateMapper          = stateMapper;
         this.walletService        = walletService;
         this.pickupSlotCapacity   = pickupSlotCapacity;
@@ -139,6 +143,12 @@ class B2bBookingServiceImpl implements B2bBookingService {
         if (account.getOwnerUserId() == null || !account.getOwnerUserId().toString().equals(userId)) {
             throw new AccountAccessException(
                     "Caller is not authorized for B2B account: " + req.getB2bAccountId());
+        }
+        // Category (optional) must be one of THIS merchant's own — never another account's category.
+        if (req.getCategoryId() != null
+                && merchantCategoryRepository.findByIdAndB2bAccountId(req.getCategoryId(), req.getB2bAccountId()).isEmpty()) {
+            throw new BookingService.InvalidBookingRequestException(
+                    "Unknown category for this account: " + req.getCategoryId());
         }
 
         // ── 2. Serviceability (outside TX) ────────────────────────────────────
@@ -244,6 +254,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
         shipment.setOrderId(effectiveOrderId);
         shipment.setCustomerType(CustomerType.B2B);
         shipment.setB2bAccountId(req.getB2bAccountId());
+        shipment.setCategoryId(req.getCategoryId());   // validated same-merchant in book()
         shipment.setDeliveryType(serviceability.deliveryType());
         shipment.setSenderName(req.getSenderName());
         shipment.setSenderPhone(req.getSenderPhone());

--- a/orders/src/main/java/com/oneday/orders/service/impl/BookingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/BookingServiceImpl.java
@@ -68,6 +68,7 @@ class BookingServiceImpl implements BookingService {
     private final PaymentTransactionRepository paymentTransactionRepository;
     private final ShipmentStateHistoryRepository historyRepository;
     private final CustomerVisibleStateMapper stateMapper;
+    private final PickupSlotCapacity pickupSlotCapacity;
     private final TransactionTemplate tx;
 
     private final CircuitBreaker serviceabilityCb;
@@ -91,6 +92,7 @@ class BookingServiceImpl implements BookingService {
                        PaymentTransactionRepository paymentTransactionRepository,
                        ShipmentStateHistoryRepository historyRepository,
                        CustomerVisibleStateMapper stateMapper,
+                       PickupSlotCapacity pickupSlotCapacity,
                        TransactionTemplate transactionTemplate,
                        CircuitBreakerRegistry circuitBreakerRegistry,
                        TimeLimiterRegistry timeLimiterRegistry,
@@ -106,6 +108,7 @@ class BookingServiceImpl implements BookingService {
         this.paymentTransactionRepository = paymentTransactionRepository;
         this.historyRepository = historyRepository;
         this.stateMapper = stateMapper;
+        this.pickupSlotCapacity = pickupSlotCapacity;
         this.tx = transactionTemplate;
         this.serviceabilityCb = circuitBreakerRegistry.circuitBreaker("serviceability");
         this.pricingCb        = circuitBreakerRegistry.circuitBreaker("pricing");
@@ -193,6 +196,9 @@ class BookingServiceImpl implements BookingService {
         int volumetricWeightGrams = priced.volumetricWeightGrams();
         int chargeableWeightGrams = priced.chargeableWeightGrams();
         QuoteResult quote = priced.quote();
+
+        // ── 3b. Pickup-slot capacity (before payment, so a full slot never charges) ──
+        pickupSlotCapacity.ensureRoom(req.getOriginCity(), req.getPickupSlotDate(), req.getPickupSlotStartHour());
 
         // ── 4. Payment verify + capture (PREPAID only, outside DB transaction) ──
         boolean isPrepaid = PaymentMode.PREPAID == req.getPaymentMode();

--- a/orders/src/main/java/com/oneday/orders/service/impl/BookingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/BookingServiceImpl.java
@@ -198,7 +198,8 @@ class BookingServiceImpl implements BookingService {
         QuoteResult quote = priced.quote();
 
         // ── 3b. Pickup-slot capacity (before payment, so a full slot never charges) ──
-        pickupSlotCapacity.ensureRoom(req.getOriginCity(), req.getPickupSlotDate(), req.getPickupSlotStartHour());
+        pickupSlotCapacity.ensureRoom(req.getOriginCity(), req.getPickupSlotDate(),
+                req.getPickupSlotStartHour(), req.getPickupType());
 
         // ── 4. Payment verify + capture (PREPAID only, outside DB transaction) ──
         boolean isPrepaid = PaymentMode.PREPAID == req.getPaymentMode();

--- a/orders/src/main/java/com/oneday/orders/service/impl/CustomerOrderQueryServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/CustomerOrderQueryServiceImpl.java
@@ -223,6 +223,7 @@ class CustomerOrderQueryServiceImpl implements CustomerOrderQueryService {
                 s.getOriginCity(),
                 s.getDestCity(),
                 s.getTotalPricePaise(),
+                s.getCategoryId(),
                 s.getCreatedAt(),
                 s.getCancelledAt());
     }

--- a/orders/src/main/java/com/oneday/orders/service/impl/MerchantCategoryServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/MerchantCategoryServiceImpl.java
@@ -1,0 +1,70 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.domain.MerchantCategory;
+import com.oneday.orders.dto.MerchantCategoryRequest;
+import com.oneday.orders.dto.MerchantCategoryResponse;
+import com.oneday.orders.repository.MerchantCategoryRepository;
+import com.oneday.orders.service.MerchantCategoryService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+class MerchantCategoryServiceImpl implements MerchantCategoryService {
+
+    private final MerchantCategoryRepository repository;
+
+    MerchantCategoryServiceImpl(MerchantCategoryRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MerchantCategoryResponse> list(UUID accountId) {
+        return repository.findByB2bAccountIdOrderByName(accountId).stream()
+                .map(MerchantCategoryResponse::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public MerchantCategoryResponse create(UUID accountId, MerchantCategoryRequest request) {
+        String name = request.getName().trim();
+        requireUnique(accountId, name);
+        MerchantCategory entity = new MerchantCategory();
+        entity.setB2bAccountId(accountId);
+        entity.setName(name);
+        return MerchantCategoryResponse.from(repository.save(entity));
+    }
+
+    @Override
+    @Transactional
+    public MerchantCategoryResponse rename(UUID accountId, UUID categoryId, MerchantCategoryRequest request) {
+        MerchantCategory entity = repository.findByIdAndB2bAccountId(categoryId, accountId)
+                .orElseThrow(() -> new CategoryNotFoundException("Category not found: " + categoryId));
+        String name = request.getName().trim();
+        if (!name.equalsIgnoreCase(entity.getName())) {
+            requireUnique(accountId, name);
+        }
+        entity.setName(name);
+        return MerchantCategoryResponse.from(repository.save(entity));
+    }
+
+    @Override
+    @Transactional
+    public void delete(UUID accountId, UUID categoryId) {
+        MerchantCategory entity = repository.findByIdAndB2bAccountId(categoryId, accountId)
+                .orElseThrow(() -> new CategoryNotFoundException("Category not found: " + categoryId));
+        // Existing shipments keep their category_id (a snapshot of the tag at booking); deleting the
+        // definition just removes it from the pick list. No cascade needed.
+        repository.delete(entity);
+    }
+
+    private void requireUnique(UUID accountId, String name) {
+        if (repository.existsByB2bAccountIdAndNameIgnoreCase(accountId, name)) {
+            throw new DuplicateCategoryException("Category already exists: " + name);
+        }
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/PickupSlotCapacity.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/PickupSlotCapacity.java
@@ -1,0 +1,55 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.PickupSlots;
+import com.oneday.orders.config.PickupSlotProperties;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.service.BookingService;
+import com.oneday.orders.service.PickupSlotFullException;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+/**
+ * Enforces the per-slot pickup cap at booking time, shared by the B2C and B2B booking flows.
+ * Called <em>before</em> payment, so a full (or invalid) slot rejects without ever charging.
+ */
+@Component
+class PickupSlotCapacity {
+
+    private final ShipmentRepository shipmentRepository;
+    private final PickupSlotProperties props;
+
+    PickupSlotCapacity(ShipmentRepository shipmentRepository, PickupSlotProperties props) {
+        this.shipmentRepository = shipmentRepository;
+        this.props = props;
+    }
+
+    /**
+     * No-op for an ASAP booking (no slot chosen). Otherwise validate the slot and reject with
+     * {@link PickupSlotFullException} if the (origin city, slot) already holds {@code maxPerSlot} active
+     * reservations.
+     *
+     * <p>ponytail: soft cap — the count-then-book gap lets concurrent writers overbook a slot by up to
+     * (concurrent bookings − 1). A hard cap needs a per-slot counter row + row lock (mirror
+     * {@code VanManifestServiceImpl}); add it only if overbooking actually bites at pilot volume.
+     */
+    void ensureRoom(String originCity, LocalDate slotDate, Integer startHour) {
+        if (slotDate == null && startHour == null) {
+            return;   // ASAP — no slot to cap
+        }
+        // Same rule as applyScheduledPickup, but pre-payment so a bad slot never charges the customer.
+        if (slotDate == null || startHour == null || !PickupSlots.isValidStartHour(startHour)) {
+            throw new BookingService.InvalidBookingRequestException(
+                    "pickupSlotDate and a valid pickupSlotStartHour (7/9/11/13/15/17/19) are both required");
+        }
+        String city = originCity.toUpperCase();
+        Instant slotStart = PickupSlots.resolve(slotDate, startHour).start();
+        int booked = shipmentRepository
+                .countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(city, slotStart);
+        if (booked >= props.getMaxPerSlot()) {
+            throw new PickupSlotFullException(
+                    "The " + startHour + ":00 pickup slot for " + city + " is full. Please choose another slot.");
+        }
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/PickupSlotCapacity.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/PickupSlotCapacity.java
@@ -1,6 +1,7 @@
 package com.oneday.orders.service.impl;
 
 import com.oneday.common.domain.PickupSlots;
+import com.oneday.common.domain.enums.PickupType;
 import com.oneday.orders.config.PickupSlotProperties;
 import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.service.BookingService;
@@ -30,11 +31,14 @@ class PickupSlotCapacity {
      * {@link PickupSlotFullException} if the (origin city, slot) already holds {@code maxPerSlot} active
      * reservations.
      *
+     * <p>Only {@code DA_PICKUP} shipments consume a pickup slot — a {@code SELF_DROP} parcel is dropped
+     * by the customer and needs no DA, so it neither counts against the cap nor is capped.
+     *
      * <p>ponytail: soft cap — the count-then-book gap lets concurrent writers overbook a slot by up to
      * (concurrent bookings − 1). A hard cap needs a per-slot counter row + row lock (mirror
      * {@code VanManifestServiceImpl}); add it only if overbooking actually bites at pilot volume.
      */
-    void ensureRoom(String originCity, LocalDate slotDate, Integer startHour) {
+    void ensureRoom(String originCity, LocalDate slotDate, Integer startHour, PickupType pickupType) {
         if (slotDate == null && startHour == null) {
             return;   // ASAP — no slot to cap
         }
@@ -43,10 +47,14 @@ class PickupSlotCapacity {
             throw new BookingService.InvalidBookingRequestException(
                     "pickupSlotDate and a valid pickupSlotStartHour (7/9/11/13/15/17/19) are both required");
         }
+        if (pickupType != PickupType.DA_PICKUP) {
+            return;   // self-drop consumes no DA pickup slot
+        }
         String city = originCity.toUpperCase();
         Instant slotStart = PickupSlots.resolve(slotDate, startHour).start();
         int booked = shipmentRepository
-                .countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(city, slotStart);
+                .countByOriginCityAndScheduledPickupStartAndPickupTypeAndCancelledAtIsNull(
+                        city, slotStart, PickupType.DA_PICKUP);
         if (booked >= props.getMaxPerSlot()) {
             throw new PickupSlotFullException(
                     "The " + startHour + ":00 pickup slot for " + city + " is full. Please choose another slot.");

--- a/orders/src/main/resources/db/migration/orders/V4_41__create_merchant_category.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_41__create_merchant_category.sql
@@ -1,0 +1,24 @@
+-- M4: per-merchant section categories. A B2B merchant defines their own categories
+-- ("Electronics", "Apparel", …) and tags each shipment with one, for their own filtering/reporting.
+-- Account-scoped: the API only ever reads/writes rows for the caller's own b2b_account_id.
+CREATE TABLE merchant_category (
+  id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- Plain UUID, no FK to b2b_accounts: orders keeps FKs implicit cross-table by convention
+  -- (matches shipments.b2b_account_id / saved_address.user_id).
+  b2b_account_id UUID        NOT NULL,
+  name           VARCHAR(60) NOT NULL,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- One category name per merchant (case-insensitive) — no duplicate "Electronics"/"electronics".
+CREATE UNIQUE INDEX ux_merchant_category_account_name ON merchant_category (b2b_account_id, lower(name));
+
+CREATE TRIGGER trg_merchant_category_updated_at
+  BEFORE UPDATE ON merchant_category
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- Tag a shipment with one of its merchant's categories (null = untagged). FK-by-convention to
+-- merchant_category; set at booking time, so immutable like the other booking facts.
+ALTER TABLE shipments ADD COLUMN category_id UUID;
+CREATE INDEX idx_shipments_category ON shipments (b2b_account_id, category_id);

--- a/orders/src/test/java/com/oneday/orders/service/impl/B2bBookingServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/B2bBookingServiceImplTest.java
@@ -102,7 +102,7 @@ class B2bBookingServiceImplTest {
         service = new B2bBookingServiceImpl(
                 b2bAccountRepository, serviceabilityPort, pricingPort, etaPort,
                 shipmentRefService, orderService, shipmentRepository, historyRepository,
-                codCollectionRepository, stateMapper, walletService, new TransactionTemplate(NO_OP_TX),
+                codCollectionRepository, stateMapper, walletService, org.mockito.Mockito.mock(PickupSlotCapacity.class), new TransactionTemplate(NO_OP_TX),
                 applicationEventPublisher,
                 CircuitBreakerRegistry.ofDefaults(),
                 TimeLimiterRegistry.ofDefaults(),

--- a/orders/src/test/java/com/oneday/orders/service/impl/B2bBookingServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/B2bBookingServiceImplTest.java
@@ -102,7 +102,8 @@ class B2bBookingServiceImplTest {
         service = new B2bBookingServiceImpl(
                 b2bAccountRepository, serviceabilityPort, pricingPort, etaPort,
                 shipmentRefService, orderService, shipmentRepository, historyRepository,
-                codCollectionRepository, stateMapper, walletService, org.mockito.Mockito.mock(PickupSlotCapacity.class), new TransactionTemplate(NO_OP_TX),
+                codCollectionRepository, org.mockito.Mockito.mock(com.oneday.orders.repository.MerchantCategoryRepository.class),
+                stateMapper, walletService, org.mockito.Mockito.mock(PickupSlotCapacity.class), new TransactionTemplate(NO_OP_TX),
                 applicationEventPublisher,
                 CircuitBreakerRegistry.ofDefaults(),
                 TimeLimiterRegistry.ofDefaults(),

--- a/orders/src/test/java/com/oneday/orders/service/impl/BookingServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/BookingServiceImplTest.java
@@ -108,7 +108,7 @@ class BookingServiceImplTest {
         service = new BookingServiceImpl(
                 serviceabilityPort, pricingPort, paymentPort, etaPort,
                 shipmentRefService, orderService, shipmentRepository, paymentTransactionRepository,
-                historyRepository, stateMapper, new TransactionTemplate(NO_OP_TX),
+                historyRepository, stateMapper, org.mockito.Mockito.mock(PickupSlotCapacity.class), new TransactionTemplate(NO_OP_TX),
                 CircuitBreakerRegistry.ofDefaults(),
                 TimeLimiterRegistry.ofDefaults(),
                 scheduler, applicationEventPublisher);

--- a/orders/src/test/java/com/oneday/orders/service/impl/MerchantCategoryServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/MerchantCategoryServiceImplTest.java
@@ -1,0 +1,84 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.domain.MerchantCategory;
+import com.oneday.orders.dto.MerchantCategoryRequest;
+import com.oneday.orders.dto.MerchantCategoryResponse;
+import com.oneday.orders.repository.MerchantCategoryRepository;
+import com.oneday.orders.service.MerchantCategoryService;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Categories are per-merchant and must stay that way: create must reject duplicate names, and
+ * rename/delete must look the row up scoped to the caller's account so one merchant can never touch
+ * another's category by id. These pin those guarantees.
+ */
+class MerchantCategoryServiceImplTest {
+
+    private final MerchantCategoryRepository repo = mock(MerchantCategoryRepository.class);
+    private final MerchantCategoryServiceImpl service = new MerchantCategoryServiceImpl(repo);
+
+    private static final UUID ACCOUNT = UUID.randomUUID();
+
+    private static MerchantCategoryRequest req(String name) {
+        MerchantCategoryRequest r = new MerchantCategoryRequest();
+        r.setName(name);
+        return r;
+    }
+
+    @Test
+    void createTrimsNameAndStampsTheCallersAccount() {
+        when(repo.existsByB2bAccountIdAndNameIgnoreCase(ACCOUNT, "Electronics")).thenReturn(false);
+        when(repo.save(any(MerchantCategory.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        MerchantCategoryResponse resp = service.create(ACCOUNT, req("  Electronics  "));
+
+        assertThat(resp.name()).isEqualTo("Electronics");
+        var saved = forClass(MerchantCategory.class);
+        verify(repo).save(saved.capture());
+        assertThat(saved.getValue().getB2bAccountId()).isEqualTo(ACCOUNT);
+        assertThat(saved.getValue().getName()).isEqualTo("Electronics");
+    }
+
+    @Test
+    void createRejectsADuplicateName() {
+        when(repo.existsByB2bAccountIdAndNameIgnoreCase(ACCOUNT, "Apparel")).thenReturn(true);
+
+        assertThatThrownBy(() -> service.create(ACCOUNT, req("Apparel")))
+                .isInstanceOf(MerchantCategoryService.DuplicateCategoryException.class);
+        verify(repo, never()).save(any());
+    }
+
+    @Test
+    void renameOfAnotherMerchantsCategoryIsNotFound() {
+        UUID foreignId = UUID.randomUUID();
+        when(repo.findByIdAndB2bAccountId(foreignId, ACCOUNT)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.rename(ACCOUNT, foreignId, req("Hijack")))
+                .isInstanceOf(MerchantCategoryService.CategoryNotFoundException.class);
+    }
+
+    @Test
+    void deleteIsScopedToTheCallersAccount() {
+        UUID id = UUID.randomUUID();
+        when(repo.findByIdAndB2bAccountId(id, ACCOUNT)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.delete(ACCOUNT, id))
+                .isInstanceOf(MerchantCategoryService.CategoryNotFoundException.class);
+        // Looked up strictly within the caller's account — never a bare findById.
+        verify(repo).findByIdAndB2bAccountId(eq(id), eq(ACCOUNT));
+        verify(repo, never()).delete(any());
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/service/impl/PickupSlotCapacityTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/PickupSlotCapacityTest.java
@@ -1,0 +1,64 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.config.PickupSlotProperties;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.service.BookingService;
+import com.oneday.orders.service.PickupSlotFullException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The per-slot cap is the whole point of the feature: a full slot must be rejected, and it must reject
+ * BEFORE payment (this component runs pre-payment). These pin the four branches so a regression that
+ * dropped the cap, or the ASAP short-circuit, or the pre-charge validation, fails loudly.
+ */
+class PickupSlotCapacityTest {
+
+    private final ShipmentRepository repo = mock(ShipmentRepository.class);
+    private final PickupSlotProperties props = mock(PickupSlotProperties.class);
+    private final PickupSlotCapacity capacity = new PickupSlotCapacity(repo, props);
+
+    private static final LocalDate DATE = LocalDate.of(2026, 8, 27);
+    private static final int VALID_HOUR = 9;
+
+    @Test
+    void asapBookingSkipsTheCapEntirely() {
+        assertThatCode(() -> capacity.ensureRoom("DEL", null, null)).doesNotThrowAnyException();
+        verify(repo, never()).countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(any(), any());
+    }
+
+    @Test
+    void allowsWhenSlotHasRoom() {
+        when(props.getMaxPerSlot()).thenReturn(2);
+        when(repo.countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(eq("DEL"), any(Instant.class)))
+                .thenReturn(1);
+        assertThatCode(() -> capacity.ensureRoom("del", DATE, VALID_HOUR)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsWhenSlotIsFull() {
+        when(props.getMaxPerSlot()).thenReturn(2);
+        when(repo.countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(eq("DEL"), any(Instant.class)))
+                .thenReturn(2);
+        assertThatThrownBy(() -> capacity.ensureRoom("DEL", DATE, VALID_HOUR))
+                .isInstanceOf(PickupSlotFullException.class);
+    }
+
+    @Test
+    void rejectsAnInvalidStartHourBeforeAnyCapLookup() {
+        assertThatThrownBy(() -> capacity.ensureRoom("DEL", DATE, 8))   // 8 is not a valid slot start
+                .isInstanceOf(BookingService.InvalidBookingRequestException.class);
+        verify(repo, never()).countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(any(), any());
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/service/impl/PickupSlotCapacityTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/PickupSlotCapacityTest.java
@@ -1,5 +1,6 @@
 package com.oneday.orders.service.impl;
 
+import com.oneday.common.domain.enums.PickupType;
 import com.oneday.orders.config.PickupSlotProperties;
 import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.service.BookingService;
@@ -34,31 +35,41 @@ class PickupSlotCapacityTest {
 
     @Test
     void asapBookingSkipsTheCapEntirely() {
-        assertThatCode(() -> capacity.ensureRoom("DEL", null, null)).doesNotThrowAnyException();
-        verify(repo, never()).countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(any(), any());
+        assertThatCode(() -> capacity.ensureRoom("DEL", null, null, PickupType.DA_PICKUP))
+                .doesNotThrowAnyException();
+        verify(repo, never()).countByOriginCityAndScheduledPickupStartAndPickupTypeAndCancelledAtIsNull(any(), any(), any());
     }
 
     @Test
     void allowsWhenSlotHasRoom() {
         when(props.getMaxPerSlot()).thenReturn(2);
-        when(repo.countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(eq("DEL"), any(Instant.class)))
-                .thenReturn(1);
-        assertThatCode(() -> capacity.ensureRoom("del", DATE, VALID_HOUR)).doesNotThrowAnyException();
+        when(repo.countByOriginCityAndScheduledPickupStartAndPickupTypeAndCancelledAtIsNull(
+                eq("DEL"), any(Instant.class), eq(PickupType.DA_PICKUP))).thenReturn(1);
+        assertThatCode(() -> capacity.ensureRoom("del", DATE, VALID_HOUR, PickupType.DA_PICKUP))
+                .doesNotThrowAnyException();
     }
 
     @Test
     void rejectsWhenSlotIsFull() {
         when(props.getMaxPerSlot()).thenReturn(2);
-        when(repo.countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(eq("DEL"), any(Instant.class)))
-                .thenReturn(2);
-        assertThatThrownBy(() -> capacity.ensureRoom("DEL", DATE, VALID_HOUR))
+        when(repo.countByOriginCityAndScheduledPickupStartAndPickupTypeAndCancelledAtIsNull(
+                eq("DEL"), any(Instant.class), eq(PickupType.DA_PICKUP))).thenReturn(2);
+        assertThatThrownBy(() -> capacity.ensureRoom("DEL", DATE, VALID_HOUR, PickupType.DA_PICKUP))
                 .isInstanceOf(PickupSlotFullException.class);
     }
 
     @Test
+    void selfDropWithASlotNeverConsumesPickupCapacity() {
+        // A self-drop parcel needs no DA pickup, so it must not count against (or be capped by) the slot.
+        assertThatCode(() -> capacity.ensureRoom("DEL", DATE, VALID_HOUR, PickupType.SELF_DROP))
+                .doesNotThrowAnyException();
+        verify(repo, never()).countByOriginCityAndScheduledPickupStartAndPickupTypeAndCancelledAtIsNull(any(), any(), any());
+    }
+
+    @Test
     void rejectsAnInvalidStartHourBeforeAnyCapLookup() {
-        assertThatThrownBy(() -> capacity.ensureRoom("DEL", DATE, 8))   // 8 is not a valid slot start
+        assertThatThrownBy(() -> capacity.ensureRoom("DEL", DATE, 8, PickupType.DA_PICKUP))   // 8 not a valid slot start
                 .isInstanceOf(BookingService.InvalidBookingRequestException.class);
-        verify(repo, never()).countByOriginCityAndScheduledPickupStartAndCancelledAtIsNull(any(), any());
+        verify(repo, never()).countByOriginCityAndScheduledPickupStartAndPickupTypeAndCancelledAtIsNull(any(), any(), any());
     }
 }


### PR DESCRIPTION
# Pull Request

> **Scope / merge-order note.** Because the stacked branches were merged into their parents, this branch (`feat/pickup-slot-caps`) now carries **two** features, and neither is on `main` yet — so this PR's diff is **both**:
> 1. per-slot pickup capacity cap (**#11**) — *also* PR #151, and
> 2. per-merchant section categories (**#1**).
>
> **Recommended:** merge **#151 first** (slot caps → main); this PR's diff then shrinks to **categories only** and can merge as a clean single-feature PR. Alternatively, close #151 and merge this one to land both features in one go.

## Summary
Two merchant/booking features landing on `main`: (1) a **per-slot pickup capacity cap** that rejects a booking whose pickup slot is full *before payment*, and (2) **per-merchant section categories** — a B2B merchant defines their own categories, tags a shipment at booking, and filters/reports by them.

---

## What Changed

**Per-merchant section categories (#1)**
- `merchant_category` table (Flyway `V4_41`) + `shipments.category_id` (nullable, tagged at booking).
- Account-scoped CRUD `/api/v1/categories` (`MerchantCategoryController/Service/Repository`) — unique name per merchant, case-insensitive.
- `B2bBookingRequest.categoryId` stamped after **same-merchant validation** (a shipment can only carry one of the booking account's own categories).
- `category_id` surfaced on the customer shipment read model (`MyShipmentSummaryResponse`).
- `MerchantCategoryServiceImplTest` over create / duplicate / rename / delete scoping.

**Per-slot pickup capacity cap (#11)** — same as #151, included here because stacked
- `PickupSlotCapacity` enforced pre-payment in both booking flows; full/invalid slot → `PickupSlotFullException` → **HTTP 409**.
- Ops-tunable `orders.pickup-slot.max-per-slot` (default 50); only `DA_PICKUP` shipments count (SELF_DROP excluded).

---

## Why This Change?
- **Categories:** merchants organise shipments into their own sections (e.g. "Electronics", "Apparel") and filter/report by them — the platform previously had no per-merchant grouping.
- **Slot cap:** a pickup window has finite DA capacity on a one-day SLA; checking before payment means a full slot rejects cleanly instead of charging then failing.

---

## Testing
- [x] Tested locally (`mvn test -pl orders`)
- [x] Edge cases considered (category same-merchant validation, duplicate names; ASAP / self-drop / invalid-hour for the slot cap)
- [x] No breaking changes introduced

### Test Evidence
```
mvn -pl orders -am test -Dtest=MerchantCategoryServiceImplTest,PickupSlotCapacityTest,\
  BookingServiceImplTest,B2bBookingServiceImplTest,AdminOrderQueryServiceExportForAccountTest,OrderStatusReducerTest
...
Tests run: 41, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
Also verified end-to-end on localhost: the categories CRUD + tagging drive the business console, and the slot cap returns 409 on a full window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
