### PR TITLE
feat(orders): pickup-slot availability endpoint (hide full slots)

### DIFF
--- a/orders/src/main/java/com/oneday/orders/api/PickupSlotController.java
+++ b/orders/src/main/java/com/oneday/orders/api/PickupSlotController.java
@@ -1,0 +1,35 @@
+package com.oneday.orders.api;
+
+import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.orders.dto.SlotAvailabilityResponse;
+import com.oneday.orders.service.PickupSlotAvailabilityService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Remaining DA-pickup slot capacity for a city, so the Ship form can grey out full slots before the
+ * merchant books. Read-only and city-level (not account-scoped) — any B2B user may query it.
+ */
+@RestController
+@RequestMapping("/api/v1/b2b/pickup-slots")
+class PickupSlotController {
+
+    private final PickupSlotAvailabilityService availability;
+
+    PickupSlotController(PickupSlotAvailabilityService availability) {
+        this.availability = availability;
+    }
+
+    /** @param city origin city code (e.g. "DEL"); @param days horizon from today (default 2). */
+    @GetMapping
+    public SlotAvailabilityResponse slots(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @RequestParam("city") String city,
+            @RequestParam(value = "days", defaultValue = "2") int days) {
+        Authz.requireRole(principal, "B2B_USER");
+        return availability.forCity(city, days);
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/dto/SlotAvailabilityResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/SlotAvailabilityResponse.java
@@ -1,0 +1,15 @@
+package com.oneday.orders.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Remaining pickup-slot capacity for a city over the next few days, so the Ship form can hide/disable
+ * full slots before booking. {@code remaining} is {@code maxPerSlot - booked} (never negative);
+ * {@code full} is {@code remaining == 0}. Only DA_PICKUP slots are capped (SELF_DROP is uncapped).
+ */
+public record SlotAvailabilityResponse(String city, List<Slot> slots) {
+
+    /** @param startHour IST slot start hour (7/9/11/13/15/17/19); the slot runs 2 hours. */
+    public record Slot(LocalDate date, int startHour, int remaining, boolean full) {}
+}

--- a/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
@@ -79,6 +79,16 @@ public interface ShipmentRepository extends JpaRepository<Shipment, UUID> {
     int countByOriginCityAndScheduledPickupStartAndPickupTypeAndCancelledAtIsNull(
             String originCity, Instant scheduledPickupStart, PickupType pickupType);
 
+    // Pickup-slot availability: booked count per slot start across a city + time window, in ONE grouped
+    // query (instead of one count per candidate slot). Backs the "hide full slots" picker.
+    @Query("SELECT s.scheduledPickupStart AS start, COUNT(s) AS count FROM Shipment s "
+            + "WHERE s.originCity = :city AND s.pickupType = :pickupType AND s.cancelledAt IS NULL "
+            + "AND s.scheduledPickupStart >= :from AND s.scheduledPickupStart < :to "
+            + "GROUP BY s.scheduledPickupStart")
+    List<SlotBookingCount> countBookedSlotsInRange(@Param("city") String city,
+                                                   @Param("pickupType") PickupType pickupType,
+                                                   @Param("from") Instant from, @Param("to") Instant to);
+
     // Order → N Shipments: the child shipments of one order (booking order preserved).
     List<Shipment> findByOrderIdOrderByCreatedAtAsc(UUID orderId);
 

--- a/orders/src/main/java/com/oneday/orders/repository/SlotBookingCount.java
+++ b/orders/src/main/java/com/oneday/orders/repository/SlotBookingCount.java
@@ -1,0 +1,9 @@
+package com.oneday.orders.repository;
+
+import java.time.Instant;
+
+/** Projection for the pickup-slot availability rollup: booked count per slot start instant. */
+public interface SlotBookingCount {
+    Instant getStart();
+    long getCount();
+}

--- a/orders/src/main/java/com/oneday/orders/service/PickupSlotAvailabilityService.java
+++ b/orders/src/main/java/com/oneday/orders/service/PickupSlotAvailabilityService.java
@@ -1,0 +1,14 @@
+package com.oneday.orders.service;
+
+import com.oneday.orders.dto.SlotAvailabilityResponse;
+
+/**
+ * Read-only remaining capacity of DA-pickup slots for a city, so the booking UI can grey out full
+ * slots. The read-side counterpart to the booking-time cap in {@code PickupSlotCapacity} — same
+ * soft-cap semantics (a point-in-time count, not a reservation).
+ */
+public interface PickupSlotAvailabilityService {
+
+    /** Availability for {@code city} across the next {@code days} days (from today, IST). */
+    SlotAvailabilityResponse forCity(String city, int days);
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/PickupSlotAvailabilityServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/PickupSlotAvailabilityServiceImpl.java
@@ -1,0 +1,62 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.PickupSlots;
+import com.oneday.common.domain.enums.PickupType;
+import com.oneday.orders.config.PickupSlotProperties;
+import com.oneday.orders.dto.SlotAvailabilityResponse;
+import com.oneday.orders.dto.SlotAvailabilityResponse.Slot;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.repository.SlotBookingCount;
+import com.oneday.orders.service.PickupSlotAvailabilityService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+class PickupSlotAvailabilityServiceImpl implements PickupSlotAvailabilityService {
+
+    private static final int MAX_DAYS = 14;
+
+    private final ShipmentRepository shipments;
+    private final PickupSlotProperties props;
+
+    PickupSlotAvailabilityServiceImpl(ShipmentRepository shipments, PickupSlotProperties props) {
+        this.shipments = shipments;
+        this.props = props;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SlotAvailabilityResponse forCity(String city, int days) {
+        String c = city.trim().toUpperCase();
+        int span = Math.min(Math.max(days, 1), MAX_DAYS);
+        LocalDate today = LocalDate.now(PickupSlots.ZONE);
+        Instant from = PickupSlots.resolve(today, PickupSlots.startHours().get(0)).start();
+        Instant to = today.plusDays(span).atStartOfDay(PickupSlots.ZONE).toInstant();
+
+        // One grouped query for the whole window, then look each slot up by its start instant.
+        Map<Instant, Long> booked = new HashMap<>();
+        for (SlotBookingCount row : shipments.countBookedSlotsInRange(c, PickupType.DA_PICKUP, from, to)) {
+            booked.put(row.getStart(), row.getCount());
+        }
+
+        int max = props.getMaxPerSlot();
+        List<Slot> slots = new ArrayList<>();
+        for (int d = 0; d < span; d++) {
+            LocalDate date = today.plusDays(d);
+            for (int hour : PickupSlots.startHours()) {
+                Instant start = PickupSlots.resolve(date, hour).start();
+                long count = booked.getOrDefault(start, 0L);
+                int remaining = (int) Math.max(0, max - count);
+                slots.add(new Slot(date, hour, remaining, remaining == 0));
+            }
+        }
+        return new SlotAvailabilityResponse(c, slots);
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/service/impl/PickupSlotAvailabilityServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/PickupSlotAvailabilityServiceImplTest.java
@@ -1,0 +1,72 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.PickupSlots;
+import com.oneday.common.domain.enums.PickupType;
+import com.oneday.orders.config.PickupSlotProperties;
+import com.oneday.orders.dto.SlotAvailabilityResponse;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.repository.SlotBookingCount;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PickupSlotAvailabilityServiceImplTest {
+
+    @Mock private ShipmentRepository shipments;
+
+    private PickupSlotAvailabilityServiceImpl service(int maxPerSlot) {
+        PickupSlotProperties props = new PickupSlotProperties();
+        props.setMaxPerSlot(maxPerSlot);
+        return new PickupSlotAvailabilityServiceImpl(shipments, props);
+    }
+
+    private static SlotBookingCount count(Instant start, long n) {
+        return new SlotBookingCount() {
+            public Instant getStart() { return start; }
+            public long getCount() { return n; }
+        };
+    }
+
+    @Test
+    void reportsRemainingPerSlot_andMarksTheFullOne() {
+        LocalDate today = LocalDate.now(PickupSlots.ZONE);
+        // Slot 09:00 today is fully booked (10 of 10); everything else empty.
+        Instant nineToday = PickupSlots.resolve(today, 9).start();
+        when(shipments.countBookedSlotsInRange(eq("DEL"), eq(PickupType.DA_PICKUP), any(), any()))
+                .thenReturn(List.of(count(nineToday, 10)));
+
+        SlotAvailabilityResponse r = service(10).forCity("del", 2);  // lowercase → normalised
+
+        assertThat(r.city()).isEqualTo("DEL");
+        // 2 days × 7 slot hours
+        assertThat(r.slots()).hasSize(14);
+        var full = r.slots().stream().filter(SlotAvailabilityResponse.Slot::full).toList();
+        assertThat(full).hasSize(1);
+        assertThat(full.get(0).date()).isEqualTo(today);
+        assertThat(full.get(0).startHour()).isEqualTo(9);
+        assertThat(full.get(0).remaining()).isZero();
+        // an untouched slot has the full capacity remaining
+        var elevenToday = r.slots().stream()
+                .filter(s -> s.date().equals(today) && s.startHour() == 11).findFirst().orElseThrow();
+        assertThat(elevenToday.remaining()).isEqualTo(10);
+        assertThat(elevenToday.full()).isFalse();
+    }
+
+    @Test
+    void clampsDaysToSaneBounds() {
+        when(shipments.countBookedSlotsInRange(any(), any(), any(), any())).thenReturn(List.of());
+        assertThat(service(50).forCity("BLR", 0).slots()).hasSize(7);    // min 1 day
+        assertThat(service(50).forCity("BLR", 999).slots()).hasSize(14 * 7); // capped at 14 days
+    }
+}


### PR DESCRIPTION

<img width="2262" height="1224" alt="image" src="https://github.com/user-attachments/assets/3576d3fa-e162-4fac-9ed0-e8334a0a101c" />


## What
The last leftover of roadmap **#11** (delay-mail/slots): surface remaining pickup-slot capacity so the Ship form can hide full slots. The per-slot **caps** already existed at booking time; this adds the read side.

`GET /api/v1/b2b/pickup-slots?city=DEL&days=2` → remaining DA-pickup capacity per slot (`remaining = maxPerSlot − booked`, `full = remaining 0`), for each of the 7 daily windows across the horizon.

## How
- One **grouped query** (`countBookedSlotsInRange`) over the whole window, then looked up per slot — not one count per slot (fast on the shared DB).
- Reuses `PickupSlots` (the 7×2h IST grid) + `PickupSlotProperties.maxPerSlot`. Same soft-cap semantics as the booking-time cap (a point-in-time read, not a reservation). Read-only, city-level, B2B-gated.

## Verified
- `PickupSlotAvailabilityServiceImplTest` (2): marks the full slot, reports remaining per slot, clamps `days`.
- Live: `GET …/pickup-slots?city=DEL` → 14 slots, correct remaining.

Web counterpart (grey-out picker): Sidarthapati/oneday-web#46.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added city-level pickup-slot availability for authenticated business users.
  * Availability can be requested for upcoming days, with results showing dates, start times, remaining capacity, and whether slots are full.
  * Requests are supported for a configurable 1–14 day range, with automatic handling of values outside that range.

* **Tests**
  * Added coverage for capacity calculations, full-slot detection, city normalization, and date-range handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->