### PR TITLE
Address CodeRabbit review on #158 (absence apply + custody scan)

### DIFF
--- a/dispatch/src/main/java/com/oneday/dispatch/api/AbsenceController.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/api/AbsenceController.java
@@ -50,11 +50,12 @@ public class AbsenceController {
     public List<DaRosterEntry> roster(@RequestParam(required = false) UUID cityId,
                                       @RequestParam(required = false)
                                       @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+                                      @RequestParam(required = false) com.oneday.common.domain.Shift shift,
                                       @AuthenticationPrincipal AuthUserDetails principal) {
         Authz.requireRole(principal, Authz.STATION_MANAGER);
         UUID scope = Authz.isAdmin(principal) ? cityId : managerCity(principal);
         LocalDate day = date != null ? date : LocalDate.now(ZoneId.of("Asia/Kolkata"));
-        return absenceService.roster(scope, day);
+        return absenceService.roster(scope, day, shift);
     }
 
     /** Preview (and stage as PENDING) the reassignment for the marked DAs. */

--- a/dispatch/src/main/java/com/oneday/dispatch/events/HubScanSeamProducer.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/events/HubScanSeamProducer.java
@@ -44,26 +44,28 @@ public class HubScanSeamProducer {
     }
 
     private void emit(UUID shipmentId, ScanEventType type) {
+        // Build the event NOW so occurredAt is the scan time, not the (possibly much later) commit time.
+        ScanEvent event = new ScanEvent(shipmentId, type);
         // Inside a transaction → publish only once it commits (a rollback must not leave a phantom scan);
         // outside one → publish now.
         if (TransactionSynchronizationManager.isSynchronizationActive()) {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
-                    publish(shipmentId, type);
+                    publish(event);
                 }
             });
         } else {
-            publish(shipmentId, type);
+            publish(event);
         }
     }
 
-    private void publish(UUID shipmentId, ScanEventType type) {
+    private void publish(ScanEvent event) {
         try {
-            eventPublisher.publish(EventStreams.SCAN_EVENTS, new ScanEvent(shipmentId, type));
+            eventPublisher.publish(EventStreams.SCAN_EVENTS, event);
         } catch (Exception e) {   // M8-SEAM: never block custody on a scan publish failure
             log.warn("M8-SEAM hub scan {} for shipment {} failed (non-blocking): {}",
-                    type, shipmentId, e.getMessage());
+                    event.eventType(), event.shipmentId(), e.getMessage());
         }
     }
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/events/HubScanSeamProducer.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/events/HubScanSeamProducer.java
@@ -7,6 +7,8 @@ import com.oneday.common.kafka.events.ScanEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.UUID;
 
@@ -15,6 +17,10 @@ import java.util.UUID;
  * the hub-custody scans that M8 (barcode) will own are emitted here on {@code oneday.scan.events} as a
  * bridge until M8 lands — the M8 owner relocates these into M8 proper. Every emit is best-effort: a
  * publish failure is logged and swallowed so it can never block the DA's custody flow.
+ *
+ * <p>When a caller emits from inside a transaction, the actual publish is deferred to AFTER_COMMIT so a
+ * later rollback never leaves the ledger describing a custody move that was never persisted (the seam
+ * has no transactional {@code RabbitTemplate}). Outside a transaction it publishes inline.</p>
  */
 @Component
 public class HubScanSeamProducer {
@@ -38,6 +44,21 @@ public class HubScanSeamProducer {
     }
 
     private void emit(UUID shipmentId, ScanEventType type) {
+        // Inside a transaction → publish only once it commits (a rollback must not leave a phantom scan);
+        // outside one → publish now.
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    publish(shipmentId, type);
+                }
+            });
+        } else {
+            publish(shipmentId, type);
+        }
+    }
+
+    private void publish(UUID shipmentId, ScanEventType type) {
         try {
             eventPublisher.publish(EventStreams.SCAN_EVENTS, new ScanEvent(shipmentId, type));
         } catch (Exception e) {   // M8-SEAM: never block custody on a scan publish failure

--- a/dispatch/src/main/java/com/oneday/dispatch/repository/DaStatusRepository.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/repository/DaStatusRepository.java
@@ -21,4 +21,15 @@ public interface DaStatusRepository extends JpaRepository<DaStatus, UUID> {
 
     /** All-city roster for a shift filtered by status (ADMIN, unscoped). */
     List<DaStatus> findByShiftDateAndStatusIn(LocalDate shiftDate, Collection<DaStatusEnum> statuses);
+
+    /** Every DA rostered to one shift on a date (any status) — the shift scope for an absence split. */
+    List<DaStatus> findByCityIdAndShiftDateAndShiftType(UUID cityId, LocalDate shiftDate, String shiftType);
+
+    /** City roster for one shift-type filtered by status (shift-scoped absence picker). */
+    List<DaStatus> findByCityIdAndShiftDateAndShiftTypeAndStatusIn(
+            UUID cityId, LocalDate shiftDate, String shiftType, Collection<DaStatusEnum> statuses);
+
+    /** All-city roster for one shift-type filtered by status (ADMIN, shift-scoped picker). */
+    List<DaStatus> findByShiftDateAndShiftTypeAndStatusIn(
+            LocalDate shiftDate, String shiftType, Collection<DaStatusEnum> statuses);
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/service/AbsenceReassignmentService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/AbsenceReassignmentService.java
@@ -19,8 +19,9 @@ public interface AbsenceReassignmentService {
     /**
      * The DAs on shift for the picker — every DA on the clock (any task type), not just those with
      * delivery scorecards. {@code scopeCityId} null = all cities (ADMIN), else a single city.
+     * {@code shift} null = both shifts on the date; else only that shift's DAs (the console filter).
      */
-    List<DaRosterEntry> roster(UUID scopeCityId, LocalDate date);
+    List<DaRosterEntry> roster(UUID scopeCityId, LocalDate date, com.oneday.common.domain.Shift shift);
 
     /** Compute + persist a PENDING plan for the given absent DAs and return it for the manager to review. */
     AbsencePreviewResponse preview(UUID cityId, List<UUID> daIds, String reason, UUID actorUserId);

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/AbsenceReassignmentServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/AbsenceReassignmentServiceImpl.java
@@ -118,18 +118,29 @@ class AbsenceReassignmentServiceImpl implements AbsenceReassignmentService {
     }
 
     /**
-     * The absent DAs' shift + its full DA roster for the date. A DA belongs to exactly one shift, so all
-     * the marked DAs must share one (a mixed selection is rejected). The returned id set scopes the M3
-     * split to this shift — without it the split would mix the day's other shift plan (same valid_date).
+     * The absent DAs' shift + its full DA roster for the date. Every requested DA must actually be
+     * rostered to <em>this</em> city and date (a foreign-city or wrong-date id is rejected), and all
+     * must share one shift (a DA belongs to exactly one; a mixed selection is rejected). The returned
+     * id set scopes the M3 split to that shift — without it the split would mix the day's other shift
+     * plan (same valid_date). {@code requireOnShift} additionally demands the DA be live on the clock —
+     * true for the manager's preview (they pick from the on-shift roster); false for apply, where an
+     * absent DA may already have dropped OFFLINE (that's the very thing being handled).
      */
-    private Set<UUID> resolveShiftScope(UUID cityId, List<UUID> absentDaIds, LocalDate date) {
+    private Set<UUID> resolveShiftScope(UUID cityId, List<UUID> absentDaIds, LocalDate date,
+                                        boolean requireOnShift) {
         String shiftType = null;
         for (UUID da : absentDaIds) {
             DaStatus st = daStatusRepository.findByDaId(da)
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.CONFLICT,
                             "DA " + da + " is not on shift for " + date));
-            if (st.getShiftType() == null) {
-                throw new ResponseStatusException(HttpStatus.CONFLICT, "DA " + da + " has no shift assigned");
+            // Must be rostered to THIS city + date + a shift — never trust a stale/foreign row.
+            if (!cityId.equals(st.getCityId()) || !date.equals(st.getShiftDate()) || st.getShiftType() == null) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT,
+                        "DA " + da + " is not on shift in this city for " + date);
+            }
+            if (requireOnShift && !ON_SHIFT.contains(st.getStatus())) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT,
+                        "DA " + da + " is not currently on the clock");
             }
             if (shiftType == null) {
                 shiftType = st.getShiftType();
@@ -138,17 +149,17 @@ class AbsenceReassignmentServiceImpl implements AbsenceReassignmentService {
                         "All absent DAs must be on the same shift (got " + shiftType + " and " + st.getShiftType() + ")");
             }
         }
-        Set<UUID> ids = daStatusRepository.findByCityIdAndShiftDateAndShiftType(cityId, date, shiftType)
+        // The roster for that shift IS the scope. Each validated absent DA is in it (same city+date+shift),
+        // so we never widen the scope past the actual roster.
+        return daStatusRepository.findByCityIdAndShiftDateAndShiftType(cityId, date, shiftType)
                 .stream().map(DaStatus::getDaId).collect(Collectors.toCollection(HashSet::new));
-        ids.addAll(absentDaIds);   // the absent DAs are always in scope, even if their row lags
-        return ids;
     }
 
     @Override
     @Transactional
     public AbsencePreviewResponse preview(UUID cityId, List<UUID> daIds, String reason, UUID actorUserId) {
         LocalDate date = today();
-        Set<UUID> inShiftDaIds = resolveShiftScope(cityId, daIds, date);
+        Set<UUID> inShiftDaIds = resolveShiftScope(cityId, daIds, date, true);
         AbsenceReassignmentPlan plan = gridService.planAbsenceReassignment(cityId, daIds, date, inShiftDaIds);
 
         List<ReceiverLoad> receivers = plan.reassignments().stream()
@@ -243,8 +254,9 @@ class AbsenceReassignmentServiceImpl implements AbsenceReassignmentService {
         UUID reviewer = system ? null : actorUserId;
 
         // 1) Commit the M3 territory split (writes + approves the INTRADAY_OVERRIDE), scoped to the
-        //    absent DAs' shift so the day's other shift plan (same valid_date) never leaks in.
-        Set<UUID> inShiftDaIds = resolveShiftScope(cityId, daIds, date);
+        //    absent DAs' shift so the day's other shift plan (same valid_date) never leaks in. Not
+        //    requireOnShift: by apply time an absent DA may already have gone OFFLINE — expected.
+        Set<UUID> inShiftDaIds = resolveShiftScope(cityId, daIds, date, false);
         AbsenceReassignmentPlan plan = gridService.applyAbsenceReassignment(cityId, daIds, date, inShiftDaIds, reviewer);
 
         // 2) Make every task follow its hex to the new owner.

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/AbsenceReassignmentServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/AbsenceReassignmentServiceImpl.java
@@ -1,8 +1,10 @@
 package com.oneday.dispatch.service.impl;
 
 import com.oneday.dispatch.config.DispatchProperties;
+import com.oneday.common.domain.Shift;
 import com.oneday.common.port.DaDirectoryPort;
 import com.oneday.dispatch.domain.AbsenceStatus;
+import com.oneday.dispatch.domain.DaStatus;
 import com.oneday.dispatch.domain.DaAbsenceEvent;
 import com.oneday.dispatch.domain.DaStatusEnum;
 import com.oneday.dispatch.domain.DispatchQueue;
@@ -91,10 +93,18 @@ class AbsenceReassignmentServiceImpl implements AbsenceReassignmentService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<DaRosterEntry> roster(UUID scopeCityId, LocalDate date) {
-        List<com.oneday.dispatch.domain.DaStatus> onShift = scopeCityId == null
-                ? daStatusRepository.findByShiftDateAndStatusIn(date, ON_SHIFT)
-                : daStatusRepository.findByCityIdAndShiftDateAndStatusIn(scopeCityId, date, ON_SHIFT);
+    public List<DaRosterEntry> roster(UUID scopeCityId, LocalDate date, Shift shift) {
+        String shiftType = shift != null ? shift.name() : null;
+        List<com.oneday.dispatch.domain.DaStatus> onShift;
+        if (shiftType != null) {
+            onShift = scopeCityId == null
+                    ? daStatusRepository.findByShiftDateAndShiftTypeAndStatusIn(date, shiftType, ON_SHIFT)
+                    : daStatusRepository.findByCityIdAndShiftDateAndShiftTypeAndStatusIn(scopeCityId, date, shiftType, ON_SHIFT);
+        } else {
+            onShift = scopeCityId == null
+                    ? daStatusRepository.findByShiftDateAndStatusIn(date, ON_SHIFT)
+                    : daStatusRepository.findByCityIdAndShiftDateAndStatusIn(scopeCityId, date, ON_SHIFT);
+        }
         List<UUID> daIds = onShift.stream().map(com.oneday.dispatch.domain.DaStatus::getDaId).toList();
         Map<UUID, DaDirectoryPort.DaContact> names = daDirectory.contactsFor(daIds);
         return daIds.stream()
@@ -107,11 +117,39 @@ class AbsenceReassignmentServiceImpl implements AbsenceReassignmentService {
                 .toList();
     }
 
+    /**
+     * The absent DAs' shift + its full DA roster for the date. A DA belongs to exactly one shift, so all
+     * the marked DAs must share one (a mixed selection is rejected). The returned id set scopes the M3
+     * split to this shift — without it the split would mix the day's other shift plan (same valid_date).
+     */
+    private Set<UUID> resolveShiftScope(UUID cityId, List<UUID> absentDaIds, LocalDate date) {
+        String shiftType = null;
+        for (UUID da : absentDaIds) {
+            DaStatus st = daStatusRepository.findByDaId(da)
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.CONFLICT,
+                            "DA " + da + " is not on shift for " + date));
+            if (st.getShiftType() == null) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT, "DA " + da + " has no shift assigned");
+            }
+            if (shiftType == null) {
+                shiftType = st.getShiftType();
+            } else if (!shiftType.equals(st.getShiftType())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "All absent DAs must be on the same shift (got " + shiftType + " and " + st.getShiftType() + ")");
+            }
+        }
+        Set<UUID> ids = daStatusRepository.findByCityIdAndShiftDateAndShiftType(cityId, date, shiftType)
+                .stream().map(DaStatus::getDaId).collect(Collectors.toCollection(HashSet::new));
+        ids.addAll(absentDaIds);   // the absent DAs are always in scope, even if their row lags
+        return ids;
+    }
+
     @Override
     @Transactional
     public AbsencePreviewResponse preview(UUID cityId, List<UUID> daIds, String reason, UUID actorUserId) {
         LocalDate date = today();
-        AbsenceReassignmentPlan plan = gridService.planAbsenceReassignment(cityId, daIds, date);
+        Set<UUID> inShiftDaIds = resolveShiftScope(cityId, daIds, date);
+        AbsenceReassignmentPlan plan = gridService.planAbsenceReassignment(cityId, daIds, date, inShiftDaIds);
 
         List<ReceiverLoad> receivers = plan.reassignments().stream()
                 .collect(Collectors.groupingBy(HexReassignment::toDaId, Collectors.counting()))
@@ -204,8 +242,10 @@ class AbsenceReassignmentServiceImpl implements AbsenceReassignmentService {
         List<UUID> daIds = event.absentDaIdList();
         UUID reviewer = system ? null : actorUserId;
 
-        // 1) Commit the M3 territory split (writes + approves the INTRADAY_OVERRIDE).
-        AbsenceReassignmentPlan plan = gridService.applyAbsenceReassignment(cityId, daIds, date, reviewer);
+        // 1) Commit the M3 territory split (writes + approves the INTRADAY_OVERRIDE), scoped to the
+        //    absent DAs' shift so the day's other shift plan (same valid_date) never leaks in.
+        Set<UUID> inShiftDaIds = resolveShiftScope(cityId, daIds, date);
+        AbsenceReassignmentPlan plan = gridService.applyAbsenceReassignment(cityId, daIds, date, inShiftDaIds, reviewer);
 
         // 2) Make every task follow its hex to the new owner.
         int moved = 0;

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaTaskServiceImpl.java
@@ -286,13 +286,17 @@ class DaTaskServiceImpl implements DaTaskService {
             DispatchQueue task = ownedTask(daId, taskId);
             requireType(task, TaskType.CUSTODY_COLLECT);
             requireCollectable(task);
+            requireScanMatchesShipment(task, parcelScans);   // the scan must be THIS parcel's label
             task.setStatus(TaskStatus.COMPLETED);
             if (task.getStartedAt() == null) {
                 task.setStartedAt(Instant.now());
             }
             task.setCompletedAt(Instant.now());
             DaTaskView view = save(task);
-            // M8-SEAM: append-only DA→DA custody scan — the source of truth that custody moved. Best-effort.
+            // M8-SEAM (best-effort): append the DA→DA custody scan to the ledger. The authoritative record
+            // that custody moved is the committed dispatch_queue transition above (this task COMPLETED +
+            // the onward leg) — the scan is a ledger bridge until M8 owns it, so a publish hiccup must
+            // never block the hand-off.
             hubScanSeamProducer.emitDaCustodyTransfer(task.getShipmentId());
             daEventProducer.emitCustodyCollected(daId, task.getCityId(), task.getShipmentId(),
                     task.getCollectFromDaId());
@@ -448,6 +452,24 @@ class DaTaskServiceImpl implements DaTaskService {
         if (task.getStatus() != TaskStatus.QUEUED && task.getStatus() != TaskStatus.IN_PROGRESS) {
             throw new ResponseStatusException(HttpStatus.CONFLICT,
                     "Task " + task.getId() + " is " + task.getStatus() + " and cannot be failed");
+        }
+    }
+
+    /**
+     * The custody hand-off must prove the right parcel was taken: at least one scan must be this
+     * shipment's label barcode (== its ref; v1 parcelId == shipmentId). Guards against a DA completing
+     * a custody transfer with a junk scan. Skipped only when the shipment has no ref to check against.
+     */
+    private void requireScanMatchesShipment(DispatchQueue task, List<String> parcelScans) {
+        String ref = shipmentRefPort.refsFor(List.of(task.getShipmentId())).get(task.getShipmentId());
+        if (ref == null) {
+            return;   // no barcode/ref to validate against — the non-empty cardinality guard still applied
+        }
+        boolean matched = parcelScans.stream()
+                .anyMatch(s -> s != null && s.trim().equalsIgnoreCase(ref.trim()));
+        if (!matched) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "Scanned parcel does not match this task's shipment " + ref);
         }
     }
 

--- a/dispatch/src/test/java/com/oneday/dispatch/events/HubScanSeamProducerTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/events/HubScanSeamProducerTest.java
@@ -1,0 +1,82 @@
+package com.oneday.dispatch.events;
+
+import com.oneday.common.kafka.EventPublisher;
+import com.oneday.common.kafka.EventStreams;
+import com.oneday.common.kafka.enums.ScanEventType;
+import com.oneday.common.kafka.events.ScanEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class HubScanSeamProducerTest {
+
+    @AfterEach
+    void tearDown() {
+        // Leave no synchronization bound if a test opened one (a failed assertion could skip cleanup).
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
+
+    @Test
+    void publishesInlineWhenNoTransactionIsActive() {
+        EventPublisher publisher = mock(EventPublisher.class);
+        HubScanSeamProducer producer = new HubScanSeamProducer(publisher);
+        UUID shipment = UUID.randomUUID();
+
+        producer.emitDaCustodyTransfer(shipment);
+
+        ArgumentCaptor<ScanEvent> captor = ArgumentCaptor.forClass(ScanEvent.class);
+        verify(publisher).publish(eq(EventStreams.SCAN_EVENTS), captor.capture());
+        assertThat(captor.getValue().eventType()).isEqualTo(ScanEventType.DA_CUSTODY_TRANSFER);
+        assertThat(captor.getValue().shipmentId()).isEqualTo(shipment);
+    }
+
+    @Test
+    void defersPublishUntilCommitWhenInsideATransaction() {
+        EventPublisher publisher = mock(EventPublisher.class);
+        HubScanSeamProducer producer = new HubScanSeamProducer(publisher);
+
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            producer.emitDaCustodyTransfer(UUID.randomUUID());
+            // Nothing published while the transaction is still open.
+            verify(publisher, never()).publish(any(), any());
+            // Simulate commit.
+            for (TransactionSynchronization s : TransactionSynchronizationManager.getSynchronizations()) {
+                s.afterCommit();
+            }
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+
+        verify(publisher).publish(eq(EventStreams.SCAN_EVENTS), any(ScanEvent.class));
+    }
+
+    @Test
+    void neverPublishesWhenTheTransactionRollsBack() {
+        EventPublisher publisher = mock(EventPublisher.class);
+        HubScanSeamProducer producer = new HubScanSeamProducer(publisher);
+
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            producer.emitDaCustodyTransfer(UUID.randomUUID());
+            // Rollback: afterCommit is never invoked, synchronizations are simply discarded.
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+
+        verify(publisher, never()).publish(any(), any());
+    }
+}

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/AbsenceReassignmentServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/AbsenceReassignmentServiceImplTest.java
@@ -223,6 +223,22 @@ class AbsenceReassignmentServiceImplTest {
         verify(gridService, never()).applyAbsenceReassignment(any(), any(), any(), any(), any());
     }
 
+    @Test
+    void previewRejectsADaThatIsNotOnThisCitysShift() {
+        DaStatus foreign = new DaStatus();
+        foreign.setDaId(RAVI);
+        foreign.setCityId(UUID.randomUUID());   // a different city's roster
+        foreign.setShiftDate(LocalDate.now(java.time.ZoneId.of("Asia/Kolkata")));
+        foreign.setShiftType("SHIFT_2");
+        foreign.setStatus(DaStatusEnum.IDLE);
+        when(daStatusRepository.findByDaId(RAVI)).thenReturn(Optional.of(foreign));
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> service.preview(CITY, List.of(RAVI), "sick", UUID.randomUUID()))
+                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
+        verify(gridService, never()).planAbsenceReassignment(any(), any(), any(), any());
+    }
+
     private DaAbsenceEvent pendingEvent() {
         DaAbsenceEvent event = new DaAbsenceEvent() {
             private final UUID id = UUID.randomUUID();
@@ -238,7 +254,10 @@ class AbsenceReassignmentServiceImplTest {
     private void stubShiftScope() {
         DaStatus st = new DaStatus();
         st.setDaId(RAVI);
+        st.setCityId(CITY);
+        st.setShiftDate(LocalDate.now(java.time.ZoneId.of("Asia/Kolkata")));   // must match service today()
         st.setShiftType("SHIFT_2");
+        st.setStatus(DaStatusEnum.IDLE);                                        // on the clock (preview path)
         when(daStatusRepository.findByDaId(RAVI)).thenReturn(Optional.of(st));
         when(daStatusRepository.findByCityIdAndShiftDateAndShiftType(eq(CITY), any(), eq("SHIFT_2")))
                 .thenReturn(List.of(st));

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/AbsenceReassignmentServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/AbsenceReassignmentServiceImplTest.java
@@ -3,6 +3,7 @@ package com.oneday.dispatch.service.impl;
 import com.oneday.dispatch.config.DispatchProperties;
 import com.oneday.dispatch.domain.AbsenceStatus;
 import com.oneday.dispatch.domain.DaAbsenceEvent;
+import com.oneday.dispatch.domain.DaStatus;
 import com.oneday.dispatch.domain.DaStatusEnum;
 import com.oneday.dispatch.domain.DispatchQueue;
 import com.oneday.dispatch.domain.TaskStatus;
@@ -84,7 +85,8 @@ class AbsenceReassignmentServiceImplTest {
 
     @Test
     void previewSplitsTasksIntoLooseCustodyAndOrphanBuckets() {
-        when(gridService.planAbsenceReassignment(eq(CITY), eq(List.of(RAVI)), any()))
+        stubShiftScope();
+        when(gridService.planAbsenceReassignment(eq(CITY), eq(List.of(RAVI)), any(), any()))
                 .thenReturn(planWithTileAToMeena());
         when(queueRepository.findByDaIdAndOperatingDateAndStatusIn(eq(RAVI), any(), any()))
                 .thenReturn(List.of(
@@ -109,9 +111,10 @@ class AbsenceReassignmentServiceImplTest {
 
     @Test
     void applyMovesLooseTaskToNewOwnerAsQueuedNeverDeferred() {
+        stubShiftScope();
         DaAbsenceEvent event = pendingEvent();
         when(absenceRepository.findById(event.getId())).thenReturn(Optional.of(event));
-        when(gridService.applyAbsenceReassignment(eq(CITY), eq(List.of(RAVI)), any(), any()))
+        when(gridService.applyAbsenceReassignment(eq(CITY), eq(List.of(RAVI)), any(), any(), any()))
                 .thenReturn(planWithTileAToMeena());
         DispatchQueue loose = row(TILE_A, TaskStatus.QUEUED, TaskType.DELIVERY);
         when(queueRepository.findByDaIdAndOperatingDateAndStatusIn(eq(RAVI), any(), any()))
@@ -138,9 +141,10 @@ class AbsenceReassignmentServiceImplTest {
 
     @Test
     void applyCreatesCustodyCollectForInProgressParcel() {
+        stubShiftScope();
         DaAbsenceEvent event = pendingEvent();
         when(absenceRepository.findById(event.getId())).thenReturn(Optional.of(event));
-        when(gridService.applyAbsenceReassignment(eq(CITY), eq(List.of(RAVI)), any(), any()))
+        when(gridService.applyAbsenceReassignment(eq(CITY), eq(List.of(RAVI)), any(), any(), any()))
                 .thenReturn(planWithTileAToMeena());
         when(queueRepository.findByDaIdAndOperatingDateAndStatusIn(eq(RAVI), any(), any()))
                 .thenReturn(List.of(row(TILE_A, TaskStatus.IN_PROGRESS, TaskType.DELIVERY)));
@@ -162,9 +166,10 @@ class AbsenceReassignmentServiceImplTest {
 
     @Test
     void applyTakesAbsentDaOfflineAndMarksApplied() {
+        stubShiftScope();
         DaAbsenceEvent event = pendingEvent();
         when(absenceRepository.findById(event.getId())).thenReturn(Optional.of(event));
-        when(gridService.applyAbsenceReassignment(any(), any(), any(), any()))
+        when(gridService.applyAbsenceReassignment(any(), any(), any(), any(), any()))
                 .thenReturn(planWithTileAToMeena());
         when(queueRepository.findByDaIdAndOperatingDateAndStatusIn(any(), any(), any()))
                 .thenReturn(List.of());
@@ -180,9 +185,10 @@ class AbsenceReassignmentServiceImplTest {
 
     @Test
     void autoApplyMarksAutoApplied() {
+        stubShiftScope();
         DaAbsenceEvent event = pendingEvent();
         when(absenceRepository.findById(event.getId())).thenReturn(Optional.of(event));
-        when(gridService.applyAbsenceReassignment(any(), any(), any(), any()))
+        when(gridService.applyAbsenceReassignment(any(), any(), any(), any(), any()))
                 .thenReturn(planWithTileAToMeena());
         when(queueRepository.findByDaIdAndOperatingDateAndStatusIn(any(), any(), any()))
                 .thenReturn(List.of());
@@ -202,7 +208,7 @@ class AbsenceReassignmentServiceImplTest {
         org.assertj.core.api.Assertions.assertThatThrownBy(
                         () -> service.apply(event.getId(), UUID.randomUUID(), otherCity))
                 .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
-        verify(gridService, never()).applyAbsenceReassignment(any(), any(), any(), any());
+        verify(gridService, never()).applyAbsenceReassignment(any(), any(), any(), any(), any());
     }
 
     @Test
@@ -214,7 +220,7 @@ class AbsenceReassignmentServiceImplTest {
         AbsenceApplyResponse res = service.apply(event.getId(), UUID.randomUUID(), null);
 
         assertThat(res.status()).isEqualTo(AbsenceStatus.APPLIED);
-        verify(gridService, never()).applyAbsenceReassignment(any(), any(), any(), any());
+        verify(gridService, never()).applyAbsenceReassignment(any(), any(), any(), any(), any());
     }
 
     private DaAbsenceEvent pendingEvent() {
@@ -227,6 +233,15 @@ class AbsenceReassignmentServiceImplTest {
         event.setAbsentDaIdList(List.of(RAVI));
         event.setStatus(AbsenceStatus.PENDING);
         return event;
+    }
+
+    private void stubShiftScope() {
+        DaStatus st = new DaStatus();
+        st.setDaId(RAVI);
+        st.setShiftType("SHIFT_2");
+        when(daStatusRepository.findByDaId(RAVI)).thenReturn(Optional.of(st));
+        when(daStatusRepository.findByCityIdAndShiftDateAndShiftType(eq(CITY), any(), eq("SHIFT_2")))
+                .thenReturn(List.of(st));
     }
 
     @SuppressWarnings("unchecked")

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/AbsenceReassignmentServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/AbsenceReassignmentServiceImplTest.java
@@ -245,7 +245,9 @@ class AbsenceReassignmentServiceImplTest {
             @Override public UUID getId() { return id; }
         };
         event.setCityId(CITY);
-        event.setOperatingDate(LocalDate.now());
+        // IST, to match the service's today() (Asia/Kolkata) and the da_status shiftDate stub — otherwise
+        // a UTC CI runner near IST-midnight lands a day earlier and the roster date-check rejects it.
+        event.setOperatingDate(LocalDate.now(java.time.ZoneId.of("Asia/Kolkata")));
         event.setAbsentDaIdList(List.of(RAVI));
         event.setStatus(AbsenceStatus.PENDING);
         return event;

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaTaskServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaTaskServiceImplTest.java
@@ -59,6 +59,8 @@ class DaTaskServiceImplTest {
     private com.oneday.dispatch.events.HubScanSeamProducer scanSeam;
     private CityMeetingModePort meetingModePort;
     private DaTaskService service;
+    // Shipment ref lookup the custody-scan validation reads; empty by default (validation skipped).
+    private final java.util.Map<UUID, String> refs = new java.util.HashMap<>();
 
     @BeforeEach
     void setUp() {
@@ -71,8 +73,9 @@ class DaTaskServiceImplTest {
         meetingModePort = mock(CityMeetingModePort.class);
         // This test's city is a HUB_RETURN city (hub-handoff/collect paths exercised below).
         when(meetingModePort.modeFor(any())).thenReturn(MeetingMode.HUB_RETURN);
+        refs.clear();
         service = new DaTaskServiceImpl(queueRepo, cronRepo, daStatus, events, props, scanSeam,
-                ids -> java.util.Map.of(), ids -> java.util.Map.of(), reorder, meetingModePort);
+                ids -> refs, ids -> java.util.Map.of(), reorder, meetingModePort);
     }
 
     @Test
@@ -335,6 +338,20 @@ class DaTaskServiceImplTest {
         assertThatThrownBy(() -> service.recordCustodyCollect(da, task.getId(), List.of("P-1")))
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("409");
+    }
+
+    @Test
+    void custodyCollectRejectsAScanThatIsNotThisParcel() {
+        DispatchQueue collect = persistCustody(TaskType.DELIVERY, UUID.randomUUID(), 28.70, 77.10);
+        refs.put(collect.getShipmentId(), "1DD-DEL-20260826-00042");   // this parcel's real label barcode
+        // A junk / wrong-parcel scan is rejected (422) and custody is NOT completed.
+        assertThatThrownBy(() -> service.recordCustodyCollect(da, collect.getId(), List.of("SOME-OTHER-CODE")))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("422");
+        assertThat(reload(collect).getStatus()).isEqualTo(TaskStatus.QUEUED);
+        // The correct barcode (matching the shipment ref, case-insensitive) completes it.
+        service.recordCustodyCollect(da, collect.getId(), List.of("1dd-del-20260826-00042"));
+        assertThat(reload(collect).getStatus()).isEqualTo(TaskStatus.COMPLETED);
     }
 
     @Test

--- a/grid/src/main/java/com/oneday/grid/service/GridService.java
+++ b/grid/src/main/java/com/oneday/grid/service/GridService.java
@@ -12,6 +12,7 @@ import com.oneday.grid.dto.response.TileDetailResponse;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 public interface GridService {
@@ -51,9 +52,11 @@ public interface GridService {
 
     // Midday DA absence (M5-triggered): split the absent DAs' hexes among their territory-neighbors.
     // plan* is compute-only (preview); apply* writes + approves the INTRADAY_OVERRIDE and returns the
-    // committed split so M5 can move the matching tasks.
-    AbsenceReassignmentPlan planAbsenceReassignment(UUID cityId, List<UUID> absentDaIds, LocalDate date);
+    // committed split so M5 can move the matching tasks. {@code inShiftDaIds} is the absent DA's shift
+    // roster — the split is scoped to it so the other shift's same-date plan doesn't leak in.
+    AbsenceReassignmentPlan planAbsenceReassignment(UUID cityId, List<UUID> absentDaIds, LocalDate date,
+                                                    Set<UUID> inShiftDaIds);
 
     AbsenceReassignmentPlan applyAbsenceReassignment(UUID cityId, List<UUID> absentDaIds, LocalDate date,
-                                                     UUID reviewerId);
+                                                     Set<UUID> inShiftDaIds, UUID reviewerId);
 }

--- a/grid/src/main/java/com/oneday/grid/service/impl/AbsenceReassignmentPlanner.java
+++ b/grid/src/main/java/com/oneday/grid/service/impl/AbsenceReassignmentPlanner.java
@@ -79,6 +79,17 @@ class AbsenceReassignmentPlanner {
      * no path to any live DA (an isolated pocket) is left an orphan.
      */
     AbsenceReassignmentPlan plan(UUID cityId, List<UUID> absentDaIds, LocalDate date) {
+        return plan(cityId, absentDaIds, date, null);
+    }
+
+    /**
+     * As {@link #plan(UUID, List, LocalDate)}, but scoped to a single shift: {@code inShiftDaIds} is the
+     * set of DAs rostered to the absent DA's shift for the date. A day carries one APPROVED plan per
+     * shift on the same {@code valid_date}, so without this the split would mix shifts — attributing a
+     * hex to the other shift's DA (whichever row loads first) or handing an absent DA's territory to a
+     * DA who isn't on the clock. {@code null} keeps the legacy (unscoped) behaviour.
+     */
+    AbsenceReassignmentPlan plan(UUID cityId, List<UUID> absentDaIds, LocalDate date, Set<UUID> inShiftDaIds) {
         Set<UUID> absent = new HashSet<>(absentDaIds);
         Grid grid = gridRepository.findByCityId(cityId)
                 .orElseThrow(() -> new IllegalArgumentException("Grid not found for city: " + cityId));
@@ -87,9 +98,13 @@ class AbsenceReassignmentPlanner {
         Set<UUID> gridHexIds = hexes.stream().map(Hex::getId).collect(Collectors.toSet());
         Map<UUID, List<UUID>> adjacency = geometricAdjacency(hexes);
 
-        // Current standing plan for the date, scoped to this city's hexes.
+        // Current standing plan for the date, scoped to this city's hexes and — when given — to the
+        // absent DA's shift, so the other shift's same-date assignments don't leak into the split.
         List<DaHexAssignment> approved = assignmentRepository.findByValidDateAndStatus(date, AssignmentStatus.APPROVED)
-                .stream().filter(a -> gridHexIds.contains(a.getHexId())).toList();
+                .stream()
+                .filter(a -> gridHexIds.contains(a.getHexId()))
+                .filter(a -> inShiftDaIds == null || inShiftDaIds.contains(a.getDaId()) || absent.contains(a.getDaId()))
+                .toList();
 
         // Live ownership (hex → a live DA) grows as hexes are claimed; load is the balancing counter.
         Map<UUID, UUID> owner = new HashMap<>();
@@ -177,7 +192,14 @@ class AbsenceReassignmentPlanner {
      */
     @Transactional
     AbsenceReassignmentPlan apply(UUID cityId, List<UUID> absentDaIds, LocalDate date, UUID reviewerId) {
-        AbsenceReassignmentPlan plan = plan(cityId, absentDaIds, date);
+        return apply(cityId, absentDaIds, date, null, reviewerId);
+    }
+
+    /** Shift-scoped apply — see {@link #plan(UUID, List, LocalDate, Set)} for what {@code inShiftDaIds} does. */
+    @Transactional
+    AbsenceReassignmentPlan apply(UUID cityId, List<UUID> absentDaIds, LocalDate date,
+                                  Set<UUID> inShiftDaIds, UUID reviewerId) {
+        AbsenceReassignmentPlan plan = plan(cityId, absentDaIds, date, inShiftDaIds);
         Set<UUID> absent = new HashSet<>(absentDaIds);
         Instant now = Instant.now();
 

--- a/grid/src/main/java/com/oneday/grid/service/impl/AbsenceReassignmentPlanner.java
+++ b/grid/src/main/java/com/oneday/grid/service/impl/AbsenceReassignmentPlanner.java
@@ -200,6 +200,10 @@ class AbsenceReassignmentPlanner {
         int covered = plan.reassignments().size();
         int total = covered + plan.orphanHexIds().size();
         double coveragePct = total == 0 ? 100.0 : (100.0 * covered / total);
+        // Record the orphan (uncovered) hexes on the proposal so reports/UI don't read "[]" as full coverage.
+        String understaffed = plan.orphanHexIds().isEmpty() ? "[]"
+                : plan.orphanHexIds().stream().map(id -> "\"" + id + "\"")
+                        .collect(Collectors.joining(",", "[", "]"));
 
         AssignmentProposal proposal = proposalRepository.save(AssignmentProposal.builder()
                 .cityId(cityId)
@@ -210,36 +214,42 @@ class AbsenceReassignmentPlanner {
                 .adjacencySource(AdjacencySource.GEOMETRIC_FALLBACK)
                 .totalDas(receivers.size())
                 .coveragePct(coveragePct)
-                .understaffedHexIds("[]")
+                .understaffedHexIds(understaffed)
                 .build());
 
-        // Append ONLY the gained hexes to each receiver, as new APPROVED rows. The receiver keeps its
-        // retained hexes through its existing APPROVED rows — leave those untouched. Re-inserting a
-        // retained hex would violate the (da_id, hex_id, valid_date) uniqueness (supersede only flips
-        // status, it does not free the slot), which is the whole reason we don't rewrite the full set.
-        // Only the absent DA's rows are superseded (done above), so their hexes move cleanly to the
-        // new owner: (receiver, gainedHex, date) is a brand-new key.
-        List<DaHexAssignment> newRows = new ArrayList<>();
+        // Give each receiver ONLY the gained hexes (the absent DA's hexes, superseded above); the
+        // receiver keeps its retained hexes through its own untouched APPROVED rows. The (da_id, hex_id,
+        // valid_date) key is unique regardless of status, so we must not blindly INSERT: a hex the
+        // receiver already holds APPROVED is a no-op, and a hex it holds SUPERSEDED (from an earlier
+        // same-day absence that bounced this hex away and back) is REACTIVATED in place — inserting a
+        // second row for that key would be rejected and roll the whole apply back.
+        List<DaHexAssignment> toSave = new ArrayList<>();
         for (UUID receiver : receivers) {
-            Set<UUID> alreadyOwned = approvedRows(receiver, date).stream()
-                    .map(DaHexAssignment::getHexId).collect(Collectors.toSet());
+            Map<UUID, DaHexAssignment> existingByHex = assignmentRepository.findByDaIdAndValidDate(receiver, date)
+                    .stream().collect(Collectors.toMap(DaHexAssignment::getHexId, a -> a, (a, b) -> a));
             for (UUID hex : new LinkedHashSet<>(gainedByReceiver.get(receiver))) {
-                if (alreadyOwned.contains(hex)) {
-                    continue;   // defensive: never double-insert a hex the receiver already holds
+                DaHexAssignment existing = existingByHex.get(hex);
+                if (existing == null) {
+                    toSave.add(DaHexAssignment.builder()
+                            .proposalId(proposal.getId())
+                            .daId(receiver)
+                            .hexId(hex)
+                            .validDate(date)
+                            .nDasOnHex(1)
+                            .status(AssignmentStatus.APPROVED)
+                            .approvedBy(reviewerId)
+                            .approvedAt(now)
+                            .build());
+                } else if (existing.getStatus() != AssignmentStatus.APPROVED) {
+                    existing.setStatus(AssignmentStatus.APPROVED);   // reactivate the slot in place
+                    existing.setApprovedBy(reviewerId);
+                    existing.setApprovedAt(now);
+                    toSave.add(existing);
                 }
-                newRows.add(DaHexAssignment.builder()
-                        .proposalId(proposal.getId())
-                        .daId(receiver)
-                        .hexId(hex)
-                        .validDate(date)
-                        .nDasOnHex(1)
-                        .status(AssignmentStatus.APPROVED)
-                        .approvedBy(reviewerId)
-                        .approvedAt(now)
-                        .build());
+                // else already APPROVED → the receiver already holds this hex, nothing to do.
             }
         }
-        assignmentRepository.saveAll(newRows);
+        assignmentRepository.saveAll(toSave);
 
         proposal.setStatus(ProposalStatus.APPROVED);
         proposal.setReviewedBy(reviewerId);

--- a/grid/src/main/java/com/oneday/grid/service/impl/GridServiceImpl.java
+++ b/grid/src/main/java/com/oneday/grid/service/impl/GridServiceImpl.java
@@ -95,14 +95,15 @@ public class GridServiceImpl implements GridService {
     }
 
     @Override
-    public AbsenceReassignmentPlan planAbsenceReassignment(UUID cityId, List<UUID> absentDaIds, LocalDate date) {
-        return absencePlanner.plan(cityId, absentDaIds, date);
+    public AbsenceReassignmentPlan planAbsenceReassignment(UUID cityId, List<UUID> absentDaIds, LocalDate date,
+                                                           Set<UUID> inShiftDaIds) {
+        return absencePlanner.plan(cityId, absentDaIds, date, inShiftDaIds);
     }
 
     @Override
     public AbsenceReassignmentPlan applyAbsenceReassignment(UUID cityId, List<UUID> absentDaIds, LocalDate date,
-                                                            UUID reviewerId) {
-        return absencePlanner.apply(cityId, absentDaIds, date, reviewerId);
+                                                            Set<UUID> inShiftDaIds, UUID reviewerId) {
+        return absencePlanner.apply(cityId, absentDaIds, date, inShiftDaIds, reviewerId);
     }
 
     @Override

--- a/grid/src/test/java/com/oneday/grid/service/impl/AbsenceReassignmentPlannerTest.java
+++ b/grid/src/test/java/com/oneday/grid/service/impl/AbsenceReassignmentPlannerTest.java
@@ -49,6 +49,7 @@ class AbsenceReassignmentPlannerTest {
     private static final UUID RAVI = UUID.fromString("00000000-0000-0000-0000-0000000000aa");
     private static final UUID MEENA = UUID.fromString("00000000-0000-0000-0000-0000000000bb");
     private static final UUID SUNIL = UUID.fromString("00000000-0000-0000-0000-0000000000cc");
+    private static final UUID NIGHT_S1 = UUID.fromString("00000000-0000-0000-0000-0000000000dd");
 
     @Mock private DaHexAssignmentRepository assignmentRepository;
     @Mock private AssignmentProposalRepository proposalRepository;
@@ -263,6 +264,51 @@ class AbsenceReassignmentPlannerTest {
     }
 
     // ── fixtures ────────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    void scopesTheSplitToTheAbsentDasShiftIgnoringTheOtherShiftsSameDatePlan() {
+        // A day carries two APPROVED plans on the same valid_date: SHIFT_2 (Ravi + Meena) and SHIFT_1
+        // (Night). Ravi (S2) owns a 7-hex blob; Meena (S2) owns the full surrounding ring; Night (S1)
+        // owns those very same ring cells for its own shift. A SHIFT_2 absence must land entirely on the
+        // SHIFT_2 neighbor (Meena) and never hand territory to the off-shift Night.
+        long center = h3.latLngToCell(28.6139, 77.2090, RES);
+        List<Long> blob = h3.gridDisk(center, 1);
+        List<Long> ring2 = subtract(h3.gridDisk(center, 2), blob);
+
+        hexIdByH3.clear();
+        List<Hex> hexes = new ArrayList<>();
+        for (Long h : blob) { registerHex(h, hexes); }
+        for (Long h : ring2) { registerHex(h, hexes); }
+        when(hexRepository.findByH3GridIdAndActiveTrue(any())).thenReturn(hexes);
+
+        List<DaHexAssignment> rows = new ArrayList<>();
+        blob.forEach(h -> rows.add(approvedRow(RAVI, h)));
+        ring2.forEach(h -> rows.add(approvedRow(MEENA, h)));      // SHIFT_2 ring
+        ring2.forEach(h -> rows.add(approvedRow(NIGHT_S1, h)));   // SHIFT_1 ring — same cells, other shift
+        when(assignmentRepository.findByValidDateAndStatus(DATE, AssignmentStatus.APPROVED)).thenReturn(rows);
+
+        // Scope = the SHIFT_2 roster only (Ravi + Meena); Night is on SHIFT_1.
+        AbsenceReassignmentPlan plan = planner.plan(CITY, List.of(RAVI), DATE, Set.of(RAVI, MEENA));
+
+        assertThat(plan.orphanHexIds()).isEmpty();
+        assertThat(plan.reassignments()).hasSize(7);
+        Set<UUID> receivers = plan.reassignments().stream()
+                .map(HexReassignment::toDaId).collect(Collectors.toSet());
+        assertThat(receivers).containsExactly(MEENA);            // the SHIFT_1 DA never receives
+        assertThat(receivers).doesNotContain(NIGHT_S1);
+    }
+
+    private void registerHex(long h3Index, List<Hex> into) {
+        UUID id = UUID.randomUUID();
+        hexIdByH3.put(h3Index, id);
+        into.add(Hex.builder().id(id).h3Index(h3Index).active(true).build());
+    }
+
+    private DaHexAssignment approvedRow(UUID da, long h3Index) {
+        return DaHexAssignment.builder()
+                .daId(da).hexId(hexIdByH3.get(h3Index))
+                .validDate(DATE).nDasOnHex(1).status(AssignmentStatus.APPROVED).build();
+    }
 
     /** Wire the hex list + APPROVED assignments implied by an h3→owner map into the mocked repos. */
     private void stubGrid(Map<Long, UUID> owners) {

--- a/grid/src/test/java/com/oneday/grid/service/impl/AbsenceReassignmentPlannerTest.java
+++ b/grid/src/test/java/com/oneday/grid/service/impl/AbsenceReassignmentPlannerTest.java
@@ -219,6 +219,49 @@ class AbsenceReassignmentPlannerTest {
         assertThat(inserted.stream().map(DaHexAssignment::getHexId).collect(Collectors.toSet())).isEqualTo(raviHexes);
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    void applyReactivatesAPriorSupersededRowInsteadOfInsertingADuplicate() {
+        // Sequential same-day absence can bounce a hex back to a DA that already has a SUPERSEDED row for
+        // it. The (da_id, hex_id, valid_date) key is unique across statuses, so apply must REACTIVATE that
+        // row, not insert a second one (which the DB rejects, rolling the whole apply back).
+        long center = h3.latLngToCell(28.6139, 77.2090, RES);
+        List<Long> blob = h3.gridDisk(center, 1);            // 7 → Ravi
+        List<Long> ring2 = subtract(h3.gridDisk(center, 2), blob);
+        Map<Long, UUID> owners = new HashMap<>();
+        blob.forEach(h -> owners.put(h, RAVI));
+        ring2.forEach(h -> owners.put(h, MEENA));            // Meena surrounds Ravi → gains all 7 blob hexes
+        stubGrid(owners);
+
+        UUID bouncedHex = hexIdByH3.get(blob.get(0));        // a Ravi hex Meena will regain
+        DaHexAssignment supersededBounce = DaHexAssignment.builder()
+                .daId(MEENA).hexId(bouncedHex).validDate(DATE).nDasOnHex(1)
+                .status(AssignmentStatus.SUPERSEDED).build();
+        when(assignmentRepository.findByDaIdAndValidDate(any(), eq(DATE))).thenAnswer(inv -> {
+            UUID da = inv.getArgument(0);
+            List<DaHexAssignment> rows = owners.entrySet().stream()
+                    .filter(e -> e.getValue().equals(da))
+                    .map(e -> DaHexAssignment.builder().daId(da).hexId(hexIdByH3.get(e.getKey()))
+                            .validDate(DATE).nDasOnHex(1).status(AssignmentStatus.APPROVED).build())
+                    .collect(Collectors.toList());
+            if (da.equals(MEENA)) rows.add(supersededBounce);   // Meena already has a SUPERSEDED slot for it
+            return rows;
+        });
+        when(proposalRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        planner.apply(CITY, List.of(RAVI), DATE, UUID.randomUUID());
+
+        // The prior SUPERSEDED row was reactivated in place — same instance, now APPROVED.
+        assertThat(supersededBounce.getStatus()).isEqualTo(AssignmentStatus.APPROVED);
+        ArgumentCaptor<List<DaHexAssignment>> cap = ArgumentCaptor.forClass(List.class);
+        verify(assignmentRepository, atLeastOnce()).saveAll(cap.capture());
+        List<DaHexAssignment> saved = cap.getAllValues().stream().flatMap(List::stream).toList();
+        // Exactly one row for (MEENA, bouncedHex), and it is the reactivated instance (no duplicate insert).
+        assertThat(saved.stream().filter(a -> MEENA.equals(a.getDaId()) && bouncedHex.equals(a.getHexId())).count())
+                .isEqualTo(1);
+        assertThat(saved).anyMatch(a -> a == supersededBounce);
+    }
+
     // ── fixtures ────────────────────────────────────────────────────────────────────────────────
 
     /** Wire the hex list + APPROVED assignments implied by an h3→owner map into the mocked repos. */


### PR DESCRIPTION
Follow-ups to the CodeRabbit review on #158 (already merged).

**Fixed (valid):**
- **Sequential same-day absence duplicate key** — `AbsenceReassignmentPlanner.apply` now *reactivates* a prior `SUPERSEDED` `(da_id, hex_id, valid_date)` row instead of inserting a second one. Without this, a hex bounced away from a DA and later back to them (a chain of same-day absences) hit the unique constraint and rolled the whole apply back. Regression test added.
- **Custody scan not validated** — `recordCustodyCollect` now checks a submitted scan matches the shipment's ref before completing custody (previously only a non-empty check, so a junk scan could complete the transfer). 422 on mismatch; test added.
- **Over-claimed source of truth** — reworded the seam comment: the committed `dispatch_queue` transition (task COMPLETED + onward leg), not the best-effort `DA_CUSTODY_TRANSFER` scan, is the authoritative record that custody moved.
- **Coverage reporting** — the `INTRADAY_OVERRIDE` proposal now records orphan hex ids in `understaffedHexIds` instead of `"[]"`.

**Skipped (already addressed on #158, or low-risk):**
- apply city-scope check — already passes `scopeCityId` and the service validates it (CodeRabbit saw the pre-fix 2-arg signature).
- `MarkAbsentRequest` `@NotNull`/`@Size` — already present.
- `DaAbsenceEvent.proposalId` null — the field was already removed in an earlier review pass.
- retire absent DA when all hexes orphan — already superseded before the early return.
- `TaskType` switch safety — no exhaustive switch exists; handlers guard via `requireType`.
- `nDasOnHex` shared-hex bookkeeping — v1 uses a single-owner default; deferred.

grid 112 tests green, dispatch 165 green, app assembles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Custody collection rejects shipment scans that do not match the shipment reference, returning a validation error.
  - Matching is case-insensitive, and valid scans complete custody successfully.
  - Absence reassignment validates city, date, and shift eligibility.

- **New Features**
  - Absence rosters and reassignment planning can be filtered by shift.
  - Reassignments are restricted to recipients within the absent DA’s shift.

- **Reliability Improvements**
  - Hub scan events retain their original scan time and publish only after successful transaction completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->