### PR TITLE
feat(orders): merchant analytics endpoint (GET /api/v1/b2b/analytics)

### DIFF
--- a/orders/src/main/java/com/oneday/orders/api/MerchantAnalyticsController.java
+++ b/orders/src/main/java/com/oneday/orders/api/MerchantAnalyticsController.java
@@ -1,0 +1,54 @@
+package com.oneday.orders.api;
+
+import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.orders.dto.MerchantAnalyticsResponse;
+import com.oneday.orders.repository.B2bAccountRepository;
+import com.oneday.orders.service.MerchantAnalyticsService;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.UUID;
+
+/**
+ * Merchant self-service analytics. Owner-scoped like the CSV export ({@link B2bShipmentController}) —
+ * the account is resolved from the caller, never taken as a parameter.
+ */
+@RestController
+@RequestMapping("/api/v1/b2b/analytics")
+class MerchantAnalyticsController {
+
+    private final MerchantAnalyticsService analytics;
+    private final B2bAccountRepository accounts;
+
+    MerchantAnalyticsController(MerchantAnalyticsService analytics, B2bAccountRepository accounts) {
+        this.analytics = analytics;
+        this.accounts = accounts;
+    }
+
+    /**
+     * @param days optional lookback window; a positive value restricts to the last N days, anything
+     *             else (absent or ≤ 0) reports all-time.
+     */
+    @GetMapping
+    public MerchantAnalyticsResponse myAnalytics(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @RequestParam(value = "days", required = false) Integer days) {
+        UUID accountId = ownedAccountId(principal);
+        Integer window = (days != null && days > 0) ? days : null;
+        return analytics.forAccount(accountId, window);
+    }
+
+    /** The B2B account owned by the caller, or 404 (also gates the endpoint to B2B users). */
+    private UUID ownedAccountId(AuthUserDetails principal) {
+        Authz.requireRole(principal, "B2B_USER");
+        UUID userId = UUID.fromString(Authz.requireUserId(principal));
+        return accounts.findByOwnerUserId(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No B2B account for this user"))
+                .getId();
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/dto/MerchantAnalyticsResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/MerchantAnalyticsResponse.java
@@ -1,0 +1,40 @@
+package com.oneday.orders.dto;
+
+import java.util.List;
+
+/**
+ * Merchant-facing shipping analytics for one B2B account over a window (null {@code windowDays} =
+ * all-time). Field names serialise to snake_case via the global Jackson config
+ * ({@code totalShipments} → {@code total_shipments}). Percentages are 0–100 ints, or null when there
+ * is nothing to rate (e.g. no delivered-with-ETA parcels yet), so the UI can show "—" rather than 0%.
+ *
+ * @param windowDays        the window in days, or null for all-time
+ * @param totalShipments    every shipment booked in the window
+ * @param delivered         reached a delivered terminal state (DROPPED or HUB_COLLECTED)
+ * @param inTransit         still moving (booked through the network, not yet terminal)
+ * @param cancelled         cancelled shipments
+ * @param rto               returned-to-origin (initiated, in transit, or completed)
+ * @param deliveryRatePct   delivered ÷ (total − cancelled), or null if nothing to rate
+ * @param onTimePct         delivered on/before promised ETA ÷ delivered-with-ETA, or null if none
+ * @param gmvPaise          total shipping charged, in paise
+ * @param codValuePaise     total COD goods-value handled, in paise
+ * @param avgShipmentPaise  gmvPaise ÷ totalShipments (0 when no shipments)
+ * @param topDestinations   busiest destination cities first
+ */
+public record MerchantAnalyticsResponse(
+        Integer windowDays,
+        long totalShipments,
+        long delivered,
+        long inTransit,
+        long cancelled,
+        long rto,
+        Integer deliveryRatePct,
+        Integer onTimePct,
+        long gmvPaise,
+        long codValuePaise,
+        long avgShipmentPaise,
+        List<DestinationCount> topDestinations) {
+
+    /** One destination city with its shipment count. */
+    public record DestinationCount(String city, long count) {}
+}

--- a/orders/src/main/java/com/oneday/orders/repository/AccountTotals.java
+++ b/orders/src/main/java/com/oneday/orders/repository/AccountTotals.java
@@ -1,0 +1,11 @@
+package com.oneday.orders.repository;
+
+/**
+ * Projection for the merchant-analytics money rollup: total shipping charged (GMV) and total COD
+ * value handled, both in paise, for one B2B account over a window. Alias names in the JPQL
+ * ({@code AS gmvPaise}, {@code AS codPaise}) must match these getters.
+ */
+public interface AccountTotals {
+    long getGmvPaise();
+    long getCodPaise();
+}

--- a/orders/src/main/java/com/oneday/orders/repository/CityCount.java
+++ b/orders/src/main/java/com/oneday/orders/repository/CityCount.java
@@ -1,0 +1,10 @@
+package com.oneday.orders.repository;
+
+/**
+ * Projection for the merchant-analytics destination split — one row per destination city with the
+ * shipment count. Alias names in the JPQL ({@code AS city}, {@code AS count}) must match these getters.
+ */
+public interface CityCount {
+    String getCity();
+    long getCount();
+}

--- a/orders/src/main/java/com/oneday/orders/repository/OnTimeStat.java
+++ b/orders/src/main/java/com/oneday/orders/repository/OnTimeStat.java
@@ -1,0 +1,11 @@
+package com.oneday.orders.repository;
+
+/**
+ * Projection for the merchant-analytics on-time metric: how many of an account's parcels reached a
+ * delivered terminal state with a promised ETA, and how many did so on or before that ETA. Alias
+ * names in the JPQL ({@code AS delivered}, {@code AS onTime}) must match these getters.
+ */
+public interface OnTimeStat {
+    long getDelivered();
+    long getOnTime();
+}

--- a/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
@@ -113,6 +113,43 @@ public interface ShipmentRepository extends JpaRepository<Shipment, UUID> {
             + "WHERE s.originCity = :city OR s.destCity = :city GROUP BY s.state")
     List<StateCount> countByStateForCity(@Param("city") String city);
 
+    // ── Merchant analytics (per B2B account, windowed by booking time) ─────────────────────────
+    // :since is always bound (the service passes Instant.EPOCH for all-time) — a nullable bind in a
+    // "? IS NULL" branch left Postgres unable to infer the parameter type. Same grouped-count shape
+    // as countByState, scoped to one account.
+
+    @Query("SELECT s.state AS state, COUNT(s) AS count FROM Shipment s "
+            + "WHERE s.b2bAccountId = :accountId AND s.createdAt >= :since "
+            + "GROUP BY s.state")
+    List<StateCount> countByStateForAccount(@Param("accountId") UUID accountId, @Param("since") Instant since);
+
+    // Money rollup: shipping GMV + COD value handled, in paise. COALESCE keeps it 0 (never null) for
+    // an account with no shipments in the window.
+    @Query("SELECT COALESCE(SUM(s.totalPricePaise), 0) AS gmvPaise, "
+            + "COALESCE(SUM(s.codAmountPaise), 0) AS codPaise "
+            + "FROM Shipment s WHERE s.b2bAccountId = :accountId "
+            + "AND s.createdAt >= :since")
+    AccountTotals sumTotalsForAccount(@Param("accountId") UUID accountId, @Param("since") Instant since);
+
+    // Destination-city split (only 5 serviceable cities, so a tiny result set), busiest first.
+    @Query("SELECT s.destCity AS city, COUNT(s) AS count FROM Shipment s "
+            + "WHERE s.b2bAccountId = :accountId AND s.createdAt >= :since "
+            + "GROUP BY s.destCity ORDER BY COUNT(s) DESC")
+    List<CityCount> destinationSplitForAccount(@Param("accountId") UUID accountId, @Param("since") Instant since);
+
+    // On-time delivery: joins each parcel's actual delivered time (the history row's occurred_at for a
+    // delivered terminal state) against its promised ETA. Theta-join because shipment↔history is a bare
+    // UUID reference, not a mapped association. Only parcels with a promised ETA are rated.
+    @Query("SELECT COUNT(h) AS delivered, "
+            + "COALESCE(SUM(CASE WHEN h.occurredAt <= s.etaPromised THEN 1 ELSE 0 END), 0) AS onTime "
+            + "FROM ShipmentStateHistory h, Shipment s "
+            + "WHERE h.shipmentId = s.id AND h.toState IN :deliveredStates "
+            + "AND s.b2bAccountId = :accountId AND s.etaPromised IS NOT NULL "
+            + "AND s.createdAt >= :since")
+    OnTimeStat onTimeForAccount(@Param("accountId") UUID accountId,
+                                @Param("deliveredStates") Collection<ShipmentState> deliveredStates,
+                                @Param("since") Instant since);
+
     /**
      * Ageing rollup: live (non-terminal) shipments grouped by state and a dwell band. Dwell is
      * {@code now() − COALESCE(last_scan_at, created_at)} (a never-scanned parcel ages from booking).

--- a/orders/src/main/java/com/oneday/orders/service/MerchantAnalyticsService.java
+++ b/orders/src/main/java/com/oneday/orders/service/MerchantAnalyticsService.java
@@ -1,0 +1,19 @@
+package com.oneday.orders.service;
+
+import com.oneday.orders.dto.MerchantAnalyticsResponse;
+
+import java.util.UUID;
+
+/**
+ * Read-only shipping analytics for a single B2B account: volumes, delivery/on-time rates, GMV and a
+ * destination split. The merchant self-service counterpart to the ADMIN ops summary
+ * ({@link AdminOrderSummaryService}) — always scoped to one owned account, never global.
+ */
+public interface MerchantAnalyticsService {
+
+    /**
+     * @param accountId  the B2B account (ownership already enforced by the caller)
+     * @param windowDays null = all-time; otherwise only shipments booked within the last N days
+     */
+    MerchantAnalyticsResponse forAccount(UUID accountId, Integer windowDays);
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/MerchantAnalyticsServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/MerchantAnalyticsServiceImpl.java
@@ -1,0 +1,79 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.dto.MerchantAnalyticsResponse;
+import com.oneday.orders.dto.MerchantAnalyticsResponse.DestinationCount;
+import com.oneday.orders.repository.AccountTotals;
+import com.oneday.orders.repository.OnTimeStat;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.repository.StateCount;
+import com.oneday.orders.service.MerchantAnalyticsService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+class MerchantAnalyticsServiceImpl implements MerchantAnalyticsService {
+
+    /** Delivered terminal states — DA drop-off and receiver hub-collect both count as delivered. */
+    private static final Set<ShipmentState> DELIVERED =
+            EnumSet.of(ShipmentState.DROPPED, ShipmentState.HUB_COLLECTED);
+    private static final Set<ShipmentState> RTO =
+            EnumSet.of(ShipmentState.RTO_INITIATED, ShipmentState.RTO_IN_TRANSIT, ShipmentState.RTO_COMPLETED);
+    /** Busiest few destinations are enough for the dashboard; there are only 5 serviceable cities today. */
+    private static final int TOP_DESTINATIONS = 6;
+
+    private final ShipmentRepository shipments;
+
+    MerchantAnalyticsServiceImpl(ShipmentRepository shipments) {
+        this.shipments = shipments;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public MerchantAnalyticsResponse forAccount(UUID accountId, Integer windowDays) {
+        // EPOCH sentinel for all-time — a null bind in a "? IS NULL" SQL branch left Postgres unable to
+        // infer the parameter's type; no shipment predates 1970, so this is equivalent and keeps the SQL simple.
+        Instant since = windowDays == null ? Instant.EPOCH : Instant.now().minus(windowDays, ChronoUnit.DAYS);
+
+        long total = 0, delivered = 0, cancelled = 0, rto = 0;
+        for (StateCount sc : shipments.countByStateForAccount(accountId, since)) {
+            long c = sc.getCount();
+            total += c;
+            ShipmentState st = sc.getState();
+            if (DELIVERED.contains(st)) delivered += c;
+            else if (st == ShipmentState.CANCELLED) cancelled += c;
+            else if (RTO.contains(st)) rto += c;
+        }
+        // ponytail: in-transit is the remainder — transient failure states (PICKUP_FAILED/DELIVERY_FAILED)
+        // fold in here as "still moving" rather than getting their own bucket. Split them out if merchants
+        // ask to see stuck parcels separately.
+        long inTransit = total - delivered - cancelled - rto;
+
+        long rateable = total - cancelled; // a cancelled parcel was never a delivery attempt
+        Integer deliveryRatePct = rateable > 0 ? Math.round(delivered * 100f / rateable) : null;
+
+        AccountTotals totals = shipments.sumTotalsForAccount(accountId, since);
+        long gmv = totals == null ? 0 : totals.getGmvPaise();
+        long cod = totals == null ? 0 : totals.getCodPaise();
+        long avg = total > 0 ? gmv / total : 0;
+
+        OnTimeStat ot = shipments.onTimeForAccount(accountId, DELIVERED, since);
+        Integer onTimePct = (ot != null && ot.getDelivered() > 0)
+                ? Math.round(ot.getOnTime() * 100f / ot.getDelivered()) : null;
+
+        List<DestinationCount> dests = shipments.destinationSplitForAccount(accountId, since).stream()
+                .limit(TOP_DESTINATIONS)
+                .map(cc -> new DestinationCount(cc.getCity(), cc.getCount()))
+                .toList();
+
+        return new MerchantAnalyticsResponse(windowDays, total, delivered, inTransit, cancelled, rto,
+                deliveryRatePct, onTimePct, gmv, cod, avg, dests);
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/service/impl/MerchantAnalyticsServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/MerchantAnalyticsServiceImplTest.java
@@ -1,0 +1,124 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.dto.MerchantAnalyticsResponse;
+import com.oneday.orders.repository.AccountTotals;
+import com.oneday.orders.repository.CityCount;
+import com.oneday.orders.repository.OnTimeStat;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.repository.StateCount;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MerchantAnalyticsServiceImplTest {
+
+    @Mock private ShipmentRepository shipments;
+
+    private final UUID acct = UUID.randomUUID();
+
+    private static StateCount state(ShipmentState s, long c) {
+        return new StateCount() {
+            public ShipmentState getState() { return s; }
+            public long getCount() { return c; }
+        };
+    }
+
+    private static AccountTotals totals(long gmv, long cod) {
+        return new AccountTotals() {
+            public long getGmvPaise() { return gmv; }
+            public long getCodPaise() { return cod; }
+        };
+    }
+
+    private static OnTimeStat onTime(long delivered, long on) {
+        return new OnTimeStat() {
+            public long getDelivered() { return delivered; }
+            public long getOnTime() { return on; }
+        };
+    }
+
+    private static CityCount city(String c, long n) {
+        return new CityCount() {
+            public String getCity() { return c; }
+            public long getCount() { return n; }
+        };
+    }
+
+    @Test
+    void classifiesStatesAndComputesRates() {
+        // 10 delivered (8 DROPPED + 2 HUB_COLLECTED), 3 in transit, 2 cancelled, 1 RTO → total 16.
+        when(shipments.countByStateForAccount(eq(acct), any())).thenReturn(List.of(
+                state(ShipmentState.DROPPED, 8),
+                state(ShipmentState.HUB_COLLECTED, 2),
+                state(ShipmentState.AT_DEST_HUB, 3),
+                state(ShipmentState.CANCELLED, 2),
+                state(ShipmentState.RTO_COMPLETED, 1)));
+        when(shipments.sumTotalsForAccount(eq(acct), any())).thenReturn(totals(1_600_000, 500_000));
+        when(shipments.onTimeForAccount(eq(acct), any(), any())).thenReturn(onTime(10, 9));
+        when(shipments.destinationSplitForAccount(eq(acct), any())).thenReturn(List.of(
+                city("DEL", 9), city("BLR", 7)));
+
+        MerchantAnalyticsServiceImpl svc = new MerchantAnalyticsServiceImpl(shipments);
+        MerchantAnalyticsResponse r = svc.forAccount(acct, 30);
+
+        assertThat(r.totalShipments()).isEqualTo(16);
+        assertThat(r.delivered()).isEqualTo(10);
+        assertThat(r.inTransit()).isEqualTo(3);
+        assertThat(r.cancelled()).isEqualTo(2);
+        assertThat(r.rto()).isEqualTo(1);
+        // delivery rate = delivered / (total - cancelled) = 10/14 = 71%
+        assertThat(r.deliveryRatePct()).isEqualTo(71);
+        // on-time = 9/10 = 90%
+        assertThat(r.onTimePct()).isEqualTo(90);
+        assertThat(r.gmvPaise()).isEqualTo(1_600_000);
+        assertThat(r.codValuePaise()).isEqualTo(500_000);
+        assertThat(r.avgShipmentPaise()).isEqualTo(100_000); // 1_600_000 / 16
+        assertThat(r.topDestinations()).hasSize(2);
+        assertThat(r.topDestinations().get(0).city()).isEqualTo("DEL");
+        assertThat(r.windowDays()).isEqualTo(30);
+    }
+
+    @Test
+    void nullPercentagesWhenNothingToRate() {
+        // No shipments at all.
+        when(shipments.countByStateForAccount(eq(acct), any())).thenReturn(List.of());
+        when(shipments.sumTotalsForAccount(eq(acct), any())).thenReturn(totals(0, 0));
+        when(shipments.onTimeForAccount(eq(acct), any(), any())).thenReturn(onTime(0, 0));
+        when(shipments.destinationSplitForAccount(eq(acct), any())).thenReturn(List.of());
+
+        MerchantAnalyticsResponse r = new MerchantAnalyticsServiceImpl(shipments).forAccount(acct, null);
+
+        assertThat(r.totalShipments()).isZero();
+        assertThat(r.deliveryRatePct()).isNull();  // nothing rateable
+        assertThat(r.onTimePct()).isNull();         // nothing delivered-with-ETA
+        assertThat(r.avgShipmentPaise()).isZero();
+        assertThat(r.windowDays()).isNull();        // all-time
+    }
+
+    @Test
+    void allCancelledIsNotRateableButOnTimeStillNull() {
+        when(shipments.countByStateForAccount(eq(acct), any())).thenReturn(List.of(
+                state(ShipmentState.CANCELLED, 4)));
+        when(shipments.sumTotalsForAccount(eq(acct), any())).thenReturn(totals(0, 0));
+        when(shipments.onTimeForAccount(eq(acct), any(), any())).thenReturn(onTime(0, 0));
+        when(shipments.destinationSplitForAccount(eq(acct), any())).thenReturn(List.of());
+
+        MerchantAnalyticsResponse r = new MerchantAnalyticsServiceImpl(shipments).forAccount(acct, 7);
+
+        assertThat(r.totalShipments()).isEqualTo(4);
+        assertThat(r.cancelled()).isEqualTo(4);
+        assertThat(r.deliveryRatePct()).isNull(); // total - cancelled = 0 → not rateable
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/service/impl/MerchantAnalyticsServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/MerchantAnalyticsServiceImplTest.java
@@ -30,28 +30,36 @@ class MerchantAnalyticsServiceImplTest {
 
     private static StateCount state(ShipmentState s, long c) {
         return new StateCount() {
+            @Override
             public ShipmentState getState() { return s; }
+            @Override
             public long getCount() { return c; }
         };
     }
 
     private static AccountTotals totals(long gmv, long cod) {
         return new AccountTotals() {
+            @Override
             public long getGmvPaise() { return gmv; }
+            @Override
             public long getCodPaise() { return cod; }
         };
     }
 
     private static OnTimeStat onTime(long delivered, long on) {
         return new OnTimeStat() {
+            @Override
             public long getDelivered() { return delivered; }
+            @Override
             public long getOnTime() { return on; }
         };
     }
 
     private static CityCount city(String c, long n) {
         return new CityCount() {
+            @Override
             public String getCity() { return c; }
+            @Override
             public long getCount() { return n; }
         };
     }


### PR DESCRIPTION

<img width="1956" height="1432" alt="image" src="https://github.com/user-attachments/assets/cc883eba-feaa-425d-8cff-c7e9fa0413ae" />


## What
Per-account shipping analytics for the Godspeed-for-Business console — closes CEO roadmap **#5 (merchant analytics dashboard)** on the backend side. New owner-scoped endpoint:

`GET /api/v1/b2b/analytics?days=<n>` → volumes, delivery rate, on-time %, GMV/COD, and a destination-city split. Omit `days` (or `≤0`) for all-time.

## How
- **Ownership**: resolved from the caller (`B2bAccountRepository.findByOwnerUserId`), never a request param — same pattern as the CSV export in `B2bShipmentController`. B2B-role gated.
- **Aggregation**: reuses the `StateCount` grouped-count projection; three more small projections (`AccountTotals`, `CityCount`, `OnTimeStat`). On-time joins `shipment_state_history.occurred_at` (actual delivery time) against `eta_promised`.
- **Classification** (in the service, unit-tested): delivered = DROPPED/HUB_COLLECTED; RTO = the three RTO states; in-transit = remainder. Percentages are null when there's nothing to rate, so the UI shows "—" not a fake 0%.
- All queries are windowed by `created_at >= :since`; the service passes `Instant.EPOCH` for all-time (a nullable bind in a `? IS NULL` branch left Postgres unable to infer the parameter type).

## Verified
- `MerchantAnalyticsServiceImplTest` (3 tests) green — state classification, rate math, null-when-nothing-to-rate.
- Booted locally against the dev DB and hit the endpoint as a real B2B user (Acme): `total_shipments=7, delivered=1, delivery_rate_pct=17, on_time_pct=100, gmv_paise=293224, top_destinations=[BLR×6, HYD×1]` — reconciles with the raw rows. `?days=7` correctly drops the one older shipment.

Web counterpart (the dashboard page): Sidarthapati/oneday-web#41.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added merchant analytics for shipment activity, delivery performance, financial totals, and top destinations.
  * Supports all-time reporting and optional positive-day lookback periods.
  * Includes shipment status counts, delivery and on-time rates, GMV, COD value, average shipment value, and reporting windows.
  * Provides the top six destination cities by shipment volume.
* **Bug Fixes**
  * Handles empty or non-rateable data without displaying misleading percentages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->