### PR TITLE
feat(exceptions): support-ticket conversation thread

### DIFF
--- a/exceptions/src/main/java/com/oneday/exceptions/api/SupportTicketController.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/api/SupportTicketController.java
@@ -1,6 +1,7 @@
 package com.oneday.exceptions.api;
 
 import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.exceptions.dto.PostMessageRequest;
 import com.oneday.exceptions.dto.SupportTicketRequest;
 import com.oneday.exceptions.dto.SupportTicketResponse;
 import com.oneday.exceptions.dto.TicketActionRequest;
@@ -59,13 +60,24 @@ public class SupportTicketController {
         return service.listMine(UUID.fromString(Authz.requireUserId(principal)));
     }
 
-    /** One of the caller's own tickets. */
+    /** One of the caller's own tickets, with its conversation thread. */
     @GetMapping("/mine/{id}")
     public SupportTicketResponse myDetail(
             @AuthenticationPrincipal AuthUserDetails principal,
             @PathVariable UUID id) {
         Authz.requireCustomerRole(principal, Authz.B2C_CUSTOMER, Authz.C2C_CUSTOMER, Authz.B2B_USER);
         return service.myDetail(UUID.fromString(Authz.requireUserId(principal)), id);
+    }
+
+    /** Post a reply into the caller's own ticket (reopens it if it was resolved). */
+    @PostMapping("/mine/{id}/messages")
+    @ResponseStatus(HttpStatus.CREATED)
+    public SupportTicketResponse replyMine(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @PathVariable UUID id,
+            @Valid @RequestBody PostMessageRequest body) {
+        Authz.requireCustomerRole(principal, Authz.B2C_CUSTOMER, Authz.C2C_CUSTOMER, Authz.B2B_USER);
+        return service.postMineMessage(UUID.fromString(Authz.requireUserId(principal)), id, body.body());
     }
 
     // ── Ops console ────────────────────────────────────────────────────────
@@ -82,13 +94,25 @@ public class SupportTicketController {
                 p.getTotalElements(), p.getTotalPages());
     }
 
-    /** One ticket for an ops agent. */
+    /** One ticket for an ops agent, with its conversation thread. */
     @GetMapping("/{id}")
     public SupportTicketResponse detail(
             @AuthenticationPrincipal AuthUserDetails principal,
             @PathVariable UUID id) {
         Authz.requireRole(principal, Authz.CALL_CENTER_AGENT, Authz.SUPERVISOR, Authz.STATION_MANAGER);
         return service.detail(id);
+    }
+
+    /** An ops agent posts a reply into a ticket (claims it if it was still OPEN). */
+    @PostMapping("/{id}/messages")
+    @ResponseStatus(HttpStatus.CREATED)
+    public SupportTicketResponse reply(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @PathVariable UUID id,
+            @Valid @RequestBody PostMessageRequest body) {
+        Authz.requireRole(principal, Authz.CALL_CENTER_AGENT, Authz.SUPERVISOR, Authz.STATION_MANAGER);
+        return service.postAgentMessage(UUID.fromString(Authz.requireUserId(principal)),
+                Authz.role(principal), id, body.body());
     }
 
     /** Action a ticket: claim (IN_PROGRESS), resolve, or cancel — with an optional note. */

--- a/exceptions/src/main/java/com/oneday/exceptions/domain/SupportTicketMessage.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/domain/SupportTicketMessage.java
@@ -1,0 +1,40 @@
+package com.oneday.exceptions.domain;
+
+import com.oneday.common.domain.MutableBaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+/**
+ * One message in a {@link SupportTicket}'s conversation thread. Either side can post: the customer/
+ * merchant who raised the ticket, or an ops agent working it. {@code fromAgent} distinguishes the two
+ * so the UI can lay the thread out left/right; the author's M1 id and role are kept for the audit trail.
+ */
+@Entity
+@Table(name = "support_ticket_message")
+@Getter
+@Setter
+@NoArgsConstructor
+public class SupportTicketMessage extends MutableBaseEntity {
+
+    @Column(name = "ticket_id", nullable = false, updatable = false)
+    private UUID ticketId;
+
+    @Column(name = "author_user_id", nullable = false, updatable = false)
+    private UUID authorUserId;
+
+    @Column(name = "author_role", length = 40, updatable = false)
+    private String authorRole;
+
+    /** True when an ops agent wrote it; false when the ticket's raiser did. */
+    @Column(name = "from_agent", nullable = false, updatable = false)
+    private boolean fromAgent;
+
+    @Column(name = "body", nullable = false)
+    private String body;
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/dto/PostMessageRequest.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/dto/PostMessageRequest.java
@@ -1,0 +1,9 @@
+package com.oneday.exceptions.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/** A reply posted into a support ticket's thread, by either the raiser or an ops agent. */
+public record PostMessageRequest(
+        @NotBlank @Size(max = 4000) String body) {
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/dto/SupportTicketMessageResponse.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/dto/SupportTicketMessageResponse.java
@@ -1,0 +1,21 @@
+package com.oneday.exceptions.dto;
+
+import com.oneday.exceptions.domain.SupportTicketMessage;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/** One message in a ticket's thread. {@code authorSide} is CUSTOMER or AGENT (derived from fromAgent). */
+public record SupportTicketMessageResponse(
+        UUID id,
+        String authorSide,
+        String authorRole,
+        String body,
+        Instant createdAt) {
+
+    public static SupportTicketMessageResponse from(SupportTicketMessage m) {
+        return new SupportTicketMessageResponse(
+                m.getId(), m.isFromAgent() ? "AGENT" : "CUSTOMER", m.getAuthorRole(),
+                m.getBody(), m.getCreatedAt());
+    }
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/dto/SupportTicketResponse.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/dto/SupportTicketResponse.java
@@ -1,13 +1,18 @@
 package com.oneday.exceptions.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.oneday.exceptions.domain.SupportTicket;
 import com.oneday.exceptions.domain.TicketChannel;
 import com.oneday.exceptions.domain.TicketStatus;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
-/** Read model for a support ticket — same shape for the customer's own view and the ops console. */
+/**
+ * Read model for a support ticket — same shape for the customer's own view and the ops console.
+ * {@code messages} is populated only on a single-ticket detail view (omitted from list/queue rows).
+ */
 public record SupportTicketResponse(
         UUID id,
         TicketChannel channel,
@@ -19,12 +24,23 @@ public record SupportTicketResponse(
         String assignedTo,
         String resolutionNote,
         Instant createdAt,
-        Instant resolvedAt) {
+        Instant resolvedAt,
+        @JsonInclude(JsonInclude.Include.NON_NULL) List<SupportTicketMessageResponse> messages) {
 
+    /** List/queue row — no thread. */
     public static SupportTicketResponse from(SupportTicket t) {
+        return build(t, null);
+    }
+
+    /** Detail view — with the full conversation thread. */
+    public static SupportTicketResponse withThread(SupportTicket t, List<SupportTicketMessageResponse> messages) {
+        return build(t, messages);
+    }
+
+    private static SupportTicketResponse build(SupportTicket t, List<SupportTicketMessageResponse> messages) {
         return new SupportTicketResponse(
                 t.getId(), t.getChannel(), t.getShipmentRef(), t.getSubject(), t.getBody(),
                 t.getContactPhone(), t.getStatus(), t.getAssignedTo(), t.getResolutionNote(),
-                t.getCreatedAt(), t.getResolvedAt());
+                t.getCreatedAt(), t.getResolvedAt(), messages);
     }
 }

--- a/exceptions/src/main/java/com/oneday/exceptions/repository/SupportTicketMessageRepository.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/repository/SupportTicketMessageRepository.java
@@ -1,0 +1,13 @@
+package com.oneday.exceptions.repository;
+
+import com.oneday.exceptions.domain.SupportTicketMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface SupportTicketMessageRepository extends JpaRepository<SupportTicketMessage, UUID> {
+
+    /** The full thread for one ticket, oldest first (reading order). */
+    List<SupportTicketMessage> findByTicketIdOrderByCreatedAtAsc(UUID ticketId);
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/repository/SupportTicketRepository.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/repository/SupportTicketRepository.java
@@ -1,9 +1,13 @@
 package com.oneday.exceptions.repository;
 
 import com.oneday.exceptions.domain.SupportTicket;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,6 +20,15 @@ public interface SupportTicketRepository extends JpaRepository<SupportTicket, UU
 
     /** Reporter-scoped fetch so one customer can never read another's ticket by id. */
     Optional<SupportTicket> findByIdAndRaisedByUserId(UUID id, UUID raisedByUserId);
+
+    /**
+     * Pessimistic-write fetch (SELECT FOR UPDATE) — serialises the OPEN→IN_PROGRESS claim so two agents
+     * replying at once can't both claim the same ticket. Must be called inside a {@code @Transactional}
+     * method. Mirrors {@code orders.B2bAccountRepository.findByIdForUpdate}.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT t FROM SupportTicket t WHERE t.id = :id")
+    Optional<SupportTicket> findByIdForUpdate(@Param("id") UUID id);
 
     /** The ops queue: live (unresolved) tickets, freshest first. */
     Page<SupportTicket> findByResolvedAtIsNullOrderByCreatedAtDesc(Pageable pageable);

--- a/exceptions/src/main/java/com/oneday/exceptions/service/SupportTicketService.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/service/SupportTicketService.java
@@ -20,14 +20,26 @@ public interface SupportTicketService {
     /** The caller's own tickets, newest first. */
     List<SupportTicketResponse> listMine(UUID raisedByUserId);
 
-    /** One of the caller's own tickets by id (404 if not theirs / unknown). */
+    /** One of the caller's own tickets by id, with its conversation thread (404 if not theirs / unknown). */
     SupportTicketResponse myDetail(UUID raisedByUserId, UUID ticketId);
+
+    /**
+     * The raiser posts a reply into their own ticket's thread; a reply to a RESOLVED ticket reopens it.
+     * Returns the updated ticket detail (with the full thread). 404 if the ticket isn't theirs.
+     */
+    SupportTicketResponse postMineMessage(UUID raisedByUserId, UUID ticketId, String body);
 
     /** Ops queue: live (unresolved) tickets, freshest first. */
     Page<SupportTicketResponse> queue(int page, int size);
 
-    /** One ticket by id for an ops agent (404 if unknown). */
+    /** One ticket by id for an ops agent, with its conversation thread (404 if unknown). */
     SupportTicketResponse detail(UUID ticketId);
+
+    /**
+     * An ops agent posts a reply into a ticket's thread; replying to an OPEN ticket claims it (→ IN_PROGRESS,
+     * assigned to the agent). Returns the updated ticket detail (with the full thread). 404 if unknown.
+     */
+    SupportTicketResponse postAgentMessage(UUID agentUserId, String agentRole, UUID ticketId, String body);
 
     /**
      * Ops action: set the ticket's status (IN_PROGRESS / RESOLVED / CANCELLED), record the acting

--- a/exceptions/src/main/java/com/oneday/exceptions/service/impl/SupportTicketServiceImpl.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/service/impl/SupportTicketServiceImpl.java
@@ -124,7 +124,9 @@ class SupportTicketServiceImpl implements SupportTicketService {
     @Override
     @Transactional
     public SupportTicketResponse postAgentMessage(UUID agentUserId, String agentRole, UUID ticketId, String body) {
-        SupportTicket t = repository.findById(ticketId).orElseThrow(() -> notFound(ticketId));
+        // Row-lock the ticket: the OPEN→IN_PROGRESS claim below must be atomic, or two agents replying at
+        // once could both pass the check and clobber each other's assignment.
+        SupportTicket t = repository.findByIdForUpdate(ticketId).orElseThrow(() -> notFound(ticketId));
         appendMessage(t, agentUserId, agentRole, true, body);
         // Replying to an untouched ticket claims it for this agent.
         if (t.getStatus() == TicketStatus.OPEN) {

--- a/exceptions/src/main/java/com/oneday/exceptions/service/impl/SupportTicketServiceImpl.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/service/impl/SupportTicketServiceImpl.java
@@ -1,10 +1,13 @@
 package com.oneday.exceptions.service.impl;
 
 import com.oneday.exceptions.domain.SupportTicket;
+import com.oneday.exceptions.domain.SupportTicketMessage;
 import com.oneday.exceptions.domain.TicketChannel;
 import com.oneday.exceptions.domain.TicketStatus;
+import com.oneday.exceptions.dto.SupportTicketMessageResponse;
 import com.oneday.exceptions.dto.SupportTicketRequest;
 import com.oneday.exceptions.dto.SupportTicketResponse;
+import com.oneday.exceptions.repository.SupportTicketMessageRepository;
 import com.oneday.exceptions.repository.SupportTicketRepository;
 import com.oneday.exceptions.service.SupportTicketService;
 import com.oneday.orders.service.ShipmentLookupService;
@@ -26,10 +29,13 @@ class SupportTicketServiceImpl implements SupportTicketService {
     private static final int MAX_PAGE_SIZE = 100;
 
     private final SupportTicketRepository repository;
+    private final SupportTicketMessageRepository messages;
     private final ShipmentLookupService shipmentLookup;
 
-    SupportTicketServiceImpl(SupportTicketRepository repository, ShipmentLookupService shipmentLookup) {
+    SupportTicketServiceImpl(SupportTicketRepository repository, SupportTicketMessageRepository messages,
+                             ShipmentLookupService shipmentLookup) {
         this.repository = repository;
+        this.messages = messages;
         this.shipmentLookup = shipmentLookup;
     }
 
@@ -82,8 +88,9 @@ class SupportTicketServiceImpl implements SupportTicketService {
     @Override
     @Transactional(readOnly = true)
     public SupportTicketResponse myDetail(UUID raisedByUserId, UUID ticketId) {
-        return SupportTicketResponse.from(repository.findByIdAndRaisedByUserId(ticketId, raisedByUserId)
-                .orElseThrow(() -> notFound(ticketId)));
+        SupportTicket t = repository.findByIdAndRaisedByUserId(ticketId, raisedByUserId)
+                .orElseThrow(() -> notFound(ticketId));
+        return withThread(t);
     }
 
     @Override
@@ -96,7 +103,36 @@ class SupportTicketServiceImpl implements SupportTicketService {
     @Override
     @Transactional(readOnly = true)
     public SupportTicketResponse detail(UUID ticketId) {
-        return SupportTicketResponse.from(repository.findById(ticketId).orElseThrow(() -> notFound(ticketId)));
+        return withThread(repository.findById(ticketId).orElseThrow(() -> notFound(ticketId)));
+    }
+
+    @Override
+    @Transactional
+    public SupportTicketResponse postMineMessage(UUID raisedByUserId, UUID ticketId, String body) {
+        SupportTicket t = repository.findByIdAndRaisedByUserId(ticketId, raisedByUserId)
+                .orElseThrow(() -> notFound(ticketId));
+        appendMessage(t, raisedByUserId, t.getRaisedByRole(), false, body);
+        // A reply from the customer on a resolved ticket reopens it (the issue evidently isn't settled).
+        if (t.getStatus() == TicketStatus.RESOLVED) {
+            t.setStatus(TicketStatus.OPEN);
+            t.setResolvedAt(null);
+            repository.save(t);
+        }
+        return withThread(t);
+    }
+
+    @Override
+    @Transactional
+    public SupportTicketResponse postAgentMessage(UUID agentUserId, String agentRole, UUID ticketId, String body) {
+        SupportTicket t = repository.findById(ticketId).orElseThrow(() -> notFound(ticketId));
+        appendMessage(t, agentUserId, agentRole, true, body);
+        // Replying to an untouched ticket claims it for this agent.
+        if (t.getStatus() == TicketStatus.OPEN) {
+            t.setStatus(TicketStatus.IN_PROGRESS);
+            t.setAssignedTo(agentUserId.toString());
+            repository.save(t);
+        }
+        return withThread(t);
     }
 
     @Override
@@ -119,6 +155,28 @@ class SupportTicketServiceImpl implements SupportTicketService {
         }
         t.setResolvedAt(status.isTerminal() ? Instant.now() : null);
         return SupportTicketResponse.from(repository.save(t));
+    }
+
+    /** Load the ticket's thread (oldest first) and pack it into the detail response. */
+    private SupportTicketResponse withThread(SupportTicket t) {
+        List<SupportTicketMessageResponse> thread = messages.findByTicketIdOrderByCreatedAtAsc(t.getId()).stream()
+                .map(SupportTicketMessageResponse::from)
+                .toList();
+        return SupportTicketResponse.withThread(t, thread);
+    }
+
+    private void appendMessage(SupportTicket t, UUID authorId, String authorRole, boolean fromAgent, String body) {
+        String trimmed = trimToNull(body);
+        if (trimmed == null) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Message body is required");
+        }
+        SupportTicketMessage m = new SupportTicketMessage();
+        m.setTicketId(t.getId());
+        m.setAuthorUserId(authorId);
+        m.setAuthorRole(authorRole);
+        m.setFromAgent(fromAgent);
+        m.setBody(trimmed);
+        messages.save(m);
     }
 
     private static ResponseStatusException notFound(UUID id) {

--- a/exceptions/src/main/resources/db/migration/exceptions/V11_5__create_support_ticket_message.sql
+++ b/exceptions/src/main/resources/db/migration/exceptions/V11_5__create_support_ticket_message.sql
@@ -1,0 +1,17 @@
+-- M11 support-ticket conversation thread: a two-way message log on a support_ticket. Either side posts —
+-- the raiser (customer/merchant) or an ops agent — distinguished by from_agent. Enum-like author_role is
+-- VARCHAR + app-side @Enumerated-free (a plain role string), same convention as support_ticket.
+
+CREATE TABLE support_ticket_message (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    ticket_id      UUID        NOT NULL,        -- the support_ticket this belongs to
+    author_user_id UUID        NOT NULL,        -- who wrote it (M1 user id)
+    author_role    VARCHAR(40),                 -- the author's role at post time
+    from_agent     BOOLEAN     NOT NULL,        -- true = ops agent, false = the ticket's raiser
+    body           TEXT        NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- The thread for one ticket, in reading order.
+CREATE INDEX idx_support_ticket_message_thread ON support_ticket_message (ticket_id, created_at);

--- a/exceptions/src/test/java/com/oneday/exceptions/service/impl/SupportTicketServiceImplTest.java
+++ b/exceptions/src/test/java/com/oneday/exceptions/service/impl/SupportTicketServiceImplTest.java
@@ -162,7 +162,7 @@ class SupportTicketServiceImplTest {
         UUID id = UUID.randomUUID();
         SupportTicket t = new SupportTicket();
         t.setStatus(TicketStatus.OPEN);
-        when(repo.findById(id)).thenReturn(Optional.of(t));
+        when(repo.findByIdForUpdate(id)).thenReturn(Optional.of(t));
         when(messages.findByTicketIdOrderByCreatedAtAsc(any())).thenReturn(java.util.List.of());
 
         UUID agent = UUID.randomUUID();

--- a/exceptions/src/test/java/com/oneday/exceptions/service/impl/SupportTicketServiceImplTest.java
+++ b/exceptions/src/test/java/com/oneday/exceptions/service/impl/SupportTicketServiceImplTest.java
@@ -5,6 +5,8 @@ import com.oneday.exceptions.domain.TicketChannel;
 import com.oneday.exceptions.domain.TicketStatus;
 import com.oneday.exceptions.dto.SupportTicketRequest;
 import com.oneday.exceptions.dto.SupportTicketResponse;
+import com.oneday.exceptions.domain.SupportTicketMessage;
+import com.oneday.exceptions.repository.SupportTicketMessageRepository;
 import com.oneday.exceptions.repository.SupportTicketRepository;
 import com.oneday.orders.dto.ShipmentInfo;
 import com.oneday.orders.service.ShipmentLookupService;
@@ -30,8 +32,10 @@ import static org.mockito.Mockito.when;
 class SupportTicketServiceImplTest {
 
     private final SupportTicketRepository repo = mock(SupportTicketRepository.class);
+    private final SupportTicketMessageRepository messages = mock(SupportTicketMessageRepository.class);
     private final ShipmentLookupService shipmentLookup = mock(ShipmentLookupService.class);
-    private final SupportTicketServiceImpl service = new SupportTicketServiceImpl(repo, shipmentLookup);
+    private final SupportTicketServiceImpl service =
+            new SupportTicketServiceImpl(repo, messages, shipmentLookup);
 
     private static final UUID USER = UUID.randomUUID();
 
@@ -121,5 +125,65 @@ class SupportTicketServiceImplTest {
         assertThatThrownBy(() -> service.act(id, "agent-1", TicketStatus.IN_PROGRESS, null))
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("already");
+    }
+
+    // ── Conversation thread ────────────────────────────────────────────────
+
+    @Test
+    void customerReplyIsScopedToTheirOwnTicket() {
+        UUID id = UUID.randomUUID();
+        when(repo.findByIdAndRaisedByUserId(id, USER)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.postMineMessage(USER, id, "any update?"))
+                .isInstanceOf(ResponseStatusException.class);
+        verify(messages, never()).save(any());
+    }
+
+    @Test
+    void customerReplyReopensAResolvedTicket() {
+        UUID id = UUID.randomUUID();
+        SupportTicket t = new SupportTicket();
+        t.setRaisedByRole("B2B_USER");
+        t.setStatus(TicketStatus.RESOLVED);
+        when(repo.findByIdAndRaisedByUserId(id, USER)).thenReturn(Optional.of(t));
+        when(messages.findByTicketIdOrderByCreatedAtAsc(any())).thenReturn(java.util.List.of());
+
+        SupportTicketResponse resp = service.postMineMessage(USER, id, "still not delivered");
+
+        assertThat(resp.status()).isEqualTo(TicketStatus.OPEN); // reopened
+        assertThat(t.getResolvedAt()).isNull();
+        org.mockito.ArgumentCaptor<SupportTicketMessage> msg = org.mockito.ArgumentCaptor.forClass(SupportTicketMessage.class);
+        verify(messages).save(msg.capture());
+        assertThat(msg.getValue().isFromAgent()).isFalse();
+        assertThat(msg.getValue().getBody()).isEqualTo("still not delivered");
+    }
+
+    @Test
+    void agentReplyClaimsAnOpenTicket() {
+        UUID id = UUID.randomUUID();
+        SupportTicket t = new SupportTicket();
+        t.setStatus(TicketStatus.OPEN);
+        when(repo.findById(id)).thenReturn(Optional.of(t));
+        when(messages.findByTicketIdOrderByCreatedAtAsc(any())).thenReturn(java.util.List.of());
+
+        UUID agent = UUID.randomUUID();
+        SupportTicketResponse resp = service.postAgentMessage(agent, "CALL_CENTER_AGENT", id, "on it now");
+
+        assertThat(resp.status()).isEqualTo(TicketStatus.IN_PROGRESS); // claimed
+        assertThat(resp.assignedTo()).isEqualTo(agent.toString());
+        org.mockito.ArgumentCaptor<SupportTicketMessage> msg = org.mockito.ArgumentCaptor.forClass(SupportTicketMessage.class);
+        verify(messages).save(msg.capture());
+        assertThat(msg.getValue().isFromAgent()).isTrue();
+    }
+
+    @Test
+    void blankMessageBodyIsRejected() {
+        UUID id = UUID.randomUUID();
+        SupportTicket t = new SupportTicket();
+        t.setStatus(TicketStatus.IN_PROGRESS);
+        when(repo.findByIdAndRaisedByUserId(id, USER)).thenReturn(Optional.of(t));
+        assertThatThrownBy(() -> service.postMineMessage(USER, id, "   "))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("body is required");
+        verify(messages, never()).save(any());
     }
 }


### PR DESCRIPTION

<img width="2934" height="1664" alt="image" src="https://github.com/user-attachments/assets/ba823312-390d-46aa-9267-921f64c0111d" />


## What
A two-way message thread on a support ticket — the **interaction-log / chat** half of CEO roadmap **#14** (Jira integration deferred; it needs external creds). Builds on the merged support-ticket foundation (M11).

## Endpoints
- `POST /api/v1/support/tickets/mine/{id}/messages` — the raiser replies to their own ticket.
- `POST /api/v1/support/tickets/{id}/messages` — an ops agent replies.
- Both return the updated ticket **with the full thread**; the thread is also folded into the two detail GETs. List/queue rows omit it (`@JsonInclude(NON_NULL)`).

## Behaviour
- A **customer** reply to a RESOLVED ticket **reopens** it (→ OPEN, resolved_at cleared) — the issue evidently isn't settled.
- An **agent** reply to an OPEN ticket **claims** it (→ IN_PROGRESS, assigned to that agent).
- `from_agent` distinguishes the two sides for the UI; author id + role kept for the audit trail.

## How
New `SupportTicketMessage` entity + `V11_5` migration; `SupportTicketMessageRepository`; `PostMessageRequest` / `SupportTicketMessageResponse` DTOs; two service methods + two controller endpoints (same role-gating as the rest of the resource).

## Verified
- `SupportTicketServiceImplTest` — 12 green (8 existing + 4 new: ownership 404, reopen-on-customer-reply, claim-on-agent-reply, blank-body reject).
- Booted locally (V11_5 applied) and ran the full loop over HTTP: merchant creates a ticket → replies (CUSTOMER) → agent replies (ticket auto-claims → IN_PROGRESS) → merchant's own detail shows both messages in order; list rows carry no `messages` key.

Web counterpart (the thread UI): Sidarthapati/oneday-web#42.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two-way conversation threads to support tickets.
  * Customers can reply to their tickets, including reopening resolved tickets.
  * Support agents can reply, claim open tickets, and update ticket status.
  * Ticket details now display messages chronologically with author information.
  * Message submissions require nonblank text up to 4,000 characters.

* **Bug Fixes**
  * Added validation and handling for invalid message content and ticket access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->