### PR TITLE
feat(orders): multiple service accounts — team membership per B2B account

### DIFF
--- a/orders/src/main/java/com/oneday/orders/api/B2bShipmentController.java
+++ b/orders/src/main/java/com/oneday/orders/api/B2bShipmentController.java
@@ -96,7 +96,7 @@ class B2bShipmentController {
     private UUID ownedAccountId(AuthUserDetails principal) {
         Authz.requireRole(principal, "B2B_USER");
         UUID userId = UUID.fromString(Authz.requireUserId(principal));
-        return accounts.findByOwnerUserId(userId)
+        return accounts.findByMemberUserId(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No B2B account for this user"))
                 .getId();
     }

--- a/orders/src/main/java/com/oneday/orders/api/BrandingController.java
+++ b/orders/src/main/java/com/oneday/orders/api/BrandingController.java
@@ -45,7 +45,7 @@ class BrandingController {
     private UUID ownedAccountId(AuthUserDetails principal) {
         Authz.requireRole(principal, "B2B_USER");
         UUID userId = UUID.fromString(Authz.requireUserId(principal));
-        return accounts.findByOwnerUserId(userId)
+        return accounts.findByMemberUserId(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No B2B account for this user"))
                 .getId();
     }

--- a/orders/src/main/java/com/oneday/orders/api/CodController.java
+++ b/orders/src/main/java/com/oneday/orders/api/CodController.java
@@ -90,7 +90,7 @@ class CodController {
     private UUID ownedAccountId(AuthUserDetails principal) {
         Authz.requireRole(principal, "B2B_USER");
         UUID userId = UUID.fromString(Authz.requireUserId(principal));
-        return accounts.findByOwnerUserId(userId)
+        return accounts.findByMemberUserId(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No B2B account for this user"))
                 .getId();
     }

--- a/orders/src/main/java/com/oneday/orders/api/DeveloperController.java
+++ b/orders/src/main/java/com/oneday/orders/api/DeveloperController.java
@@ -61,7 +61,7 @@ class DeveloperController {
     private UUID ownedAccountId(AuthUserDetails principal) {
         Authz.requireRole(principal, "B2B_USER");
         UUID userId = UUID.fromString(Authz.requireUserId(principal));
-        return accounts.findByOwnerUserId(userId)
+        return accounts.findByMemberUserId(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No B2B account for this user"))
                 .getId();
     }

--- a/orders/src/main/java/com/oneday/orders/api/MembersController.java
+++ b/orders/src/main/java/com/oneday/orders/api/MembersController.java
@@ -1,0 +1,72 @@
+package com.oneday.orders.api;
+
+import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.orders.dto.AddMemberRequest;
+import com.oneday.orders.dto.MemberResponse;
+import com.oneday.orders.repository.B2bAccountRepository;
+import com.oneday.orders.service.B2bMemberService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Team management for the caller's B2B account (the "multiple service accounts" feature). Owner-scoped:
+ * the account is resolved from the caller (a member), never a param. Listing is open to any member;
+ * adding/removing is enforced OWNER-only in the service.
+ */
+@RestController
+@RequestMapping("/api/v1/b2b/members")
+class MembersController {
+
+    private final B2bMemberService members;
+    private final B2bAccountRepository accounts;
+
+    MembersController(B2bMemberService members, B2bAccountRepository accounts) {
+        this.members = members;
+        this.accounts = accounts;
+    }
+
+    /** Everyone on the caller's account, owner first. */
+    @GetMapping
+    public List<MemberResponse> list(@AuthenticationPrincipal AuthUserDetails principal) {
+        return members.list(ownedAccountId(principal));
+    }
+
+    /** Invite an existing business user (by email) to the caller's account. OWNER-only. */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public MemberResponse add(@AuthenticationPrincipal AuthUserDetails principal,
+                              @Valid @RequestBody AddMemberRequest request) {
+        UUID caller = UUID.fromString(Authz.requireUserId(principal));
+        return members.add(ownedAccountId(principal), caller, request.email());
+    }
+
+    /** Remove a member from the caller's account. OWNER-only; the owner can't be removed. */
+    @DeleteMapping("/{userId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void remove(@AuthenticationPrincipal AuthUserDetails principal, @PathVariable UUID userId) {
+        UUID caller = UUID.fromString(Authz.requireUserId(principal));
+        members.remove(ownedAccountId(principal), caller, userId);
+    }
+
+    /** The B2B account the caller belongs to, or 404 (also gates the endpoint to B2B users). */
+    private UUID ownedAccountId(AuthUserDetails principal) {
+        Authz.requireRole(principal, "B2B_USER");
+        UUID userId = UUID.fromString(Authz.requireUserId(principal));
+        return accounts.findByMemberUserId(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No B2B account for this user"))
+                .getId();
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/api/MerchantAnalyticsController.java
+++ b/orders/src/main/java/com/oneday/orders/api/MerchantAnalyticsController.java
@@ -47,7 +47,7 @@ class MerchantAnalyticsController {
     private UUID ownedAccountId(AuthUserDetails principal) {
         Authz.requireRole(principal, "B2B_USER");
         UUID userId = UUID.fromString(Authz.requireUserId(principal));
-        return accounts.findByOwnerUserId(userId)
+        return accounts.findByMemberUserId(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No B2B account for this user"))
                 .getId();
     }

--- a/orders/src/main/java/com/oneday/orders/api/MerchantCategoryController.java
+++ b/orders/src/main/java/com/oneday/orders/api/MerchantCategoryController.java
@@ -67,7 +67,7 @@ class MerchantCategoryController {
     private UUID ownedAccountId(AuthUserDetails principal) {
         Authz.requireRole(principal, "B2B_USER");
         UUID userId = UUID.fromString(Authz.requireUserId(principal));
-        return accounts.findByOwnerUserId(userId)
+        return accounts.findByMemberUserId(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No B2B account for this user"))
                 .getId();
     }

--- a/orders/src/main/java/com/oneday/orders/api/MockWalletController.java
+++ b/orders/src/main/java/com/oneday/orders/api/MockWalletController.java
@@ -44,7 +44,7 @@ class MockWalletController {
     private UUID ownedAccountId(AuthUserDetails principal) {
         Authz.requireRole(principal, "B2B_USER");
         UUID userId = UUID.fromString(Authz.requireUserId(principal));
-        return accounts.findByOwnerUserId(userId)
+        return accounts.findByMemberUserId(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No B2B account for this user"))
                 .getId();
     }

--- a/orders/src/main/java/com/oneday/orders/api/NotificationsController.java
+++ b/orders/src/main/java/com/oneday/orders/api/NotificationsController.java
@@ -45,7 +45,7 @@ class NotificationsController {
     private B2bAccount ownedAccount(AuthUserDetails principal) {
         Authz.requireRole(principal, "B2B_USER");
         UUID userId = UUID.fromString(Authz.requireUserId(principal));
-        return accounts.findByOwnerUserId(userId)
+        return accounts.findByMemberUserId(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No B2B account for this user"));
     }
 }

--- a/orders/src/main/java/com/oneday/orders/api/WalletController.java
+++ b/orders/src/main/java/com/oneday/orders/api/WalletController.java
@@ -72,7 +72,7 @@ class WalletController {
     private UUID ownedAccountId(AuthUserDetails principal) {
         Authz.requireRole(principal, "B2B_USER");
         UUID userId = UUID.fromString(Authz.requireUserId(principal));
-        return accounts.findByOwnerUserId(userId)
+        return accounts.findByMemberUserId(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No B2B account for this user"))
                 .getId();
     }

--- a/orders/src/main/java/com/oneday/orders/domain/B2bAccountMember.java
+++ b/orders/src/main/java/com/oneday/orders/domain/B2bAccountMember.java
@@ -1,0 +1,43 @@
+package com.oneday.orders.domain;
+
+import com.oneday.common.domain.MutableBaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+/**
+ * Links an M1 user to a B2B account — the "multiple service accounts" model. One account can have many
+ * members; a user belongs to at most one account (unique user_id). The OWNER (the account creator,
+ * backfilled from {@code b2b_accounts.owner_user_id}) can invite/remove; a MEMBER just uses the account.
+ * {@code email}/{@code name} are denormalised at invite time for a display-only member list.
+ */
+@Entity
+@Table(name = "b2b_account_member")
+@Getter
+@Setter
+@NoArgsConstructor
+public class B2bAccountMember extends MutableBaseEntity {
+
+    @Column(name = "b2b_account_id", nullable = false, updatable = false)
+    private UUID b2bAccountId;
+
+    @Column(name = "user_id", nullable = false, updatable = false)
+    private UUID userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", length = 16, nullable = false)
+    private MemberRole role = MemberRole.MEMBER;
+
+    @Column(name = "email", length = 254)
+    private String email;
+
+    @Column(name = "name", length = 200)
+    private String name;
+}

--- a/orders/src/main/java/com/oneday/orders/domain/MemberRole.java
+++ b/orders/src/main/java/com/oneday/orders/domain/MemberRole.java
@@ -1,0 +1,7 @@
+package com.oneday.orders.domain;
+
+/** A user's role within a B2B account. OWNER manages membership; MEMBER can use the account. */
+public enum MemberRole {
+    OWNER,
+    MEMBER
+}

--- a/orders/src/main/java/com/oneday/orders/dto/AddMemberRequest.java
+++ b/orders/src/main/java/com/oneday/orders/dto/AddMemberRequest.java
@@ -1,0 +1,8 @@
+package com.oneday.orders.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+/** Invite an existing Godspeed business user to the caller's account (as a MEMBER). */
+public record AddMemberRequest(@NotBlank @Email String email) {
+}

--- a/orders/src/main/java/com/oneday/orders/dto/MemberResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/MemberResponse.java
@@ -1,0 +1,13 @@
+package com.oneday.orders.dto;
+
+import com.oneday.orders.domain.B2bAccountMember;
+
+import java.util.UUID;
+
+/** A row in the account's team list. {@code role} is OWNER or MEMBER. */
+public record MemberResponse(UUID userId, String email, String name, String role) {
+
+    public static MemberResponse from(B2bAccountMember m) {
+        return new MemberResponse(m.getUserId(), m.getEmail(), m.getName(), m.getRole().name());
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/repository/B2bAccountMemberRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/B2bAccountMemberRepository.java
@@ -1,0 +1,20 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.B2bAccountMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface B2bAccountMemberRepository extends JpaRepository<B2bAccountMember, UUID> {
+
+    /** Members of one account, oldest first (the owner, backfilled first, sorts to the top). */
+    List<B2bAccountMember> findByB2bAccountIdOrderByCreatedAtAsc(UUID b2bAccountId);
+
+    /** The caller's membership in a specific account (for the owner-only guard). */
+    Optional<B2bAccountMember> findByB2bAccountIdAndUserId(UUID b2bAccountId, UUID userId);
+
+    /** True if this user already belongs to any account (a user is on at most one account in v1). */
+    boolean existsByUserId(UUID userId);
+}

--- a/orders/src/main/java/com/oneday/orders/repository/B2bAccountRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/B2bAccountRepository.java
@@ -21,6 +21,14 @@ public interface B2bAccountRepository extends JpaRepository<B2bAccount, UUID> {
 
     Optional<B2bAccount> findByOwnerUserId(UUID ownerUserId);
 
+    /**
+     * The account a user can act on, resolved via membership (owners are members too, backfilled by
+     * V4_44) — so an invited teammate resolves to the same account as the owner. A user belongs to at
+     * most one account in v1, so at most one row.
+     */
+    @Query("SELECT a FROM B2bAccount a, B2bAccountMember m WHERE m.b2bAccountId = a.id AND m.userId = :userId")
+    Optional<B2bAccount> findByMemberUserId(@Param("userId") UUID userId);
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT a FROM B2bAccount a WHERE a.id = :id")
     Optional<B2bAccount> findByIdForUpdate(@Param("id") UUID id);

--- a/orders/src/main/java/com/oneday/orders/repository/B2bAccountRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/B2bAccountRepository.java
@@ -23,11 +23,17 @@ public interface B2bAccountRepository extends JpaRepository<B2bAccount, UUID> {
 
     /**
      * The account a user can act on, resolved via membership (owners are members too, backfilled by
-     * V4_44) — so an invited teammate resolves to the same account as the owner. A user belongs to at
-     * most one account in v1, so at most one row.
+     * V4_44) — so an invited teammate resolves to the same account as the owner. A user is normally on
+     * one account; if the DB has more (the seeded demo principal owns both demo accounts), this resolves
+     * deterministically to the earliest-joined one rather than erroring on a non-unique result.
      */
-    @Query("SELECT a FROM B2bAccount a, B2bAccountMember m WHERE m.b2bAccountId = a.id AND m.userId = :userId")
-    Optional<B2bAccount> findByMemberUserId(@Param("userId") UUID userId);
+    default Optional<B2bAccount> findByMemberUserId(UUID userId) {
+        return findAccountsForMember(userId).stream().findFirst();
+    }
+
+    @Query("SELECT a FROM B2bAccount a, B2bAccountMember m WHERE m.b2bAccountId = a.id AND m.userId = :userId "
+            + "ORDER BY m.createdAt ASC, a.id ASC")
+    List<B2bAccount> findAccountsForMember(@Param("userId") UUID userId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT a FROM B2bAccount a WHERE a.id = :id")

--- a/orders/src/main/java/com/oneday/orders/service/B2bMemberService.java
+++ b/orders/src/main/java/com/oneday/orders/service/B2bMemberService.java
@@ -1,0 +1,26 @@
+package com.oneday.orders.service;
+
+import com.oneday.orders.dto.MemberResponse;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Team management for a B2B account (the "multiple service accounts" feature). Membership resolution is
+ * in {@code B2bAccountRepository.findByMemberUserId}; this manages who is on the account. Mutations are
+ * OWNER-only; listing is open to any member.
+ */
+public interface B2bMemberService {
+
+    /** Everyone on the account, owner first. */
+    List<MemberResponse> list(UUID accountId);
+
+    /**
+     * Add an existing business user (looked up by email) to the account as a MEMBER. OWNER-only.
+     * 404 if no such user, 422 if they're not a business user, 409 if they already belong to an account.
+     */
+    MemberResponse add(UUID accountId, UUID callerUserId, String email);
+
+    /** Remove a member. OWNER-only; the OWNER cannot be removed. */
+    void remove(UUID accountId, UUID callerUserId, UUID targetUserId);
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/B2bAccountServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/B2bAccountServiceImpl.java
@@ -23,7 +23,7 @@ class B2bAccountServiceImpl implements B2bAccountService {
     @Override
     @Transactional(readOnly = true)
     public B2bAccountResponse getMine(UUID ownerUserId) {
-        B2bAccount a = accounts.findByOwnerUserId(ownerUserId)
+        B2bAccount a = accounts.findByMemberUserId(ownerUserId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
                         "No business account for this user"));
         long available = Math.max(0L, a.getCreditLimitPaise() - a.getOutstandingBalancePaise());

--- a/orders/src/main/java/com/oneday/orders/service/impl/B2bMemberServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/B2bMemberServiceImpl.java
@@ -1,0 +1,98 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.auth.dto.response.UserResponse;
+import com.oneday.auth.exception.UserNotFoundException;
+import com.oneday.auth.service.UserService;
+import com.oneday.orders.domain.B2bAccountMember;
+import com.oneday.orders.domain.MemberRole;
+import com.oneday.orders.dto.MemberResponse;
+import com.oneday.orders.repository.B2bAccountMemberRepository;
+import com.oneday.orders.service.B2bMemberService;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+class B2bMemberServiceImpl implements B2bMemberService {
+
+    private static final String B2B_USER = "B2B_USER";
+
+    private final B2bAccountMemberRepository members;
+    private final UserService userService;
+
+    B2bMemberServiceImpl(B2bAccountMemberRepository members, UserService userService) {
+        this.members = members;
+        this.userService = userService;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MemberResponse> list(UUID accountId) {
+        return members.findByB2bAccountIdOrderByCreatedAtAsc(accountId).stream()
+                .map(MemberResponse::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public MemberResponse add(UUID accountId, UUID callerUserId, String email) {
+        requireOwner(accountId, callerUserId);
+
+        UserResponse user;
+        try {
+            user = userService.getUserByEmail(email.trim());
+        } catch (UserNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                    "No Godspeed user with that email — ask them to sign up first.");
+        }
+        // v1: only an existing business user can join (we don't elevate a customer's M1 role here).
+        if (!B2B_USER.equals(user.role())) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "That user isn't a business user, so they can't join a business account yet.");
+        }
+        if (members.existsByUserId(user.id())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "That user already belongs to a business account.");
+        }
+
+        B2bAccountMember m = new B2bAccountMember();
+        m.setB2bAccountId(accountId);
+        m.setUserId(user.id());
+        m.setRole(MemberRole.MEMBER);
+        m.setEmail(user.email());
+        m.setName(user.name());
+        try {
+            return MemberResponse.from(members.save(m));
+        } catch (DataIntegrityViolationException e) {
+            // Lost a race on the unique(user_id) constraint.
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "That user already belongs to a business account.");
+        }
+    }
+
+    @Override
+    @Transactional
+    public void remove(UUID accountId, UUID callerUserId, UUID targetUserId) {
+        requireOwner(accountId, callerUserId);
+        B2bAccountMember target = members.findByB2bAccountIdAndUserId(accountId, targetUserId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Not a member of this account"));
+        if (target.getRole() == MemberRole.OWNER) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "The account owner can't be removed.");
+        }
+        members.delete(target);
+    }
+
+    /** The caller must be the account's OWNER to manage membership. */
+    private void requireOwner(UUID accountId, UUID callerUserId) {
+        B2bAccountMember me = members.findByB2bAccountIdAndUserId(accountId, callerUserId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN, "Not a member of this account"));
+        if (me.getRole() != MemberRole.OWNER) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only the account owner can manage the team.");
+        }
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/B2bProvisioningAdapter.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/B2bProvisioningAdapter.java
@@ -3,7 +3,10 @@ package com.oneday.orders.service.impl;
 import com.oneday.common.port.B2bProvisioningPort;
 import com.oneday.common.port.dto.B2bProvisioningRequest;
 import com.oneday.orders.domain.B2bAccount;
+import com.oneday.orders.domain.B2bAccountMember;
 import com.oneday.orders.domain.B2bVerificationStatus;
+import com.oneday.orders.domain.MemberRole;
+import com.oneday.orders.repository.B2bAccountMemberRepository;
 import com.oneday.orders.repository.B2bAccountRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,9 +27,11 @@ class B2bProvisioningAdapter implements B2bProvisioningPort {
     private static final Logger log = LoggerFactory.getLogger(B2bProvisioningAdapter.class);
 
     private final B2bAccountRepository accounts;
+    private final B2bAccountMemberRepository members;
 
-    B2bProvisioningAdapter(B2bAccountRepository accounts) {
+    B2bProvisioningAdapter(B2bAccountRepository accounts, B2bAccountMemberRepository members) {
         this.accounts = accounts;
+        this.members = members;
     }
 
     @Override
@@ -61,6 +66,15 @@ class B2bProvisioningAdapter implements B2bProvisioningPort {
             a.setActivatedAt(Instant.now());
         }
         a = accounts.save(a);
+
+        // The owner is the account's first member, so membership-based resolution works from creation.
+        B2bAccountMember owner = new B2bAccountMember();
+        owner.setB2bAccountId(a.getId());
+        owner.setUserId(r.ownerUserId());
+        owner.setRole(MemberRole.OWNER);
+        owner.setEmail(r.billingEmail());
+        members.save(owner);
+
         log.info("Provisioned B2B account {} for owner {} (status={})", a.getId(), r.ownerUserId(), status);
         return a.getId();
     }

--- a/orders/src/main/java/com/oneday/orders/service/impl/B2bProvisioningAdapter.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/B2bProvisioningAdapter.java
@@ -73,6 +73,7 @@ class B2bProvisioningAdapter implements B2bProvisioningPort {
         owner.setUserId(r.ownerUserId());
         owner.setRole(MemberRole.OWNER);
         owner.setEmail(r.billingEmail());
+        owner.setName(r.companyName());   // match the V4_44 backfill (account_name), so the owner row isn't nameless
         members.save(owner);
 
         log.info("Provisioned B2B account {} for owner {} (status={})", a.getId(), r.ownerUserId(), status);

--- a/orders/src/main/resources/db/migration/orders/V4_44__create_b2b_account_member.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_44__create_b2b_account_member.sql
@@ -1,7 +1,9 @@
 -- Multiple service accounts: a B2B account can have many users. Until now a user linked to an account
 -- only via b2b_accounts.owner_user_id (one owner). This membership table generalises that — one account
--- ↔ many members; a user belongs to at most one account (unique user_id, a v1 simplification).
--- email/name are denormalised at invite time for a display-only member list.
+-- ↔ many members. The DB permits a user on more than one account (unique per account+user, not per user):
+-- the seeded demo principal owns BOTH demo accounts (V4_16), so a per-user unique would abort the backfill
+-- below. The invite flow still enforces one-account-per-user for real invites; resolution is deterministic
+-- (earliest membership). email/name are denormalised for a display-only member list.
 
 CREATE TABLE b2b_account_member (
     id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -12,7 +14,7 @@ CREATE TABLE b2b_account_member (
     name           VARCHAR(200),
     created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
-    CONSTRAINT uq_b2b_member_user UNIQUE (user_id)
+    CONSTRAINT uq_b2b_member_account_user UNIQUE (b2b_account_id, user_id)
 );
 
 -- The member list for one account, owner first.

--- a/orders/src/main/resources/db/migration/orders/V4_44__create_b2b_account_member.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_44__create_b2b_account_member.sql
@@ -1,0 +1,26 @@
+-- Multiple service accounts: a B2B account can have many users. Until now a user linked to an account
+-- only via b2b_accounts.owner_user_id (one owner). This membership table generalises that — one account
+-- ↔ many members; a user belongs to at most one account (unique user_id, a v1 simplification).
+-- email/name are denormalised at invite time for a display-only member list.
+
+CREATE TABLE b2b_account_member (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    b2b_account_id UUID        NOT NULL,
+    user_id        UUID        NOT NULL,
+    role           VARCHAR(16) NOT NULL DEFAULT 'MEMBER',   -- OWNER | MEMBER
+    email          VARCHAR(254),
+    name           VARCHAR(200),
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT uq_b2b_member_user UNIQUE (user_id)
+);
+
+-- The member list for one account, owner first.
+CREATE INDEX idx_b2b_member_account ON b2b_account_member (b2b_account_id, created_at);
+
+-- Backfill: every existing account's owner becomes its OWNER member, so the membership-based account
+-- resolution keeps working for everyone who already had an account.
+INSERT INTO b2b_account_member (id, b2b_account_id, user_id, role, email, name, created_at, updated_at)
+SELECT gen_random_uuid(), id, owner_user_id, 'OWNER', billing_email, account_name, now(), now()
+FROM b2b_accounts
+WHERE owner_user_id IS NOT NULL;

--- a/orders/src/test/java/com/oneday/orders/service/impl/B2bMemberServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/B2bMemberServiceImplTest.java
@@ -1,0 +1,139 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.auth.dto.response.UserResponse;
+import com.oneday.auth.exception.UserNotFoundException;
+import com.oneday.auth.service.UserService;
+import com.oneday.orders.domain.B2bAccountMember;
+import com.oneday.orders.domain.MemberRole;
+import com.oneday.orders.dto.MemberResponse;
+import com.oneday.orders.repository.B2bAccountMemberRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class B2bMemberServiceImplTest {
+
+    @Mock private B2bAccountMemberRepository members;
+    @Mock private UserService userService;
+
+    private final UUID account = UUID.randomUUID();
+    private final UUID owner = UUID.randomUUID();
+
+    private B2bMemberServiceImpl service() {
+        return new B2bMemberServiceImpl(members, userService);
+    }
+
+    private void callerIsOwner() {
+        B2bAccountMember m = new B2bAccountMember();
+        m.setRole(MemberRole.OWNER);
+        when(members.findByB2bAccountIdAndUserId(account, owner)).thenReturn(Optional.of(m));
+    }
+
+    private static UserResponse user(UUID id, String email, String role) {
+        return new UserResponse(id, email, "Teammate", role, null, true);
+    }
+
+    @Test
+    void ownerAddsAnExistingBusinessUser_asMember() {
+        callerIsOwner();
+        UUID newUser = UUID.randomUUID();
+        when(userService.getUserByEmail("teammate@acme.example")).thenReturn(user(newUser, "teammate@acme.example", "B2B_USER"));
+        when(members.existsByUserId(newUser)).thenReturn(false);
+        when(members.save(any(B2bAccountMember.class))).thenAnswer(i -> i.getArgument(0));
+
+        MemberResponse r = service().add(account, owner, "teammate@acme.example");
+
+        assertThat(r.role()).isEqualTo("MEMBER");
+        ArgumentCaptor<B2bAccountMember> saved = ArgumentCaptor.forClass(B2bAccountMember.class);
+        verify(members).save(saved.capture());
+        assertThat(saved.getValue().getB2bAccountId()).isEqualTo(account);
+        assertThat(saved.getValue().getUserId()).isEqualTo(newUser);
+        assertThat(saved.getValue().getRole()).isEqualTo(MemberRole.MEMBER);
+    }
+
+    @Test
+    void nonOwnerCannotAdd() {
+        B2bAccountMember plain = new B2bAccountMember();
+        plain.setRole(MemberRole.MEMBER);
+        UUID caller = UUID.randomUUID();
+        when(members.findByB2bAccountIdAndUserId(account, caller)).thenReturn(Optional.of(plain));
+
+        assertThatThrownBy(() -> service().add(account, caller, "x@y.com"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("owner");
+        verify(members, never()).save(any());
+    }
+
+    @Test
+    void unknownEmailIs404() {
+        callerIsOwner();
+        when(userService.getUserByEmail("nobody@x.com")).thenThrow(new UserNotFoundException("nope"));
+        assertThatThrownBy(() -> service().add(account, owner, "nobody@x.com"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("sign up");
+        verify(members, never()).save(any());
+    }
+
+    @Test
+    void nonBusinessUserRejected() {
+        callerIsOwner();
+        when(userService.getUserByEmail("cust@x.com")).thenReturn(user(UUID.randomUUID(), "cust@x.com", "B2C_CUSTOMER"));
+        assertThatThrownBy(() -> service().add(account, owner, "cust@x.com"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("business user");
+        verify(members, never()).save(any());
+    }
+
+    @Test
+    void alreadyOnAnAccountIsConflict() {
+        callerIsOwner();
+        UUID u = UUID.randomUUID();
+        when(userService.getUserByEmail("dup@x.com")).thenReturn(user(u, "dup@x.com", "B2B_USER"));
+        when(members.existsByUserId(u)).thenReturn(true);
+        assertThatThrownBy(() -> service().add(account, owner, "dup@x.com"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("already belongs");
+        verify(members, never()).save(any());
+    }
+
+    @Test
+    void ownerCannotBeRemoved() {
+        callerIsOwner();
+        B2bAccountMember target = new B2bAccountMember();
+        target.setRole(MemberRole.OWNER);
+        UUID ownerTarget = UUID.randomUUID();
+        when(members.findByB2bAccountIdAndUserId(account, ownerTarget)).thenReturn(Optional.of(target));
+
+        assertThatThrownBy(() -> service().remove(account, owner, ownerTarget))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("owner can't be removed");
+        verify(members, never()).delete(any());
+    }
+
+    @Test
+    void ownerRemovesAMember() {
+        callerIsOwner();
+        B2bAccountMember target = new B2bAccountMember();
+        target.setRole(MemberRole.MEMBER);
+        UUID memberId = UUID.randomUUID();
+        when(members.findByB2bAccountIdAndUserId(account, memberId)).thenReturn(Optional.of(target));
+
+        service().remove(account, owner, memberId);
+
+        verify(members).delete(target);
+    }
+}


### PR DESCRIPTION

<img width="2422" height="1302" alt="image" src="https://github.com/user-attachments/assets/9b4097f9-eda8-43a4-8242-a9d23b89eb52" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added B2B account member management, including member listing, invitations, and removals.
- Added owner and member roles with appropriate access controls.
- Existing business account owners are automatically registered as account members.
- Account members can access supported B2B features across shipments, branding, wallets, notifications, analytics, and more.

## Tests
- Added coverage for authorization, invitations, duplicate memberships, invalid users, and member removal rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->