### PR TITLE
feat(orders): wallet-low merchant alert (#7)

### DIFF
--- a/common/src/main/java/com/oneday/common/port/dto/NotificationEventType.java
+++ b/common/src/main/java/com/oneday/common/port/dto/NotificationEventType.java
@@ -5,5 +5,8 @@ public enum NotificationEventType {
     STATE_CHANGED,
     // M10: an SLA leg went RED / breached — the notification service resolves the on-duty
     // supervisor / station manager for the parcel's city and pushes an ops alert.
-    SLA_ESCALATION
+    SLA_ESCALATION,
+    // M4: a B2B merchant's prepaid wallet just dropped below the low-balance threshold — alert the
+    // account owner to top up before bookings start failing.
+    WALLET_LOW
 }

--- a/common/src/main/java/com/oneday/common/port/dto/NotificationRequest.java
+++ b/common/src/main/java/com/oneday/common/port/dto/NotificationRequest.java
@@ -1,6 +1,7 @@
 package com.oneday.common.port.dto;
 
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * A request to notify a recipient of an event. The notification service resolves the template for
@@ -13,19 +14,29 @@ import java.util.Map;
  * @param recipientEmail nullable; enables the email channel
  * @param recipientPhone nullable; E.164 (e.g. "+919876543210"); enables the SMS channel
  * @param params         template variables, e.g. {@code {"otp":"123456","shipment_ref":"1DD-…"}}
+ * @param accountId      nullable; the owning B2B account, so the in-app bell can scope notifications by
+ *                       account identity rather than the mutable recipient string. Null for platform
+ *                       notifications with no account (e.g. OTP to a walk-up phone).
  */
 public record NotificationRequest(
         NotificationEventType type,
         String recipientEmail,
         String recipientPhone,
-        Map<String, String> params
+        Map<String, String> params,
+        UUID accountId
 ) {
     public NotificationRequest {
         params = params == null ? Map.of() : Map.copyOf(params);
     }
 
+    /** Back-compat: a request not tied to an account (accountId null). */
+    public NotificationRequest(NotificationEventType type, String recipientEmail, String recipientPhone,
+                               Map<String, String> params) {
+        this(type, recipientEmail, recipientPhone, params, null);
+    }
+
     /** Convenience for a single-recipient email/SMS with no template variables. */
     public static NotificationRequest of(NotificationEventType type, String email, String phone) {
-        return new NotificationRequest(type, email, phone, Map.of());
+        return new NotificationRequest(type, email, phone, Map.of(), null);
     }
 }

--- a/orders/src/main/java/com/oneday/orders/api/NotificationsController.java
+++ b/orders/src/main/java/com/oneday/orders/api/NotificationsController.java
@@ -1,0 +1,66 @@
+package com.oneday.orders.api;
+
+import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.orders.domain.B2bAccount;
+import com.oneday.orders.dto.NotificationView;
+import com.oneday.orders.repository.B2bAccountRepository;
+import com.oneday.orders.repository.NotificationLogRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * The merchant's in-app notifications (the header bell). Returns the recent notifications addressed to
+ * the caller's B2B account — wallet-low today, and every future alert built on the notification
+ * foundation. Scoped to the caller's own account contacts, never a param.
+ */
+@RestController
+@RequestMapping("/api/v1/notifications")
+class NotificationsController {
+
+    private final NotificationLogRepository notifications;
+    private final B2bAccountRepository accounts;
+
+    NotificationsController(NotificationLogRepository notifications, B2bAccountRepository accounts) {
+        this.notifications = notifications;
+        this.accounts = accounts;
+    }
+
+    /** The caller's recent notifications, newest first. */
+    @GetMapping("/mine")
+    public List<NotificationView> mine(@AuthenticationPrincipal AuthUserDetails principal) {
+        B2bAccount account = ownedAccount(principal);
+        List<String> recipients = new ArrayList<>(2);
+        if (isSet(account.getBillingEmail())) {
+            recipients.add(account.getBillingEmail());
+        }
+        if (isSet(account.getSupportPhone())) {
+            recipients.add(account.getSupportPhone());
+        }
+        if (recipients.isEmpty()) {
+            return List.of();
+        }
+        return notifications.findTop50ByRecipientInOrderByCreatedAtDesc(recipients).stream()
+                .map(NotificationView::from)
+                .toList();
+    }
+
+    /** The B2B account owned by the caller, or 404 (also gates the endpoint to B2B users). */
+    private B2bAccount ownedAccount(AuthUserDetails principal) {
+        Authz.requireRole(principal, "B2B_USER");
+        UUID userId = UUID.fromString(Authz.requireUserId(principal));
+        return accounts.findByOwnerUserId(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No B2B account for this user"));
+    }
+
+    private static boolean isSet(String s) {
+        return s != null && !s.isBlank();
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/api/NotificationsController.java
+++ b/orders/src/main/java/com/oneday/orders/api/NotificationsController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -33,21 +32,11 @@ class NotificationsController {
         this.accounts = accounts;
     }
 
-    /** The caller's recent notifications, newest first. */
+    /** The caller's recent notifications, newest first. Scoped by account id (not recipient string). */
     @GetMapping("/mine")
     public List<NotificationView> mine(@AuthenticationPrincipal AuthUserDetails principal) {
         B2bAccount account = ownedAccount(principal);
-        List<String> recipients = new ArrayList<>(2);
-        if (isSet(account.getBillingEmail())) {
-            recipients.add(account.getBillingEmail());
-        }
-        if (isSet(account.getSupportPhone())) {
-            recipients.add(account.getSupportPhone());
-        }
-        if (recipients.isEmpty()) {
-            return List.of();
-        }
-        return notifications.findTop50ByRecipientInOrderByCreatedAtDesc(recipients).stream()
+        return notifications.findTop50ByB2bAccountIdOrderByCreatedAtDesc(account.getId()).stream()
                 .map(NotificationView::from)
                 .toList();
     }
@@ -58,9 +47,5 @@ class NotificationsController {
         UUID userId = UUID.fromString(Authz.requireUserId(principal));
         return accounts.findByOwnerUserId(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No B2B account for this user"));
-    }
-
-    private static boolean isSet(String s) {
-        return s != null && !s.isBlank();
     }
 }

--- a/orders/src/main/java/com/oneday/orders/api/OrdersGlobalExceptionHandler.java
+++ b/orders/src/main/java/com/oneday/orders/api/OrdersGlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import com.oneday.orders.service.CancellationService;
 import com.oneday.orders.service.CartService;
 import com.oneday.orders.service.MerchantCategoryService;
 import com.oneday.orders.service.PaymentPort;
+import com.oneday.orders.service.WalletService;
 import com.oneday.orders.service.PickupSlotFullException;
 import com.oneday.orders.service.exception.IllegalStateTransitionException;
 import com.oneday.pricing.service.NoRateConfiguredException;
@@ -100,6 +101,14 @@ class OrdersGlobalExceptionHandler {
         ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.PAYMENT_REQUIRED);
         pd.setTitle("Payment capture failed");
         pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    @ExceptionHandler(WalletService.InsufficientWalletBalanceException.class)
+    ProblemDetail handleInsufficientWallet(WalletService.InsufficientWalletBalanceException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.PAYMENT_REQUIRED);
+        pd.setTitle("Insufficient wallet balance");
+        pd.setDetail("Your wallet balance isn't enough for this booking. Recharge your wallet, or switch payment to Credit.");
         return pd;
     }
 

--- a/orders/src/main/java/com/oneday/orders/config/WalletProperties.java
+++ b/orders/src/main/java/com/oneday/orders/config/WalletProperties.java
@@ -1,0 +1,31 @@
+package com.oneday.orders.config;
+
+import jakarta.validation.constraints.PositiveOrZero;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * B2B prepaid-wallet config.
+ *
+ * <pre>{@code
+ * orders:
+ *   wallet:
+ *     low-balance-threshold-paise: 100000   # ₹1,000
+ * }</pre>
+ */
+@Component
+@ConfigurationProperties(prefix = "orders.wallet")
+@Validated
+public class WalletProperties {
+
+    /**
+     * When a wallet debit drops the balance from at/above this to below it, the merchant is alerted
+     * once to top up. Default ₹1,000. Set to 0 to disable the alert.
+     */
+    @PositiveOrZero
+    private long lowBalanceThresholdPaise = 100_000;
+
+    public long getLowBalanceThresholdPaise() { return lowBalanceThresholdPaise; }
+    public void setLowBalanceThresholdPaise(long v) { this.lowBalanceThresholdPaise = v; }
+}

--- a/orders/src/main/java/com/oneday/orders/domain/NotificationLog.java
+++ b/orders/src/main/java/com/oneday/orders/domain/NotificationLog.java
@@ -29,6 +29,14 @@ public class NotificationLog extends MutableBaseEntity {
     @Column(name = "event_type", nullable = false, updatable = false)
     private String eventType;
 
+    /**
+     * The B2B account this notification belongs to (nullable — platform notifications like OTP have no
+     * account). The in-app notifications bell scopes by this id, not by the mutable recipient string, so
+     * accounts that happen to share a contact can't see each other's messages.
+     */
+    @Column(name = "b2b_account_id", updatable = false)
+    private java.util.UUID b2bAccountId;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "channel", nullable = false, updatable = false)
     private NotificationChannel channel;

--- a/orders/src/main/java/com/oneday/orders/dto/NotificationView.java
+++ b/orders/src/main/java/com/oneday/orders/dto/NotificationView.java
@@ -1,0 +1,22 @@
+package com.oneday.orders.dto;
+
+import com.oneday.orders.domain.NotificationChannel;
+import com.oneday.orders.domain.NotificationLog;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/** One notification for the in-app bell. Snake_case on the wire (project-wide Jackson strategy). */
+public record NotificationView(
+        UUID id,
+        String eventType,
+        NotificationChannel channel,
+        String subject,
+        String body,
+        Instant createdAt) {
+
+    public static NotificationView from(NotificationLog n) {
+        return new NotificationView(n.getId(), n.getEventType(), n.getChannel(),
+                n.getSubject(), n.getBody(), n.getCreatedAt());
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/repository/NotificationLogRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/NotificationLogRepository.java
@@ -18,10 +18,9 @@ public interface NotificationLogRepository extends JpaRepository<NotificationLog
             Collection<NotificationStatus> statuses, int maxAttempts);
 
     /**
-     * The recent notifications addressed to any of these recipients (a merchant's billing email /
-     * support phone), newest first — backs the in-app notifications bell.
-     * ponytail: scoped by recipient string (no account_id on the row yet); add an account_id column
-     * if a merchant ever changes their billing email and needs history to follow.
+     * The recent notifications owned by one B2B account, newest first — backs the in-app notifications
+     * bell. Scoped by account identity (not the mutable recipient string), so accounts sharing a billing
+     * email or support phone can't see each other's messages. Backed by {@code idx_notification_log_account}.
      */
-    List<NotificationLog> findTop50ByRecipientInOrderByCreatedAtDesc(Collection<String> recipients);
+    List<NotificationLog> findTop50ByB2bAccountIdOrderByCreatedAtDesc(UUID b2bAccountId);
 }

--- a/orders/src/main/java/com/oneday/orders/repository/NotificationLogRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/NotificationLogRepository.java
@@ -16,4 +16,12 @@ public interface NotificationLogRepository extends JpaRepository<NotificationLog
      */
     List<NotificationLog> findTop200ByStatusInAndAttemptsLessThanOrderByCreatedAtAsc(
             Collection<NotificationStatus> statuses, int maxAttempts);
+
+    /**
+     * The recent notifications addressed to any of these recipients (a merchant's billing email /
+     * support phone), newest first — backs the in-app notifications bell.
+     * ponytail: scoped by recipient string (no account_id on the row yet); add an account_id column
+     * if a merchant ever changes their billing email and needs history to follow.
+     */
+    List<NotificationLog> findTop50ByRecipientInOrderByCreatedAtDesc(Collection<String> recipients);
 }

--- a/orders/src/main/java/com/oneday/orders/service/impl/NotificationServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/NotificationServiceImpl.java
@@ -59,6 +59,7 @@ class NotificationServiceImpl implements NotificationPort {
             }
             NotificationLog row = new NotificationLog();
             row.setEventType(request.type().name());
+            row.setB2bAccountId(request.accountId());
             row.setChannel(channel);
             row.setRecipient(recipient.trim());
             row.setSubject(channel == NotificationChannel.EMAIL ? subject : null);

--- a/orders/src/main/java/com/oneday/orders/service/impl/NotificationTemplateResolverImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/NotificationTemplateResolverImpl.java
@@ -42,6 +42,11 @@ class NotificationTemplateResolverImpl implements NotificationTemplateResolver {
                 EnumSet.of(NotificationChannel.EMAIL),
                 "SLA alert: {shipment_ref} needs attention",
                 "Shipment {shipment_ref} ({city}) has breached its SLA: {detail}. Please action it."));
+
+        TEMPLATES.put(NotificationEventType.WALLET_LOW, new Template(
+                EnumSet.of(NotificationChannel.EMAIL, NotificationChannel.SMS),
+                "Your Godspeed wallet is running low",
+                "Your Godspeed wallet balance is now ₹{balance}. Top up to keep shipping without interruption."));
     }
 
     @Override

--- a/orders/src/main/java/com/oneday/orders/service/impl/WalletServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/WalletServiceImpl.java
@@ -141,7 +141,8 @@ class WalletServiceImpl implements WalletService {
                 com.oneday.common.port.dto.NotificationEventType.WALLET_LOW,
                 account.getBillingEmail(),
                 account.getSupportPhone(),                 // nullable — SMS only if the account has one
-                java.util.Map.of("balance", rupees)));
+                java.util.Map.of("balance", rupees),
+                account.getId()));                         // scopes the in-app bell to this account
     }
 
     @Override

--- a/orders/src/main/java/com/oneday/orders/service/impl/WalletServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/WalletServiceImpl.java
@@ -30,15 +30,21 @@ class WalletServiceImpl implements WalletService {
     private final WalletTransactionRepository ledger;
     private final WalletRechargeOrderRepository rechargeOrders;
     private final PaymentPort paymentPort;
+    private final com.oneday.common.port.NotificationPort notificationPort;
+    private final com.oneday.orders.config.WalletProperties walletProperties;
 
     WalletServiceImpl(B2bAccountRepository accounts,
                       WalletTransactionRepository ledger,
                       WalletRechargeOrderRepository rechargeOrders,
-                      PaymentPort paymentPort) {
+                      PaymentPort paymentPort,
+                      com.oneday.common.port.NotificationPort notificationPort,
+                      com.oneday.orders.config.WalletProperties walletProperties) {
         this.accounts = accounts;
         this.ledger = ledger;
         this.rechargeOrders = rechargeOrders;
         this.paymentPort = paymentPort;
+        this.notificationPort = notificationPort;
+        this.walletProperties = walletProperties;
     }
 
     @Override
@@ -115,6 +121,27 @@ class WalletServiceImpl implements WalletService {
                 shipmentRef, "Shipment " + shipmentRef, actorId);
         log.info("Wallet debited: account {} -{} paise → {} (shipment {})",
                 account.getId(), amountPaise, newBalance, safe(shipmentRef));
+
+        maybeAlertLowBalance(account, current, newBalance);
+    }
+
+    /**
+     * Alert the merchant to top up — but only on the CROSSING (a debit that took the balance from
+     * at/above the threshold to below it), so they get one nudge per low episode, not one per debit
+     * while already low. Enqueued in the caller's booking TX via the notification outbox, so it
+     * commits atomically and a rolled-back booking never alerts.
+     */
+    private void maybeAlertLowBalance(B2bAccount account, long balanceBefore, long balanceAfter) {
+        long threshold = walletProperties.getLowBalanceThresholdPaise();
+        if (threshold <= 0 || balanceBefore < threshold || balanceAfter >= threshold) {
+            return;
+        }
+        String rupees = java.math.BigDecimal.valueOf(balanceAfter, 2).toPlainString();
+        notificationPort.send(new com.oneday.common.port.dto.NotificationRequest(
+                com.oneday.common.port.dto.NotificationEventType.WALLET_LOW,
+                account.getBillingEmail(),
+                account.getSupportPhone(),                 // nullable — SMS only if the account has one
+                java.util.Map.of("balance", rupees)));
     }
 
     @Override

--- a/orders/src/main/resources/db/migration/orders/V4_43__notification_log_account_scope.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_43__notification_log_account_scope.sql
@@ -1,0 +1,11 @@
+-- Scope in-app notifications by account identity, not by mutable recipient strings.
+-- The merchant notifications bell matched rows by billing email / support phone, so two accounts
+-- sharing a contact (e.g. one company running several B2B accounts on one billing email) could see
+-- each other's notification bodies. Persist the owning B2B account id and query by that instead;
+-- recipient stays as delivery metadata. Nullable: platform notifications (OTP etc.) have no account.
+
+ALTER TABLE notification_log ADD COLUMN b2b_account_id UUID;
+
+-- Backs the bell query: an account's recent notifications, newest first.
+CREATE INDEX idx_notification_log_account ON notification_log (b2b_account_id, created_at DESC)
+    WHERE b2b_account_id IS NOT NULL;

--- a/orders/src/test/java/com/oneday/orders/service/impl/NotificationServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/NotificationServiceImplTest.java
@@ -82,4 +82,24 @@ class NotificationServiceImplTest {
                 Map.of("otp", "123456")));
         verify(repo, never()).saveAll(org.mockito.ArgumentMatchers.any());
     }
+
+    @Test
+    void stampsTheOwningAccountIdOnEveryRow_soSharedContactsStayIsolated() {
+        // Two accounts share a billing email. Each notification carries its own account id, so the
+        // in-app bell (which queries by account id) can never surface one account's row to the other.
+        java.util.UUID accountA = java.util.UUID.randomUUID();
+        java.util.UUID accountB = java.util.UUID.randomUUID();
+        String sharedEmail = "billing@shared-corp.example";
+
+        service.send(new NotificationRequest(NotificationEventType.WALLET_LOW, sharedEmail, "+919000000001",
+                Map.of("balance", "900.00"), accountA));
+        List<NotificationLog> aRows = captureSaved();
+        assertThat(aRows).isNotEmpty();
+        assertThat(aRows).allSatisfy(r -> assertThat(r.getB2bAccountId()).isEqualTo(accountA));
+
+        // Account B's request carries B's id (not A's); a platform notification has no account → null.
+        assertThat(new NotificationRequest(NotificationEventType.WALLET_LOW, sharedEmail, null,
+                Map.of("balance", "1.00"), accountB).accountId()).isEqualTo(accountB);
+        assertThat(NotificationRequest.of(NotificationEventType.OTP_GENERATED, "x@y.com", null).accountId()).isNull();
+    }
 }

--- a/orders/src/test/java/com/oneday/orders/service/impl/WalletServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/WalletServiceImplTest.java
@@ -1,5 +1,9 @@
 package com.oneday.orders.service.impl;
 
+import com.oneday.common.port.NotificationPort;
+import com.oneday.common.port.dto.NotificationEventType;
+import com.oneday.common.port.dto.NotificationRequest;
+import com.oneday.orders.config.WalletProperties;
 import com.oneday.orders.domain.B2bAccount;
 import com.oneday.orders.domain.WalletRechargeOrder;
 import com.oneday.orders.dto.WalletResponse;
@@ -38,6 +42,8 @@ class WalletServiceImplTest {
     @Mock private WalletTransactionRepository ledger;
     @Mock private WalletRechargeOrderRepository rechargeOrders;
     @Mock private PaymentPort paymentPort;
+    @Mock private NotificationPort notificationPort;
+    private final WalletProperties walletProperties = new WalletProperties();   // threshold ₹1,000 default
 
     private static final UUID ACCOUNT = UUID.randomUUID();
     private static final String ORDER_ID = "order_abc";
@@ -45,7 +51,35 @@ class WalletServiceImplTest {
     private static final String SIG = "sig";
 
     private WalletServiceImpl service() {
-        return new WalletServiceImpl(accounts, ledger, rechargeOrders, paymentPort);
+        return new WalletServiceImpl(accounts, ledger, rechargeOrders, paymentPort,
+                notificationPort, walletProperties);
+    }
+
+    @Test
+    void debitCrossingBelowThreshold_alertsMerchantOnce() {
+        B2bAccount acc = new B2bAccount();
+        acc.setWalletBalancePaise(150_000L);        // ₹1,500 — above the ₹1,000 threshold
+        acc.setBillingEmail("merchant@acme.example");
+        acc.setSupportPhone("+919000000001");
+
+        service().debitForBooking(acc, 60_000L, "1DD-REF", UUID.randomUUID());   // → ₹900, below
+
+        ArgumentCaptor<NotificationRequest> req = ArgumentCaptor.forClass(NotificationRequest.class);
+        verify(notificationPort).send(req.capture());
+        assertThat(req.getValue().type()).isEqualTo(NotificationEventType.WALLET_LOW);
+        assertThat(req.getValue().recipientEmail()).isEqualTo("merchant@acme.example");
+        assertThat(req.getValue().params().get("balance")).isEqualTo("900.00");
+    }
+
+    @Test
+    void debitWhileAlreadyBelowThreshold_doesNotAlertAgain() {
+        B2bAccount acc = new B2bAccount();
+        acc.setWalletBalancePaise(90_000L);         // ₹900 — already below threshold
+        acc.setBillingEmail("merchant@acme.example");
+
+        service().debitForBooking(acc, 10_000L, "1DD-REF", UUID.randomUUID());   // → ₹800, still below
+
+        verify(notificationPort, never()).send(org.mockito.ArgumentMatchers.any());
     }
 
     @Test

--- a/orders/src/test/java/com/oneday/orders/service/impl/WalletServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/WalletServiceImplTest.java
@@ -58,6 +58,7 @@ class WalletServiceImplTest {
     @Test
     void debitCrossingBelowThreshold_alertsMerchantOnce() {
         B2bAccount acc = new B2bAccount();
+        org.springframework.test.util.ReflectionTestUtils.setField(acc, "id", ACCOUNT);
         acc.setWalletBalancePaise(150_000L);        // ₹1,500 — above the ₹1,000 threshold
         acc.setBillingEmail("merchant@acme.example");
         acc.setSupportPhone("+919000000001");
@@ -69,6 +70,8 @@ class WalletServiceImplTest {
         assertThat(req.getValue().type()).isEqualTo(NotificationEventType.WALLET_LOW);
         assertThat(req.getValue().recipientEmail()).isEqualTo("merchant@acme.example");
         assertThat(req.getValue().params().get("balance")).isEqualTo("900.00");
+        // Scoped to the account, so the in-app bell can't leak it to another account sharing a contact.
+        assertThat(req.getValue().accountId()).isEqualTo(ACCOUNT);
     }
 
     @Test


### PR DESCRIPTION

<img width="2918" height="798" alt="image" src="https://github.com/user-attachments/assets/902f1fed-a77e-446b-b581-4fe6fb7136f2" />


## Feature #7 — Merchant alerts (wallet-low)

The **first merchant alert built on the notification foundation** (#160). When a wallet-funded B2B booking debits a merchant's prepaid wallet **from at/above the low-balance threshold to below it**, the account owner is alerted to top up before bookings start failing.

### How
- New `WALLET_LOW` `NotificationEventType` + a template (email + SMS) in `NotificationTemplateResolverImpl`.
- Threshold is a global property `orders.wallet.low-balance-threshold-paise` (default **₹1,000**; `0` disables). No migration.
- Hooked at the **single choke point** `WalletServiceImpl.debitForBooking` — any wallet-debit caller is covered. Fires **only on the crossing** (balanceBefore ≥ threshold && balanceAfter < threshold), so a merchant gets **one nudge per low episode**, not one per debit while already low.
- Recipient: `B2bAccount.billingEmail` (nonnull) for email; `supportPhone` for SMS if the account has one.
- Enqueued via the notification outbox **inside the booking transaction**, so it commits atomically and a rolled-back booking never alerts; the scheduled drain delivers it (logged in dev, MSG91/SendGrid in prod).

### Deliberately out of scope (ponytail)
- **New-booking confirmation** — the merchant already gets the synchronous `BookingResponse`, and `BOOKED` isn't a milestone email, so a separate alert would be noise. Add if a merchant asks.
- **Card-expiry** — no stored cards (Razorpay), N/A.
- **Per-account threshold** + **alert preferences** — greenfield, not needed for v1 (always-send, matching the existing `Notifier`). Add a column/toggle when a merchant needs tuning/mute.

### Testing
`mvn test -pl orders -Dtest=WalletServiceImplTest` → **5 green** (2 new: crossing alerts once with the right recipient + rendered balance; a debit while already-below does not re-alert). Senders stay `log` by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added low prepaid-wallet balance notifications via email and SMS.
  * Alerts include the remaining balance and are sent when a debit crosses below the configured threshold.
  * Added a configurable low-balance threshold, defaulting to 100,000 paise.
  * Added an in-app endpoint showing up to 50 recent account notifications.
  * Notifications are associated with the relevant account for secure retrieval.
  * Added clearer payment guidance when wallet funds are insufficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->