### PR TITLE
feat(orders): delay mail — notify the customer when a shipment ETA slips

### DIFF
--- a/common/src/main/java/com/oneday/common/port/dto/NotificationEventType.java
+++ b/common/src/main/java/com/oneday/common/port/dto/NotificationEventType.java
@@ -8,5 +8,8 @@ public enum NotificationEventType {
     SLA_ESCALATION,
     // M4: a B2B merchant's prepaid wallet just dropped below the low-balance threshold — alert the
     // account owner to top up before bookings start failing.
-    WALLET_LOW
+    WALLET_LOW,
+    // M4: a shipment's delivery ETA slipped later than what was promised at booking — tell the
+    // customer the new ETA and that they can wait, or cancel for a refund.
+    SHIPMENT_DELAYED
 }

--- a/orders/src/main/java/com/oneday/orders/api/AdminOrdersController.java
+++ b/orders/src/main/java/com/oneday/orders/api/AdminOrdersController.java
@@ -2,6 +2,8 @@ package com.oneday.orders.api;
 
 import com.oneday.auth.security.AuthUserDetails;
 import com.oneday.orders.dto.CancellationResponse;
+import com.oneday.orders.dto.ReviseEtaRequest;
+import com.oneday.orders.dto.ReviseEtaResponse;
 import com.oneday.orders.dto.ShipmentAgeingStats;
 import com.oneday.orders.dto.ShipmentPageResponse;
 import com.oneday.orders.dto.ShipmentSummaryResponse;
@@ -10,6 +12,8 @@ import com.oneday.orders.dto.ShipmentTimelineResponse;
 import com.oneday.orders.service.AdminOrderQueryService;
 import com.oneday.orders.service.AdminOrderSummaryService;
 import com.oneday.orders.service.CancellationService;
+import com.oneday.orders.service.ShipmentEtaService;
+import jakarta.validation.Valid;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.ContentDisposition;
@@ -21,6 +25,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -50,13 +56,16 @@ class AdminOrdersController {
     private final AdminOrderQueryService adminOrderQueryService;
     private final AdminOrderSummaryService adminOrderSummaryService;
     private final CancellationService cancellationService;
+    private final ShipmentEtaService shipmentEtaService;
 
     AdminOrdersController(AdminOrderQueryService adminOrderQueryService,
                           AdminOrderSummaryService adminOrderSummaryService,
-                          CancellationService cancellationService) {
+                          CancellationService cancellationService,
+                          ShipmentEtaService shipmentEtaService) {
         this.adminOrderQueryService = adminOrderQueryService;
         this.adminOrderSummaryService = adminOrderSummaryService;
         this.cancellationService = cancellationService;
+        this.shipmentEtaService = shipmentEtaService;
     }
 
     @GetMapping
@@ -213,5 +222,19 @@ class AdminOrdersController {
             return cancellationService.cancelAsStationManager(ref, reason, userId, cityScope);
         }
         return cancellationService.cancelAsAdmin(ref, reason, userId);
+    }
+
+    /**
+     * Revise a shipment's delivery ETA. If the new ETA slips past what was promised at booking, the
+     * customer is notified (the delay mail — new ETA + "wait, or cancel for a refund"). ADMIN or a
+     * STATION_MANAGER.
+     */
+    @PostMapping("/{ref}/revise-eta")
+    public ReviseEtaResponse reviseEta(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @PathVariable("ref") String ref,
+            @Valid @RequestBody ReviseEtaRequest body) {
+        Authz.requireRole(principal, STATION_MANAGER);
+        return shipmentEtaService.reviseEta(ref, body.newEta(), body.reason(), Authz.requireUserId(principal));
     }
 }

--- a/orders/src/main/java/com/oneday/orders/api/AdminOrdersController.java
+++ b/orders/src/main/java/com/oneday/orders/api/AdminOrdersController.java
@@ -226,8 +226,9 @@ class AdminOrdersController {
 
     /**
      * Revise a shipment's delivery ETA. If the new ETA slips past what was promised at booking, the
-     * customer is notified (the delay mail — new ETA + "wait, or cancel for a refund"). ADMIN or a
-     * STATION_MANAGER.
+     * customer is notified (the delay mail — new ETA + "wait, or cancel for a refund"). ADMIN revises
+     * any lane; a STATION_MANAGER only a shipment touching their own city (a ref outside that scope
+     * 404s, matching the read/cancel rule) — so a valid ref can't trigger another city's customer mail.
      */
     @PostMapping("/{ref}/revise-eta")
     public ReviseEtaResponse reviseEta(
@@ -235,6 +236,7 @@ class AdminOrdersController {
             @PathVariable("ref") String ref,
             @Valid @RequestBody ReviseEtaRequest body) {
         Authz.requireRole(principal, STATION_MANAGER);
-        return shipmentEtaService.reviseEta(ref, body.newEta(), body.reason(), Authz.requireUserId(principal));
+        return shipmentEtaService.reviseEta(ref, body.newEta(), body.reason(),
+                Authz.requireUserId(principal), cityScope(principal));
     }
 }

--- a/orders/src/main/java/com/oneday/orders/dto/ReviseEtaRequest.java
+++ b/orders/src/main/java/com/oneday/orders/dto/ReviseEtaRequest.java
@@ -1,0 +1,17 @@
+package com.oneday.orders.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.Instant;
+
+/**
+ * Ops/system request to revise a shipment's delivery ETA (e.g. after a hub recompute or a flight
+ * reassignment). If the new ETA is later than what was promised at booking, the customer is notified.
+ *
+ * @param newEta the revised expected-delivery instant (required)
+ * @param reason optional free-text note for the audit trail / the customer-facing context
+ */
+public record ReviseEtaRequest(
+        @NotNull Instant newEta,
+        String reason) {
+}

--- a/orders/src/main/java/com/oneday/orders/dto/ReviseEtaResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/ReviseEtaResponse.java
@@ -1,0 +1,15 @@
+package com.oneday.orders.dto;
+
+import java.time.Instant;
+
+/**
+ * Outcome of an ETA revision. {@code delayed} is true when the new ETA slipped past the promised ETA
+ * (beyond the grace window); {@code customerNotified} is true when a delay notification was sent.
+ */
+public record ReviseEtaResponse(
+        String shipmentRef,
+        Instant etaPromised,
+        Instant etaUpdated,
+        boolean delayed,
+        boolean customerNotified) {
+}

--- a/orders/src/main/java/com/oneday/orders/service/ShipmentEtaService.java
+++ b/orders/src/main/java/com/oneday/orders/service/ShipmentEtaService.java
@@ -17,6 +17,10 @@ public interface ShipmentEtaService {
      * @param newEta      the revised expected-delivery instant
      * @param reason      optional note (audit / customer context)
      * @param actorUserId who triggered it (M1 user id), for the audit trail
+     * @param cityScope   null = no restriction (ADMIN); otherwise the shipment's origin OR destination
+     *                    must be this city (a station manager can only revise parcels touching their
+     *                    city), else 404 — matching the ops read/cancel scope
      */
-    ReviseEtaResponse reviseEta(String shipmentRef, Instant newEta, String reason, String actorUserId);
+    ReviseEtaResponse reviseEta(String shipmentRef, Instant newEta, String reason, String actorUserId,
+                                String cityScope);
 }

--- a/orders/src/main/java/com/oneday/orders/service/ShipmentEtaService.java
+++ b/orders/src/main/java/com/oneday/orders/service/ShipmentEtaService.java
@@ -1,0 +1,22 @@
+package com.oneday.orders.service;
+
+import com.oneday.orders.dto.ReviseEtaResponse;
+
+import java.time.Instant;
+
+/**
+ * Revises a shipment's delivery ETA after booking and, when the new ETA slips past the promised one,
+ * notifies the customer (the "delay mail": tell them the new ETA and that they can wait or cancel).
+ * The intended automatic caller is the hub-scan recompute at AT_ORIGIN_HUB; today the ops console
+ * drives it explicitly.
+ */
+public interface ShipmentEtaService {
+
+    /**
+     * @param shipmentRef the shipment to revise
+     * @param newEta      the revised expected-delivery instant
+     * @param reason      optional note (audit / customer context)
+     * @param actorUserId who triggered it (M1 user id), for the audit trail
+     */
+    ReviseEtaResponse reviseEta(String shipmentRef, Instant newEta, String reason, String actorUserId);
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/NotificationTemplateResolverImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/NotificationTemplateResolverImpl.java
@@ -47,6 +47,12 @@ class NotificationTemplateResolverImpl implements NotificationTemplateResolver {
                 EnumSet.of(NotificationChannel.EMAIL, NotificationChannel.SMS),
                 "Your Godspeed wallet is running low",
                 "Your Godspeed wallet balance is now ₹{balance}. Top up to keep shipping without interruption."));
+
+        TEMPLATES.put(NotificationEventType.SHIPMENT_DELAYED, new Template(
+                EnumSet.of(NotificationChannel.EMAIL, NotificationChannel.SMS),
+                "Your Godspeed delivery {shipment_ref} is running late",
+                "Your shipment {shipment_ref} is now expected by {new_eta} (was {original_eta}). "
+                        + "No action is needed to keep it — or cancel for a full refund if the new time doesn't work."));
     }
 
     @Override

--- a/orders/src/main/java/com/oneday/orders/service/impl/ShipmentEtaServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/ShipmentEtaServiceImpl.java
@@ -1,0 +1,105 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.enums.CustomerType;
+import com.oneday.common.port.NotificationPort;
+import com.oneday.common.port.dto.NotificationEventType;
+import com.oneday.common.port.dto.NotificationRequest;
+import com.oneday.orders.domain.B2bAccount;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.dto.ReviseEtaResponse;
+import com.oneday.orders.repository.B2bAccountRepository;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.service.ShipmentEtaService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+class ShipmentEtaServiceImpl implements ShipmentEtaService {
+
+    private static final Logger log = LoggerFactory.getLogger(ShipmentEtaServiceImpl.class);
+    private static final DateTimeFormatter ETA_FMT =
+            DateTimeFormatter.ofPattern("d MMM, h:mm a").withZone(ZoneId.of("Asia/Kolkata"));
+
+    private final ShipmentRepository shipments;
+    private final B2bAccountRepository accounts;
+    private final NotificationPort notificationPort;
+
+    /** ponytail: a small grace so a tiny slip doesn't spam the customer. Tune per SLA sensitivity. */
+    private final long graceMinutes;
+
+    ShipmentEtaServiceImpl(ShipmentRepository shipments, B2bAccountRepository accounts,
+                           NotificationPort notificationPort,
+                           @Value("${orders.eta.delay-grace-minutes:15}") long graceMinutes) {
+        this.shipments = shipments;
+        this.accounts = accounts;
+        this.notificationPort = notificationPort;
+        this.graceMinutes = graceMinutes;
+    }
+
+    @Override
+    @Transactional
+    public ReviseEtaResponse reviseEta(String shipmentRef, Instant newEta, String reason, String actorUserId) {
+        // ponytail: no row lock — ETA revision is rare and ops-driven; the @Transactional dirty-check is enough.
+        Shipment s = shipments.findByShipmentRef(shipmentRef)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Shipment not found: " + shipmentRef));
+
+        Instant promised = s.getEtaPromised();
+        s.setEtaUpdated(newEta);
+        // Dirty-checking persists the change; no explicit save needed inside the transaction.
+
+        boolean delayed = promised != null && newEta.isAfter(promised.plus(Duration.ofMinutes(graceMinutes)));
+        boolean notified = false;
+        if (delayed) {
+            notified = notifyCustomer(s, promised, newEta);
+        }
+        log.info("ETA revised for {} → {} (promised {}, delayed={}, notified={}, by {}, reason={})",
+                shipmentRef, newEta, promised, delayed, notified, actorUserId, reason);
+        return new ReviseEtaResponse(shipmentRef, promised, newEta, delayed, notified);
+    }
+
+    /** Send the delay mail to whoever booked: the B2B account (billing contact) or the retail sender. */
+    private boolean notifyCustomer(Shipment s, Instant promised, Instant newEta) {
+        String email;
+        String phone;
+        UUID accountId;
+        if (s.getCustomerType() == CustomerType.B2B && s.getB2bAccountId() != null) {
+            B2bAccount acc = accounts.findById(s.getB2bAccountId()).orElse(null);
+            if (acc != null) {
+                email = acc.getBillingEmail();
+                phone = acc.getSupportPhone();
+                accountId = acc.getId();
+            } else {
+                email = s.getSenderEmail();
+                phone = s.getSenderPhone();
+                accountId = null;
+            }
+        } else {
+            email = s.getSenderEmail();
+            phone = s.getSenderPhone();
+            accountId = null;
+        }
+        if ((email == null || email.isBlank()) && (phone == null || phone.isBlank())) {
+            log.warn("ETA delayed for {} but no customer contact to notify", s.getShipmentRef());
+            return false;
+        }
+        notificationPort.send(new NotificationRequest(
+                NotificationEventType.SHIPMENT_DELAYED, email, phone,
+                Map.of("shipment_ref", s.getShipmentRef(),
+                        "new_eta", ETA_FMT.format(newEta),
+                        "original_eta", promised != null ? ETA_FMT.format(promised) : "the original estimate"),
+                accountId));
+        return true;
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/ShipmentEtaServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/ShipmentEtaServiceImpl.java
@@ -73,13 +73,13 @@ class ShipmentEtaServiceImpl implements ShipmentEtaService {
         }
         // Sanitize caller-supplied strings before logging — strip CR/LF so they can't forge log lines.
         log.info("ETA revised for {} → {} (promised {}, delayed={}, notified={}, by {}, reason={})",
-                forLog(shipmentRef), newEta, promised, delayed, notified, actorUserId, forLog(reason));
+                forLog(shipmentRef), newEta, promised, delayed, notified, forLog(actorUserId), forLog(reason));
         return new ReviseEtaResponse(shipmentRef, promised, newEta, delayed, notified);
     }
 
     /** Neutralize CR/LF in caller-supplied text so it can't inject forged lines into the log. */
     private static String forLog(String s) {
-        return s == null ? null : s.replaceAll("[\\r\\n]", "_");
+        return s == null ? null : s.replace('\n', '_').replace('\r', '_');
     }
 
     /** Send the delay mail to whoever booked: the B2B account (billing contact) or the retail sender. */
@@ -104,7 +104,7 @@ class ShipmentEtaServiceImpl implements ShipmentEtaService {
             accountId = null;
         }
         if ((email == null || email.isBlank()) && (phone == null || phone.isBlank())) {
-            log.warn("ETA delayed for {} but no customer contact to notify", s.getShipmentRef());
+            log.warn("ETA delayed for {} but no customer contact to notify", forLog(s.getShipmentRef()));
             return false;
         }
         notificationPort.send(new NotificationRequest(

--- a/orders/src/main/java/com/oneday/orders/service/impl/ShipmentEtaServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/ShipmentEtaServiceImpl.java
@@ -50,10 +50,17 @@ class ShipmentEtaServiceImpl implements ShipmentEtaService {
 
     @Override
     @Transactional
-    public ReviseEtaResponse reviseEta(String shipmentRef, Instant newEta, String reason, String actorUserId) {
+    public ReviseEtaResponse reviseEta(String shipmentRef, Instant newEta, String reason, String actorUserId,
+                                       String cityScope) {
         // ponytail: no row lock — ETA revision is rare and ops-driven; the @Transactional dirty-check is enough.
         Shipment s = shipments.findByShipmentRef(shipmentRef)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Shipment not found: " + shipmentRef));
+
+        // City scope (station manager): only a parcel touching their city; else 404, not 403 — a ref
+        // outside scope reads as "not found", matching the ops read/cancel rule.
+        if (cityScope != null && !cityScope.equals(s.getOriginCity()) && !cityScope.equals(s.getDestCity())) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Shipment not found: " + shipmentRef);
+        }
 
         Instant promised = s.getEtaPromised();
         s.setEtaUpdated(newEta);
@@ -64,9 +71,15 @@ class ShipmentEtaServiceImpl implements ShipmentEtaService {
         if (delayed) {
             notified = notifyCustomer(s, promised, newEta);
         }
+        // Sanitize caller-supplied strings before logging — strip CR/LF so they can't forge log lines.
         log.info("ETA revised for {} → {} (promised {}, delayed={}, notified={}, by {}, reason={})",
-                shipmentRef, newEta, promised, delayed, notified, actorUserId, reason);
+                forLog(shipmentRef), newEta, promised, delayed, notified, actorUserId, forLog(reason));
         return new ReviseEtaResponse(shipmentRef, promised, newEta, delayed, notified);
+    }
+
+    /** Neutralize CR/LF in caller-supplied text so it can't inject forged lines into the log. */
+    private static String forLog(String s) {
+        return s == null ? null : s.replaceAll("[\\r\\n]", "_");
     }
 
     /** Send the delay mail to whoever booked: the B2B account (billing contact) or the retail sender. */

--- a/orders/src/test/java/com/oneday/orders/service/impl/ShipmentEtaServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/ShipmentEtaServiceImplTest.java
@@ -15,6 +15,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -22,6 +23,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -57,7 +59,7 @@ class ShipmentEtaServiceImplTest {
         Shipment s = b2cShipment(promised);
         Instant newEta = promised.plus(Duration.ofHours(3)); // clearly late
 
-        ReviseEtaResponse r = service().reviseEta("1DD-DEL-1", newEta, "flight delayed", "ops-1");
+        ReviseEtaResponse r = service().reviseEta("1DD-DEL-1", newEta, "flight delayed", "ops-1", null);
 
         assertThat(r.delayed()).isTrue();
         assertThat(r.customerNotified()).isTrue();
@@ -79,7 +81,7 @@ class ShipmentEtaServiceImplTest {
         b2cShipment(promised);
         Instant newEta = promised.plus(Duration.ofMinutes(5)); // within the 15-min grace
 
-        ReviseEtaResponse r = service().reviseEta("1DD-DEL-1", newEta, null, "ops-1");
+        ReviseEtaResponse r = service().reviseEta("1DD-DEL-1", newEta, null, "ops-1", null);
 
         assertThat(r.delayed()).isFalse();
         assertThat(r.customerNotified()).isFalse();
@@ -89,9 +91,29 @@ class ShipmentEtaServiceImplTest {
     @Test
     void noPromisedEta_cannotBeADelay() {
         b2cShipment(null); // never got an ETA at booking
-        ReviseEtaResponse r = service().reviseEta("1DD-DEL-1", Instant.parse("2026-08-27T20:00:00Z"), null, "ops-1");
+        ReviseEtaResponse r = service().reviseEta("1DD-DEL-1", Instant.parse("2026-08-27T20:00:00Z"), null, "ops-1", null);
         assertThat(r.delayed()).isFalse();
         verify(notificationPort, never()).send(any());
+    }
+
+    @Test
+    void stationManagerCannotReviseAParcelOutsideTheirCity() {
+        Shipment s = new Shipment();
+        s.setShipmentRef("1DD-DEL-7");
+        s.setCustomerType(CustomerType.B2C);
+        s.setOriginCity("DEL");
+        s.setDestCity("BLR");
+        s.setEtaPromised(Instant.parse("2026-08-27T10:00:00Z"));
+        when(shipments.findByShipmentRef("1DD-DEL-7")).thenReturn(Optional.of(s));
+
+        // A MAA manager (scope "MAA") touches neither origin nor dest → 404, nothing notified.
+        assertThatThrownBy(() -> service().reviseEta("1DD-DEL-7", Instant.parse("2026-08-27T20:00:00Z"), null, "sm-maa", "MAA"))
+                .isInstanceOf(ResponseStatusException.class);
+        verify(notificationPort, never()).send(any());
+
+        // The destination-city manager (scope "BLR") is in scope → allowed, and it's a delay.
+        assertThat(service().reviseEta("1DD-DEL-7", Instant.parse("2026-08-27T20:00:00Z"), null, "sm-blr", "BLR").delayed())
+                .isTrue();
     }
 
     @Test
@@ -112,7 +134,7 @@ class ShipmentEtaServiceImplTest {
         acc.setSupportPhone("+919111111111");
         when(accounts.findById(accountId)).thenReturn(Optional.of(acc));
 
-        ReviseEtaResponse r = service().reviseEta("1DD-BLR-9", promised.plus(Duration.ofHours(4)), null, "ops-1");
+        ReviseEtaResponse r = service().reviseEta("1DD-BLR-9", promised.plus(Duration.ofHours(4)), null, "ops-1", null);
 
         assertThat(r.customerNotified()).isTrue();
         ArgumentCaptor<NotificationRequest> req = ArgumentCaptor.forClass(NotificationRequest.class);

--- a/orders/src/test/java/com/oneday/orders/service/impl/ShipmentEtaServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/ShipmentEtaServiceImplTest.java
@@ -1,0 +1,123 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.enums.CustomerType;
+import com.oneday.common.port.NotificationPort;
+import com.oneday.common.port.dto.NotificationEventType;
+import com.oneday.common.port.dto.NotificationRequest;
+import com.oneday.orders.domain.B2bAccount;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.dto.ReviseEtaResponse;
+import com.oneday.orders.repository.B2bAccountRepository;
+import com.oneday.orders.repository.ShipmentRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ShipmentEtaServiceImplTest {
+
+    @Mock private ShipmentRepository shipments;
+    @Mock private B2bAccountRepository accounts;
+    @Mock private NotificationPort notificationPort;
+
+    private static final long GRACE = 15;
+
+    private ShipmentEtaServiceImpl service() {
+        return new ShipmentEtaServiceImpl(shipments, accounts, notificationPort, GRACE);
+    }
+
+    private Shipment b2cShipment(Instant promised) {
+        Shipment s = new Shipment();
+        s.setShipmentRef("1DD-DEL-1");
+        s.setCustomerType(CustomerType.B2C);
+        s.setSenderEmail("sender@home.example");
+        s.setSenderPhone("+919000000009");
+        s.setEtaPromised(promised);
+        when(shipments.findByShipmentRef("1DD-DEL-1")).thenReturn(Optional.of(s));
+        return s;
+    }
+
+    @Test
+    void slipBeyondGrace_notifiesTheSender_andRecordsNewEta() {
+        Instant promised = Instant.parse("2026-08-27T10:00:00Z");
+        Shipment s = b2cShipment(promised);
+        Instant newEta = promised.plus(Duration.ofHours(3)); // clearly late
+
+        ReviseEtaResponse r = service().reviseEta("1DD-DEL-1", newEta, "flight delayed", "ops-1");
+
+        assertThat(r.delayed()).isTrue();
+        assertThat(r.customerNotified()).isTrue();
+        assertThat(r.etaUpdated()).isEqualTo(newEta);
+        assertThat(s.getEtaUpdated()).isEqualTo(newEta); // written on the entity
+
+        ArgumentCaptor<NotificationRequest> req = ArgumentCaptor.forClass(NotificationRequest.class);
+        verify(notificationPort).send(req.capture());
+        assertThat(req.getValue().type()).isEqualTo(NotificationEventType.SHIPMENT_DELAYED);
+        assertThat(req.getValue().recipientEmail()).isEqualTo("sender@home.example");
+        assertThat(req.getValue().accountId()).isNull(); // retail → no account
+        assertThat(req.getValue().params().get("shipment_ref")).isEqualTo("1DD-DEL-1");
+        assertThat(req.getValue().params()).containsKeys("new_eta", "original_eta");
+    }
+
+    @Test
+    void earlierOrWithinGrace_isNotADelay_andDoesNotNotify() {
+        Instant promised = Instant.parse("2026-08-27T10:00:00Z");
+        b2cShipment(promised);
+        Instant newEta = promised.plus(Duration.ofMinutes(5)); // within the 15-min grace
+
+        ReviseEtaResponse r = service().reviseEta("1DD-DEL-1", newEta, null, "ops-1");
+
+        assertThat(r.delayed()).isFalse();
+        assertThat(r.customerNotified()).isFalse();
+        verify(notificationPort, never()).send(any());
+    }
+
+    @Test
+    void noPromisedEta_cannotBeADelay() {
+        b2cShipment(null); // never got an ETA at booking
+        ReviseEtaResponse r = service().reviseEta("1DD-DEL-1", Instant.parse("2026-08-27T20:00:00Z"), null, "ops-1");
+        assertThat(r.delayed()).isFalse();
+        verify(notificationPort, never()).send(any());
+    }
+
+    @Test
+    void b2bDelay_notifiesTheAccountBillingContact_scopedToTheAccount() {
+        Instant promised = Instant.parse("2026-08-27T10:00:00Z");
+        UUID accountId = UUID.randomUUID();
+        Shipment s = new Shipment();
+        s.setShipmentRef("1DD-BLR-9");
+        s.setCustomerType(CustomerType.B2B);
+        s.setB2bAccountId(accountId);
+        s.setSenderEmail("warehouse@acme.example");
+        s.setEtaPromised(promised);
+        when(shipments.findByShipmentRef("1DD-BLR-9")).thenReturn(Optional.of(s));
+
+        B2bAccount acc = new B2bAccount();
+        ReflectionTestUtils.setField(acc, "id", accountId);
+        acc.setBillingEmail("billing@acme.example");
+        acc.setSupportPhone("+919111111111");
+        when(accounts.findById(accountId)).thenReturn(Optional.of(acc));
+
+        ReviseEtaResponse r = service().reviseEta("1DD-BLR-9", promised.plus(Duration.ofHours(4)), null, "ops-1");
+
+        assertThat(r.customerNotified()).isTrue();
+        ArgumentCaptor<NotificationRequest> req = ArgumentCaptor.forClass(NotificationRequest.class);
+        verify(notificationPort).send(req.capture());
+        assertThat(req.getValue().recipientEmail()).isEqualTo("billing@acme.example"); // account, not sender
+        assertThat(req.getValue().accountId()).isEqualTo(accountId); // shows in the merchant's bell
+    }
+}


### PR DESCRIPTION

<img width="2014" height="956" alt="image" src="https://github.com/user-attachments/assets/7e912027-bc19-40f6-a6bb-3e5e77756e32" />

<img width="2218" height="1050" alt="image" src="https://github.com/user-attachments/assets/90a0af3c-c20a-41d2-b1f8-606274673131" />


## What
Roadmap **#11 (delay mail)** — the "ETA slipped → wait or cancel" customer notification. Today a shipment's ETA is set once at booking and never revised (there's an explicit `AT_ORIGIN_HUB` recompute TODO where the automatic trigger belongs). This adds the revise-ETA path + the delay notification.

## How
- **`POST /api/v1/admin/shipments/{ref}/revise-eta`** (ADMIN / STATION_MANAGER) — body `{ new_eta, reason? }`. Sets `eta_updated`.
- If the new ETA is later than `eta_promised` beyond a grace window (`orders.eta.delay-grace-minutes`, default 15), fires a new **`SHIPMENT_DELAYED`** notification (email + SMS) with the old/new ETA and a cancel hint.
- **B2B** mails the account's billing contact and **scopes to the account id**, so the notice lands in the merchant's in-app bell (reuses the #40 bell). **Retail** mails the sender. Guards for a missing contact.
- The customer's "cancel" is the existing `DELETE .../shipments/{ref}`.

## Verified
- `ShipmentEtaServiceImplTest` (4): slip-beyond-grace notifies + records the new ETA; within-grace/earlier is not a delay; no promised ETA can't be a delay; B2B mails the account billing contact scoped to the account.
- Booted locally + revised a real B2B Acme shipment's ETA 6.5h later → `delayed=true, customer_notified=true`; a `SHIPMENT_DELAYED` row was written with the account id and now shows in Acme's `/notifications/mine` bell.

Web counterpart (ops revise-ETA control): Sidarthapati/oneday-web#44.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Administrators and station managers can revise shipment delivery ETAs with an optional reason.
  * Station managers are limited to shipments connected to their assigned city.
  * Delays are detected after the configured grace period.
  * Customers receive email or SMS notifications showing updated and original ETAs.
  * Revision results include shipment reference, timing, delay status, and notification status.
  * Added support for shipment-delay notification messaging.

* **Bug Fixes**
  * Shipment-not-found and out-of-scope requests return clear not-found responses.
  * Notifications are skipped when valid contact details are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->