### PR TITLE
feat(exceptions): customer/merchant support tickets + callbacks (#13)

### DIFF
--- a/exceptions/src/main/java/com/oneday/exceptions/api/Authz.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/api/Authz.java
@@ -15,6 +15,10 @@ final class Authz {
     static final String SUPERVISOR = "SUPERVISOR";
     static final String CALL_CENTER_AGENT = "CALL_CENTER_AGENT";
 
+    static final String B2C_CUSTOMER = "B2C_CUSTOMER";
+    static final String C2C_CUSTOMER = "C2C_CUSTOMER";
+    static final String B2B_USER = "B2B_USER";
+
     private Authz() {}
 
     static String requireUserId(AuthUserDetails principal) {
@@ -44,6 +48,21 @@ final class Authz {
         }
         throw new ResponseStatusException(HttpStatus.FORBIDDEN,
                 "Role " + role + " is not permitted to view exceptions");
+    }
+
+    /**
+     * Authorize a customer-facing write against {@code allowedRoles} — NO ADMIN bypass (ADMIN has no
+     * tickets of its own; it uses the ops console). Mirrors {@code orders.api.Authz.requireCustomerRole}.
+     */
+    static void requireCustomerRole(AuthUserDetails principal, String... allowedRoles) {
+        String role = role(principal);
+        for (String allowed : allowedRoles) {
+            if (allowed.equals(role)) {
+                return;
+            }
+        }
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                "Role " + role + " is not permitted to raise support tickets");
     }
 
     /** The city an ops query is scoped to: {@code null} for ADMIN, else the user's own city (403 if none). */

--- a/exceptions/src/main/java/com/oneday/exceptions/api/SupportTicketController.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/api/SupportTicketController.java
@@ -1,0 +1,103 @@
+package com.oneday.exceptions.api;
+
+import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.exceptions.dto.SupportTicketRequest;
+import com.oneday.exceptions.dto.SupportTicketResponse;
+import com.oneday.exceptions.dto.TicketActionRequest;
+import com.oneday.exceptions.dto.TicketQueueResponse;
+import com.oneday.exceptions.service.SupportTicketService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Support tickets + "call me" callbacks. Two audiences on one resource:
+ * <ul>
+ *   <li><b>Customers/merchants</b> raise and track their own tickets ({@code /mine}).</li>
+ *   <li><b>Ops</b> (CALL_CENTER_AGENT + SUPERVISOR/STATION_MANAGER/ADMIN) work the queue and action them —
+ *       the same console that handles {@link ExceptionController exception cases}.</li>
+ * </ul>
+ */
+@RestController
+@RequestMapping("/api/v1/support/tickets")
+public class SupportTicketController {
+
+    private final SupportTicketService service;
+
+    public SupportTicketController(SupportTicketService service) {
+        this.service = service;
+    }
+
+    // ── Customer / merchant ────────────────────────────────────────────────
+
+    /** Raise a ticket or a callback request. */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public SupportTicketResponse create(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @Valid @RequestBody SupportTicketRequest request) {
+        Authz.requireCustomerRole(principal, Authz.B2C_CUSTOMER, Authz.C2C_CUSTOMER, Authz.B2B_USER);
+        return service.create(UUID.fromString(Authz.requireUserId(principal)), Authz.role(principal), request);
+    }
+
+    /** The caller's own tickets, newest first. */
+    @GetMapping("/mine")
+    public List<SupportTicketResponse> mine(@AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireCustomerRole(principal, Authz.B2C_CUSTOMER, Authz.C2C_CUSTOMER, Authz.B2B_USER);
+        return service.listMine(UUID.fromString(Authz.requireUserId(principal)));
+    }
+
+    /** One of the caller's own tickets. */
+    @GetMapping("/mine/{id}")
+    public SupportTicketResponse myDetail(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @PathVariable UUID id) {
+        Authz.requireCustomerRole(principal, Authz.B2C_CUSTOMER, Authz.C2C_CUSTOMER, Authz.B2B_USER);
+        return service.myDetail(UUID.fromString(Authz.requireUserId(principal)), id);
+    }
+
+    // ── Ops console ────────────────────────────────────────────────────────
+
+    /** The support queue: live tickets, freshest first. */
+    @GetMapping
+    public TicketQueueResponse queue(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "50") int size) {
+        Authz.requireRole(principal, Authz.CALL_CENTER_AGENT, Authz.SUPERVISOR, Authz.STATION_MANAGER);
+        Page<SupportTicketResponse> p = service.queue(page, size);
+        return new TicketQueueResponse(p.getContent(), p.getNumber(), p.getSize(),
+                p.getTotalElements(), p.getTotalPages());
+    }
+
+    /** One ticket for an ops agent. */
+    @GetMapping("/{id}")
+    public SupportTicketResponse detail(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @PathVariable UUID id) {
+        Authz.requireRole(principal, Authz.CALL_CENTER_AGENT, Authz.SUPERVISOR, Authz.STATION_MANAGER);
+        return service.detail(id);
+    }
+
+    /** Action a ticket: claim (IN_PROGRESS), resolve, or cancel — with an optional note. */
+    @PostMapping("/{id}/action")
+    public SupportTicketResponse act(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @PathVariable UUID id,
+            @Valid @RequestBody TicketActionRequest body) {
+        Authz.requireRole(principal, Authz.CALL_CENTER_AGENT, Authz.SUPERVISOR, Authz.STATION_MANAGER);
+        return service.act(id, Authz.requireUserId(principal), body.status(), body.note());
+    }
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/domain/SupportTicket.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/domain/SupportTicket.java
@@ -1,0 +1,65 @@
+package com.oneday.exceptions.domain;
+
+import com.oneday.common.domain.MutableBaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * A customer/merchant-initiated support request. Unlike {@link ExceptionCase} (opened by a failure
+ * event, always bound to one shipment), a ticket is raised by a person, is shipment-optional, and
+ * carries the reporter's identity + contact. Handled from the same ops console by the CALL_CENTER_AGENT.
+ */
+@Entity
+@Table(name = "support_ticket")
+@Getter
+@Setter
+@NoArgsConstructor
+public class SupportTicket extends MutableBaseEntity {
+
+    @Column(name = "raised_by_user_id", nullable = false, updatable = false)
+    private UUID raisedByUserId;
+
+    @Column(name = "raised_by_role", updatable = false)
+    private String raisedByRole;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "channel", nullable = false, updatable = false)
+    private TicketChannel channel;
+
+    /** Optional shipment this ticket is about (validated best-effort at intake). */
+    @Column(name = "shipment_ref", updatable = false)
+    private String shipmentRef;
+
+    @Column(name = "subject", length = 200)
+    private String subject;
+
+    @Column(name = "body")
+    private String body;
+
+    /** For CALLBACK tickets — the number to call back. */
+    @Column(name = "contact_phone", length = 20)
+    private String contactPhone;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private TicketStatus status = TicketStatus.OPEN;
+
+    /** The ops agent handling it (M1 user id). */
+    @Column(name = "assigned_to")
+    private String assignedTo;
+
+    @Column(name = "resolution_note")
+    private String resolutionNote;
+
+    @Column(name = "resolved_at")
+    private Instant resolvedAt;
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/domain/TicketChannel.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/domain/TicketChannel.java
@@ -1,0 +1,9 @@
+package com.oneday.exceptions.domain;
+
+/** How a support ticket was raised. */
+public enum TicketChannel {
+    /** A written help request (subject + body), optionally about a shipment. */
+    TICKET,
+    /** A "call me" callback request — the agent phones the reporter back. */
+    CALLBACK
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/domain/TicketStatus.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/domain/TicketStatus.java
@@ -1,0 +1,13 @@
+package com.oneday.exceptions.domain;
+
+/** Lifecycle of a support ticket. RESOLVED and CANCELLED are terminal (they stamp resolved_at). */
+public enum TicketStatus {
+    OPEN,
+    IN_PROGRESS,
+    RESOLVED,
+    CANCELLED;
+
+    public boolean isTerminal() {
+        return this == RESOLVED || this == CANCELLED;
+    }
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/dto/SupportTicketRequest.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/dto/SupportTicketRequest.java
@@ -1,0 +1,18 @@
+package com.oneday.exceptions.dto;
+
+import com.oneday.exceptions.domain.TicketChannel;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Customer/merchant intake for a support ticket. Channel decides which fields matter:
+ * TICKET needs a body; CALLBACK needs a contact phone. That cross-field rule is enforced in the
+ * service (so the message is specific), not by bean validation here.
+ */
+public record SupportTicketRequest(
+        @NotNull TicketChannel channel,
+        @Size(max = 64) String shipmentRef,     // optional — the shipment this is about
+        @Size(max = 200) String subject,
+        @Size(max = 4000) String body,
+        @Size(max = 20) String contactPhone) {  // required for CALLBACK
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/dto/SupportTicketResponse.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/dto/SupportTicketResponse.java
@@ -1,0 +1,30 @@
+package com.oneday.exceptions.dto;
+
+import com.oneday.exceptions.domain.SupportTicket;
+import com.oneday.exceptions.domain.TicketChannel;
+import com.oneday.exceptions.domain.TicketStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/** Read model for a support ticket — same shape for the customer's own view and the ops console. */
+public record SupportTicketResponse(
+        UUID id,
+        TicketChannel channel,
+        String shipmentRef,
+        String subject,
+        String body,
+        String contactPhone,
+        TicketStatus status,
+        String assignedTo,
+        String resolutionNote,
+        Instant createdAt,
+        Instant resolvedAt) {
+
+    public static SupportTicketResponse from(SupportTicket t) {
+        return new SupportTicketResponse(
+                t.getId(), t.getChannel(), t.getShipmentRef(), t.getSubject(), t.getBody(),
+                t.getContactPhone(), t.getStatus(), t.getAssignedTo(), t.getResolutionNote(),
+                t.getCreatedAt(), t.getResolvedAt());
+    }
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/dto/TicketActionRequest.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/dto/TicketActionRequest.java
@@ -1,0 +1,14 @@
+package com.oneday.exceptions.dto;
+
+import com.oneday.exceptions.domain.TicketStatus;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * An ops agent's action on a ticket: move it to IN_PROGRESS (claim), RESOLVED, or CANCELLED, with an
+ * optional note. RESOLVED/CANCELLED stamp {@code resolved_at} and close it out of the queue.
+ */
+public record TicketActionRequest(
+        @NotNull TicketStatus status,
+        @Size(max = 4000) String note) {
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/dto/TicketQueueResponse.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/dto/TicketQueueResponse.java
@@ -1,0 +1,12 @@
+package com.oneday.exceptions.dto;
+
+import java.util.List;
+
+/** A page of the ops support queue. */
+public record TicketQueueResponse(
+        List<SupportTicketResponse> tickets,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages) {
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/repository/SupportTicketRepository.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/repository/SupportTicketRepository.java
@@ -1,0 +1,22 @@
+package com.oneday.exceptions.repository;
+
+import com.oneday.exceptions.domain.SupportTicket;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SupportTicketRepository extends JpaRepository<SupportTicket, UUID> {
+
+    /** A customer's own tickets, newest first. */
+    List<SupportTicket> findByRaisedByUserIdOrderByCreatedAtDesc(UUID raisedByUserId);
+
+    /** Reporter-scoped fetch so one customer can never read another's ticket by id. */
+    Optional<SupportTicket> findByIdAndRaisedByUserId(UUID id, UUID raisedByUserId);
+
+    /** The ops queue: live (unresolved) tickets, freshest first. */
+    Page<SupportTicket> findByResolvedAtIsNullOrderByCreatedAtDesc(Pageable pageable);
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/service/SupportTicketService.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/service/SupportTicketService.java
@@ -1,0 +1,37 @@
+package com.oneday.exceptions.service;
+
+import com.oneday.exceptions.dto.SupportTicketRequest;
+import com.oneday.exceptions.dto.SupportTicketResponse;
+import com.oneday.exceptions.domain.TicketStatus;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Customer/merchant support tickets + "call me" callbacks. Intake is self-scoped (the reporter is the
+ * authenticated caller); the queue/detail/action side is the ops console (CALL_CENTER_AGENT et al.).
+ */
+public interface SupportTicketService {
+
+    /** Raise a ticket as the given customer. Validates channel-specific fields and any shipment ref. */
+    SupportTicketResponse create(UUID raisedByUserId, String raisedByRole, SupportTicketRequest request);
+
+    /** The caller's own tickets, newest first. */
+    List<SupportTicketResponse> listMine(UUID raisedByUserId);
+
+    /** One of the caller's own tickets by id (404 if not theirs / unknown). */
+    SupportTicketResponse myDetail(UUID raisedByUserId, UUID ticketId);
+
+    /** Ops queue: live (unresolved) tickets, freshest first. */
+    Page<SupportTicketResponse> queue(int page, int size);
+
+    /** One ticket by id for an ops agent (404 if unknown). */
+    SupportTicketResponse detail(UUID ticketId);
+
+    /**
+     * Ops action: set the ticket's status (IN_PROGRESS / RESOLVED / CANCELLED), record the acting
+     * agent + note; terminal statuses stamp resolved_at.
+     */
+    SupportTicketResponse act(UUID ticketId, String agentUserId, TicketStatus status, String note);
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/service/impl/SupportTicketServiceImpl.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/service/impl/SupportTicketServiceImpl.java
@@ -107,6 +107,10 @@ class SupportTicketServiceImpl implements SupportTicketService {
             throw new ResponseStatusException(HttpStatus.CONFLICT,
                     "Ticket is already " + t.getStatus() + " and cannot be actioned");
         }
+        if (status == TicketStatus.OPEN) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "OPEN is not a valid action; use IN_PROGRESS, RESOLVED, or CANCELLED");
+        }
         t.setStatus(status);
         t.setAssignedTo(agentUserId);
         String trimmedNote = trimToNull(note);

--- a/exceptions/src/main/java/com/oneday/exceptions/service/impl/SupportTicketServiceImpl.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/service/impl/SupportTicketServiceImpl.java
@@ -1,0 +1,131 @@
+package com.oneday.exceptions.service.impl;
+
+import com.oneday.exceptions.domain.SupportTicket;
+import com.oneday.exceptions.domain.TicketChannel;
+import com.oneday.exceptions.domain.TicketStatus;
+import com.oneday.exceptions.dto.SupportTicketRequest;
+import com.oneday.exceptions.dto.SupportTicketResponse;
+import com.oneday.exceptions.repository.SupportTicketRepository;
+import com.oneday.exceptions.service.SupportTicketService;
+import com.oneday.orders.service.ShipmentLookupService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+class SupportTicketServiceImpl implements SupportTicketService {
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final SupportTicketRepository repository;
+    private final ShipmentLookupService shipmentLookup;
+
+    SupportTicketServiceImpl(SupportTicketRepository repository, ShipmentLookupService shipmentLookup) {
+        this.repository = repository;
+        this.shipmentLookup = shipmentLookup;
+    }
+
+    @Override
+    @Transactional
+    public SupportTicketResponse create(UUID raisedByUserId, String raisedByRole, SupportTicketRequest request) {
+        String shipmentRef = trimToNull(request.shipmentRef());
+        String contactPhone = trimToNull(request.contactPhone());
+        String subject = trimToNull(request.subject());
+        String body = trimToNull(request.body());
+
+        // Channel-specific required fields — a specific 422 beats a generic bean-validation message.
+        if (request.channel() == TicketChannel.CALLBACK) {
+            if (contactPhone == null) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                        "contactPhone is required for a CALLBACK request");
+            }
+        } else if (body == null) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "body is required for a TICKET");
+        }
+
+        // Best-effort validation: if the reporter named a shipment, it must exist. (Ownership is not
+        // enforced here — a ticket may legitimately be about an order the caller is chasing.)
+        if (shipmentRef != null && shipmentLookup.findByRef(shipmentRef).isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "Unknown shipment: " + shipmentRef);
+        }
+
+        SupportTicket t = new SupportTicket();
+        t.setRaisedByUserId(raisedByUserId);
+        t.setRaisedByRole(raisedByRole);
+        t.setChannel(request.channel());
+        t.setShipmentRef(shipmentRef);
+        t.setSubject(subject);
+        t.setBody(body);
+        t.setContactPhone(contactPhone);
+        t.setStatus(TicketStatus.OPEN);
+        return SupportTicketResponse.from(repository.save(t));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<SupportTicketResponse> listMine(UUID raisedByUserId) {
+        return repository.findByRaisedByUserIdOrderByCreatedAtDesc(raisedByUserId).stream()
+                .map(SupportTicketResponse::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SupportTicketResponse myDetail(UUID raisedByUserId, UUID ticketId) {
+        return SupportTicketResponse.from(repository.findByIdAndRaisedByUserId(ticketId, raisedByUserId)
+                .orElseThrow(() -> notFound(ticketId)));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<SupportTicketResponse> queue(int page, int size) {
+        Pageable pageable = PageRequest.of(Math.max(0, page), Math.min(Math.max(1, size), MAX_PAGE_SIZE));
+        return repository.findByResolvedAtIsNullOrderByCreatedAtDesc(pageable).map(SupportTicketResponse::from);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SupportTicketResponse detail(UUID ticketId) {
+        return SupportTicketResponse.from(repository.findById(ticketId).orElseThrow(() -> notFound(ticketId)));
+    }
+
+    @Override
+    @Transactional
+    public SupportTicketResponse act(UUID ticketId, String agentUserId, TicketStatus status, String note) {
+        SupportTicket t = repository.findById(ticketId).orElseThrow(() -> notFound(ticketId));
+        if (t.getStatus().isTerminal()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Ticket is already " + t.getStatus() + " and cannot be actioned");
+        }
+        t.setStatus(status);
+        t.setAssignedTo(agentUserId);
+        String trimmedNote = trimToNull(note);
+        if (trimmedNote != null) {
+            t.setResolutionNote(trimmedNote);
+        }
+        t.setResolvedAt(status.isTerminal() ? Instant.now() : null);
+        return SupportTicketResponse.from(repository.save(t));
+    }
+
+    private static ResponseStatusException notFound(UUID id) {
+        return new ResponseStatusException(HttpStatus.NOT_FOUND, "Ticket not found: " + id);
+    }
+
+    private static String trimToNull(String s) {
+        if (s == null) {
+            return null;
+        }
+        String t = s.trim();
+        return t.isEmpty() ? null : t;
+    }
+}

--- a/exceptions/src/main/resources/db/migration/exceptions/V11_4__create_support_ticket.sql
+++ b/exceptions/src/main/resources/db/migration/exceptions/V11_4__create_support_ticket.sql
@@ -1,0 +1,26 @@
+-- M11 support tickets: customer/merchant-initiated help requests and "call me" callbacks. Unlike
+-- exception_case (opened by a failure event, always bound to one shipment), a ticket is raised by a
+-- person, is shipment-OPTIONAL, and carries the reporter's identity + contact. Enum-like columns are
+-- VARCHAR + app-side @Enumerated(STRING), same convention as the rest of M11.
+
+CREATE TABLE support_ticket (
+    id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    raised_by_user_id UUID        NOT NULL,               -- the customer/merchant (M1 user id)
+    raised_by_role    VARCHAR(32),                        -- B2C_CUSTOMER | C2C_CUSTOMER | B2B_USER
+    channel           VARCHAR(16) NOT NULL,               -- TICKET | CALLBACK
+    shipment_ref      VARCHAR(64),                        -- optional; validated best-effort at intake
+    subject           VARCHAR(200),
+    body              TEXT,
+    contact_phone     VARCHAR(20),                        -- for CALLBACK ("call me on…")
+    status            VARCHAR(16) NOT NULL DEFAULT 'OPEN', -- OPEN | IN_PROGRESS | RESOLVED | CANCELLED
+    assigned_to       VARCHAR(64),                        -- ops agent handling it (M1 user id)
+    resolution_note   TEXT,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    resolved_at       TIMESTAMPTZ
+);
+
+-- Ops queue: open tickets, freshest first. Partial index keeps the read over just the live set.
+CREATE INDEX idx_support_ticket_open ON support_ticket (created_at DESC) WHERE resolved_at IS NULL;
+-- A customer's own tickets, newest first.
+CREATE INDEX idx_support_ticket_raiser ON support_ticket (raised_by_user_id, created_at DESC);

--- a/exceptions/src/test/java/com/oneday/exceptions/service/impl/SupportTicketServiceImplTest.java
+++ b/exceptions/src/test/java/com/oneday/exceptions/service/impl/SupportTicketServiceImplTest.java
@@ -102,6 +102,17 @@ class SupportTicketServiceImplTest {
     }
 
     @Test
+    void movingATicketBackToOpenIsRejected() {
+        UUID id = UUID.randomUUID();
+        SupportTicket t = new SupportTicket();
+        t.setStatus(TicketStatus.IN_PROGRESS);
+        when(repo.findById(id)).thenReturn(Optional.of(t));
+        assertThatThrownBy(() -> service.act(id, "agent-1", TicketStatus.OPEN, null))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("OPEN is not a valid action");
+    }
+
+    @Test
     void actingOnAClosedTicketConflicts() {
         UUID id = UUID.randomUUID();
         SupportTicket t = new SupportTicket();

--- a/exceptions/src/test/java/com/oneday/exceptions/service/impl/SupportTicketServiceImplTest.java
+++ b/exceptions/src/test/java/com/oneday/exceptions/service/impl/SupportTicketServiceImplTest.java
@@ -1,0 +1,114 @@
+package com.oneday.exceptions.service.impl;
+
+import com.oneday.exceptions.domain.SupportTicket;
+import com.oneday.exceptions.domain.TicketChannel;
+import com.oneday.exceptions.domain.TicketStatus;
+import com.oneday.exceptions.dto.SupportTicketRequest;
+import com.oneday.exceptions.dto.SupportTicketResponse;
+import com.oneday.exceptions.repository.SupportTicketRepository;
+import com.oneday.orders.dto.ShipmentInfo;
+import com.oneday.orders.service.ShipmentLookupService;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Intake validation and ticket lifecycle are the load-bearing bits: a callback must carry a phone, a
+ * ticket must carry a body, a named shipment must exist, a customer can't read another's ticket, and a
+ * closed ticket can't be re-actioned. These pin those.
+ */
+class SupportTicketServiceImplTest {
+
+    private final SupportTicketRepository repo = mock(SupportTicketRepository.class);
+    private final ShipmentLookupService shipmentLookup = mock(ShipmentLookupService.class);
+    private final SupportTicketServiceImpl service = new SupportTicketServiceImpl(repo, shipmentLookup);
+
+    private static final UUID USER = UUID.randomUUID();
+
+    @Test
+    void callbackWithoutPhoneIsRejected() {
+        var req = new SupportTicketRequest(TicketChannel.CALLBACK, null, "call me", null, null);
+        assertThatThrownBy(() -> service.create(USER, "B2B_USER", req))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("contactPhone");
+        verify(repo, never()).save(any());
+    }
+
+    @Test
+    void ticketWithoutBodyIsRejected() {
+        var req = new SupportTicketRequest(TicketChannel.TICKET, null, "subject only", "  ", null);
+        assertThatThrownBy(() -> service.create(USER, "B2B_USER", req))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("body");
+        verify(repo, never()).save(any());
+    }
+
+    @Test
+    void unknownShipmentRefIsRejected() {
+        when(shipmentLookup.findByRef("1DD-NOPE")).thenReturn(Optional.empty());
+        var req = new SupportTicketRequest(TicketChannel.TICKET, "1DD-NOPE", null, "where is it?", null);
+        assertThatThrownBy(() -> service.create(USER, "B2B_USER", req))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Unknown shipment");
+        verify(repo, never()).save(any());
+    }
+
+    @Test
+    void validTicketIsPersistedOpenWithRaiser() {
+        when(repo.save(any(SupportTicket.class))).thenAnswer(i -> i.getArgument(0));
+        var req = new SupportTicketRequest(TicketChannel.TICKET, null, "Damaged box", "Arrived crushed", null);
+
+        SupportTicketResponse resp = service.create(USER, "B2B_USER", req);
+
+        assertThat(resp.status()).isEqualTo(TicketStatus.OPEN);
+        assertThat(resp.body()).isEqualTo("Arrived crushed");
+        var saved = org.mockito.ArgumentCaptor.forClass(SupportTicket.class);
+        verify(repo).save(saved.capture());
+        assertThat(saved.getValue().getRaisedByUserId()).isEqualTo(USER);
+        assertThat(saved.getValue().getRaisedByRole()).isEqualTo("B2B_USER");
+    }
+
+    @Test
+    void myDetailIsScopedToTheCaller() {
+        UUID id = UUID.randomUUID();
+        when(repo.findByIdAndRaisedByUserId(id, USER)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.myDetail(USER, id)).isInstanceOf(ResponseStatusException.class);
+    }
+
+    @Test
+    void resolvingStampsResolvedAtAndAgent() {
+        UUID id = UUID.randomUUID();
+        SupportTicket t = new SupportTicket();
+        t.setStatus(TicketStatus.OPEN);
+        when(repo.findById(id)).thenReturn(Optional.of(t));
+        when(repo.save(any(SupportTicket.class))).thenAnswer(i -> i.getArgument(0));
+
+        SupportTicketResponse resp = service.act(id, "agent-1", TicketStatus.RESOLVED, "called back, sorted");
+
+        assertThat(resp.status()).isEqualTo(TicketStatus.RESOLVED);
+        assertThat(resp.assignedTo()).isEqualTo("agent-1");
+        assertThat(resp.resolvedAt()).isNotNull();
+        assertThat(resp.resolutionNote()).isEqualTo("called back, sorted");
+    }
+
+    @Test
+    void actingOnAClosedTicketConflicts() {
+        UUID id = UUID.randomUUID();
+        SupportTicket t = new SupportTicket();
+        t.setStatus(TicketStatus.RESOLVED);
+        when(repo.findById(id)).thenReturn(Optional.of(t));
+        assertThatThrownBy(() -> service.act(id, "agent-1", TicketStatus.IN_PROGRESS, null))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("already");
+    }
+}


### PR DESCRIPTION

<img width="2938" height="1660" alt="image" src="https://github.com/user-attachments/assets/cbf4fd64-ac58-4c04-8789-d291d26a7979" />
<img width="1464" height="478" alt="Screenshot 2026-08-26 at 7 43 48 PM" src="https://github.com/user-attachments/assets/d159437f-5a99-4eb2-8a7b-52ea79e8b16f" />


## Feature #13 — Call center / support ticket

Adds a **person-raised, shipment-optional** support ticket (and "call me" **callback**) alongside the existing event-driven `ExceptionCase`. Customers/merchants raise and track their own; the **same ops console** (CALL_CENTER_AGENT + supervisors/admin) works the queue and actions them.

### Why a separate entity, not `ExceptionCase`?
`ExceptionCase` is shipment-**mandatory** (`shipment_id NOT NULL` + unique-per-live-shipment index) and every path — event capture, M4 enrichment, city-scoped queue, journey lookup, RTO/resolve — assumes a shipment. A support ticket is raised by a person, is shipment-optional, and carries reporter identity + contact. Bending the case entity would thread `null` branches through all of that and break its unique index, so a standalone `support_ticket` is the smaller, safer diff.

### What changed
- **`support_ticket` table** (Flyway `V11_4`) + `SupportTicket` entity (+ `TicketChannel`, `TicketStatus`).
- **Customer intake:** `POST /api/v1/support/tickets` — one endpoint, `channel` = `TICKET | CALLBACK`. Channel-specific validation (callback needs a phone; ticket needs a body); a named `shipmentRef` is validated best-effort via `ShipmentLookupService.findByRef`.
- **Customer views:** `GET /mine`, `GET /mine/{id}` — reporter-scoped (can't read another's ticket).
- **Ops console:** `GET /` (live queue), `GET /{id}`, `POST /{id}/action` (claim → `IN_PROGRESS`, `RESOLVED`, `CANCELLED` with a note; terminal stamps `resolved_at`). Reuses the `CALL_CENTER_AGENT` gate.
- **Authz:** added a customer-role gate for intake (no ADMIN bypass, mirrors `orders.api.Authz.requireCustomerRole`); ops reads reuse the existing role gate.

### Not in scope (deliberate)
- No message thread/conversation table — that's feature **#14** (chat). v1 keeps a single `resolution_note` on the ticket.
- No notifications yet (agent isn't pinged on new callback) — waits on the **notification foundation**.

### Testing
`mvn test -pl exceptions` → **27 green** (7 new: callback-needs-phone, ticket-needs-body, unknown-shipment-ref, valid-persist, reporter-scoping, resolve-stamps-resolved-at, action-on-closed-conflicts).

**Web counterpart** (customer "Contact support" + ops support queue) will follow as a separate PR to `main` in `oneday-web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added customer and merchant support ticket creation, callback requests, and self-service ticket history.
  - Added ticket details, status updates, resolution notes, and support operations queue management.
  - Added pagination for unresolved support tickets.
  - Added ticket lifecycle statuses and channels, including callback requests.
- **Access & Validation**
  - Restricted ticket views and actions according to customer and support-agent permissions.
  - Added validation for required ticket information, contact details, shipment references, and action notes.
- **Bug Fixes**
  - Prevented updates to already resolved or cancelled tickets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->