### PR TITLE
feat(orders): notification foundation — send seam, templating, outbox + retry (Step 5)

### DIFF
--- a/common/src/main/java/com/oneday/common/port/dto/NotificationRequest.java
+++ b/common/src/main/java/com/oneday/common/port/dto/NotificationRequest.java
@@ -1,27 +1,31 @@
 package com.oneday.common.port.dto;
 
-import com.oneday.common.domain.enums.ShipmentState;
-
-import java.time.Instant;
+import java.util.Map;
 
 /**
- * Payload published to oneday.notifications.requested. The notification service
- * selects channels (SMS/email/WhatsApp) and templates based on type and newState.
+ * A request to notify a recipient of an event. The notification service resolves the template for
+ * {@code type}, renders it with {@code params}, and delivers over whichever channels the template
+ * declares AND the recipient supports (email when {@code recipientEmail} is set, SMS when
+ * {@code recipientPhone} is set). Fire-and-forget for the caller — the service persists the request,
+ * delivers it, and retries transient failures.
  *
- * @param type           OTP_GENERATED or STATE_CHANGED
- * @param recipientPhone E.164 format, e.g. "+919876543210"
- * @param recipientEmail nullable; not all customers provide email
- * @param shipmentRef    human-readable ref, e.g. "1DD-BLR-20260519-000042"
- * @param newState       the state just entered; null for OTP_GENERATED
- * @param otp            4-digit code; null for STATE_CHANGED
- * @param eta            latest ETA; null if not applicable to this notification
+ * @param type           what happened (selects the template)
+ * @param recipientEmail nullable; enables the email channel
+ * @param recipientPhone nullable; E.164 (e.g. "+919876543210"); enables the SMS channel
+ * @param params         template variables, e.g. {@code {"otp":"123456","shipment_ref":"1DD-…"}}
  */
 public record NotificationRequest(
         NotificationEventType type,
-        String recipientPhone,
         String recipientEmail,
-        String shipmentRef,
-        ShipmentState newState,
-        String otp,
-        Instant eta
-) {}
+        String recipientPhone,
+        Map<String, String> params
+) {
+    public NotificationRequest {
+        params = params == null ? Map.of() : Map.copyOf(params);
+    }
+
+    /** Convenience for a single-recipient email/SMS with no template variables. */
+    public static NotificationRequest of(NotificationEventType type, String email, String phone) {
+        return new NotificationRequest(type, email, phone, Map.of());
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/api/PickupOtpController.java
+++ b/orders/src/main/java/com/oneday/orders/api/PickupOtpController.java
@@ -120,8 +120,8 @@ public class PickupOtpController {
         }
 
         try {
+            // resend() SMSes the new OTP to the sender via the notification outbox; also returned for DA display.
             String newOtp = pickupOtpService.resend(shipment.getId());
-            // TODO (PR #10): call NotificationPort to SMS the new OTP to the sender.
             return ResponseEntity.ok(Map.of("otp", newOtp));
         } catch (PickupOtpService.ResendLimitExceededException e) {
             throw new ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS, e.getMessage());

--- a/orders/src/main/java/com/oneday/orders/config/NotifyProperties.java
+++ b/orders/src/main/java/com/oneday/orders/config/NotifyProperties.java
@@ -16,8 +16,13 @@ public class NotifyProperties {
     private final Sms sms = new Sms();
     private final Email email = new Email();
 
+    /** How many delivery attempts the outbox drain makes before leaving a row FAILED. */
+    private int maxAttempts = 3;
+
     public Sms getSms() { return sms; }
     public Email getEmail() { return email; }
+    public int getMaxAttempts() { return maxAttempts; }
+    public void setMaxAttempts(int maxAttempts) { this.maxAttempts = maxAttempts; }
 
     public static class Sms {
         /** log | msg91 */

--- a/orders/src/main/java/com/oneday/orders/config/NotifyProperties.java
+++ b/orders/src/main/java/com/oneday/orders/config/NotifyProperties.java
@@ -22,7 +22,9 @@ public class NotifyProperties {
     public Sms getSms() { return sms; }
     public Email getEmail() { return email; }
     public int getMaxAttempts() { return maxAttempts; }
-    public void setMaxAttempts(int maxAttempts) { this.maxAttempts = maxAttempts; }
+    // Clamp to >= 1: a zero/negative cap would make the drain query (attempts < max) exclude every
+    // new row, stranding notifications PENDING forever.
+    public void setMaxAttempts(int maxAttempts) { this.maxAttempts = Math.max(1, maxAttempts); }
 
     public static class Sms {
         /** log | msg91 */

--- a/orders/src/main/java/com/oneday/orders/domain/NotificationChannel.java
+++ b/orders/src/main/java/com/oneday/orders/domain/NotificationChannel.java
@@ -1,0 +1,7 @@
+package com.oneday.orders.domain;
+
+/** Delivery channel for a notification. */
+public enum NotificationChannel {
+    EMAIL,
+    SMS
+}

--- a/orders/src/main/java/com/oneday/orders/domain/NotificationLog.java
+++ b/orders/src/main/java/com/oneday/orders/domain/NotificationLog.java
@@ -1,0 +1,58 @@
+package com.oneday.orders.domain;
+
+import com.oneday.common.domain.MutableBaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+/**
+ * One outbox row = one rendered message to one recipient on one channel. The notification service
+ * enqueues it PENDING; a scheduled drain delivers it (SENT) or records the failure (FAILED) and
+ * retries until the attempt cap. Persisting first makes delivery observable and survivable across
+ * restarts — the transactional-outbox pattern, mirroring {@code webhook_delivery}.
+ */
+@Entity
+@Table(name = "notification_log")
+@Getter
+@Setter
+@NoArgsConstructor
+public class NotificationLog extends MutableBaseEntity {
+
+    /** The event that triggered this (the NotificationEventType name), for reference/filtering. */
+    @Column(name = "event_type", nullable = false, updatable = false)
+    private String eventType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "channel", nullable = false, updatable = false)
+    private NotificationChannel channel;
+
+    /** Email address or E.164 phone, depending on channel. */
+    @Column(name = "recipient", nullable = false, updatable = false)
+    private String recipient;
+
+    @Column(name = "subject", length = 300, updatable = false)
+    private String subject;
+
+    @Column(name = "body", nullable = false, updatable = false)
+    private String body;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private NotificationStatus status = NotificationStatus.PENDING;
+
+    @Column(name = "attempts", nullable = false)
+    private int attempts;
+
+    @Column(name = "error")
+    private String error;
+
+    @Column(name = "sent_at")
+    private Instant sentAt;
+}

--- a/orders/src/main/java/com/oneday/orders/domain/NotificationStatus.java
+++ b/orders/src/main/java/com/oneday/orders/domain/NotificationStatus.java
@@ -1,0 +1,8 @@
+package com.oneday.orders.domain;
+
+/** Outbox lifecycle: PENDING (enqueued) → SENT (delivered) or FAILED (retryable until the attempt cap). */
+public enum NotificationStatus {
+    PENDING,
+    SENT,
+    FAILED
+}

--- a/orders/src/main/java/com/oneday/orders/repository/NotificationLogRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/NotificationLogRepository.java
@@ -1,0 +1,19 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.NotificationLog;
+import com.oneday.orders.domain.NotificationStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+public interface NotificationLogRepository extends JpaRepository<NotificationLog, UUID> {
+
+    /**
+     * The drain batch: undelivered rows still under the retry cap, oldest first. Bounded to avoid a
+     * runaway sweep. Backed by {@code idx_notification_log_undelivered}.
+     */
+    List<NotificationLog> findTop200ByStatusInAndAttemptsLessThanOrderByCreatedAtAsc(
+            Collection<NotificationStatus> statuses, int maxAttempts);
+}

--- a/orders/src/main/java/com/oneday/orders/service/NotificationDeliveryException.java
+++ b/orders/src/main/java/com/oneday/orders/service/NotificationDeliveryException.java
@@ -1,0 +1,15 @@
+package com.oneday.orders.service;
+
+/**
+ * A channel sender failed to deliver a notification. Lets the outbox drain mark the row FAILED and
+ * retry; best-effort callers (the legacy {@code Notifier}) simply swallow it.
+ */
+public class NotificationDeliveryException extends RuntimeException {
+    public NotificationDeliveryException(String message) {
+        super(message);
+    }
+
+    public NotificationDeliveryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/NotificationTemplateResolver.java
+++ b/orders/src/main/java/com/oneday/orders/service/NotificationTemplateResolver.java
@@ -1,0 +1,25 @@
+package com.oneday.orders.service;
+
+import com.oneday.common.port.dto.NotificationEventType;
+import com.oneday.orders.domain.NotificationChannel;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Resolves and renders the message for a notification event. The one place that decides, per event,
+ * which channels fire and what the copy says. A new notification = a new template entry in the impl
+ * (plus a {@link NotificationEventType} value).
+ */
+public interface NotificationTemplateResolver {
+
+    /** A rendered message: the channels to deliver on, plus the (email) subject and the body. */
+    record Rendered(Set<NotificationChannel> channels, String subject, String body) {}
+
+    /**
+     * Resolve the template for {@code type} and render it with {@code params}, or empty when no
+     * template is defined for the event (the caller drops it).
+     */
+    Optional<Rendered> resolve(NotificationEventType type, Map<String, String> params);
+}

--- a/orders/src/main/java/com/oneday/orders/service/NotificationTemplates.java
+++ b/orders/src/main/java/com/oneday/orders/service/NotificationTemplates.java
@@ -1,0 +1,60 @@
+package com.oneday.orders.service;
+
+import com.oneday.common.port.dto.NotificationEventType;
+import com.oneday.orders.domain.NotificationChannel;
+
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The one place that decides, per event, which channels fire and what the message says. A template is
+ * a channel set + a subject (email) + a body, both with {@code {placeholder}} variables filled from
+ * the request's params. New event types add an entry here (and a value to
+ * {@link NotificationEventType}) — that's the whole extension point for a new notification.
+ */
+public final class NotificationTemplates {
+
+    /** channels this event delivers over; {@code subject} is used for email only. */
+    public record Template(Set<NotificationChannel> channels, String subject, String body) {}
+
+    private static final Map<NotificationEventType, Template> TEMPLATES =
+            new EnumMap<>(NotificationEventType.class);
+
+    static {
+        TEMPLATES.put(NotificationEventType.OTP_GENERATED, new Template(
+                EnumSet.of(NotificationChannel.SMS),
+                null,
+                "Your Godspeed pickup OTP is {otp}. It expires in {ttl_minutes} minutes."));
+
+        TEMPLATES.put(NotificationEventType.STATE_CHANGED, new Template(
+                EnumSet.of(NotificationChannel.EMAIL, NotificationChannel.SMS),
+                "Update on your shipment {shipment_ref}",
+                "Your shipment {shipment_ref} is now {status}."));
+
+        TEMPLATES.put(NotificationEventType.SLA_ESCALATION, new Template(
+                EnumSet.of(NotificationChannel.EMAIL),
+                "SLA alert: {shipment_ref} needs attention",
+                "Shipment {shipment_ref} ({city}) has breached its SLA: {detail}. Please action it."));
+    }
+
+    private NotificationTemplates() {}
+
+    /** The template for an event, or {@code null} if none is defined (the service skips + logs). */
+    public static Template forType(NotificationEventType type) {
+        return TEMPLATES.get(type);
+    }
+
+    /** Substitute every {@code {key}} present in {@code params}; unknown placeholders are left as-is. */
+    public static String render(String pattern, Map<String, String> params) {
+        if (pattern == null || params.isEmpty()) {
+            return pattern;
+        }
+        String out = pattern;
+        for (Map.Entry<String, String> e : params.entrySet()) {
+            out = out.replace("{" + e.getKey() + "}", e.getValue() == null ? "" : e.getValue());
+        }
+        return out;
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/NotificationTemplates.java
+++ b/orders/src/main/java/com/oneday/orders/service/NotificationTemplates.java
@@ -46,15 +46,26 @@ public final class NotificationTemplates {
         return TEMPLATES.get(type);
     }
 
-    /** Substitute every {@code {key}} present in {@code params}; unknown placeholders are left as-is. */
+    private static final java.util.regex.Pattern PLACEHOLDER =
+            java.util.regex.Pattern.compile("\\{([a-zA-Z0-9_]+)\\}");
+
+    /**
+     * Substitute every {@code {key}} present in {@code params} in a SINGLE pass over the original
+     * pattern; unknown placeholders are left as-is. Single-pass matters: a param value that itself
+     * contains {@code {something}} must not be re-substituted (that would let template data inject
+     * into later placeholders).
+     */
     public static String render(String pattern, Map<String, String> params) {
         if (pattern == null || params.isEmpty()) {
             return pattern;
         }
-        String out = pattern;
-        for (Map.Entry<String, String> e : params.entrySet()) {
-            out = out.replace("{" + e.getKey() + "}", e.getValue() == null ? "" : e.getValue());
+        java.util.regex.Matcher m = PLACEHOLDER.matcher(pattern);
+        StringBuilder sb = new StringBuilder();
+        while (m.find()) {
+            String value = params.get(m.group(1));
+            m.appendReplacement(sb, java.util.regex.Matcher.quoteReplacement(value != null ? value : m.group()));
         }
-        return out;
+        m.appendTail(sb);
+        return sb.toString();
     }
 }

--- a/orders/src/main/java/com/oneday/orders/service/impl/Msg91SmsSender.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/Msg91SmsSender.java
@@ -55,11 +55,18 @@ class Msg91SmsSender implements SmsSender {
                     .build();
             HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
             if (resp.statusCode() / 100 != 2) {
-                log.warn("[notify:sms] msg91 returned {} for {}: {}", resp.statusCode(), mobile, resp.body());
+                throw new com.oneday.orders.service.NotificationDeliveryException(
+                        "msg91 " + resp.statusCode() + " for " + mobile + ": " + resp.body());
             }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();   // only an actual interrupt sets the flag
+            throw new com.oneday.orders.service.NotificationDeliveryException(
+                    "interrupted sending to " + phone, e);
+        } catch (com.oneday.orders.service.NotificationDeliveryException e) {
+            throw e;
         } catch (Exception e) {
-            log.warn("[notify:sms] msg91 send to {} failed: {}", phone, e.toString());
-            Thread.currentThread().interrupt();
+            throw new com.oneday.orders.service.NotificationDeliveryException(
+                    "msg91 send to " + phone + " failed: " + e, e);
         }
     }
 }

--- a/orders/src/main/java/com/oneday/orders/service/impl/NotificationDispatchJob.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/NotificationDispatchJob.java
@@ -1,0 +1,82 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.config.NotifyProperties;
+import com.oneday.orders.domain.NotificationChannel;
+import com.oneday.orders.domain.NotificationLog;
+import com.oneday.orders.domain.NotificationStatus;
+import com.oneday.orders.repository.NotificationLogRepository;
+import com.oneday.orders.service.EmailSender;
+import com.oneday.orders.service.SmsSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Drains the notification outbox: picks up PENDING + retryable FAILED rows and delivers them via the
+ * channel senders, recording the outcome per row. Retries a failed row on each sweep until the attempt
+ * cap ({@code notify.max-attempts}), then leaves it FAILED for inspection.
+ *
+ * <p>Deliberately does NOT hold a DB transaction across the sender's HTTP call — each row is loaded,
+ * sent, then saved in its own write. ponytail: single-instance-safe as-is (a bounded batch, idempotent
+ * enough for pilot); add a SELECT … FOR UPDATE SKIP LOCKED claim if this ever runs multi-instance.
+ */
+@Component
+class NotificationDispatchJob {
+
+    private static final Logger log = LoggerFactory.getLogger(NotificationDispatchJob.class);
+    private static final int MAX_ERROR_LEN = 500;
+
+    private final NotificationLogRepository repository;
+    private final EmailSender emailSender;
+    private final SmsSender smsSender;
+    private final NotifyProperties props;
+
+    NotificationDispatchJob(NotificationLogRepository repository, EmailSender emailSender,
+                            SmsSender smsSender, NotifyProperties props) {
+        this.repository = repository;
+        this.emailSender = emailSender;
+        this.smsSender = smsSender;
+        this.props = props;
+    }
+
+    @Scheduled(fixedDelayString = "${notify.dispatch-interval-ms:5000}")
+    public void drain() {
+        List<NotificationLog> batch = repository.findTop200ByStatusInAndAttemptsLessThanOrderByCreatedAtAsc(
+                List.of(NotificationStatus.PENDING, NotificationStatus.FAILED), props.getMaxAttempts());
+        if (batch.isEmpty()) {
+            return;
+        }
+        int sent = 0, failed = 0;
+        for (NotificationLog row : batch) {
+            row.setAttempts(row.getAttempts() + 1);
+            try {
+                if (row.getChannel() == NotificationChannel.EMAIL) {
+                    emailSender.send(row.getRecipient(), row.getSubject(), row.getBody());
+                } else {
+                    smsSender.send(row.getRecipient(), row.getBody());
+                }
+                row.setStatus(NotificationStatus.SENT);
+                row.setSentAt(Instant.now());
+                row.setError(null);
+                sent++;
+            } catch (Exception e) {
+                row.setStatus(NotificationStatus.FAILED);
+                row.setError(truncate(e.getMessage()));
+                failed++;
+            }
+            repository.save(row);   // own write per row — no tx held across the send
+        }
+        log.info("[notify] drained {} ({} sent, {} failed)", batch.size(), sent, failed);
+    }
+
+    private static String truncate(String s) {
+        if (s == null) {
+            return "unknown error";
+        }
+        return s.length() <= MAX_ERROR_LEN ? s : s.substring(0, MAX_ERROR_LEN);
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/NotificationServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/NotificationServiceImpl.java
@@ -1,0 +1,73 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.port.NotificationPort;
+import com.oneday.common.port.dto.NotificationRequest;
+import com.oneday.orders.domain.NotificationChannel;
+import com.oneday.orders.domain.NotificationLog;
+import com.oneday.orders.domain.NotificationStatus;
+import com.oneday.orders.repository.NotificationLogRepository;
+import com.oneday.orders.service.NotificationTemplates;
+import com.oneday.orders.service.NotificationTemplates.Template;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The notification foundation. {@code send} renders the event's template and ENQUEUES an outbox row
+ * per (deliverable) channel — a fast, transactional insert that commits with the caller's work, so a
+ * rolled-back business action never notifies. The actual delivery + retry is the
+ * {@link NotificationDispatchJob} draining the outbox.
+ *
+ * <p>Generic seam for the whole platform (cross-module callers reach it via {@link NotificationPort}).
+ * The older {@code Notifier} (shipment milestones / remittance) is a separate, still-live path; folding
+ * it through this outbox is a follow-up — see {@code ponytail} note.
+ */
+@Service
+class NotificationServiceImpl implements NotificationPort {
+
+    private static final Logger log = LoggerFactory.getLogger(NotificationServiceImpl.class);
+
+    private final NotificationLogRepository repository;
+
+    NotificationServiceImpl(NotificationLogRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    @Transactional
+    public void send(NotificationRequest request) {
+        Template template = NotificationTemplates.forType(request.type());
+        if (template == null) {
+            log.warn("[notify] no template for event {} — dropping", request.type());
+            return;
+        }
+        String subject = NotificationTemplates.render(template.subject(), request.params());
+        String body = NotificationTemplates.render(template.body(), request.params());
+
+        List<NotificationLog> rows = new ArrayList<>(2);
+        for (NotificationChannel channel : template.channels()) {
+            String recipient = channel == NotificationChannel.EMAIL
+                    ? request.recipientEmail() : request.recipientPhone();
+            if (recipient == null || recipient.isBlank()) {
+                continue;   // template wants this channel but the recipient can't receive it
+            }
+            NotificationLog row = new NotificationLog();
+            row.setEventType(request.type().name());
+            row.setChannel(channel);
+            row.setRecipient(recipient.trim());
+            row.setSubject(channel == NotificationChannel.EMAIL ? subject : null);
+            row.setBody(body);
+            row.setStatus(NotificationStatus.PENDING);
+            rows.add(row);
+        }
+        if (rows.isEmpty()) {
+            log.warn("[notify] {} had no deliverable channel (no email/phone) — dropping", request.type());
+            return;
+        }
+        repository.saveAll(rows);
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/NotificationServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/NotificationServiceImpl.java
@@ -6,8 +6,8 @@ import com.oneday.orders.domain.NotificationChannel;
 import com.oneday.orders.domain.NotificationLog;
 import com.oneday.orders.domain.NotificationStatus;
 import com.oneday.orders.repository.NotificationLogRepository;
-import com.oneday.orders.service.NotificationTemplates;
-import com.oneday.orders.service.NotificationTemplates.Template;
+import com.oneday.orders.service.NotificationTemplateResolver;
+import com.oneday.orders.service.NotificationTemplateResolver.Rendered;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -32,24 +32,26 @@ class NotificationServiceImpl implements NotificationPort {
     private static final Logger log = LoggerFactory.getLogger(NotificationServiceImpl.class);
 
     private final NotificationLogRepository repository;
+    private final NotificationTemplateResolver templates;
 
-    NotificationServiceImpl(NotificationLogRepository repository) {
+    NotificationServiceImpl(NotificationLogRepository repository, NotificationTemplateResolver templates) {
         this.repository = repository;
+        this.templates = templates;
     }
 
     @Override
     @Transactional
     public void send(NotificationRequest request) {
-        Template template = NotificationTemplates.forType(request.type());
-        if (template == null) {
+        Rendered rendered = templates.resolve(request.type(), request.params()).orElse(null);
+        if (rendered == null) {
             log.warn("[notify] no template for event {} — dropping", request.type());
             return;
         }
-        String subject = NotificationTemplates.render(template.subject(), request.params());
-        String body = NotificationTemplates.render(template.body(), request.params());
+        String subject = rendered.subject();
+        String body = rendered.body();
 
         List<NotificationLog> rows = new ArrayList<>(2);
-        for (NotificationChannel channel : template.channels()) {
+        for (NotificationChannel channel : rendered.channels()) {
             String recipient = channel == NotificationChannel.EMAIL
                     ? request.recipientEmail() : request.recipientPhone();
             if (recipient == null || recipient.isBlank()) {

--- a/orders/src/main/java/com/oneday/orders/service/impl/NotificationTemplateResolverImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/NotificationTemplateResolverImpl.java
@@ -1,23 +1,28 @@
-package com.oneday.orders.service;
+package com.oneday.orders.service.impl;
 
 import com.oneday.common.port.dto.NotificationEventType;
 import com.oneday.orders.domain.NotificationChannel;
+import com.oneday.orders.service.NotificationTemplateResolver;
+import org.springframework.stereotype.Component;
 
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
- * The one place that decides, per event, which channels fire and what the message says. A template is
- * a channel set + a subject (email) + a body, both with {@code {placeholder}} variables filled from
- * the request's params. New event types add an entry here (and a value to
- * {@link NotificationEventType}) — that's the whole extension point for a new notification.
+ * @see NotificationTemplateResolver
  */
-public final class NotificationTemplates {
+@Component
+class NotificationTemplateResolverImpl implements NotificationTemplateResolver {
 
     /** channels this event delivers over; {@code subject} is used for email only. */
-    public record Template(Set<NotificationChannel> channels, String subject, String body) {}
+    private record Template(Set<NotificationChannel> channels, String subject, String body) {}
+
+    private static final Pattern PLACEHOLDER = Pattern.compile("\\{([a-zA-Z0-9_]+)\\}");
 
     private static final Map<NotificationEventType, Template> TEMPLATES =
             new EnumMap<>(NotificationEventType.class);
@@ -39,31 +44,30 @@ public final class NotificationTemplates {
                 "Shipment {shipment_ref} ({city}) has breached its SLA: {detail}. Please action it."));
     }
 
-    private NotificationTemplates() {}
-
-    /** The template for an event, or {@code null} if none is defined (the service skips + logs). */
-    public static Template forType(NotificationEventType type) {
-        return TEMPLATES.get(type);
+    @Override
+    public Optional<Rendered> resolve(NotificationEventType type, Map<String, String> params) {
+        Template t = TEMPLATES.get(type);
+        if (t == null) {
+            return Optional.empty();
+        }
+        Map<String, String> safe = params == null ? Map.of() : params;
+        return Optional.of(new Rendered(t.channels(), render(t.subject(), safe), render(t.body(), safe)));
     }
-
-    private static final java.util.regex.Pattern PLACEHOLDER =
-            java.util.regex.Pattern.compile("\\{([a-zA-Z0-9_]+)\\}");
 
     /**
      * Substitute every {@code {key}} present in {@code params} in a SINGLE pass over the original
      * pattern; unknown placeholders are left as-is. Single-pass matters: a param value that itself
-     * contains {@code {something}} must not be re-substituted (that would let template data inject
-     * into later placeholders).
+     * contains {@code {something}} must not be re-substituted into a later placeholder.
      */
-    public static String render(String pattern, Map<String, String> params) {
+    private static String render(String pattern, Map<String, String> params) {
         if (pattern == null || params.isEmpty()) {
             return pattern;
         }
-        java.util.regex.Matcher m = PLACEHOLDER.matcher(pattern);
+        Matcher m = PLACEHOLDER.matcher(pattern);
         StringBuilder sb = new StringBuilder();
         while (m.find()) {
             String value = params.get(m.group(1));
-            m.appendReplacement(sb, java.util.regex.Matcher.quoteReplacement(value != null ? value : m.group()));
+            m.appendReplacement(sb, Matcher.quoteReplacement(value != null ? value : m.group()));
         }
         m.appendTail(sb);
         return sb.toString();

--- a/orders/src/main/java/com/oneday/orders/service/impl/PickupOtpServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/PickupOtpServiceImpl.java
@@ -43,16 +43,19 @@ class PickupOtpServiceImpl implements PickupOtpService {
     private final PickupOtpRepository otpRepository;
     private final ShipmentRepository shipmentRepository;
     private final PickupOtpProperties properties;
+    private final com.oneday.common.port.NotificationPort notificationPort;
     // Absent in prod (the bean is @Profile("!prod")) — the peek is a field-test aid only.
     private final ObjectProvider<DevOtpRegistry> devOtpRegistry;
 
     PickupOtpServiceImpl(PickupOtpRepository otpRepository,
                          ShipmentRepository shipmentRepository,
                          PickupOtpProperties properties,
+                         com.oneday.common.port.NotificationPort notificationPort,
                          ObjectProvider<DevOtpRegistry> devOtpRegistry) {
         this.otpRepository      = otpRepository;
         this.shipmentRepository = shipmentRepository;
         this.properties         = properties;
+        this.notificationPort   = notificationPort;
         this.devOtpRegistry     = devOtpRegistry;
     }
 
@@ -75,6 +78,14 @@ class PickupOtpServiceImpl implements PickupOtpService {
         record.setResendCount((short) 0);
         record.setUsed(false);
         otpRepository.save(record);
+
+        // SMS the cleartext OTP to the sender (they read it to the pickup DA). Enqueued in this same
+        // transaction via the notification outbox, so it commits atomically with the OTP.
+        notificationPort.send(new com.oneday.common.port.dto.NotificationRequest(
+                com.oneday.common.port.dto.NotificationEventType.OTP_GENERATED,
+                null,                          // OTP is SMS-only — no email
+                shipment.getSenderPhone(),
+                java.util.Map.of("otp", otp, "ttl_minutes", String.valueOf(properties.getTtlMinutes()))));
 
         devOtpRegistry.ifAvailable(r -> r.put(shipmentId, otp));   // no-op in prod (bean absent)
         log.debug("OTP generated for shipmentId={}", shipmentId);
@@ -134,6 +145,12 @@ class PickupOtpServiceImpl implements PickupOtpService {
         record.setResendCount(newResendCount);
         record.setUsed(false);
         otpRepository.save(record);
+
+        notificationPort.send(new com.oneday.common.port.dto.NotificationRequest(
+                com.oneday.common.port.dto.NotificationEventType.OTP_GENERATED,
+                null,
+                shipment.getSenderPhone(),
+                java.util.Map.of("otp", otp, "ttl_minutes", String.valueOf(properties.getTtlMinutes()))));
 
         devOtpRegistry.ifAvailable(r -> r.put(shipmentId, otp));   // no-op in prod (bean absent)
         log.debug("OTP resent (attempt {}/{}) for shipmentId={}",

--- a/orders/src/main/java/com/oneday/orders/service/impl/SendGridEmailSender.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/SendGridEmailSender.java
@@ -56,11 +56,18 @@ class SendGridEmailSender implements EmailSender {
                     .build();
             HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
             if (resp.statusCode() / 100 != 2) {
-                log.warn("[notify:email] sendgrid returned {} for {}: {}", resp.statusCode(), toEmail, resp.body());
+                throw new com.oneday.orders.service.NotificationDeliveryException(
+                        "sendgrid " + resp.statusCode() + " for " + toEmail + ": " + resp.body());
             }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();   // only an actual interrupt sets the flag
+            throw new com.oneday.orders.service.NotificationDeliveryException(
+                    "interrupted sending to " + toEmail, e);
+        } catch (com.oneday.orders.service.NotificationDeliveryException e) {
+            throw e;
         } catch (Exception e) {
-            log.warn("[notify:email] sendgrid send to {} failed: {}", toEmail, e.toString());
-            Thread.currentThread().interrupt();
+            throw new com.oneday.orders.service.NotificationDeliveryException(
+                    "sendgrid send to " + toEmail + " failed: " + e, e);
         }
     }
 }

--- a/orders/src/main/resources/db/migration/orders/V4_42__create_notification_log.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_42__create_notification_log.sql
@@ -1,0 +1,23 @@
+-- Notification outbox: one row per rendered message to one recipient on one channel. The service
+-- enqueues PENDING; a scheduled drain delivers (SENT) or records the failure (FAILED) and retries
+-- until the attempt cap. Transactional-outbox pattern, mirroring webhook_delivery (V4_29). Enum-like
+-- columns are VARCHAR + app-side @Enumerated(STRING).
+CREATE TABLE notification_log (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_type  VARCHAR(32)  NOT NULL,               -- NotificationEventType name
+    channel     VARCHAR(8)   NOT NULL,               -- EMAIL | SMS
+    recipient   VARCHAR(254) NOT NULL,               -- email address or E.164 phone
+    subject     VARCHAR(300),
+    body        TEXT         NOT NULL,
+    status      VARCHAR(12)  NOT NULL DEFAULT 'PENDING', -- PENDING | SENT | FAILED
+    attempts    INTEGER      NOT NULL DEFAULT 0,
+    error       TEXT,
+    sent_at     TIMESTAMPTZ,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+-- The drain query: undelivered rows (PENDING/FAILED), oldest first. Partial index keeps it over just
+-- the live set — SENT rows (the vast majority over time) are excluded.
+CREATE INDEX idx_notification_log_undelivered ON notification_log (created_at)
+    WHERE status <> 'SENT';

--- a/orders/src/test/java/com/oneday/orders/service/impl/NotificationDispatchJobTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/NotificationDispatchJobTest.java
@@ -1,0 +1,77 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.config.NotifyProperties;
+import com.oneday.orders.domain.NotificationChannel;
+import com.oneday.orders.domain.NotificationLog;
+import com.oneday.orders.domain.NotificationStatus;
+import com.oneday.orders.repository.NotificationLogRepository;
+import com.oneday.orders.service.EmailSender;
+import com.oneday.orders.service.NotificationDeliveryException;
+import com.oneday.orders.service.SmsSender;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The drain must mark a delivered row SENT and a thrown-on row FAILED, always bumping attempts so the
+ * retry cap eventually stops it. These pin both outcomes.
+ */
+class NotificationDispatchJobTest {
+
+    private final NotificationLogRepository repo = mock(NotificationLogRepository.class);
+    private final EmailSender email = mock(EmailSender.class);
+    private final SmsSender sms = mock(SmsSender.class);
+    private final NotifyProperties props = new NotifyProperties();
+    private final NotificationDispatchJob job = new NotificationDispatchJob(repo, email, sms, props);
+
+    private static NotificationLog emailRow() {
+        NotificationLog r = new NotificationLog();
+        r.setEventType("STATE_CHANGED");
+        r.setChannel(NotificationChannel.EMAIL);
+        r.setRecipient("a@b.com");
+        r.setSubject("Hi");
+        r.setBody("Body");
+        r.setStatus(NotificationStatus.PENDING);
+        return r;
+    }
+
+    @Test
+    void deliveredRowIsMarkedSent() {
+        NotificationLog row = emailRow();
+        when(repo.findTop200ByStatusInAndAttemptsLessThanOrderByCreatedAtAsc(any(), anyInt()))
+                .thenReturn(List.of(row));
+
+        job.drain();
+
+        verify(email).send("a@b.com", "Hi", "Body");
+        assertThat(row.getStatus()).isEqualTo(NotificationStatus.SENT);
+        assertThat(row.getAttempts()).isEqualTo(1);
+        assertThat(row.getSentAt()).isNotNull();
+        verify(repo).save(row);
+    }
+
+    @Test
+    void failedSendIsMarkedFailedWithErrorAndBumpedAttempts() {
+        NotificationLog row = emailRow();
+        row.setAttempts(1);   // a prior failed attempt
+        when(repo.findTop200ByStatusInAndAttemptsLessThanOrderByCreatedAtAsc(any(), anyInt()))
+                .thenReturn(List.of(row));
+        doThrow(new NotificationDeliveryException("sendgrid 500")).when(email).send(any(), any(), any());
+
+        job.drain();
+
+        assertThat(row.getStatus()).isEqualTo(NotificationStatus.FAILED);
+        assertThat(row.getAttempts()).isEqualTo(2);
+        assertThat(row.getError()).contains("sendgrid 500");
+        assertThat(row.getSentAt()).isNull();
+        verify(repo).save(row);
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/service/impl/NotificationServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/NotificationServiceImplTest.java
@@ -1,0 +1,83 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.port.dto.NotificationEventType;
+import com.oneday.common.port.dto.NotificationRequest;
+import com.oneday.orders.domain.NotificationChannel;
+import com.oneday.orders.domain.NotificationLog;
+import com.oneday.orders.domain.NotificationStatus;
+import com.oneday.orders.repository.NotificationLogRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * The seam's contract: render the event's template, and enqueue exactly one outbox row per channel
+ * the template declares AND the recipient can receive on. These pin the fan-out + the template render.
+ */
+class NotificationServiceImplTest {
+
+    private final NotificationLogRepository repo = mock(NotificationLogRepository.class);
+    private final NotificationServiceImpl service = new NotificationServiceImpl(repo);
+
+    @SuppressWarnings("unchecked")
+    private List<NotificationLog> captureSaved() {
+        ArgumentCaptor<List<NotificationLog>> cap = ArgumentCaptor.forClass(List.class);
+        verify(repo).saveAll(cap.capture());
+        return cap.getValue();
+    }
+
+    @Test
+    void otpGoesToSmsOnly_withRenderedBody() {
+        service.send(new NotificationRequest(NotificationEventType.OTP_GENERATED, "a@b.com", "+919000000001",
+                Map.of("otp", "123456", "ttl_minutes", "10")));
+
+        List<NotificationLog> rows = captureSaved();
+        assertThat(rows).hasSize(1);
+        NotificationLog r = rows.get(0);
+        assertThat(r.getChannel()).isEqualTo(NotificationChannel.SMS);
+        assertThat(r.getRecipient()).isEqualTo("+919000000001");
+        assertThat(r.getBody()).isEqualTo("Your Godspeed pickup OTP is 123456. It expires in 10 minutes.");
+        assertThat(r.getStatus()).isEqualTo(NotificationStatus.PENDING);
+        assertThat(r.getSubject()).isNull();   // SMS carries no subject
+    }
+
+    @Test
+    void stateChangeFansOutToEmailAndSms() {
+        service.send(new NotificationRequest(NotificationEventType.STATE_CHANGED, "a@b.com", "+919000000001",
+                Map.of("shipment_ref", "1DD-DEL-1", "status", "Delivered")));
+
+        List<NotificationLog> rows = captureSaved();
+        assertThat(rows).hasSize(2);
+        assertThat(rows).extracting(NotificationLog::getChannel)
+                .containsExactlyInAnyOrder(NotificationChannel.EMAIL, NotificationChannel.SMS);
+        NotificationLog email = rows.stream().filter(r -> r.getChannel() == NotificationChannel.EMAIL).findFirst().orElseThrow();
+        assertThat(email.getSubject()).isEqualTo("Update on your shipment 1DD-DEL-1");
+        assertThat(email.getBody()).isEqualTo("Your shipment 1DD-DEL-1 is now Delivered.");
+    }
+
+    @Test
+    void skipsAChannelWhenTheRecipientCantReceiveIt() {
+        // STATE_CHANGED wants EMAIL+SMS, but only an email is given → just the email row.
+        service.send(new NotificationRequest(NotificationEventType.STATE_CHANGED, "a@b.com", null,
+                Map.of("shipment_ref", "1DD-DEL-1", "status", "Delivered")));
+
+        List<NotificationLog> rows = captureSaved();
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getChannel()).isEqualTo(NotificationChannel.EMAIL);
+    }
+
+    @Test
+    void nothingEnqueuedWhenNoDeliverableChannel() {
+        // OTP wants SMS, but no phone → nothing to send.
+        service.send(new NotificationRequest(NotificationEventType.OTP_GENERATED, "a@b.com", null,
+                Map.of("otp", "123456")));
+        verify(repo, never()).saveAll(org.mockito.ArgumentMatchers.any());
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/service/impl/NotificationServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/NotificationServiceImplTest.java
@@ -24,7 +24,9 @@ import static org.mockito.Mockito.verify;
 class NotificationServiceImplTest {
 
     private final NotificationLogRepository repo = mock(NotificationLogRepository.class);
-    private final NotificationServiceImpl service = new NotificationServiceImpl(repo);
+    // Real resolver (stateless) so the template fan-out + render are exercised end-to-end.
+    private final NotificationServiceImpl service =
+            new NotificationServiceImpl(repo, new NotificationTemplateResolverImpl());
 
     @SuppressWarnings("unchecked")
     private List<NotificationLog> captureSaved() {

--- a/orders/src/test/java/com/oneday/orders/service/impl/PickupOtpServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/PickupOtpServiceImplTest.java
@@ -1,11 +1,15 @@
 package com.oneday.orders.service.impl;
 
+import com.oneday.common.port.NotificationPort;
+import com.oneday.common.port.dto.NotificationEventType;
+import com.oneday.common.port.dto.NotificationRequest;
 import com.oneday.orders.config.PickupOtpProperties;
 import com.oneday.orders.domain.Shipment;
 import com.oneday.orders.repository.PickupOtpRepository;
 import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.service.DevOtpRegistry;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.ObjectProvider;
 
 import java.util.Optional;
@@ -16,16 +20,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class PickupOtpServiceImplTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void generate_populatesDevOtpRegistryWithCleartext() {
+    void generate_populatesDevRegistryAndSmsesTheOtpToTheSender() {
         PickupOtpRepository otpRepo = mock(PickupOtpRepository.class);
         ShipmentRepository shipmentRepo = mock(ShipmentRepository.class);
         PickupOtpProperties props = new PickupOtpProperties();
+        NotificationPort notificationPort = mock(NotificationPort.class);
         DevOtpRegistry registry = new DevOtpRegistry();
         ObjectProvider<DevOtpRegistry> provider = mock(ObjectProvider.class);
         // Mirror ObjectProvider.ifAvailable: invoke the consumer with the (present) registry.
@@ -33,13 +39,23 @@ class PickupOtpServiceImplTest {
                 .when(provider).ifAvailable(any());
 
         UUID shipmentId = UUID.randomUUID();
-        when(shipmentRepo.findById(shipmentId)).thenReturn(Optional.of(new Shipment()));
+        Shipment shipment = new Shipment();
+        shipment.setSenderPhone("+919000000001");
+        when(shipmentRepo.findById(shipmentId)).thenReturn(Optional.of(shipment));
 
-        PickupOtpServiceImpl service = new PickupOtpServiceImpl(otpRepo, shipmentRepo, props, provider);
+        PickupOtpServiceImpl service =
+                new PickupOtpServiceImpl(otpRepo, shipmentRepo, props, notificationPort, provider);
         String otp = service.generate(shipmentId);
 
         // The peek must echo exactly the cleartext the DA is given.
         assertThat(registry.get(shipmentId)).isEqualTo(otp);
         assertThat(otp).hasSize(4);
+
+        // …and the same cleartext is SMSed to the sender via the notification seam.
+        ArgumentCaptor<NotificationRequest> req = ArgumentCaptor.forClass(NotificationRequest.class);
+        verify(notificationPort).send(req.capture());
+        assertThat(req.getValue().type()).isEqualTo(NotificationEventType.OTP_GENERATED);
+        assertThat(req.getValue().recipientPhone()).isEqualTo("+919000000001");
+        assertThat(req.getValue().params().get("otp")).isEqualTo(otp);
     }
 }


### PR DESCRIPTION

<img width="2934" height="900" alt="image" src="https://github.com/user-attachments/assets/1013a443-6774-4dda-a457-098be9afb909" />


What happens when a merchant clicks "Regenerate OTP" (verified live)

1. The merchant opens a shipment that's waiting for pickup and clicks Regenerate to get a fresh pickup code.
2. The app creates a new one-time code (e.g. 8022) and shows it on screen. The merchant reads this code to the delivery agent at pickup.
3. At the same moment, the system automatically sends that code to the sender by SMS — the merchant no longer has to pass it along manually.
4. The SMS isn't fired off blindly. It's first written into an outbox (a to-send list) as "pending", so it can't get lost.
5. A background worker checks the outbox every few seconds, delivers the message, and marks it "sent". If a message ever fails, it stays in the outbox and is retried automatically (up to 3 times).
6. In this test run the message was delivered and marked sent on the first try. In development the SMS is written to the app log instead of a real phone; in production the exact same flow sends it through the real SMS provider (MSG91) with no code changes.

Result: one click → the pickup code is shown on screen and reliably texted to the sender, with a full record of every message and automatic retries if delivery hiccups.

## Notification foundation (Step 5)

A reliable, generic notification seam that later features — **merchant alerts (#7)**, **pickup delay mail (#11)**, **support/chat notifications (#14)**, and Sid's DA-push/escalations — call instead of each rolling their own. Implements the previously-stubbed `common.NotificationPort` (the "split-brain" designed-but-unbuilt seam).

### How it works (transactional outbox)
1. `NotificationPort.send(NotificationRequest)` resolves the event's template, renders it, and **enqueues one `notification_log` row per deliverable channel** — a fast, transactional insert. Because it commits with the caller's work, a rolled-back business action never notifies.
2. `NotificationDispatchJob` (`@Scheduled`, `notify.dispatch-interval-ms`, default 5s) **drains** the outbox: delivers via the existing SendGrid/Msg91 senders, marks each row `SENT`/`FAILED`, and **retries** failed rows each sweep up to `notify.max-attempts` (default 3).

### What's included
- **Generic seam:** `NotificationRequest` reshaped to `(type, recipient_email, recipient_phone, params)` — a template-driven payload any module can build.
- **Templating:** `NotificationTemplates` — per-event channel set + `{placeholder}` subject/body. Seeded with OTP / state-change / SLA-escalation; a new notification = one entry here + one `NotificationEventType` value.
- **Outbox + retry:** `notification_log` table (`V4_42`), `NotificationLog` + repo, the scheduled drain. Mirrors `webhook_delivery`, and adds the actual retry loop that one lacked.
- **Productionized senders:** the real SendGrid/Msg91 adapters now **throw** `NotificationDeliveryException` on delivery failure (non-2xx / IO) so the drain can detect + retry; the default logging senders never fail, and the legacy `Notifier` stays best-effort (wraps in `safe()`). Fixed the `Thread.interrupt()`-in-generic-catch bug in both.
- Channel selection: a template's channels ∩ the recipient's reachable channels (email if an address is present, SMS if a phone is).

### Deliberately out of scope (ponytail)
- The legacy `Notifier` (shipment milestones / COD remittance) keeps its own live path; folding it through this outbox is a follow-up (no behaviour change here).
- Drain is single-instance-safe (bounded batch, no tx held across the HTTP send); a `SELECT … FOR UPDATE SKIP LOCKED` claim can be added if it ever runs multi-instance.
- Wiring specific triggers (OTP SMS, wallet-low alert, delay mail) is each consuming feature's work — this PR is the foundation they call.

### Testing
`mvn test -pl orders -Dtest=NotificationServiceImplTest,NotificationDispatchJobTest` → **6 green** (template fan-out to EMAIL+SMS, channel-skip when unreachable, render substitution; drain marks SENT vs FAILED + bumps attempts for retry). Senders stay `log` by default, so nothing sends externally without real creds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added template-based notifications for OTPs, shipment updates, and SLA escalations.
  * Notifications can be delivered by email, SMS, or both when valid recipient details are available.
  * Added personalized message rendering with event-specific parameters.
  * Added reliable background delivery with status tracking and automatic retries.
  * OTP resend notifications are now sent through the notification system.
* **Bug Fixes**
  * Failed deliveries retain error details and retry safely.
  * Invalid retry limits no longer prevent pending notifications from being processed.
* **Tests**
  * Added coverage for rendering, channel selection, delivery outcomes, and retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->