### PR TITLE
M5/M3: Midday DA-absence territory reassignment (single + multi-DA)

### DIFF
--- a/common/src/main/java/com/oneday/common/kafka/enums/DaEventType.java
+++ b/common/src/main/java/com/oneday/common/kafka/enums/DaEventType.java
@@ -44,6 +44,11 @@ public enum DaEventType {
     // COD cash collected at delivery; emitted alongside DROP_COMPLETED. → finance / M10
     COD_COLLECTED,
 
+    // Midday absence: the covering DA physically collected an in-custody parcel from an absent DA
+    // (a CUSTODY_COLLECT task completed). Custody moved between DAs, so state consumers can re-anchor
+    // the parcel to the new owner. → M10, M11
+    CUSTODY_COLLECTED,
+
     // QUEUED tasks deferred at shift end (carried to next day / RTO path). → M11
     TASK_DEFERRED_SHIFT_ENDED
 }

--- a/common/src/main/java/com/oneday/common/kafka/enums/ScanEventType.java
+++ b/common/src/main/java/com/oneday/common/kafka/enums/ScanEventType.java
@@ -10,5 +10,6 @@ public enum ScanEventType {
     LABEL_GENERATED,
     HUB_COLLECT_COMPLETED,  // hub-collect path: AWAITING_HUB_COLLECT → HUB_COLLECTED
     HUB_DEST_OUT,           // HUB_RETURN: DA collected a dest parcel from the hub for last-mile (ledger only)
+    DA_CUSTODY_TRANSFER,    // midday absence: covering DA collected an in-custody parcel from the absent DA (ledger only)
     DELIVERED,              // DA delivered the box (custody fact only, Option A — DROPPED stays OTP-owned)
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/api/AbsenceController.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/api/AbsenceController.java
@@ -1,0 +1,85 @@
+package com.oneday.dispatch.api;
+
+import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.dispatch.dto.request.MarkAbsentRequest;
+import com.oneday.dispatch.dto.response.AbsenceApplyResponse;
+import com.oneday.dispatch.dto.response.AbsencePreviewResponse;
+import com.oneday.dispatch.service.AbsenceReassignmentService;
+import com.oneday.grid.service.GridService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.UUID;
+
+/**
+ * Station-manager control for midday DA absence. Mark one or more DAs absent to preview the
+ * reassignment (hexes split among neighbors, tasks following their hex, custody handoffs), then apply
+ * it — or let it auto-apply after the timeout. STATION_MANAGER is scoped to their own city; ADMIN may
+ * act on any city (passing {@code cityId} in the body).
+ */
+@RestController
+public class AbsenceController {
+
+    private final AbsenceReassignmentService absenceService;
+    private final GridService gridService;
+
+    public AbsenceController(AbsenceReassignmentService absenceService, GridService gridService) {
+        this.absenceService = absenceService;
+        this.gridService = gridService;
+    }
+
+    /** Preview (and stage as PENDING) the reassignment for the marked DAs. */
+    @PostMapping("/dispatch/absence/preview")
+    public AbsencePreviewResponse preview(@Valid @RequestBody MarkAbsentRequest request,
+                                          @AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireRole(principal, Authz.STATION_MANAGER);
+        UUID cityId = resolveCity(principal, request.cityId());
+        UUID actor = Authz.requireUserId(principal);
+        return absenceService.preview(cityId, request.daIds(), request.reason(), actor);
+    }
+
+    /** Apply a previewed plan on the manager's approval (before the auto-approve timeout fires). */
+    @PostMapping("/dispatch/absence/{eventId}/apply")
+    public AbsenceApplyResponse apply(@PathVariable UUID eventId,
+                                      @AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireRole(principal, Authz.STATION_MANAGER);
+        UUID actor = Authz.requireUserId(principal);
+        return absenceService.apply(eventId, actor);
+    }
+
+    /**
+     * The city this action targets: a STATION_MANAGER is pinned to their own city (a mismatched body
+     * city is rejected); ADMIN uses the body {@code cityId} (required for them).
+     */
+    private UUID resolveCity(AuthUserDetails principal, UUID requestedCity) {
+        if (Authz.isAdmin(principal)) {
+            if (requestedCity == null) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "ADMIN must specify cityId");
+            }
+            return requestedCity;
+        }
+        UUID managerCity = managerCity(principal);
+        if (requestedCity != null && !requestedCity.equals(managerCity)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Cannot act outside your city");
+        }
+        return managerCity;
+    }
+
+    private UUID managerCity(AuthUserDetails principal) {
+        String city = principal.getUser().getCityId();
+        if (city == null || city.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Station manager has no city scope");
+        }
+        try {
+            return UUID.fromString(city);
+        } catch (IllegalArgumentException notUuid) {
+            return gridService.resolveCityId(city);
+        }
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/api/AbsenceController.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/api/AbsenceController.java
@@ -50,7 +50,9 @@ public class AbsenceController {
                                       @AuthenticationPrincipal AuthUserDetails principal) {
         Authz.requireRole(principal, Authz.STATION_MANAGER);
         UUID actor = Authz.requireUserId(principal);
-        return absenceService.apply(eventId, actor);
+        // A STATION_MANAGER may only apply an event in their own city; ADMIN (null scope) any city.
+        UUID scopeCityId = Authz.isAdmin(principal) ? null : managerCity(principal);
+        return absenceService.apply(eventId, actor, scopeCityId);
     }
 
     /**

--- a/dispatch/src/main/java/com/oneday/dispatch/api/AbsenceController.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/api/AbsenceController.java
@@ -4,17 +4,24 @@ import com.oneday.auth.security.AuthUserDetails;
 import com.oneday.dispatch.dto.request.MarkAbsentRequest;
 import com.oneday.dispatch.dto.response.AbsenceApplyResponse;
 import com.oneday.dispatch.dto.response.AbsencePreviewResponse;
+import com.oneday.dispatch.dto.response.DaRosterEntry;
 import com.oneday.dispatch.service.AbsenceReassignmentService;
 import com.oneday.grid.service.GridService;
 import jakarta.validation.Valid;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -32,6 +39,22 @@ public class AbsenceController {
     public AbsenceController(AbsenceReassignmentService absenceService, GridService gridService) {
         this.absenceService = absenceService;
         this.gridService = gridService;
+    }
+
+    /**
+     * The DAs on shift for the absence picker — every DA on the clock (any task type), so a DA doing
+     * only pickups can be marked absent (the delivery scorecards would hide them). ADMIN may pass
+     * {@code cityId} to scope to one city (omit for all); a STATION_MANAGER is pinned to their city.
+     */
+    @GetMapping("/dispatch/absence/roster")
+    public List<DaRosterEntry> roster(@RequestParam(required = false) UUID cityId,
+                                      @RequestParam(required = false)
+                                      @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+                                      @AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireRole(principal, Authz.STATION_MANAGER);
+        UUID scope = Authz.isAdmin(principal) ? cityId : managerCity(principal);
+        LocalDate day = date != null ? date : LocalDate.now(ZoneId.of("Asia/Kolkata"));
+        return absenceService.roster(scope, day);
     }
 
     /** Preview (and stage as PENDING) the reassignment for the marked DAs. */

--- a/dispatch/src/main/java/com/oneday/dispatch/api/DaDispatchController.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/api/DaDispatchController.java
@@ -1,6 +1,7 @@
 package com.oneday.dispatch.api;
 
 import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.dispatch.dto.request.CustodyCollectRequest;
 import com.oneday.dispatch.dto.request.DropCompletedRequest;
 import com.oneday.dispatch.dto.request.GpsPingRequest;
 import com.oneday.dispatch.dto.request.HubHandoffRequest;
@@ -163,6 +164,14 @@ public class DaDispatchController {
         Authz.requireDaSelf(principal, daId);
         boolean cod = request != null && request.codCollected();
         return daTaskService.markDropCompleted(daId, taskId, cod);
+    }
+
+    @PostMapping("/tasks/{taskId}/custody-collected")
+    public DaTaskView custodyCollected(@PathVariable UUID daId, @PathVariable UUID taskId,
+                                       @AuthenticationPrincipal AuthUserDetails principal,
+                                       @Valid @RequestBody CustodyCollectRequest request) {
+        Authz.requireDaSelf(principal, daId);
+        return daTaskService.recordCustodyCollect(daId, taskId, request.parcelScans());
     }
 
     @PostMapping("/tasks/{taskId}/verify-otp")

--- a/dispatch/src/main/java/com/oneday/dispatch/batch/AbsenceAutoApplyJob.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/batch/AbsenceAutoApplyJob.java
@@ -1,0 +1,50 @@
+package com.oneday.dispatch.batch;
+
+import com.oneday.dispatch.domain.AbsenceStatus;
+import com.oneday.dispatch.domain.DaAbsenceEvent;
+import com.oneday.dispatch.repository.DaAbsenceEventRepository;
+import com.oneday.dispatch.service.AbsenceReassignmentService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+
+/**
+ * Auto-approves a previewed absence plan the station manager didn't act on: any PENDING
+ * {@code da_absence_event} past its {@code auto_approve_at} deadline is applied automatically
+ * (AUTO_APPLIED). Honours "manager approves intraday changes" while an absent DA is being covered —
+ * respected when someone's watching, self-healing when they're not.
+ */
+@Component
+public class AbsenceAutoApplyJob {
+
+    private static final Logger log = LoggerFactory.getLogger(AbsenceAutoApplyJob.class);
+
+    private final DaAbsenceEventRepository absenceRepository;
+    private final AbsenceReassignmentService absenceService;
+
+    public AbsenceAutoApplyJob(DaAbsenceEventRepository absenceRepository,
+                               AbsenceReassignmentService absenceService) {
+        this.absenceRepository = absenceRepository;
+        this.absenceService = absenceService;
+    }
+
+    @Scheduled(fixedDelayString = "${dispatch.absence.auto-apply-sweep-ms:60000}")
+    public void run() {
+        sweep(Instant.now());
+    }
+
+    /** Package-visible for direct testing with a fixed clock. */
+    void sweep(Instant now) {
+        for (DaAbsenceEvent event : absenceRepository.findByStatusAndAutoApproveAtBefore(AbsenceStatus.PENDING, now)) {
+            try {
+                absenceService.autoApply(event.getId());
+                log.info("Auto-applied absence plan {} (deadline lapsed)", event.getId());
+            } catch (RuntimeException e) {
+                log.error("Auto-apply of absence plan {} failed: {}", event.getId(), e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/config/DispatchProperties.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/config/DispatchProperties.java
@@ -66,6 +66,8 @@ public class DispatchProperties {
     private Reorder reorder = new Reorder();
     @NestedConfigurationProperty
     private Dlq dlq = new Dlq();
+    @NestedConfigurationProperty
+    private Absence absence = new Absence();
 
     public Cron getCron() { return cron; }
     public void setCron(Cron cron) { this.cron = cron; }
@@ -95,6 +97,8 @@ public class DispatchProperties {
     public void setDeferred(Deferred deferred) { this.deferred = deferred; }
     public Dlq getDlq() { return dlq; }
     public void setDlq(Dlq dlq) { this.dlq = dlq; }
+    public Absence getAbsence() { return absence; }
+    public void setAbsence(Absence absence) { this.absence = absence; }
 
     /** Cron-meeting protection (the hard constraint). */
     public static class Cron {
@@ -117,6 +121,21 @@ public class DispatchProperties {
         public void setAbsentThresholdMinutes(int absentThresholdMinutes) {
             this.absentThresholdMinutes = absentThresholdMinutes;
         }
+    }
+
+    /** Midday DA-absence reassignment (manager-triggered; auto-approves if unattended). */
+    public static class Absence {
+        /** A PENDING absence plan auto-applies this many minutes after preview if no one approves it. */
+        private int autoApproveTimeoutMinutes = 5;
+        /** How often the auto-apply sweep runs, in milliseconds. */
+        private long autoApplySweepMs = 60_000;
+
+        public int getAutoApproveTimeoutMinutes() { return autoApproveTimeoutMinutes; }
+        public void setAutoApproveTimeoutMinutes(int autoApproveTimeoutMinutes) {
+            this.autoApproveTimeoutMinutes = autoApproveTimeoutMinutes;
+        }
+        public long getAutoApplySweepMs() { return autoApplySweepMs; }
+        public void setAutoApplySweepMs(long autoApplySweepMs) { this.autoApplySweepMs = autoApplySweepMs; }
     }
 
     public static class Gps {

--- a/dispatch/src/main/java/com/oneday/dispatch/domain/AbsenceStatus.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/domain/AbsenceStatus.java
@@ -1,0 +1,13 @@
+package com.oneday.dispatch.domain;
+
+/** Lifecycle of a midday DA-absence reassignment plan. */
+public enum AbsenceStatus {
+    /** Previewed, awaiting approval (or the auto-approve timeout). */
+    PENDING,
+    /** Applied by a station manager. */
+    APPLIED,
+    /** Applied automatically after the auto-approve timeout lapsed. */
+    AUTO_APPLIED,
+    /** Withdrawn before it was applied. */
+    CANCELLED
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/domain/DaAbsenceEvent.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/domain/DaAbsenceEvent.java
@@ -53,9 +53,6 @@ public class DaAbsenceEvent extends MutableBaseEntity {
     @Column(name = "applied_at")
     private Instant appliedAt;
 
-    @Column(name = "proposal_id")
-    private UUID proposalId;
-
     @Column(name = "orphan_count", nullable = false)
     private int orphanCount;
 

--- a/dispatch/src/main/java/com/oneday/dispatch/domain/DaAbsenceEvent.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/domain/DaAbsenceEvent.java
@@ -1,0 +1,74 @@
+package com.oneday.dispatch.domain;
+
+import com.oneday.common.domain.MutableBaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * One midday DA-absence reassignment: a station manager marks a set of DAs absent, the plan is
+ * previewed (PENDING), then applied — by the manager, or automatically once {@code autoApproveAt}
+ * passes. Backed by {@code da_absence_event}. The absent-DA set is a small comma-joined list (v1).
+ */
+@Entity
+@Table(name = "da_absence_event")
+@Getter
+@Setter
+@NoArgsConstructor
+public class DaAbsenceEvent extends MutableBaseEntity {
+
+    @Column(name = "city_id", nullable = false, updatable = false)
+    private UUID cityId;
+
+    @Column(name = "operating_date", nullable = false, updatable = false)
+    private java.time.LocalDate operatingDate;
+
+    @Column(name = "absent_da_ids", nullable = false, updatable = false)
+    private String absentDaIds;
+
+    @Column(name = "reason", length = 500, updatable = false)
+    private String reason;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private AbsenceStatus status;
+
+    @Column(name = "created_by", updatable = false)
+    private UUID createdBy;
+
+    @Column(name = "auto_approve_at", nullable = false)
+    private Instant autoApproveAt;
+
+    @Column(name = "applied_at")
+    private Instant appliedAt;
+
+    @Column(name = "proposal_id")
+    private UUID proposalId;
+
+    @Column(name = "orphan_count", nullable = false)
+    private int orphanCount;
+
+    public List<UUID> absentDaIdList() {
+        if (absentDaIds == null || absentDaIds.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(absentDaIds.split(","))
+                .map(String::trim).filter(s -> !s.isBlank())
+                .map(UUID::fromString).toList();
+    }
+
+    public void setAbsentDaIdList(List<UUID> ids) {
+        this.absentDaIds = ids.stream().map(UUID::toString).collect(Collectors.joining(","));
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/domain/DispatchQueue.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/domain/DispatchQueue.java
@@ -78,6 +78,19 @@ public class DispatchQueue extends MutableBaseEntity {
     @Column(name = "collect_from_da_id", updatable = false)
     private UUID collectFromDaId;
 
+    // Set only on CUSTODY_COLLECT tasks: the in-custody parcel's original leg (PICKUP/DELIVERY) and its
+    // destination, so on collection the covering DA's onward task resumes at the right place. task_lat/lon
+    // on this row is the COLLECT point; these carry where the parcel goes next. Null on ordinary tasks.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "onward_task_type", updatable = false, length = 20)
+    private TaskType onwardTaskType;
+
+    @Column(name = "onward_task_lat", updatable = false)
+    private Double onwardTaskLat;
+
+    @Column(name = "onward_task_lon", updatable = false)
+    private Double onwardTaskLon;
+
     @Column(name = "cron_safe", nullable = false, updatable = false)
     private boolean cronSafe;
 

--- a/dispatch/src/main/java/com/oneday/dispatch/domain/DispatchQueue.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/domain/DispatchQueue.java
@@ -73,6 +73,11 @@ public class DispatchQueue extends MutableBaseEntity {
     @Column(name = "home_tile_id", updatable = false)
     private UUID homeTileId;
 
+    // Set only on CUSTODY_COLLECT tasks: the absent DA the covering DA collects this parcel from
+    // (task_lat/task_lon carry the collect location). Null for ordinary pickup/delivery tasks.
+    @Column(name = "collect_from_da_id", updatable = false)
+    private UUID collectFromDaId;
+
     @Column(name = "cron_safe", nullable = false, updatable = false)
     private boolean cronSafe;
 

--- a/dispatch/src/main/java/com/oneday/dispatch/domain/TaskType.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/domain/TaskType.java
@@ -1,7 +1,11 @@
 package com.oneday.dispatch.domain;
 
-/** What a dispatch task is — a first-mile pickup or a last-mile delivery. */
+/** What a dispatch task is — a first-mile pickup, a last-mile delivery, or a custody handoff. */
 public enum TaskType {
     PICKUP,
-    DELIVERY
+    DELIVERY,
+    // Midday-absence handoff: the covering DA physically collects an in-custody parcel from the
+    // absent DA (task_lat/lon = collect location, collect_from_da_id = the absent DA) before its
+    // onward leg resumes. Recorded via an M8 custody scan on completion.
+    CUSTODY_COLLECT
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/dto/request/CustodyCollectRequest.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/dto/request/CustodyCollectRequest.java
@@ -1,0 +1,9 @@
+package com.oneday.dispatch.dto.request;
+
+import java.util.List;
+
+/** Midday-absence custody collect: the parcel barcodes the covering DA scanned when taking the
+ *  parcel(s) from the absent DA. Must be non-empty (proves the physical hand-off). */
+public record CustodyCollectRequest(
+        List<String> parcelScans) {
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/dto/request/MarkAbsentRequest.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/dto/request/MarkAbsentRequest.java
@@ -1,6 +1,8 @@
 package com.oneday.dispatch.dto.request;
 
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import java.util.List;
 import java.util.UUID;
@@ -10,8 +12,8 @@ import java.util.UUID;
  * is recorded on the audit trail; the response previews the reassignment plan before it is applied.
  */
 public record MarkAbsentRequest(
-        @NotEmpty(message = "At least one DA id is required") List<UUID> daIds,
-        String reason,
+        @NotEmpty(message = "At least one DA id is required") List<@NotNull UUID> daIds,
+        @Size(max = 500, message = "Reason must be at most 500 characters") String reason,
         // Optional — a STATION_MANAGER is scoped to their own city; ADMIN must pass the target city.
         UUID cityId) {
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/dto/request/MarkAbsentRequest.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/dto/request/MarkAbsentRequest.java
@@ -1,0 +1,17 @@
+package com.oneday.dispatch.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Station-manager request to mark one or more DAs absent for the current shift (midday). The reason
+ * is recorded on the audit trail; the response previews the reassignment plan before it is applied.
+ */
+public record MarkAbsentRequest(
+        @NotEmpty(message = "At least one DA id is required") List<UUID> daIds,
+        String reason,
+        // Optional — a STATION_MANAGER is scoped to their own city; ADMIN must pass the target city.
+        UUID cityId) {
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/dto/response/AbsenceApplyResponse.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/dto/response/AbsenceApplyResponse.java
@@ -1,0 +1,15 @@
+package com.oneday.dispatch.dto.response;
+
+import com.oneday.dispatch.domain.AbsenceStatus;
+
+import java.util.UUID;
+
+/** Outcome of applying a midday-absence plan (manager click or auto-approve timeout). */
+public record AbsenceApplyResponse(
+        UUID eventId,
+        AbsenceStatus status,
+        int reassignedHexCount,
+        int movedTaskCount,
+        int custodyTaskCount,
+        int orphanCount) {
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/dto/response/AbsencePreviewResponse.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/dto/response/AbsencePreviewResponse.java
@@ -1,0 +1,34 @@
+package com.oneday.dispatch.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * The previewed midday-absence reassignment a station manager reviews before applying. Three task
+ * buckets, exactly as the console renders them: loose (not-yet-collected) tasks that follow their hex
+ * to a new owner, in-custody parcels that become CUSTODY_COLLECT handoffs, and orphaned work with no
+ * live neighbor. {@code autoApproveAt} is when the plan self-applies if no one acts.
+ */
+public record AbsencePreviewResponse(
+        UUID eventId,
+        UUID cityId,
+        List<UUID> absentDaIds,
+        Instant autoApproveAt,
+        int reassignedHexCount,
+        int orphanHexCount,
+        List<ReceiverLoad> receivers,
+        List<TaskMove> looseTasks,
+        List<CustodyMove> custodyTasks,
+        List<TaskMove> orphanTasks) {
+
+    /** A neighbor and how many of the absent DAs' hexes it inherits. */
+    public record ReceiverLoad(UUID daId, int gainedHexes) {}
+
+    /** A not-yet-collected task moving from the absent DA to the hex's new owner. */
+    public record TaskMove(UUID shipmentId, String orderRef, String taskType, UUID fromDaId, UUID toDaId) {}
+
+    /** An in-custody parcel the new owner must physically collect from the absent DA. */
+    public record CustodyMove(UUID shipmentId, String orderRef, UUID fromDaId, UUID toDaId,
+                              double collectLat, double collectLon) {}
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/dto/response/DaRosterEntry.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/dto/response/DaRosterEntry.java
@@ -1,0 +1,11 @@
+package com.oneday.dispatch.dto.response;
+
+import java.util.UUID;
+
+/**
+ * One DA on shift, for the DA-absence picker. Unlike the delivery scorecards (which only surface DAs
+ * with last-mile tasks), this lists every DA currently on the clock — so a DA doing only pickups can
+ * still be marked absent. {@code stopsPending} = active tasks of any type (pickup / delivery / custody).
+ */
+public record DaRosterEntry(UUID daId, String daName, int stopsPending) {
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/events/DaEventProducer.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/events/DaEventProducer.java
@@ -109,6 +109,13 @@ public class DaEventProducer {
         emit(DaEventType.COD_COLLECTED, daId, cityId, shipmentId, null, null);
     }
 
+    /** Midday absence: covering DA collected an in-custody parcel from the absent DA. → M10, M11.
+     *  {@code fromDaId} (the absent DA) rides in the reason slot for audit/triage. */
+    public void emitCustodyCollected(UUID daId, UUID cityId, UUID shipmentId, UUID fromDaId) {
+        emit(DaEventType.CUSTODY_COLLECTED, daId, cityId, shipmentId, null,
+                fromDaId != null ? "FROM_DA:" + fromDaId : null);
+    }
+
     private void emit(DaEventType type, UUID daId, UUID cityId, UUID shipmentId,
                       String shipmentRef, String reasonCode) {
         // v1: parcel id == shipment id (no M8 barcode yet); validDate = operating date in the shift zone.

--- a/dispatch/src/main/java/com/oneday/dispatch/events/HubScanSeamProducer.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/events/HubScanSeamProducer.java
@@ -32,6 +32,11 @@ public class HubScanSeamProducer {
         emit(shipmentId, ScanEventType.HUB_DEST_OUT);
     }
 
+    /** Midday absence: covering DA collected an in-custody parcel from the absent DA (ledger only). */
+    public void emitDaCustodyTransfer(UUID shipmentId) {
+        emit(shipmentId, ScanEventType.DA_CUSTODY_TRANSFER);
+    }
+
     private void emit(UUID shipmentId, ScanEventType type) {
         try {
             eventPublisher.publish(EventStreams.SCAN_EVENTS, new ScanEvent(shipmentId, type));

--- a/dispatch/src/main/java/com/oneday/dispatch/repository/DaAbsenceEventRepository.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/repository/DaAbsenceEventRepository.java
@@ -15,4 +15,7 @@ public interface DaAbsenceEventRepository extends JpaRepository<DaAbsenceEvent, 
 
     /** Recent absence events for a city (console history), newest first. */
     List<DaAbsenceEvent> findByCityIdOrderByCreatedAtDesc(UUID cityId);
+
+    /** Live plans in a city with a given status — used to retire stale PENDING plans on a re-preview. */
+    List<DaAbsenceEvent> findByCityIdAndStatus(UUID cityId, AbsenceStatus status);
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/repository/DaAbsenceEventRepository.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/repository/DaAbsenceEventRepository.java
@@ -1,0 +1,18 @@
+package com.oneday.dispatch.repository;
+
+import com.oneday.dispatch.domain.AbsenceStatus;
+import com.oneday.dispatch.domain.DaAbsenceEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public interface DaAbsenceEventRepository extends JpaRepository<DaAbsenceEvent, UUID> {
+
+    /** PENDING plans whose auto-approve deadline has passed — the auto-apply sweep. */
+    List<DaAbsenceEvent> findByStatusAndAutoApproveAtBefore(AbsenceStatus status, Instant cutoff);
+
+    /** Recent absence events for a city (console history), newest first. */
+    List<DaAbsenceEvent> findByCityIdOrderByCreatedAtDesc(UUID cityId);
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/repository/DaStatusRepository.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/repository/DaStatusRepository.java
@@ -18,4 +18,7 @@ public interface DaStatusRepository extends JpaRepository<DaStatus, UUID> {
     /** City roster for a shift filtered by status (absent detection, station view). */
     List<DaStatus> findByCityIdAndShiftDateAndStatusIn(
             UUID cityId, LocalDate shiftDate, Collection<DaStatusEnum> statuses);
+
+    /** All-city roster for a shift filtered by status (ADMIN, unscoped). */
+    List<DaStatus> findByShiftDateAndStatusIn(LocalDate shiftDate, Collection<DaStatusEnum> statuses);
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/service/AbsenceReassignmentService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/AbsenceReassignmentService.java
@@ -2,7 +2,9 @@ package com.oneday.dispatch.service;
 
 import com.oneday.dispatch.dto.response.AbsenceApplyResponse;
 import com.oneday.dispatch.dto.response.AbsencePreviewResponse;
+import com.oneday.dispatch.dto.response.DaRosterEntry;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -13,6 +15,12 @@ import java.util.UUID;
  * (grid override + task moves + custody handoffs). {@link #autoApply} is the timeout path.
  */
 public interface AbsenceReassignmentService {
+
+    /**
+     * The DAs on shift for the picker — every DA on the clock (any task type), not just those with
+     * delivery scorecards. {@code scopeCityId} null = all cities (ADMIN), else a single city.
+     */
+    List<DaRosterEntry> roster(UUID scopeCityId, LocalDate date);
 
     /** Compute + persist a PENDING plan for the given absent DAs and return it for the manager to review. */
     AbsencePreviewResponse preview(UUID cityId, List<UUID> daIds, String reason, UUID actorUserId);

--- a/dispatch/src/main/java/com/oneday/dispatch/service/AbsenceReassignmentService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/AbsenceReassignmentService.java
@@ -17,8 +17,12 @@ public interface AbsenceReassignmentService {
     /** Compute + persist a PENDING plan for the given absent DAs and return it for the manager to review. */
     AbsencePreviewResponse preview(UUID cityId, List<UUID> daIds, String reason, UUID actorUserId);
 
-    /** Apply a PENDING plan on a manager's approval. Idempotent once applied. */
-    AbsenceApplyResponse apply(UUID eventId, UUID actorUserId);
+    /**
+     * Apply a PENDING plan on a manager's approval. Idempotent once applied. {@code scopeCityId} pins
+     * the caller to one city (a STATION_MANAGER's own city); pass {@code null} for an unrestricted
+     * (ADMIN) caller. A mismatch is rejected before anything is applied.
+     */
+    AbsenceApplyResponse apply(UUID eventId, UUID actorUserId, UUID scopeCityId);
 
     /** Apply a PENDING plan automatically (auto-approve timeout). Idempotent once applied. */
     AbsenceApplyResponse autoApply(UUID eventId);

--- a/dispatch/src/main/java/com/oneday/dispatch/service/AbsenceReassignmentService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/AbsenceReassignmentService.java
@@ -1,0 +1,25 @@
+package com.oneday.dispatch.service;
+
+import com.oneday.dispatch.dto.response.AbsenceApplyResponse;
+import com.oneday.dispatch.dto.response.AbsencePreviewResponse;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Midday DA-absence reassignment (M5). A station manager marks one or more DAs absent; the absent
+ * DAs' hexes are split among their territory-neighbors (M3) and every task follows its hex to the new
+ * owner. {@link #preview} computes the plan without mutating anything; {@link #apply} commits it
+ * (grid override + task moves + custody handoffs). {@link #autoApply} is the timeout path.
+ */
+public interface AbsenceReassignmentService {
+
+    /** Compute + persist a PENDING plan for the given absent DAs and return it for the manager to review. */
+    AbsencePreviewResponse preview(UUID cityId, List<UUID> daIds, String reason, UUID actorUserId);
+
+    /** Apply a PENDING plan on a manager's approval. Idempotent once applied. */
+    AbsenceApplyResponse apply(UUID eventId, UUID actorUserId);
+
+    /** Apply a PENDING plan automatically (auto-approve timeout). Idempotent once applied. */
+    AbsenceApplyResponse autoApply(UUID eventId);
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/service/DaTaskService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/DaTaskService.java
@@ -63,4 +63,13 @@ public interface DaTaskService {
 
     /** DELIVERY task IN_PROGRESS → COMPLETED; emits DROP_COMPLETED (+ COD_COLLECTED if cash taken). */
     DaTaskView markDropCompleted(UUID daId, UUID taskId, boolean codCollected);
+
+    /**
+     * Midday-absence handoff: a CUSTODY_COLLECT task (QUEUED/IN_PROGRESS) → COMPLETED when the covering
+     * DA physically takes the in-custody parcel from the absent DA. Records the append-only M8 DA→DA
+     * custody scan (the source of truth that custody moved), emits CUSTODY_COLLECTED, and spawns the
+     * parcel's onward leg (the original PICKUP/DELIVERY, in-hand) on this DA so it isn't stranded.
+     * {@code parcelScans} must be non-empty.
+     */
+    DaTaskView recordCustodyCollect(UUID daId, UUID taskId, List<String> parcelScans);
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/service/DaTaskView.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/DaTaskView.java
@@ -35,7 +35,10 @@ public record DaTaskView(
         String contactPhone,
         String addressText,
         Long codAmountPaise,
-        boolean pickedUp) {
+        boolean pickedUp,
+        // Set only on a CUSTODY_COLLECT task: the absent DA this parcel is collected from
+        // (task_lat/task_lon is the meet point). Null on ordinary pickups/deliveries.
+        UUID collectFromDaId) {
 
     /** Mutation responses don't need the ref/contact (the app already holds them from listTasks). */
     public static DaTaskView of(DispatchQueue row) {
@@ -47,7 +50,7 @@ public record DaTaskView(
                 row.getOrderId(), row.getOrderRef(), row.getTaskType(),
                 row.getStatus(), row.getQueuePosition(), row.getExpectedEta(),
                 row.getTaskLat(), row.getTaskLon(), row.getPaymentMode(),
-                null, null, null, null, row.isPickedUp());
+                null, null, null, null, row.isPickedUp(), row.getCollectFromDaId());
     }
 
     /** List rows carry the field contact — sender end for a PICKUP, receiver end for a DELIVERY. */
@@ -61,6 +64,6 @@ public record DaTaskView(
                 row.getOrderId(), row.getOrderRef(), row.getTaskType(),
                 row.getStatus(), row.getQueuePosition(), row.getExpectedEta(),
                 row.getTaskLat(), row.getTaskLon(), row.getPaymentMode(),
-                name, phone, addr, cod, row.isPickedUp());
+                name, phone, addr, cod, row.isPickedUp(), row.getCollectFromDaId());
     }
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/AbsenceReassignmentServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/AbsenceReassignmentServiceImpl.java
@@ -1,0 +1,279 @@
+package com.oneday.dispatch.service.impl;
+
+import com.oneday.dispatch.config.DispatchProperties;
+import com.oneday.dispatch.domain.AbsenceStatus;
+import com.oneday.dispatch.domain.DaAbsenceEvent;
+import com.oneday.dispatch.domain.DaStatusEnum;
+import com.oneday.dispatch.domain.DispatchQueue;
+import com.oneday.dispatch.domain.TaskStatus;
+import com.oneday.dispatch.domain.TaskType;
+import com.oneday.dispatch.dto.response.AbsenceApplyResponse;
+import com.oneday.dispatch.dto.response.AbsencePreviewResponse;
+import com.oneday.dispatch.dto.response.AbsencePreviewResponse.CustodyMove;
+import com.oneday.dispatch.dto.response.AbsencePreviewResponse.ReceiverLoad;
+import com.oneday.dispatch.dto.response.AbsencePreviewResponse.TaskMove;
+import com.oneday.dispatch.repository.DaAbsenceEventRepository;
+import com.oneday.dispatch.repository.DispatchQueueRepository;
+import com.oneday.dispatch.service.AbsenceReassignmentService;
+import com.oneday.dispatch.service.DaStatusService;
+import com.oneday.dispatch.service.model.DaLiveStatus;
+import com.oneday.grid.dto.response.AbsenceReassignmentPlan;
+import com.oneday.grid.dto.response.AbsenceReassignmentPlan.HexReassignment;
+import com.oneday.grid.dto.response.AssignmentResponse;
+import com.oneday.grid.service.GridService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Orchestrates midday DA absence. Preview computes the M3 territory split + the per-task consequence
+ * (loose task → new owner, in-custody parcel → CUSTODY_COLLECT handoff, orphan) without mutating
+ * anything. Apply commits the grid override, then makes each task follow its hex: a not-yet-collected
+ * task is re-created on the new owner and the reorder parks it before/beyond the cron; an in-custody
+ * parcel becomes a CUSTODY_COLLECT task (collect from the absent DA's last location). Never routes
+ * through the cron-feasibility gate — the task goes to the hex owner regardless of the cron.
+ */
+@Service
+class AbsenceReassignmentServiceImpl implements AbsenceReassignmentService {
+
+    private static final Logger log = LoggerFactory.getLogger(AbsenceReassignmentServiceImpl.class);
+    private static final List<TaskStatus> ACTIVE = List.of(TaskStatus.QUEUED, TaskStatus.IN_PROGRESS);
+
+    private final GridService gridService;
+    private final DispatchQueueRepository queueRepository;
+    private final DaAbsenceEventRepository absenceRepository;
+    private final DaStatusService daStatusService;
+    private final QueueReorderService reorderService;
+    private final DispatchProperties props;
+
+    AbsenceReassignmentServiceImpl(GridService gridService,
+                                   DispatchQueueRepository queueRepository,
+                                   DaAbsenceEventRepository absenceRepository,
+                                   DaStatusService daStatusService,
+                                   QueueReorderService reorderService,
+                                   DispatchProperties props) {
+        this.gridService = gridService;
+        this.queueRepository = queueRepository;
+        this.absenceRepository = absenceRepository;
+        this.daStatusService = daStatusService;
+        this.reorderService = reorderService;
+        this.props = props;
+    }
+
+    @Override
+    @Transactional
+    public AbsencePreviewResponse preview(UUID cityId, List<UUID> daIds, String reason, UUID actorUserId) {
+        LocalDate date = today();
+        AbsenceReassignmentPlan plan = gridService.planAbsenceReassignment(cityId, daIds, date);
+
+        List<ReceiverLoad> receivers = plan.reassignments().stream()
+                .collect(Collectors.groupingBy(HexReassignment::toDaId, Collectors.counting()))
+                .entrySet().stream()
+                .map(e -> new ReceiverLoad(e.getKey(), e.getValue().intValue()))
+                .sorted(Comparator.comparing(r -> r.daId().toString()))
+                .toList();
+
+        List<TaskMove> loose = new ArrayList<>();
+        List<CustodyMove> custody = new ArrayList<>();
+        List<TaskMove> orphans = new ArrayList<>();
+        for (UUID absentDa : daIds) {
+            for (DispatchQueue row : queueRepository.findByDaIdAndOperatingDateAndStatusIn(absentDa, date, ACTIVE)) {
+                UUID newOwner = plan.ownerOf(row.getTileId());
+                if (newOwner == null) {
+                    orphans.add(new TaskMove(row.getShipmentId(), row.getOrderRef(),
+                            row.getTaskType().name(), absentDa, null));
+                } else if (row.getStatus() == TaskStatus.IN_PROGRESS) {
+                    double[] at = collectLocation(absentDa, row);
+                    custody.add(new CustodyMove(row.getShipmentId(), row.getOrderRef(),
+                            absentDa, newOwner, at[0], at[1]));
+                } else {
+                    loose.add(new TaskMove(row.getShipmentId(), row.getOrderRef(),
+                            row.getTaskType().name(), absentDa, newOwner));
+                }
+            }
+        }
+
+        Instant autoApproveAt = Instant.now().plus(props.getAbsence().getAutoApproveTimeoutMinutes(),
+                ChronoUnit.MINUTES);
+        DaAbsenceEvent event = new DaAbsenceEvent();
+        event.setCityId(cityId);
+        event.setOperatingDate(date);
+        event.setAbsentDaIdList(daIds);
+        event.setReason(reason);
+        event.setStatus(AbsenceStatus.PENDING);
+        event.setCreatedBy(actorUserId);
+        event.setAutoApproveAt(autoApproveAt);
+        event.setOrphanCount(plan.orphanHexIds().size());
+        UUID eventId = absenceRepository.save(event).getId();
+
+        log.info("Absence preview {} cityId={} absent={} → {} hexes, {} loose, {} custody, {} orphan tasks",
+                eventId, cityId, daIds.size(), plan.reassignments().size(),
+                loose.size(), custody.size(), orphans.size());
+        return new AbsencePreviewResponse(eventId, cityId, daIds.stream().sorted().toList(), autoApproveAt,
+                plan.reassignments().size(), plan.orphanHexIds().size(), receivers, loose, custody, orphans);
+    }
+
+    @Override
+    @Transactional
+    public AbsenceApplyResponse apply(UUID eventId, UUID actorUserId) {
+        return doApply(loadPending(eventId), false, actorUserId);
+    }
+
+    @Override
+    @Transactional
+    public AbsenceApplyResponse autoApply(UUID eventId) {
+        return doApply(loadPending(eventId), true, null);
+    }
+
+    private DaAbsenceEvent loadPending(UUID eventId) {
+        return absenceRepository.findById(eventId)
+                .orElseThrow(() -> new IllegalArgumentException("No absence event " + eventId));
+    }
+
+    private AbsenceApplyResponse doApply(DaAbsenceEvent event, boolean system, UUID actorUserId) {
+        if (event.getStatus() != AbsenceStatus.PENDING) {
+            // Already applied/cancelled — idempotent.
+            return new AbsenceApplyResponse(event.getId(), event.getStatus(), 0, 0, 0, event.getOrphanCount());
+        }
+        UUID cityId = event.getCityId();
+        LocalDate date = event.getOperatingDate();
+        List<UUID> daIds = event.absentDaIdList();
+        UUID reviewer = system ? null : actorUserId;
+
+        // 1) Commit the M3 territory split (writes + approves the INTRADAY_OVERRIDE).
+        AbsenceReassignmentPlan plan = gridService.applyAbsenceReassignment(cityId, daIds, date, reviewer);
+
+        // 2) Make every task follow its hex to the new owner.
+        int moved = 0;
+        int custody = 0;
+        for (UUID absentDa : daIds) {
+            for (DispatchQueue row : queueRepository.findByDaIdAndOperatingDateAndStatusIn(absentDa, date, ACTIVE)) {
+                UUID newOwner = plan.ownerOf(row.getTileId());
+                if (newOwner == null) {
+                    row.setStatus(TaskStatus.DEFERRED);   // orphan hex — surfaced for manual escalation
+                    queueRepository.save(row);
+                    continue;
+                }
+                if (row.getStatus() == TaskStatus.IN_PROGRESS) {
+                    double[] at = collectLocation(absentDa, row);
+                    DispatchQueue collect = custodyCollectRow(newOwner, row, absentDa, at, date);
+                    daStatusService.withDaLock(newOwner, () -> {
+                        collect.setQueuePosition(nextPosition(newOwner, date));
+                        queueRepository.save(collect);
+                        QueueMirror.rebuild(daStatusService, queueRepository, newOwner, date);
+                        return null;
+                    });
+                    custody++;
+                } else {
+                    DispatchQueue copy = followHexRow(newOwner, row, date);
+                    daStatusService.withDaLock(newOwner, () -> {
+                        copy.setQueuePosition(nextPosition(newOwner, date));
+                        queueRepository.save(copy);
+                        // Not the cron gate: place it, then let the reorder park it before / beyond the cron.
+                        reorderService.reorder(newOwner, date);
+                        return null;
+                    });
+                    moved++;
+                }
+                row.setStatus(TaskStatus.CANCELLED);   // vacate the absent DA's copy (append-only audit)
+                queueRepository.save(row);
+            }
+        }
+
+        // 3) Take the absent DAs offline and hand their territory to the receivers.
+        for (UUID absentDa : daIds) {
+            daStatusService.updateStatus(absentDa, DaStatusEnum.ABSENT);
+            daStatusService.setTerritory(absentDa, List.of());
+            QueueMirror.rebuild(daStatusService, queueRepository, absentDa, date);
+        }
+        Map<UUID, List<UUID>> territoryByDa = gridService.getActiveAssignments(cityId, date).stream()
+                .collect(Collectors.groupingBy(AssignmentResponse::daId,
+                        Collectors.mapping(AssignmentResponse::hexId, Collectors.toList())));
+        Set<UUID> receivers = plan.reassignments().stream()
+                .map(HexReassignment::toDaId).collect(Collectors.toSet());
+        for (UUID receiver : receivers) {
+            daStatusService.setTerritory(receiver, territoryByDa.getOrDefault(receiver, List.of()));
+        }
+
+        event.setStatus(system ? AbsenceStatus.AUTO_APPLIED : AbsenceStatus.APPLIED);
+        event.setAppliedAt(Instant.now());
+        absenceRepository.save(event);
+
+        log.info("Absence applied {} ({}): {} hexes, {} tasks moved, {} custody handoffs, {} orphan hexes",
+                event.getId(), event.getStatus(), plan.reassignments().size(), moved, custody,
+                plan.orphanHexIds().size());
+        return new AbsenceApplyResponse(event.getId(), event.getStatus(),
+                plan.reassignments().size(), moved, custody, plan.orphanHexIds().size());
+    }
+
+    /** A not-yet-collected task, re-created for the hex's new owner (append-only; the old row is cancelled). */
+    private DispatchQueue followHexRow(UUID newOwner, DispatchQueue src, LocalDate date) {
+        DispatchQueue r = baseRow(newOwner, src, date);
+        r.setTaskType(src.getTaskType());
+        r.setTaskLat(src.getTaskLat());
+        r.setTaskLon(src.getTaskLon());
+        return r;
+    }
+
+    /** A CUSTODY_COLLECT task: the new owner collects the in-custody parcel from the absent DA. */
+    private DispatchQueue custodyCollectRow(UUID newOwner, DispatchQueue src, UUID absentDa,
+                                            double[] at, LocalDate date) {
+        DispatchQueue r = baseRow(newOwner, src, date);
+        r.setTaskType(TaskType.CUSTODY_COLLECT);
+        r.setTaskLat(at[0]);
+        r.setTaskLon(at[1]);
+        r.setCollectFromDaId(absentDa);
+        return r;
+    }
+
+    private DispatchQueue baseRow(UUID newOwner, DispatchQueue src, LocalDate date) {
+        DispatchQueue r = new DispatchQueue();
+        r.setDaId(newOwner);
+        r.setCityId(src.getCityId());
+        r.setShipmentId(src.getShipmentId());
+        r.setOrderId(src.getOrderId());
+        r.setOrderRef(src.getOrderRef());
+        r.setTileId(src.getTileId());
+        r.setHomeTileId(src.getHomeTileId());
+        r.setStatus(TaskStatus.QUEUED);
+        r.setPaymentMode(src.getPaymentMode());
+        r.setCrossTerritory(false);
+        r.setCronSafe(false);
+        r.setBeyondCron(false);
+        r.setPickedUp(false);
+        r.setAssignedAt(Instant.now());
+        r.setOperatingDate(date);
+        return r;
+    }
+
+    private int nextPosition(UUID daId, LocalDate date) {
+        return queueRepository.findByDaIdAndOperatingDateAndStatusIn(daId, date, ACTIVE).stream()
+                .mapToInt(DispatchQueue::getQueuePosition).max().orElse(-1) + 1;
+    }
+
+    /** Where the new owner collects a parcel: the absent DA's last GPS, else the task's own location. */
+    private double[] collectLocation(UUID absentDa, DispatchQueue row) {
+        DaLiveStatus live = daStatusService.getLiveStatus(absentDa);
+        if (live != null && live.getLat() != null && live.getLon() != null) {
+            return new double[] {live.getLat(), live.getLon()};
+        }
+        return new double[] {row.getTaskLat(), row.getTaskLon()};
+    }
+
+    private LocalDate today() {
+        return LocalDate.now(ZoneId.of(props.getShift().getZone()));
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/AbsenceReassignmentServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/AbsenceReassignmentServiceImpl.java
@@ -1,10 +1,13 @@
 package com.oneday.dispatch.service.impl;
 
 import com.oneday.dispatch.config.DispatchProperties;
+import com.oneday.common.port.DaDirectoryPort;
 import com.oneday.dispatch.domain.AbsenceStatus;
 import com.oneday.dispatch.domain.DaAbsenceEvent;
 import com.oneday.dispatch.domain.DaStatusEnum;
 import com.oneday.dispatch.domain.DispatchQueue;
+import com.oneday.dispatch.dto.response.DaRosterEntry;
+import com.oneday.dispatch.repository.DaStatusRepository;
 import com.oneday.dispatch.domain.TaskStatus;
 import com.oneday.dispatch.domain.TaskType;
 import com.oneday.dispatch.dto.response.AbsenceApplyResponse;
@@ -34,6 +37,7 @@ import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -54,10 +58,16 @@ class AbsenceReassignmentServiceImpl implements AbsenceReassignmentService {
     private static final Logger log = LoggerFactory.getLogger(AbsenceReassignmentServiceImpl.class);
     private static final List<TaskStatus> ACTIVE = List.of(TaskStatus.QUEUED, TaskStatus.IN_PROGRESS);
 
+    // On-shift DAs (any of these) are candidates for the absence picker; OFFLINE / ABSENT are excluded.
+    private static final List<DaStatusEnum> ON_SHIFT = List.of(
+            DaStatusEnum.IDLE, DaStatusEnum.IN_PROGRESS, DaStatusEnum.CRON_LOCKED, DaStatusEnum.AT_CRON);
+
     private final GridService gridService;
     private final DispatchQueueRepository queueRepository;
     private final DaAbsenceEventRepository absenceRepository;
     private final DaStatusService daStatusService;
+    private final DaStatusRepository daStatusRepository;
+    private final DaDirectoryPort daDirectory;
     private final QueueReorderService reorderService;
     private final DispatchProperties props;
 
@@ -65,14 +75,36 @@ class AbsenceReassignmentServiceImpl implements AbsenceReassignmentService {
                                    DispatchQueueRepository queueRepository,
                                    DaAbsenceEventRepository absenceRepository,
                                    DaStatusService daStatusService,
+                                   DaStatusRepository daStatusRepository,
+                                   DaDirectoryPort daDirectory,
                                    QueueReorderService reorderService,
                                    DispatchProperties props) {
         this.gridService = gridService;
         this.queueRepository = queueRepository;
         this.absenceRepository = absenceRepository;
         this.daStatusService = daStatusService;
+        this.daStatusRepository = daStatusRepository;
+        this.daDirectory = daDirectory;
         this.reorderService = reorderService;
         this.props = props;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<DaRosterEntry> roster(UUID scopeCityId, LocalDate date) {
+        List<com.oneday.dispatch.domain.DaStatus> onShift = scopeCityId == null
+                ? daStatusRepository.findByShiftDateAndStatusIn(date, ON_SHIFT)
+                : daStatusRepository.findByCityIdAndShiftDateAndStatusIn(scopeCityId, date, ON_SHIFT);
+        List<UUID> daIds = onShift.stream().map(com.oneday.dispatch.domain.DaStatus::getDaId).toList();
+        Map<UUID, DaDirectoryPort.DaContact> names = daDirectory.contactsFor(daIds);
+        return daIds.stream()
+                .map(daId -> {
+                    int open = queueRepository.findByDaIdAndOperatingDateAndStatusIn(daId, date, ACTIVE).size();
+                    DaDirectoryPort.DaContact c = names.get(daId);
+                    return new DaRosterEntry(daId, c != null ? c.name() : null, open);
+                })
+                .sorted(Comparator.comparing(r -> r.daName() == null ? "" : r.daName()))
+                .toList();
     }
 
     @Override
@@ -105,6 +137,17 @@ class AbsenceReassignmentServiceImpl implements AbsenceReassignmentService {
                     loose.add(new TaskMove(row.getShipmentId(), row.getOrderRef(),
                             row.getTaskType().name(), absentDa, newOwner));
                 }
+            }
+        }
+
+        // One live plan per DA: retire any still-PENDING plan in this city that overlaps these DAs, so a
+        // re-preview can't leave a second plan whose auto-apply later races this one's apply on the same
+        // territory (which would collide / land a confusing 0-count apply). The freshest preview wins.
+        Set<UUID> theseDas = new HashSet<>(daIds);
+        for (DaAbsenceEvent prior : absenceRepository.findByCityIdAndStatus(cityId, AbsenceStatus.PENDING)) {
+            if (prior.absentDaIdList().stream().anyMatch(theseDas::contains)) {
+                prior.setStatus(AbsenceStatus.CANCELLED);
+                absenceRepository.save(prior);
             }
         }
 
@@ -241,9 +284,13 @@ class AbsenceReassignmentServiceImpl implements AbsenceReassignmentService {
                                             double[] at, LocalDate date) {
         DispatchQueue r = baseRow(newOwner, src, date);
         r.setTaskType(TaskType.CUSTODY_COLLECT);
-        r.setTaskLat(at[0]);
+        r.setTaskLat(at[0]);           // where to meet the absent DA (their last GPS / the task location)
         r.setTaskLon(at[1]);
         r.setCollectFromDaId(absentDa);
+        // Carry the original leg + its destination so the onward task can resume once collected.
+        r.setOnwardTaskType(src.getTaskType());
+        r.setOnwardTaskLat(src.getTaskLat());
+        r.setOnwardTaskLon(src.getTaskLon());
         return r;
     }
 

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/AbsenceReassignmentServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/AbsenceReassignmentServiceImpl.java
@@ -23,8 +23,10 @@ import com.oneday.grid.dto.response.AssignmentResponse;
 import com.oneday.grid.service.GridService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -128,19 +130,25 @@ class AbsenceReassignmentServiceImpl implements AbsenceReassignmentService {
 
     @Override
     @Transactional
-    public AbsenceApplyResponse apply(UUID eventId, UUID actorUserId) {
-        return doApply(loadPending(eventId), false, actorUserId);
+    public AbsenceApplyResponse apply(UUID eventId, UUID actorUserId, UUID scopeCityId) {
+        DaAbsenceEvent event = loadEvent(eventId);
+        // City scope first — a manager may only apply an absence event in their own city (404, not 403,
+        // so a cross-city event id isn't confirmed to exist). ADMIN passes scopeCityId == null.
+        if (scopeCityId != null && !scopeCityId.equals(event.getCityId())) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No absence event " + eventId);
+        }
+        return doApply(event, false, actorUserId);
     }
 
     @Override
     @Transactional
     public AbsenceApplyResponse autoApply(UUID eventId) {
-        return doApply(loadPending(eventId), true, null);
+        return doApply(loadEvent(eventId), true, null);
     }
 
-    private DaAbsenceEvent loadPending(UUID eventId) {
+    private DaAbsenceEvent loadEvent(UUID eventId) {
         return absenceRepository.findById(eventId)
-                .orElseThrow(() -> new IllegalArgumentException("No absence event " + eventId));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No absence event " + eventId));
     }
 
     private AbsenceApplyResponse doApply(DaAbsenceEvent event, boolean system, UUID actorUserId) {

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
@@ -190,10 +190,12 @@ class DaTaskServiceImpl implements DaTaskService {
             task.setStatus(TaskStatus.FAILED);
             task.setCompletedAt(Instant.now());
             DaTaskView view = save(task);
-            if (task.getTaskType() == TaskType.PICKUP) {
-                daEventProducer.emitPickupFailed(daId, task.getCityId(), task.getShipmentId(), reason);
-            } else {
+            // A custody collect is a pickup-shaped custody take → PICKUP_FAILED (not DROP_FAILED),
+            // so M11 triages a failed hand-off correctly rather than as a delivery miss.
+            if (task.getTaskType() == TaskType.DELIVERY) {
                 daEventProducer.emitDropFailed(daId, task.getCityId(), task.getShipmentId(), reason);
+            } else {
+                daEventProducer.emitPickupFailed(daId, task.getCityId(), task.getShipmentId(), reason);
             }
             return view;
         });
@@ -272,6 +274,80 @@ class DaTaskServiceImpl implements DaTaskService {
             queueReorderService.reorder(daId, task.getOperatingDate());
             return view;
         });
+    }
+
+    @Override
+    @Transactional
+    public DaTaskView recordCustodyCollect(UUID daId, UUID taskId, List<String> parcelScans) {
+        if (parcelScans == null || parcelScans.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "At least one parcel scan is required");
+        }
+        return daStatusService.withDaLock(daId, () -> {
+            DispatchQueue task = ownedTask(daId, taskId);
+            requireType(task, TaskType.CUSTODY_COLLECT);
+            requireCollectable(task);
+            task.setStatus(TaskStatus.COMPLETED);
+            if (task.getStartedAt() == null) {
+                task.setStartedAt(Instant.now());
+            }
+            task.setCompletedAt(Instant.now());
+            DaTaskView view = save(task);
+            // M8-SEAM: append-only DA→DA custody scan — the source of truth that custody moved. Best-effort.
+            hubScanSeamProducer.emitDaCustodyTransfer(task.getShipmentId());
+            daEventProducer.emitCustodyCollected(daId, task.getCityId(), task.getShipmentId(),
+                    task.getCollectFromDaId());
+            // The parcel is now in this DA's hands → resume its onward leg on this DA (in-hand).
+            spawnOnwardLeg(daId, task);
+            AuditLog.event("da.custody_collected")
+                    .kv("daId", daId)
+                    .kv("taskId", taskId)
+                    .kv("shipmentId", task.getShipmentId())
+                    .kv("fromDaId", task.getCollectFromDaId())
+                    .kv("onwardTaskType", task.getOnwardTaskType())
+                    .log();
+            // Collect head removed + onward leg inserted → re-rank the tail (cron-aware).
+            queueReorderService.reorder(daId, task.getOperatingDate());
+            return view;
+        });
+    }
+
+    /**
+     * Re-create the in-custody parcel's onward leg (its original PICKUP/DELIVERY) for the covering DA,
+     * IN_PROGRESS because the parcel is already in hand — no re-collect step. The onward type and its
+     * destination were captured on the CUSTODY_COLLECT row when the absence was applied.
+     */
+    private void spawnOnwardLeg(UUID daId, DispatchQueue collect) {
+        TaskType onwardType = collect.getOnwardTaskType();
+        if (onwardType == null || onwardType == TaskType.CUSTODY_COLLECT) {
+            return;   // nothing to resume (defensive — a well-formed collect row always carries an onward leg)
+        }
+        DispatchQueue onward = new DispatchQueue();
+        onward.setDaId(daId);
+        onward.setCityId(collect.getCityId());
+        onward.setShipmentId(collect.getShipmentId());
+        onward.setOrderId(collect.getOrderId());
+        onward.setOrderRef(collect.getOrderRef());
+        onward.setTaskType(onwardType);
+        onward.setTaskLat(collect.getOnwardTaskLat() != null ? collect.getOnwardTaskLat() : collect.getTaskLat());
+        onward.setTaskLon(collect.getOnwardTaskLon() != null ? collect.getOnwardTaskLon() : collect.getTaskLon());
+        onward.setTileId(collect.getTileId());
+        onward.setHomeTileId(collect.getHomeTileId());
+        onward.setPaymentMode(collect.getPaymentMode());
+        onward.setStatus(TaskStatus.IN_PROGRESS);        // parcel already in hand
+        onward.setPickedUp(onwardType == TaskType.PICKUP);
+        onward.setCrossTerritory(false);
+        onward.setCronSafe(false);
+        onward.setBeyondCron(false);
+        onward.setStartedAt(Instant.now());
+        onward.setAssignedAt(Instant.now());
+        onward.setOperatingDate(collect.getOperatingDate());
+        onward.setQueuePosition(nextPosition(daId, collect.getOperatingDate()));
+        queueRepository.save(onward);
+    }
+
+    private int nextPosition(UUID daId, LocalDate date) {
+        return queueRepository.findByDaIdAndOperatingDateOrderByQueuePosition(daId, date).stream()
+                .mapToInt(DispatchQueue::getQueuePosition).max().orElse(-1) + 1;
     }
 
     // ── helpers ──────────────────────────────────────────────────────────────────────────────────
@@ -372,6 +448,14 @@ class DaTaskServiceImpl implements DaTaskService {
         if (task.getStatus() != TaskStatus.QUEUED && task.getStatus() != TaskStatus.IN_PROGRESS) {
             throw new ResponseStatusException(HttpStatus.CONFLICT,
                     "Task " + task.getId() + " is " + task.getStatus() + " and cannot be failed");
+        }
+    }
+
+    /** A CUSTODY_COLLECT can be confirmed straight from QUEUED (no separate en-route step) or IN_PROGRESS. */
+    private static void requireCollectable(DispatchQueue task) {
+        if (task.getStatus() != TaskStatus.QUEUED && task.getStatus() != TaskStatus.IN_PROGRESS) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Task " + task.getId() + " is " + task.getStatus() + " and cannot be collected");
         }
     }
 }

--- a/dispatch/src/main/resources/db/migration/dispatch/V5_14__create_da_absence_event.sql
+++ b/dispatch/src/main/resources/db/migration/dispatch/V5_14__create_da_absence_event.sql
@@ -13,8 +13,6 @@ CREATE TABLE da_absence_event (
     created_by       UUID,
     auto_approve_at  TIMESTAMPTZ NOT NULL,
     applied_at       TIMESTAMPTZ,
-    -- The grid INTRADAY_OVERRIDE proposal committed on apply (null while PENDING / if nothing moved).
-    proposal_id      UUID,
     orphan_count     INT         NOT NULL DEFAULT 0,
     created_at       TIMESTAMPTZ NOT NULL,
     updated_at       TIMESTAMPTZ NOT NULL

--- a/dispatch/src/main/resources/db/migration/dispatch/V5_14__create_da_absence_event.sql
+++ b/dispatch/src/main/resources/db/migration/dispatch/V5_14__create_da_absence_event.sql
@@ -1,0 +1,29 @@
+-- Midday DA-absence reassignment (M5). A station manager marks one or more DAs absent (with a reason);
+-- the system splits their hexes among territory-neighbors (M3) and moves the matching tasks. The plan is
+-- previewed first, then applied — either by the manager, or automatically once auto_approve_at passes.
+CREATE TABLE da_absence_event (
+    id               UUID PRIMARY KEY,
+    city_id          UUID        NOT NULL,
+    operating_date   DATE        NOT NULL,
+    -- Comma-joined absent DA ids (v1: small set, no relational child table needed).
+    absent_da_ids    TEXT        NOT NULL,
+    reason           VARCHAR(500),
+    -- PENDING → APPLIED (manager) / AUTO_APPLIED (timeout) / CANCELLED.
+    status           VARCHAR(20) NOT NULL,
+    created_by       UUID,
+    auto_approve_at  TIMESTAMPTZ NOT NULL,
+    applied_at       TIMESTAMPTZ,
+    -- The grid INTRADAY_OVERRIDE proposal committed on apply (null while PENDING / if nothing moved).
+    proposal_id      UUID,
+    orphan_count     INT         NOT NULL DEFAULT 0,
+    created_at       TIMESTAMPTZ NOT NULL,
+    updated_at       TIMESTAMPTZ NOT NULL
+);
+
+-- The auto-apply sweep scans for still-PENDING plans past their deadline.
+CREATE INDEX idx_da_absence_event_pending
+    ON da_absence_event (auto_approve_at) WHERE status = 'PENDING';
+
+-- CUSTODY_COLLECT tasks: which absent DA the new owner physically collects the parcel from
+-- (task_lat/task_lon already carry the collect location). Null for ordinary pickup/delivery tasks.
+ALTER TABLE dispatch_queue ADD COLUMN collect_from_da_id UUID;

--- a/dispatch/src/main/resources/db/migration/dispatch/V5_15__custody_collect_onward_leg.sql
+++ b/dispatch/src/main/resources/db/migration/dispatch/V5_15__custody_collect_onward_leg.sql
@@ -1,0 +1,7 @@
+-- Midday DA-absence handoff (M5), completion half. A CUSTODY_COLLECT task's task_lat/task_lon is the
+-- COLLECT point (where the covering DA meets the absent DA). To resume the parcel's journey once
+-- collected, the row also carries the original leg (PICKUP/DELIVERY) and its destination — used to
+-- spawn the onward task, in-hand (IN_PROGRESS), on the covering DA. Nullable; set only on CUSTODY_COLLECT.
+ALTER TABLE dispatch_queue ADD COLUMN onward_task_type VARCHAR(20);
+ALTER TABLE dispatch_queue ADD COLUMN onward_task_lat  DOUBLE PRECISION;
+ALTER TABLE dispatch_queue ADD COLUMN onward_task_lon  DOUBLE PRECISION;

--- a/dispatch/src/test/java/com/oneday/dispatch/api/DaDispatchControllerTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/api/DaDispatchControllerTest.java
@@ -122,6 +122,6 @@ class DaDispatchControllerTest {
         return new DaTaskView(taskId, UUID.randomUUID(), "1DD-BLR-20260716-00001",
                 UUID.randomUUID(), "1DD-ORD-BLR-20260716-00001", TaskType.PICKUP,
                 TaskStatus.IN_PROGRESS, 0, null, 12.9716, 77.5946, "PREPAID",
-                "Asha Rao", "+919000000001", "12, MG Road, Bengaluru, 560001", null, false);
+                "Asha Rao", "+919000000001", "12, MG Road, Bengaluru, 560001", null, false, null);
     }
 }

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/AbsenceReassignmentServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/AbsenceReassignmentServiceImplTest.java
@@ -1,0 +1,223 @@
+package com.oneday.dispatch.service.impl;
+
+import com.oneday.dispatch.config.DispatchProperties;
+import com.oneday.dispatch.domain.AbsenceStatus;
+import com.oneday.dispatch.domain.DaAbsenceEvent;
+import com.oneday.dispatch.domain.DaStatusEnum;
+import com.oneday.dispatch.domain.DispatchQueue;
+import com.oneday.dispatch.domain.TaskStatus;
+import com.oneday.dispatch.domain.TaskType;
+import com.oneday.dispatch.dto.response.AbsenceApplyResponse;
+import com.oneday.dispatch.dto.response.AbsencePreviewResponse;
+import com.oneday.dispatch.repository.DaAbsenceEventRepository;
+import com.oneday.dispatch.repository.DispatchQueueRepository;
+import com.oneday.dispatch.service.DaStatusService;
+import com.oneday.grid.dto.response.AbsenceReassignmentPlan;
+import com.oneday.grid.dto.response.AbsenceReassignmentPlan.HexReassignment;
+import com.oneday.grid.service.GridService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AbsenceReassignmentServiceImplTest {
+
+    private static final UUID CITY = UUID.randomUUID();
+    private static final UUID RAVI = UUID.randomUUID();
+    private static final UUID MEENA = UUID.randomUUID();
+    private static final UUID TILE_A = UUID.randomUUID();
+    private static final UUID TILE_ORPHAN = UUID.randomUUID();
+
+    @Mock private GridService gridService;
+    @Mock private DispatchQueueRepository queueRepository;
+    @Mock private DaAbsenceEventRepository absenceRepository;
+    @Mock private DaStatusService daStatusService;
+    @Mock private QueueReorderService reorderService;
+
+    private AbsenceReassignmentServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        DispatchProperties props = new DispatchProperties();
+        props.getShift().setZone("Asia/Kolkata");
+        props.getAbsence().setAutoApproveTimeoutMinutes(5);
+        service = new AbsenceReassignmentServiceImpl(gridService, queueRepository, absenceRepository,
+                daStatusService, reorderService, props);
+    }
+
+    private AbsenceReassignmentPlan planWithTileAToMeena() {
+        return new AbsenceReassignmentPlan(CITY, LocalDate.now(), List.of(RAVI),
+                List.of(new HexReassignment(TILE_A, RAVI, MEENA)), List.of());
+    }
+
+    private DispatchQueue row(UUID tile, TaskStatus status, TaskType type) {
+        DispatchQueue r = new DispatchQueue();
+        r.setDaId(RAVI);
+        r.setCityId(CITY);
+        r.setShipmentId(UUID.randomUUID());
+        r.setTaskType(type);
+        r.setTaskLat(28.6);
+        r.setTaskLon(77.2);
+        r.setTileId(tile);
+        r.setStatus(status);
+        r.setQueuePosition(0);
+        return r;
+    }
+
+    @Test
+    void previewSplitsTasksIntoLooseCustodyAndOrphanBuckets() {
+        when(gridService.planAbsenceReassignment(eq(CITY), eq(List.of(RAVI)), any()))
+                .thenReturn(planWithTileAToMeena());
+        when(queueRepository.findByDaIdAndOperatingDateAndStatusIn(eq(RAVI), any(), any()))
+                .thenReturn(List.of(
+                        row(TILE_A, TaskStatus.QUEUED, TaskType.DELIVERY),        // loose
+                        row(TILE_A, TaskStatus.IN_PROGRESS, TaskType.DELIVERY),   // in custody
+                        row(TILE_ORPHAN, TaskStatus.QUEUED, TaskType.PICKUP)));   // orphan hex
+        when(absenceRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        AbsencePreviewResponse preview = service.preview(CITY, List.of(RAVI), "sick", UUID.randomUUID());
+
+        assertThat(preview.reassignedHexCount()).isEqualTo(1);
+        assertThat(preview.looseTasks()).hasSize(1);
+        assertThat(preview.looseTasks().get(0).toDaId()).isEqualTo(MEENA);
+        assertThat(preview.custodyTasks()).hasSize(1);
+        assertThat(preview.custodyTasks().get(0).toDaId()).isEqualTo(MEENA);
+        assertThat(preview.orphanTasks()).hasSize(1);
+        // Staged as PENDING for the manager / auto-apply.
+        ArgumentCaptor<DaAbsenceEvent> saved = ArgumentCaptor.forClass(DaAbsenceEvent.class);
+        verify(absenceRepository).save(saved.capture());
+        assertThat(saved.getValue().getStatus()).isEqualTo(AbsenceStatus.PENDING);
+    }
+
+    @Test
+    void applyMovesLooseTaskToNewOwnerAsQueuedNeverDeferred() {
+        DaAbsenceEvent event = pendingEvent();
+        when(absenceRepository.findById(event.getId())).thenReturn(Optional.of(event));
+        when(gridService.applyAbsenceReassignment(eq(CITY), eq(List.of(RAVI)), any(), any()))
+                .thenReturn(planWithTileAToMeena());
+        DispatchQueue loose = row(TILE_A, TaskStatus.QUEUED, TaskType.DELIVERY);
+        when(queueRepository.findByDaIdAndOperatingDateAndStatusIn(eq(RAVI), any(), any()))
+                .thenReturn(List.of(loose));
+        when(queueRepository.findByDaIdAndOperatingDateAndStatusIn(eq(MEENA), any(), any()))
+                .thenReturn(List.of());
+        runLockInline();
+
+        AbsenceApplyResponse res = service.apply(event.getId(), UUID.randomUUID());
+
+        assertThat(res.movedTaskCount()).isEqualTo(1);
+        // A new QUEUED row for the new owner + the old row cancelled — no DEFERRED anywhere.
+        ArgumentCaptor<DispatchQueue> saved = ArgumentCaptor.forClass(DispatchQueue.class);
+        verify(queueRepository, org.mockito.Mockito.atLeastOnce()).save(saved.capture());
+        assertThat(saved.getAllValues()).anySatisfy(r -> {
+            assertThat(r.getDaId()).isEqualTo(MEENA);
+            assertThat(r.getTaskType()).isEqualTo(TaskType.DELIVERY);
+            assertThat(r.getStatus()).isEqualTo(TaskStatus.QUEUED);
+        });
+        assertThat(loose.getStatus()).isEqualTo(TaskStatus.CANCELLED);
+        assertThat(saved.getAllValues()).noneMatch(r -> r.getStatus() == TaskStatus.DEFERRED);
+        verify(reorderService).reorder(eq(MEENA), any());
+    }
+
+    @Test
+    void applyCreatesCustodyCollectForInProgressParcel() {
+        DaAbsenceEvent event = pendingEvent();
+        when(absenceRepository.findById(event.getId())).thenReturn(Optional.of(event));
+        when(gridService.applyAbsenceReassignment(eq(CITY), eq(List.of(RAVI)), any(), any()))
+                .thenReturn(planWithTileAToMeena());
+        when(queueRepository.findByDaIdAndOperatingDateAndStatusIn(eq(RAVI), any(), any()))
+                .thenReturn(List.of(row(TILE_A, TaskStatus.IN_PROGRESS, TaskType.DELIVERY)));
+        when(queueRepository.findByDaIdAndOperatingDateAndStatusIn(eq(MEENA), any(), any()))
+                .thenReturn(List.of());
+        runLockInline();
+
+        AbsenceApplyResponse res = service.apply(event.getId(), UUID.randomUUID());
+
+        assertThat(res.custodyTaskCount()).isEqualTo(1);
+        ArgumentCaptor<DispatchQueue> saved = ArgumentCaptor.forClass(DispatchQueue.class);
+        verify(queueRepository, org.mockito.Mockito.atLeastOnce()).save(saved.capture());
+        assertThat(saved.getAllValues()).anySatisfy(r -> {
+            assertThat(r.getDaId()).isEqualTo(MEENA);
+            assertThat(r.getTaskType()).isEqualTo(TaskType.CUSTODY_COLLECT);
+            assertThat(r.getCollectFromDaId()).isEqualTo(RAVI);
+        });
+    }
+
+    @Test
+    void applyTakesAbsentDaOfflineAndMarksApplied() {
+        DaAbsenceEvent event = pendingEvent();
+        when(absenceRepository.findById(event.getId())).thenReturn(Optional.of(event));
+        when(gridService.applyAbsenceReassignment(any(), any(), any(), any()))
+                .thenReturn(planWithTileAToMeena());
+        when(queueRepository.findByDaIdAndOperatingDateAndStatusIn(any(), any(), any()))
+                .thenReturn(List.of());
+        when(gridService.getActiveAssignments(any(), any())).thenReturn(List.of());
+
+        AbsenceApplyResponse res = service.apply(event.getId(), UUID.randomUUID());
+
+        verify(daStatusService).updateStatus(RAVI, DaStatusEnum.ABSENT);
+        verify(daStatusService).setTerritory(eq(RAVI), eq(List.of()));
+        assertThat(res.status()).isEqualTo(AbsenceStatus.APPLIED);
+        assertThat(event.getStatus()).isEqualTo(AbsenceStatus.APPLIED);
+    }
+
+    @Test
+    void autoApplyMarksAutoApplied() {
+        DaAbsenceEvent event = pendingEvent();
+        when(absenceRepository.findById(event.getId())).thenReturn(Optional.of(event));
+        when(gridService.applyAbsenceReassignment(any(), any(), any(), any()))
+                .thenReturn(planWithTileAToMeena());
+        when(queueRepository.findByDaIdAndOperatingDateAndStatusIn(any(), any(), any()))
+                .thenReturn(List.of());
+        when(gridService.getActiveAssignments(any(), any())).thenReturn(List.of());
+
+        AbsenceApplyResponse res = service.autoApply(event.getId());
+
+        assertThat(res.status()).isEqualTo(AbsenceStatus.AUTO_APPLIED);
+    }
+
+    @Test
+    void applyIsIdempotentOnceApplied() {
+        DaAbsenceEvent event = pendingEvent();
+        event.setStatus(AbsenceStatus.APPLIED);
+        when(absenceRepository.findById(event.getId())).thenReturn(Optional.of(event));
+
+        AbsenceApplyResponse res = service.apply(event.getId(), UUID.randomUUID());
+
+        assertThat(res.status()).isEqualTo(AbsenceStatus.APPLIED);
+        verify(gridService, never()).applyAbsenceReassignment(any(), any(), any(), any());
+    }
+
+    private DaAbsenceEvent pendingEvent() {
+        DaAbsenceEvent event = new DaAbsenceEvent() {
+            private final UUID id = UUID.randomUUID();
+            @Override public UUID getId() { return id; }
+        };
+        event.setCityId(CITY);
+        event.setOperatingDate(LocalDate.now());
+        event.setAbsentDaIdList(List.of(RAVI));
+        event.setStatus(AbsenceStatus.PENDING);
+        return event;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void runLockInline() {
+        when(daStatusService.withDaLock(any(), any()))
+                .thenAnswer(i -> ((Supplier<Object>) i.getArgument(1)).get());
+    }
+}

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/AbsenceReassignmentServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/AbsenceReassignmentServiceImplTest.java
@@ -48,6 +48,8 @@ class AbsenceReassignmentServiceImplTest {
     @Mock private DispatchQueueRepository queueRepository;
     @Mock private DaAbsenceEventRepository absenceRepository;
     @Mock private DaStatusService daStatusService;
+    @Mock private com.oneday.dispatch.repository.DaStatusRepository daStatusRepository;
+    @Mock private com.oneday.common.port.DaDirectoryPort daDirectory;
     @Mock private QueueReorderService reorderService;
 
     private AbsenceReassignmentServiceImpl service;
@@ -58,7 +60,7 @@ class AbsenceReassignmentServiceImplTest {
         props.getShift().setZone("Asia/Kolkata");
         props.getAbsence().setAutoApproveTimeoutMinutes(5);
         service = new AbsenceReassignmentServiceImpl(gridService, queueRepository, absenceRepository,
-                daStatusService, reorderService, props);
+                daStatusService, daStatusRepository, daDirectory, reorderService, props);
     }
 
     private AbsenceReassignmentPlan planWithTileAToMeena() {

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/AbsenceReassignmentServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/AbsenceReassignmentServiceImplTest.java
@@ -118,7 +118,7 @@ class AbsenceReassignmentServiceImplTest {
                 .thenReturn(List.of());
         runLockInline();
 
-        AbsenceApplyResponse res = service.apply(event.getId(), UUID.randomUUID());
+        AbsenceApplyResponse res = service.apply(event.getId(), UUID.randomUUID(), null);
 
         assertThat(res.movedTaskCount()).isEqualTo(1);
         // A new QUEUED row for the new owner + the old row cancelled — no DEFERRED anywhere.
@@ -146,7 +146,7 @@ class AbsenceReassignmentServiceImplTest {
                 .thenReturn(List.of());
         runLockInline();
 
-        AbsenceApplyResponse res = service.apply(event.getId(), UUID.randomUUID());
+        AbsenceApplyResponse res = service.apply(event.getId(), UUID.randomUUID(), null);
 
         assertThat(res.custodyTaskCount()).isEqualTo(1);
         ArgumentCaptor<DispatchQueue> saved = ArgumentCaptor.forClass(DispatchQueue.class);
@@ -168,7 +168,7 @@ class AbsenceReassignmentServiceImplTest {
                 .thenReturn(List.of());
         when(gridService.getActiveAssignments(any(), any())).thenReturn(List.of());
 
-        AbsenceApplyResponse res = service.apply(event.getId(), UUID.randomUUID());
+        AbsenceApplyResponse res = service.apply(event.getId(), UUID.randomUUID(), null);
 
         verify(daStatusService).updateStatus(RAVI, DaStatusEnum.ABSENT);
         verify(daStatusService).setTerritory(eq(RAVI), eq(List.of()));
@@ -192,12 +192,24 @@ class AbsenceReassignmentServiceImplTest {
     }
 
     @Test
+    void applyRejectsAnEventOutsideTheCallersCity() {
+        DaAbsenceEvent event = pendingEvent();   // cityId == CITY
+        when(absenceRepository.findById(event.getId())).thenReturn(Optional.of(event));
+        UUID otherCity = UUID.randomUUID();
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> service.apply(event.getId(), UUID.randomUUID(), otherCity))
+                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
+        verify(gridService, never()).applyAbsenceReassignment(any(), any(), any(), any());
+    }
+
+    @Test
     void applyIsIdempotentOnceApplied() {
         DaAbsenceEvent event = pendingEvent();
         event.setStatus(AbsenceStatus.APPLIED);
         when(absenceRepository.findById(event.getId())).thenReturn(Optional.of(event));
 
-        AbsenceApplyResponse res = service.apply(event.getId(), UUID.randomUUID());
+        AbsenceApplyResponse res = service.apply(event.getId(), UUID.randomUUID(), null);
 
         assertThat(res.status()).isEqualTo(AbsenceStatus.APPLIED);
         verify(gridService, never()).applyAbsenceReassignment(any(), any(), any(), any());

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaTaskServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaTaskServiceImplTest.java
@@ -283,7 +283,89 @@ class DaTaskServiceImplTest {
         verify(events).emitCodCollected(eq(da), eq(city), eq(task.getShipmentId()));
     }
 
+    @Test
+    void custodyCollectCompletesRecordsScanAndSpawnsOnwardDelivery() {
+        // The in-custody parcel was an out-for-delivery leg; after collect the covering DA delivers it.
+        UUID absentDa = UUID.randomUUID();
+        DispatchQueue collect = persistCustody(TaskType.DELIVERY, absentDa, 28.70, 77.10);
+
+        service.recordCustodyCollect(da, collect.getId(), List.of("P-1"));
+
+        assertThat(reload(collect).getStatus()).isEqualTo(TaskStatus.COMPLETED);
+        verify(scanSeam).emitDaCustodyTransfer(eq(collect.getShipmentId()));
+        verify(events).emitCustodyCollected(eq(da), eq(city), eq(collect.getShipmentId()), eq(absentDa));
+
+        // The onward delivery is now on this DA, in hand (IN_PROGRESS), at the parcel's destination.
+        DispatchQueue onward = queueRepo.findByDaIdAndOperatingDateOrderByQueuePosition(da, today).stream()
+                .filter(r -> r.getTaskType() == TaskType.DELIVERY
+                        && r.getShipmentId().equals(collect.getShipmentId()))
+                .findFirst().orElseThrow();
+        assertThat(onward.getStatus()).isEqualTo(TaskStatus.IN_PROGRESS);
+        assertThat(onward.isPickedUp()).isFalse();
+        assertThat(onward.getTaskLat()).isEqualTo(28.70);
+        assertThat(onward.getTaskLon()).isEqualTo(77.10);
+    }
+
+    @Test
+    void custodyCollectSpawnsOnwardPickupInHand() {
+        // An in-custody pickup (sender collected, en route to hub) resumes as a PICKUP, in hand.
+        DispatchQueue collect = persistCustody(TaskType.PICKUP, UUID.randomUUID(), 28.55, 77.20);
+
+        service.recordCustodyCollect(da, collect.getId(), List.of("P-1"));
+
+        DispatchQueue onward = queueRepo.findByDaIdAndOperatingDateOrderByQueuePosition(da, today).stream()
+                .filter(r -> r.getTaskType() == TaskType.PICKUP
+                        && r.getShipmentId().equals(collect.getShipmentId()))
+                .findFirst().orElseThrow();
+        assertThat(onward.getStatus()).isEqualTo(TaskStatus.IN_PROGRESS);
+        assertThat(onward.isPickedUp()).isTrue();
+    }
+
+    @Test
+    void custodyCollectWithNoScansIs422() {
+        DispatchQueue collect = persistCustody(TaskType.DELIVERY, UUID.randomUUID(), 28.70, 77.10);
+        assertThatThrownBy(() -> service.recordCustodyCollect(da, collect.getId(), List.of()))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("422");
+    }
+
+    @Test
+    void custodyCollectOnANonCustodyTaskIs409() {
+        DispatchQueue task = persist(TaskType.PICKUP, TaskStatus.QUEUED);
+        assertThatThrownBy(() -> service.recordCustodyCollect(da, task.getId(), List.of("P-1")))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("409");
+    }
+
+    @Test
+    void failedCustodyCollectEmitsPickupFailedNotDrop() {
+        DispatchQueue collect = persistCustody(TaskType.DELIVERY, UUID.randomUUID(), 28.70, 77.10);
+        service.markFailed(da, collect.getId(), "colleague unreachable");
+        assertThat(reload(collect).getStatus()).isEqualTo(TaskStatus.FAILED);
+        verify(events).emitPickupFailed(eq(da), eq(city), eq(collect.getShipmentId()), eq("colleague unreachable"));
+    }
+
     // ── helpers ──
+
+    private DispatchQueue persistCustody(TaskType onwardType, UUID absentDa, double onwardLat, double onwardLon) {
+        DispatchQueue d = new DispatchQueue();
+        d.setDaId(da);
+        d.setCityId(city);
+        d.setShipmentId(UUID.randomUUID());
+        d.setTaskType(TaskType.CUSTODY_COLLECT);
+        d.setTaskLat(28.60);            // the meet point (absent DA's location)
+        d.setTaskLon(77.05);
+        d.setTileId(tile);
+        d.setQueuePosition(0);
+        d.setStatus(TaskStatus.QUEUED);
+        d.setCronSafe(false);
+        d.setCollectFromDaId(absentDa);
+        d.setOnwardTaskType(onwardType);
+        d.setOnwardTaskLat(onwardLat);
+        d.setOnwardTaskLon(onwardLon);
+        d.setOperatingDate(today);
+        return queueRepo.saveAndFlush(d);
+    }
 
     private DispatchQueue persist(TaskType type, TaskStatus status) {
         DispatchQueue d = new DispatchQueue();

--- a/grid/src/main/java/com/oneday/grid/dto/response/AbsenceReassignmentPlan.java
+++ b/grid/src/main/java/com/oneday/grid/dto/response/AbsenceReassignmentPlan.java
@@ -1,0 +1,35 @@
+package com.oneday.grid.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * The territory-split plan for one or more absent DAs (M3, midday absence). Every hex owned by an
+ * absent DA is folded into exactly one <b>territory-neighbor</b> — the adjacent DA (H3 1-ring) with
+ * the most spare capacity, contiguity preserved. Hexes whose every neighbor is also absent (or that
+ * are isolated) have no receiver and surface as {@code orphanHexIds} for manual escalation.
+ *
+ * <p>Compute-only when returned from {@code planAbsenceReassignment} (advisory preview); the same
+ * shape is returned from {@code applyAbsenceReassignment} after the {@code INTRADAY_OVERRIDE}
+ * proposal has been written + approved, so the caller (M5) can move the matching tasks.</p>
+ */
+public record AbsenceReassignmentPlan(
+        UUID cityId,
+        LocalDate date,
+        List<UUID> absentDaIds,
+        List<HexReassignment> reassignments,
+        List<UUID> orphanHexIds) {
+
+    /** One absent-DA hex folded into a neighbor. */
+    public record HexReassignment(UUID hexId, UUID fromDaId, UUID toDaId) {}
+
+    /** The receiving neighbor for {@code hexId}, or {@code null} if the hex is an orphan. */
+    public UUID ownerOf(UUID hexId) {
+        return reassignments.stream()
+                .filter(r -> r.hexId().equals(hexId))
+                .map(HexReassignment::toDaId)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/grid/src/main/java/com/oneday/grid/service/GridService.java
+++ b/grid/src/main/java/com/oneday/grid/service/GridService.java
@@ -1,6 +1,7 @@
 package com.oneday.grid.service;
 
 import com.oneday.grid.domain.Grid;
+import com.oneday.grid.dto.response.AbsenceReassignmentPlan;
 import com.oneday.grid.dto.response.AssignmentResponse;
 import com.oneday.grid.dto.response.DaTerritoryResponse;
 import com.oneday.grid.dto.response.GridVertexResponse;
@@ -47,4 +48,12 @@ public interface GridService {
     // DA territories for the date — DA → hexes (+ demand) → corner vertices. M6's planning input
     // (§6); built from ACTIVE da_hex_assignment rows joined to the date's demand snapshot.
     List<DaTerritoryResponse> getDaTerritories(UUID cityId, LocalDate date);
+
+    // Midday DA absence (M5-triggered): split the absent DAs' hexes among their territory-neighbors.
+    // plan* is compute-only (preview); apply* writes + approves the INTRADAY_OVERRIDE and returns the
+    // committed split so M5 can move the matching tasks.
+    AbsenceReassignmentPlan planAbsenceReassignment(UUID cityId, List<UUID> absentDaIds, LocalDate date);
+
+    AbsenceReassignmentPlan applyAbsenceReassignment(UUID cityId, List<UUID> absentDaIds, LocalDate date,
+                                                     UUID reviewerId);
 }

--- a/grid/src/main/java/com/oneday/grid/service/impl/AbsenceReassignmentPlanner.java
+++ b/grid/src/main/java/com/oneday/grid/service/impl/AbsenceReassignmentPlanner.java
@@ -1,0 +1,272 @@
+package com.oneday.grid.service.impl;
+
+import com.oneday.grid.domain.AdjacencySource;
+import com.oneday.grid.domain.AssignmentProposal;
+import com.oneday.grid.domain.AssignmentStatus;
+import com.oneday.grid.domain.DaHexAssignment;
+import com.oneday.grid.domain.Grid;
+import com.oneday.grid.domain.Hex;
+import com.oneday.grid.domain.ProposalStatus;
+import com.oneday.grid.domain.ProposalType;
+import com.oneday.grid.domain.SolverType;
+import com.oneday.grid.dto.response.AbsenceReassignmentPlan;
+import com.oneday.grid.dto.response.AbsenceReassignmentPlan.HexReassignment;
+import com.oneday.grid.repository.AssignmentProposalRepository;
+import com.oneday.grid.repository.DaHexAssignmentRepository;
+import com.oneday.grid.repository.GridRepository;
+import com.oneday.grid.repository.HexRepository;
+import com.uber.h3core.H3Core;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Territory-split planner for midday DA absence (M3). The <b>only</b> decision is which neighbor
+ * inherits each hex left uncovered by an absent DA; once split, M5 makes every task follow its hex to
+ * the new owner (no per-task feasibility gate — {@code QueueReorderService} handles cron ordering).
+ *
+ * <p>A hex needs re-cover only when <em>every</em> DA owning it is absent (a shared hex with a live
+ * co-owner is already covered). Its receiver is the H3 1-ring adjacent DA with the most spare capacity
+ * — approximated by fewest currently-assigned hexes (capacity is a soft preference, §5), ties broken
+ * by the strongest shared border then DA id for determinism. Because a receiver is chosen only from
+ * DAs bordering the hex, adding the hex keeps that receiver's territory connected — no separate
+ * contiguity repair needed. Hexes with no live neighbor are {@code orphans} for manual escalation.</p>
+ */
+@Service
+class AbsenceReassignmentPlanner {
+
+    private static final Logger log = LoggerFactory.getLogger(AbsenceReassignmentPlanner.class);
+
+    private final DaHexAssignmentRepository assignmentRepository;
+    private final AssignmentProposalRepository proposalRepository;
+    private final GridRepository gridRepository;
+    private final HexRepository hexRepository;
+    private final H3Core h3Core;
+
+    AbsenceReassignmentPlanner(DaHexAssignmentRepository assignmentRepository,
+                              AssignmentProposalRepository proposalRepository,
+                              GridRepository gridRepository,
+                              HexRepository hexRepository,
+                              H3Core h3Core) {
+        this.assignmentRepository = assignmentRepository;
+        this.proposalRepository = proposalRepository;
+        this.gridRepository = gridRepository;
+        this.hexRepository = hexRepository;
+        this.h3Core = h3Core;
+    }
+
+    /**
+     * Compute the split without writing anything (advisory preview). Balanced multi-source region
+     * growing: neighbors grow inward from the vacated territory's border. Each round the globally
+     * least-loaded live DA that borders any still-unclaimed vacated hex claims one adjacent hex (the
+     * one it shares the most border with). Since every claim glues onto a hex the claimer already
+     * owns — original or just-claimed — each receiver stays contiguous; growing the least-loaded one
+     * first spreads the load across <em>all</em> the vacated territory's neighbors. A vacated hex with
+     * no path to any live DA (an isolated pocket) is left an orphan.
+     */
+    AbsenceReassignmentPlan plan(UUID cityId, List<UUID> absentDaIds, LocalDate date) {
+        Set<UUID> absent = new HashSet<>(absentDaIds);
+        Grid grid = gridRepository.findByCityId(cityId)
+                .orElseThrow(() -> new IllegalArgumentException("Grid not found for city: " + cityId));
+
+        List<Hex> hexes = hexRepository.findByH3GridIdAndActiveTrue(grid.getId());
+        Set<UUID> gridHexIds = hexes.stream().map(Hex::getId).collect(Collectors.toSet());
+        Map<UUID, List<UUID>> adjacency = geometricAdjacency(hexes);
+
+        // Current standing plan for the date, scoped to this city's hexes.
+        List<DaHexAssignment> approved = assignmentRepository.findByValidDateAndStatus(date, AssignmentStatus.APPROVED)
+                .stream().filter(a -> gridHexIds.contains(a.getHexId())).toList();
+
+        // Live ownership (hex → a live DA) grows as hexes are claimed; load is the balancing counter.
+        Map<UUID, UUID> owner = new HashMap<>();
+        Map<UUID, Integer> load = new HashMap<>();
+        Map<UUID, UUID> absentOwner = new HashMap<>();   // hex → an absent owner (the fromDa)
+        for (DaHexAssignment a : approved) {
+            if (absent.contains(a.getDaId())) {
+                absentOwner.putIfAbsent(a.getHexId(), a.getDaId());
+            } else {
+                owner.putIfAbsent(a.getHexId(), a.getDaId());
+                load.merge(a.getDaId(), 1, Integer::sum);
+            }
+        }
+
+        // Vacated = owned by an absent DA and by no live co-owner (a shared hex with a live owner is fine).
+        Set<UUID> unclaimed = absentOwner.keySet().stream()
+                .filter(h -> !owner.containsKey(h))
+                .collect(Collectors.toCollection(java.util.TreeSet::new));
+
+        List<HexReassignment> reassignments = new ArrayList<>();
+        while (!unclaimed.isEmpty()) {
+            // Which live DAs can currently claim which unclaimed hexes (adjacency to a hex they own).
+            Map<UUID, List<UUID>> claimableByDa = new HashMap<>();
+            for (UUID h : unclaimed) {
+                Set<UUID> adjOwners = new HashSet<>();
+                for (UUID nb : adjacency.getOrDefault(h, List.of())) {
+                    UUID d = owner.get(nb);
+                    if (d != null) {
+                        adjOwners.add(d);
+                    }
+                }
+                for (UUID d : adjOwners) {
+                    claimableByDa.computeIfAbsent(d, k -> new ArrayList<>()).add(h);
+                }
+            }
+            if (claimableByDa.isEmpty()) {
+                break;   // remaining unclaimed hexes have no live neighbor → orphans
+            }
+            // Grow the globally least-loaded eligible DA (ties by id) — spreads load across neighbors.
+            UUID grower = claimableByDa.keySet().stream()
+                    .min(Comparator.comparingInt((UUID d) -> load.getOrDefault(d, 0)).thenComparing(UUID::toString))
+                    .orElseThrow();
+            // It claims the adjacent hex it shares the most border with (ties by hex id, for determinism).
+            UUID hex = pickStrongestBorder(claimableByDa.get(grower), grower, adjacency, owner);
+
+            owner.put(hex, grower);
+            unclaimed.remove(hex);
+            load.merge(grower, 1, Integer::sum);
+            reassignments.add(new HexReassignment(hex, absentOwner.get(hex), grower));
+        }
+
+        List<UUID> orphans = new ArrayList<>(unclaimed);
+        List<UUID> sortedAbsent = absentDaIds.stream().sorted().toList();
+        log.info("Absence plan cityId={} absent={} → {} hexes reassigned, {} orphans",
+                cityId, sortedAbsent.size(), reassignments.size(), orphans.size());
+        return new AbsenceReassignmentPlan(cityId, date, sortedAbsent, reassignments, orphans);
+    }
+
+    /** The candidate hex sharing the most border with {@code da}; ties broken by hex id (deterministic). */
+    private UUID pickStrongestBorder(List<UUID> candidates, UUID da,
+                                     Map<UUID, List<UUID>> adjacency, Map<UUID, UUID> owner) {
+        UUID best = null;
+        int bestBorder = -1;
+        for (UUID h : candidates) {
+            int border = 0;
+            for (UUID nb : adjacency.getOrDefault(h, List.of())) {
+                if (da.equals(owner.get(nb))) {
+                    border++;
+                }
+            }
+            if (border > bestBorder || (border == bestBorder && (best == null || h.compareTo(best) < 0))) {
+                bestBorder = border;
+                best = h;
+            }
+        }
+        return best;
+    }
+
+    /**
+     * Recompute the split and commit it as one append-only {@code INTRADAY_OVERRIDE} proposal:
+     * receivers get their full new hex-set (existing + gained), absent DAs are fully vacated (no new
+     * rows), and the affected DAs' standing APPROVED rows are superseded. Returns the applied plan so
+     * M5 can move the matching tasks.
+     */
+    @Transactional
+    AbsenceReassignmentPlan apply(UUID cityId, List<UUID> absentDaIds, LocalDate date, UUID reviewerId) {
+        AbsenceReassignmentPlan plan = plan(cityId, absentDaIds, date);
+        if (plan.reassignments().isEmpty()) {
+            return plan;   // nothing to move (all covered, or all orphaned → caller escalates)
+        }
+
+        Set<UUID> absent = new HashSet<>(absentDaIds);
+        Map<UUID, List<UUID>> gainedByReceiver = plan.reassignments().stream()
+                .collect(Collectors.groupingBy(HexReassignment::toDaId,
+                        Collectors.mapping(HexReassignment::hexId, Collectors.toList())));
+        Set<UUID> receivers = gainedByReceiver.keySet();
+
+        AssignmentProposal proposal = proposalRepository.save(AssignmentProposal.builder()
+                .cityId(cityId)
+                .validForDate(date)
+                .status(ProposalStatus.PROPOSED)
+                .proposalType(ProposalType.INTRADAY_OVERRIDE)
+                .solverType(SolverType.MANUAL)
+                .adjacencySource(AdjacencySource.GEOMETRIC_FALLBACK)
+                .totalDas(receivers.size())
+                .coveragePct(100.0)
+                .understaffedHexIds("[]")
+                .build());
+
+        // Write each receiver's full new hex-set (append-only; absent DAs get nothing → vacated).
+        List<DaHexAssignment> newRows = new ArrayList<>();
+        for (UUID receiver : receivers) {
+            Set<UUID> merged = new LinkedHashSet<>(activeAssignedHexes(receiver, date));
+            merged.addAll(gainedByReceiver.get(receiver));
+            for (UUID hex : merged) {
+                newRows.add(DaHexAssignment.builder()
+                        .proposalId(proposal.getId())
+                        .daId(receiver)
+                        .hexId(hex)
+                        .validDate(date)
+                        .nDasOnHex(1)
+                        .status(AssignmentStatus.PROPOSED)
+                        .build());
+            }
+        }
+        assignmentRepository.saveAll(newRows);
+
+        // Approve: supersede the standing APPROVED rows of every affected DA, activate the new rows.
+        Instant now = Instant.now();
+        Set<UUID> affected = new HashSet<>(receivers);
+        affected.addAll(absent);
+        for (UUID da : affected) {
+            assignmentRepository.findByDaIdAndValidDate(da, date).stream()
+                    .filter(a -> a.getStatus() == AssignmentStatus.APPROVED)
+                    .forEach(a -> {
+                        a.setStatus(AssignmentStatus.SUPERSEDED);
+                        assignmentRepository.save(a);
+                    });
+        }
+        newRows.forEach(a -> {
+            a.setStatus(AssignmentStatus.APPROVED);
+            a.setApprovedBy(reviewerId);
+            a.setApprovedAt(now);
+        });
+        assignmentRepository.saveAll(newRows);
+
+        proposal.setStatus(ProposalStatus.APPROVED);
+        proposal.setReviewedBy(reviewerId);
+        proposal.setReviewedAt(now);
+        proposalRepository.save(proposal);
+
+        log.info("Absence reassignment applied: proposal={} receivers={} hexes={} absent={} orphans={}",
+                proposal.getId(), receivers.size(), plan.reassignments().size(),
+                absent.size(), plan.orphanHexIds().size());
+        return plan;
+    }
+
+    private List<UUID> activeAssignedHexes(UUID daId, LocalDate date) {
+        return assignmentRepository.findByDaIdAndValidDate(daId, date).stream()
+                .filter(a -> a.getStatus() == AssignmentStatus.APPROVED)
+                .map(DaHexAssignment::getHexId)
+                .toList();
+    }
+
+    /** H3 1-ring adjacency over the city's active hexes — hexId → neighboring hexIds. */
+    private Map<UUID, List<UUID>> geometricAdjacency(List<Hex> hexes) {
+        Set<Long> activeH3 = hexes.stream().map(Hex::getH3Index).collect(Collectors.toSet());
+        Map<Long, UUID> h3ToId = hexes.stream().collect(Collectors.toMap(Hex::getH3Index, Hex::getId));
+        Map<UUID, List<UUID>> graph = new HashMap<>();
+        for (Hex hex : hexes) {
+            long center = hex.getH3Index();
+            List<UUID> neighbors = h3Core.gridDisk(center, 1).stream()
+                    .filter(h -> h != center && activeH3.contains(h))
+                    .map(h3ToId::get)
+                    .toList();
+            graph.put(hex.getId(), neighbors);
+        }
+        return graph;
+    }
+}

--- a/grid/src/main/java/com/oneday/grid/service/impl/AbsenceReassignmentPlanner.java
+++ b/grid/src/main/java/com/oneday/grid/service/impl/AbsenceReassignmentPlanner.java
@@ -213,36 +213,32 @@ class AbsenceReassignmentPlanner {
                 .understaffedHexIds("[]")
                 .build());
 
-        // Write each receiver's full new hex-set (append-only). Retained hexes keep their existing
-        // nDasOnHex (a shared hex stays shared); gained hexes get a single new owner (nDasOnHex=1).
+        // Append ONLY the gained hexes to each receiver, as new APPROVED rows. The receiver keeps its
+        // retained hexes through its existing APPROVED rows — leave those untouched. Re-inserting a
+        // retained hex would violate the (da_id, hex_id, valid_date) uniqueness (supersede only flips
+        // status, it does not free the slot), which is the whole reason we don't rewrite the full set.
+        // Only the absent DA's rows are superseded (done above), so their hexes move cleanly to the
+        // new owner: (receiver, gainedHex, date) is a brand-new key.
         List<DaHexAssignment> newRows = new ArrayList<>();
         for (UUID receiver : receivers) {
-            Map<UUID, Integer> retainedCount = approvedRows(receiver, date).stream()
-                    .collect(Collectors.toMap(DaHexAssignment::getHexId, DaHexAssignment::getNDasOnHex));
-            Set<UUID> merged = new LinkedHashSet<>(retainedCount.keySet());
-            merged.addAll(gainedByReceiver.get(receiver));
-            for (UUID hex : merged) {
+            Set<UUID> alreadyOwned = approvedRows(receiver, date).stream()
+                    .map(DaHexAssignment::getHexId).collect(Collectors.toSet());
+            for (UUID hex : new LinkedHashSet<>(gainedByReceiver.get(receiver))) {
+                if (alreadyOwned.contains(hex)) {
+                    continue;   // defensive: never double-insert a hex the receiver already holds
+                }
                 newRows.add(DaHexAssignment.builder()
                         .proposalId(proposal.getId())
                         .daId(receiver)
                         .hexId(hex)
                         .validDate(date)
-                        .nDasOnHex(retainedCount.getOrDefault(hex, 1))
-                        .status(AssignmentStatus.PROPOSED)
+                        .nDasOnHex(1)
+                        .status(AssignmentStatus.APPROVED)
+                        .approvedBy(reviewerId)
+                        .approvedAt(now)
                         .build());
             }
         }
-        assignmentRepository.saveAll(newRows);
-
-        // Supersede the receivers' standing APPROVED rows (absent DAs were retired above), activate the new.
-        for (UUID receiver : receivers) {
-            supersedeApproved(receiver, date);
-        }
-        newRows.forEach(a -> {
-            a.setStatus(AssignmentStatus.APPROVED);
-            a.setApprovedBy(reviewerId);
-            a.setApprovedAt(now);
-        });
         assignmentRepository.saveAll(newRows);
 
         proposal.setStatus(ProposalStatus.APPROVED);

--- a/grid/src/main/java/com/oneday/grid/service/impl/AbsenceReassignmentPlanner.java
+++ b/grid/src/main/java/com/oneday/grid/service/impl/AbsenceReassignmentPlanner.java
@@ -170,22 +170,36 @@ class AbsenceReassignmentPlanner {
 
     /**
      * Recompute the split and commit it as one append-only {@code INTRADAY_OVERRIDE} proposal:
-     * receivers get their full new hex-set (existing + gained), absent DAs are fully vacated (no new
-     * rows), and the affected DAs' standing APPROVED rows are superseded. Returns the applied plan so
-     * M5 can move the matching tasks.
+     * receivers get their full new hex-set (existing + gained), absent DAs are fully vacated, and the
+     * affected DAs' standing APPROVED rows are superseded. The absent DAs are retired even when no hex
+     * finds a receiver (their orphaned hexes are simply left uncovered for escalation). Returns the
+     * applied plan so M5 can move the matching tasks.
      */
     @Transactional
     AbsenceReassignmentPlan apply(UUID cityId, List<UUID> absentDaIds, LocalDate date, UUID reviewerId) {
         AbsenceReassignmentPlan plan = plan(cityId, absentDaIds, date);
+        Set<UUID> absent = new HashSet<>(absentDaIds);
+        Instant now = Instant.now();
+
+        // Always retire the absent DAs — they're absent whether or not any of their hexes found a
+        // receiver. Hexes with no live neighbor (orphans) are left uncovered for manual escalation.
+        for (UUID da : absent) {
+            supersedeApproved(da, date);
+        }
         if (plan.reassignments().isEmpty()) {
-            return plan;   // nothing to move (all covered, or all orphaned → caller escalates)
+            log.info("Absence reassignment: retired {} absent DA(s), no receiver for any hex ({} orphans)",
+                    absent.size(), plan.orphanHexIds().size());
+            return plan;
         }
 
-        Set<UUID> absent = new HashSet<>(absentDaIds);
         Map<UUID, List<UUID>> gainedByReceiver = plan.reassignments().stream()
                 .collect(Collectors.groupingBy(HexReassignment::toDaId,
                         Collectors.mapping(HexReassignment::hexId, Collectors.toList())));
         Set<UUID> receivers = gainedByReceiver.keySet();
+
+        int covered = plan.reassignments().size();
+        int total = covered + plan.orphanHexIds().size();
+        double coveragePct = total == 0 ? 100.0 : (100.0 * covered / total);
 
         AssignmentProposal proposal = proposalRepository.save(AssignmentProposal.builder()
                 .cityId(cityId)
@@ -195,14 +209,17 @@ class AbsenceReassignmentPlanner {
                 .solverType(SolverType.MANUAL)
                 .adjacencySource(AdjacencySource.GEOMETRIC_FALLBACK)
                 .totalDas(receivers.size())
-                .coveragePct(100.0)
+                .coveragePct(coveragePct)
                 .understaffedHexIds("[]")
                 .build());
 
-        // Write each receiver's full new hex-set (append-only; absent DAs get nothing → vacated).
+        // Write each receiver's full new hex-set (append-only). Retained hexes keep their existing
+        // nDasOnHex (a shared hex stays shared); gained hexes get a single new owner (nDasOnHex=1).
         List<DaHexAssignment> newRows = new ArrayList<>();
         for (UUID receiver : receivers) {
-            Set<UUID> merged = new LinkedHashSet<>(activeAssignedHexes(receiver, date));
+            Map<UUID, Integer> retainedCount = approvedRows(receiver, date).stream()
+                    .collect(Collectors.toMap(DaHexAssignment::getHexId, DaHexAssignment::getNDasOnHex));
+            Set<UUID> merged = new LinkedHashSet<>(retainedCount.keySet());
             merged.addAll(gainedByReceiver.get(receiver));
             for (UUID hex : merged) {
                 newRows.add(DaHexAssignment.builder()
@@ -210,24 +227,16 @@ class AbsenceReassignmentPlanner {
                         .daId(receiver)
                         .hexId(hex)
                         .validDate(date)
-                        .nDasOnHex(1)
+                        .nDasOnHex(retainedCount.getOrDefault(hex, 1))
                         .status(AssignmentStatus.PROPOSED)
                         .build());
             }
         }
         assignmentRepository.saveAll(newRows);
 
-        // Approve: supersede the standing APPROVED rows of every affected DA, activate the new rows.
-        Instant now = Instant.now();
-        Set<UUID> affected = new HashSet<>(receivers);
-        affected.addAll(absent);
-        for (UUID da : affected) {
-            assignmentRepository.findByDaIdAndValidDate(da, date).stream()
-                    .filter(a -> a.getStatus() == AssignmentStatus.APPROVED)
-                    .forEach(a -> {
-                        a.setStatus(AssignmentStatus.SUPERSEDED);
-                        assignmentRepository.save(a);
-                    });
+        // Supersede the receivers' standing APPROVED rows (absent DAs were retired above), activate the new.
+        for (UUID receiver : receivers) {
+            supersedeApproved(receiver, date);
         }
         newRows.forEach(a -> {
             a.setStatus(AssignmentStatus.APPROVED);
@@ -241,17 +250,22 @@ class AbsenceReassignmentPlanner {
         proposal.setReviewedAt(now);
         proposalRepository.save(proposal);
 
-        log.info("Absence reassignment applied: proposal={} receivers={} hexes={} absent={} orphans={}",
-                proposal.getId(), receivers.size(), plan.reassignments().size(),
-                absent.size(), plan.orphanHexIds().size());
+        log.info("Absence reassignment applied: proposal={} receivers={} hexes={} absent={} orphans={} coverage={}%",
+                proposal.getId(), receivers.size(), covered, absent.size(), plan.orphanHexIds().size(),
+                String.format("%.1f", coveragePct));
         return plan;
     }
 
-    private List<UUID> activeAssignedHexes(UUID daId, LocalDate date) {
+    private List<DaHexAssignment> approvedRows(UUID daId, LocalDate date) {
         return assignmentRepository.findByDaIdAndValidDate(daId, date).stream()
                 .filter(a -> a.getStatus() == AssignmentStatus.APPROVED)
-                .map(DaHexAssignment::getHexId)
                 .toList();
+    }
+
+    private void supersedeApproved(UUID daId, LocalDate date) {
+        List<DaHexAssignment> rows = approvedRows(daId, date);
+        rows.forEach(a -> a.setStatus(AssignmentStatus.SUPERSEDED));
+        assignmentRepository.saveAll(rows);
     }
 
     /** H3 1-ring adjacency over the city's active hexes — hexId → neighboring hexIds. */

--- a/grid/src/main/java/com/oneday/grid/service/impl/GridServiceImpl.java
+++ b/grid/src/main/java/com/oneday/grid/service/impl/GridServiceImpl.java
@@ -12,6 +12,7 @@ import com.oneday.grid.domain.Hex;
 import com.oneday.grid.domain.HexDemandSnapshot;
 import com.oneday.grid.domain.HexVertex;
 import com.oneday.grid.domain.PincodeMapping;
+import com.oneday.grid.dto.response.AbsenceReassignmentPlan;
 import com.oneday.grid.dto.response.AssignmentResponse;
 import com.oneday.grid.dto.response.DaTerritoryResponse;
 import com.oneday.grid.dto.response.GridVertexResponse;
@@ -61,6 +62,7 @@ public class GridServiceImpl implements GridService {
     private final ResourceLoader resourceLoader;
     private final GridProperties gridProperties;
     private final H3Core h3Core;
+    private final AbsenceReassignmentPlanner absencePlanner;
     private final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
 
     private final Map<UUID, Grid> gridCache = new ConcurrentHashMap<>();
@@ -73,7 +75,8 @@ public class GridServiceImpl implements GridService {
                     DaHexAssignmentRepository assignmentRepository,
                     ResourceLoader resourceLoader,
                     GridProperties gridProperties,
-                    H3Core h3Core) {
+                    H3Core h3Core,
+                    AbsenceReassignmentPlanner absencePlanner) {
         this.gridRepository = gridRepository;
         this.hexRepository = hexRepository;
         this.pincodeMappingRepository = pincodeMappingRepository;
@@ -83,11 +86,23 @@ public class GridServiceImpl implements GridService {
         this.resourceLoader = resourceLoader;
         this.gridProperties = gridProperties;
         this.h3Core = h3Core;
+        this.absencePlanner = absencePlanner;
     }
 
     @PostConstruct
     void loadGridCache() {
         gridRepository.findAll().forEach(g -> gridCache.put(g.getCityId(), g));
+    }
+
+    @Override
+    public AbsenceReassignmentPlan planAbsenceReassignment(UUID cityId, List<UUID> absentDaIds, LocalDate date) {
+        return absencePlanner.plan(cityId, absentDaIds, date);
+    }
+
+    @Override
+    public AbsenceReassignmentPlan applyAbsenceReassignment(UUID cityId, List<UUID> absentDaIds, LocalDate date,
+                                                            UUID reviewerId) {
+        return absencePlanner.apply(cityId, absentDaIds, date, reviewerId);
     }
 
     @Override

--- a/grid/src/test/java/com/oneday/grid/service/impl/AbsenceReassignmentPlannerTest.java
+++ b/grid/src/test/java/com/oneday/grid/service/impl/AbsenceReassignmentPlannerTest.java
@@ -1,0 +1,191 @@
+package com.oneday.grid.service.impl;
+
+import com.oneday.grid.domain.AssignmentStatus;
+import com.oneday.grid.domain.DaHexAssignment;
+import com.oneday.grid.domain.Grid;
+import com.oneday.grid.domain.Hex;
+import com.oneday.grid.dto.response.AbsenceReassignmentPlan;
+import com.oneday.grid.dto.response.AbsenceReassignmentPlan.HexReassignment;
+import com.oneday.grid.repository.AssignmentProposalRepository;
+import com.oneday.grid.repository.DaHexAssignmentRepository;
+import com.oneday.grid.repository.GridRepository;
+import com.oneday.grid.repository.HexRepository;
+import com.uber.h3core.H3Core;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Exercises the balanced flood-fill split against real H3 geometry (a genuine hex disk), with the
+ * repositories mocked to supply a synthetic ownership map.
+ */
+@ExtendWith(MockitoExtension.class)
+class AbsenceReassignmentPlannerTest {
+
+    private static final int RES = 9;
+    private static final LocalDate DATE = LocalDate.of(2026, 8, 25);
+    private static final UUID CITY = UUID.randomUUID();
+    // Fixed ids so the tie-break (by id) is deterministic across runs.
+    private static final UUID RAVI = UUID.fromString("00000000-0000-0000-0000-0000000000aa");
+    private static final UUID MEENA = UUID.fromString("00000000-0000-0000-0000-0000000000bb");
+    private static final UUID SUNIL = UUID.fromString("00000000-0000-0000-0000-0000000000cc");
+
+    @Mock private DaHexAssignmentRepository assignmentRepository;
+    @Mock private AssignmentProposalRepository proposalRepository;
+    @Mock private GridRepository gridRepository;
+    @Mock private HexRepository hexRepository;
+
+    private H3Core h3;
+    private AbsenceReassignmentPlanner planner;
+
+    // h3 index → hex id, for the active grid we build per test.
+    private final Map<Long, UUID> hexIdByH3 = new HashMap<>();
+
+    @BeforeEach
+    void setUp() throws IOException {
+        h3 = H3Core.newInstance();
+        planner = new AbsenceReassignmentPlanner(assignmentRepository, proposalRepository,
+                gridRepository, hexRepository, h3);
+        when(gridRepository.findByCityId(any())).thenReturn(java.util.Optional.of(Grid.builder().build()));
+    }
+
+    @Test
+    void splitsAnAbsentBlobAcrossBothNeighborsWithNoOrphans() {
+        // Ravi owns a 7-hex blob (a center + its ring); Meena seeds one flank, Sunil the other.
+        long center = h3.latLngToCell(28.6139, 77.2090, RES);
+        List<Long> blob = h3.gridDisk(center, 1);            // 7 cells → Ravi
+        List<Long> ring2 = subtract(h3.gridDisk(center, 2), blob);
+
+        Map<Long, UUID> owners = new HashMap<>();
+        blob.forEach(h -> owners.put(h, RAVI));
+        // Alternate the surrounding ring between the two live neighbors so both border the blob.
+        List<Long> sortedRing = ring2.stream().sorted().toList();
+        for (int i = 0; i < sortedRing.size(); i++) {
+            owners.put(sortedRing.get(i), i % 2 == 0 ? MEENA : SUNIL);
+        }
+        stubGrid(owners);
+
+        AbsenceReassignmentPlan plan = planner.plan(CITY, List.of(RAVI), DATE);
+
+        assertThat(plan.orphanHexIds()).isEmpty();
+        assertThat(plan.reassignments()).hasSize(7);                       // every Ravi hex re-covered
+        Set<UUID> receivers = plan.reassignments().stream()
+                .map(HexReassignment::toDaId).collect(Collectors.toSet());
+        assertThat(receivers).containsExactlyInAnyOrder(MEENA, SUNIL);     // split across BOTH, not dumped on one
+        Map<UUID, Long> perReceiver = plan.reassignments().stream()
+                .collect(Collectors.groupingBy(HexReassignment::toDaId, Collectors.counting()));
+        assertThat(perReceiver.get(MEENA)).isBetween(1L, 6L);             // balanced — neither takes all 7
+        assertThat(perReceiver.get(SUNIL)).isBetween(1L, 6L);
+        assertThat(plan.reassignments()).allSatisfy(r -> assertThat(r.fromDaId()).isEqualTo(RAVI));
+    }
+
+    @Test
+    void absorbsInteriorHexesViaInwardGrowth() {
+        // A bigger blob (disk radius 2 = 19 cells): its interior touches only other Ravi hexes, so a
+        // border-only algorithm would orphan them. Flood-fill must reach every one.
+        long center = h3.latLngToCell(19.0760, 72.8777, RES);
+        List<Long> blob = h3.gridDisk(center, 2);            // 19 cells → Ravi
+        List<Long> ring3 = subtract(h3.gridDisk(center, 3), blob);
+
+        Map<Long, UUID> owners = new HashMap<>();
+        blob.forEach(h -> owners.put(h, RAVI));
+        List<Long> sortedRing = ring3.stream().sorted().toList();
+        for (int i = 0; i < sortedRing.size(); i++) {
+            owners.put(sortedRing.get(i), i % 2 == 0 ? MEENA : SUNIL);
+        }
+        stubGrid(owners);
+
+        AbsenceReassignmentPlan plan = planner.plan(CITY, List.of(RAVI), DATE);
+
+        assertThat(plan.orphanHexIds()).isEmpty();
+        assertThat(plan.reassignments()).hasSize(19);        // interior included, none orphaned
+    }
+
+    @Test
+    void leavesAnIsolatedPocketAsAnOrphan() {
+        long center = h3.latLngToCell(13.0827, 80.2707, RES);
+        List<Long> blob = h3.gridDisk(center, 1);            // Ravi blob with live neighbors
+        List<Long> ring2 = subtract(h3.gridDisk(center, 2), blob);
+        // A far-away cell Ravi also owns, with no active neighbor in the grid → unreachable.
+        long island = h3.latLngToCell(13.20, 80.40, RES);
+
+        Map<Long, UUID> owners = new HashMap<>();
+        blob.forEach(h -> owners.put(h, RAVI));
+        ring2.forEach(h -> owners.put(h, MEENA));
+        owners.put(island, RAVI);
+        stubGrid(owners);
+
+        AbsenceReassignmentPlan plan = planner.plan(CITY, List.of(RAVI), DATE);
+
+        assertThat(plan.orphanHexIds()).containsExactly(hexIdByH3.get(island));
+        assertThat(plan.reassignments()).allSatisfy(r -> assertThat(r.toDaId()).isEqualTo(MEENA));
+    }
+
+    @Test
+    void coversTwoAdjacentAbsentDasFromTheSurvivingNeighbor() {
+        // Ravi and Meena are adjacent and BOTH absent; Sunil surrounds them and must absorb everything.
+        long center = h3.latLngToCell(17.3850, 78.4867, RES);
+        List<Long> inner = h3.gridDisk(center, 1);           // 7 cells split Ravi/Meena
+        List<Long> ring2 = subtract(h3.gridDisk(center, 2), inner);
+
+        Map<Long, UUID> owners = new HashMap<>();
+        List<Long> sortedInner = inner.stream().sorted().toList();
+        for (int i = 0; i < sortedInner.size(); i++) {
+            owners.put(sortedInner.get(i), i % 2 == 0 ? RAVI : MEENA);
+        }
+        ring2.forEach(h -> owners.put(h, SUNIL));            // the only live neighbor
+        stubGrid(owners);
+
+        AbsenceReassignmentPlan plan = planner.plan(CITY, List.of(RAVI, MEENA), DATE);
+
+        assertThat(plan.orphanHexIds()).isEmpty();
+        assertThat(plan.reassignments()).hasSize(7);
+        assertThat(plan.reassignments()).allSatisfy(r -> assertThat(r.toDaId()).isEqualTo(SUNIL));
+    }
+
+    // ── fixtures ────────────────────────────────────────────────────────────────────────────────
+
+    /** Wire the hex list + APPROVED assignments implied by an h3→owner map into the mocked repos. */
+    private void stubGrid(Map<Long, UUID> owners) {
+        hexIdByH3.clear();
+        List<Hex> hexes = new ArrayList<>();
+        for (Long h3Index : owners.keySet()) {
+            UUID id = UUID.randomUUID();
+            hexIdByH3.put(h3Index, id);
+            hexes.add(Hex.builder().id(id).h3Index(h3Index).active(true).build());
+        }
+        when(hexRepository.findByH3GridIdAndActiveTrue(any())).thenReturn(hexes);
+
+        List<DaHexAssignment> rows = owners.entrySet().stream()
+                .map(e -> DaHexAssignment.builder()
+                        .daId(e.getValue())
+                        .hexId(hexIdByH3.get(e.getKey()))
+                        .validDate(DATE)
+                        .nDasOnHex(1)
+                        .status(AssignmentStatus.APPROVED)
+                        .build())
+                .toList();
+        when(assignmentRepository.findByValidDateAndStatus(DATE, AssignmentStatus.APPROVED)).thenReturn(rows);
+    }
+
+    private static List<Long> subtract(List<Long> all, List<Long> remove) {
+        Set<Long> r = Set.copyOf(remove);
+        return all.stream().filter(h -> !r.contains(h)).toList();
+    }
+}

--- a/grid/src/test/java/com/oneday/grid/service/impl/AbsenceReassignmentPlannerTest.java
+++ b/grid/src/test/java/com/oneday/grid/service/impl/AbsenceReassignmentPlannerTest.java
@@ -14,6 +14,7 @@ import com.uber.h3core.H3Core;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -29,6 +30,9 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -157,6 +161,62 @@ class AbsenceReassignmentPlannerTest {
         assertThat(plan.orphanHexIds()).isEmpty();
         assertThat(plan.reassignments()).hasSize(7);
         assertThat(plan.reassignments()).allSatisfy(r -> assertThat(r.toDaId()).isEqualTo(SUNIL));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void applyAppendsOnlyGainedHexesNeverRewritingAReceiversOwnHexes() {
+        // Regression: the (da_id, hex_id, valid_date) uniqueness means apply must NOT re-insert a hex a
+        // receiver already owns — earlier it rewrote each receiver's full set (retained + gained) and
+        // collided on the receiver's existing APPROVED rows. Here Meena/Sunil already own their flanks;
+        // apply must only add the absent Ravi's hexes to them, leaving the flank rows untouched.
+        long center = h3.latLngToCell(28.6139, 77.2090, RES);
+        List<Long> blob = h3.gridDisk(center, 1);            // 7 cells → Ravi
+        List<Long> ring2 = subtract(h3.gridDisk(center, 2), blob);
+        Map<Long, UUID> owners = new HashMap<>();
+        blob.forEach(h -> owners.put(h, RAVI));
+        List<Long> sortedRing = ring2.stream().sorted().toList();
+        for (int i = 0; i < sortedRing.size(); i++) {
+            owners.put(sortedRing.get(i), i % 2 == 0 ? MEENA : SUNIL);
+        }
+        stubGrid(owners);
+        // approvedRows(da) — each DA's own existing hexes (what a receiver already holds).
+        when(assignmentRepository.findByDaIdAndValidDate(any(), eq(DATE))).thenAnswer(inv -> {
+            UUID da = inv.getArgument(0);
+            return owners.entrySet().stream()
+                    .filter(e -> e.getValue().equals(da))
+                    .map(e -> DaHexAssignment.builder().daId(da).hexId(hexIdByH3.get(e.getKey()))
+                            .validDate(DATE).nDasOnHex(1).status(AssignmentStatus.APPROVED).build())
+                    .toList();
+        });
+        when(proposalRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        planner.apply(CITY, List.of(RAVI), DATE, UUID.randomUUID());
+
+        // Every hex Ravi owned, keyed for lookup.
+        Set<UUID> raviHexes = blob.stream().map(hexIdByH3::get).collect(Collectors.toSet());
+        Map<UUID, Set<UUID>> ownHexes = Map.of(
+                MEENA, sortedRing.stream().filter(h -> owners.get(h) == MEENA).map(hexIdByH3::get).collect(Collectors.toSet()),
+                SUNIL, sortedRing.stream().filter(h -> owners.get(h) == SUNIL).map(hexIdByH3::get).collect(Collectors.toSet()));
+
+        ArgumentCaptor<List<DaHexAssignment>> cap = ArgumentCaptor.forClass(List.class);
+        verify(assignmentRepository, atLeastOnce()).saveAll(cap.capture());
+        List<DaHexAssignment> inserted = cap.getAllValues().stream()
+                .flatMap(List::stream)
+                .filter(a -> a.getStatus() == AssignmentStatus.APPROVED)   // the newly-added gained rows
+                .toList();
+
+        assertThat(inserted).isNotEmpty();
+        // 1) Every inserted row is one of Ravi's hexes (a genuine gain) — never a hex already owned.
+        assertThat(inserted).allSatisfy(a -> {
+            assertThat(raviHexes).contains(a.getHexId());
+            assertThat(ownHexes.get(a.getDaId())).doesNotContain(a.getHexId());
+        });
+        // 2) No (da_id, hex_id) duplicated among the inserts (the exact unique key that used to blow up).
+        assertThat(inserted.stream().map(a -> a.getDaId() + ":" + a.getHexId()).distinct().count())
+                .isEqualTo(inserted.size());
+        // 3) All 7 of Ravi's hexes were covered exactly once.
+        assertThat(inserted.stream().map(DaHexAssignment::getHexId).collect(Collectors.toSet())).isEqualTo(raviHexes);
     }
 
     // ── fixtures ────────────────────────────────────────────────────────────────────────────────

--- a/grid/src/test/java/com/oneday/grid/service/impl/GridServiceImplTest.java
+++ b/grid/src/test/java/com/oneday/grid/service/impl/GridServiceImplTest.java
@@ -41,6 +41,7 @@ class GridServiceImplTest {
     @Mock ResourceLoader resourceLoader;
     @Mock GridProperties gridProperties;
     @Mock H3Core h3Core;
+    @Mock AbsenceReassignmentPlanner absencePlanner;
     @Mock Grid grid;
 
     GridServiceImpl service;
@@ -60,7 +61,7 @@ class GridServiceImplTest {
         service = new GridServiceImpl(gridRepository, hexRepository,
                 pincodeMappingRepository, hexVertexRepository,
                 demandSnapshotRepository, assignmentRepository,
-                resourceLoader, gridProperties, h3Core);
+                resourceLoader, gridProperties, h3Core, absencePlanner);
         service.loadGridCache();
     }
 

--- a/orders/src/main/java/com/oneday/orders/events/ScanEventsConsumer.java
+++ b/orders/src/main/java/com/oneday/orders/events/ScanEventsConsumer.java
@@ -58,6 +58,10 @@ public class ScanEventsConsumer {
             // HUB_RETURN custody ledger record (DA collected a dest parcel from the hub); the DA's
             // later DROP_* events drive the last-mile state, so this is not an M4 transition.
             case HUB_DEST_OUT          -> null;
+            // Midday absence: a covering DA took an in-custody parcel from an absent DA. Custody moved
+            // between DAs but the shipment state hasn't — the covering DA's onward DROP_*/handoff events
+            // drive it. Ledger record only.
+            case DA_CUSTODY_TRANSFER   -> null;
             // DELIVERED is a custody fact only (Option A) — DROPPED stays owned by the delivery-OTP
             // verify path (scan = right box, OTP = right customer, mirroring LABEL_GENERATED/PICKED_UP).
             case DELIVERED             -> null;


### PR DESCRIPTION
## What & why

When a DA drops out mid-shift, their hexes' pickups/deliveries currently strand — `AbsentDaDetectionJob` emits `DA_ABSENT` but nothing re-covers the territory, `AdjacentDaProvider` is a no-op, and cross-territory spill is disabled. This adds a **station-manager control** to mark one or more DAs absent (with a reason) and re-cover their territory.

## Model (settled with product)

- **Territory split is the only decision.** Each absent DA's hexes are folded into their **territory-neighbors** via a **balanced multi-source flood-fill**: neighbors grow inward from the border, the globally least-loaded eligible neighbor claims each hex, so the load spreads across **all** neighbors, every receiver stays **contiguous**, and **interior hexes are absorbed** (not orphaned). Only a fully isolated pocket is left an orphan.
- **Task follows the hex, deterministically** — no per-task feasibility tournament, no fallback to a third DA.
- **Cron is not a gate.** Loose (not-yet-collected) tasks are re-created on the new owner and ordered by the existing cron-aware `QueueReorderService` — feasible before the cron, the rest flagged `beyond_cron` (after the meeting). Never deferred off-queue. Hub-return cities (no cron) just append.
- **Custody changes the fetch source, not the owner.** In-custody parcels become `CUSTODY_COLLECT` handoff tasks for the new owner (collect from the absent DA's last location).
- **Auto-approve after timeout** — previewed as PENDING, applied by the manager, or auto-applied after `dispatch.absence.auto-approve-timeout-minutes` (default 5).

## Changes

**Grid (M3):** `AbsenceReassignmentPlanner` (flood-fill compute + append-only `INTRADAY_OVERRIDE` apply); `GridService.planAbsenceReassignment` / `applyAbsenceReassignment`.

**Dispatch (M5):** `DaAbsenceEvent` + **V5_14** migration (+ `dispatch_queue.collect_from_da_id`); `AbsenceReassignmentService` (preview/apply/autoApply); `AbsenceController` (`POST /dispatch/absence/preview`, `/{eventId}/apply`, STATION_MANAGER/ADMIN, city-scoped); `AbsenceAutoApplyJob`; `TaskType.CUSTODY_COLLECT`; `dispatch.absence.*` config.

## Tests
Planner ×4 (blob split across both neighbors, interior absorption, isolated orphan, two-adjacent-absentees). Service ×6 (bucket classification, loose move not deferred, custody handoff, DA offline + APPLIED, AUTO_APPLIED, idempotent). Full grid + dispatch suites green (JDK 21).

## Scope / follow-ups
Midday only (endpoint/console-triggered). Deferred: **planned absence** (roster exclusion — belongs in grid's roster layer, not dispatch's table); the `DA_ABSENT`-heartbeat auto-trigger (thin wrapper over `apply`); the onward-leg re-dispatch + M8 custody scan on `CUSTODY_COLLECT` completion (driver-app work); real `AdjacentDaProvider` for cross-territory spill.

Web (station console: mark-absent modal + plan-preview drawer) lands in a paired `oneday-web` PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added station-manager workflows to view rosters and preview or apply delivery-agent absence coverage.
  - Automatically applies pending absence plans after a configurable approval period.
  - Reassigns territories and tasks, creates custody-collection tasks, and identifies orphaned work.
  - Added absence history, statuses, approval timing, reassignment results, and city-scope authorization.
  - Added delivery-agent custody handoff scanning and onward task continuation.
- **Tests**
  - Added coverage for balancing, orphan detection, reassignment, custody collection, automation, authorization, and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->