### PR TITLE
feat(exceptions): Jira integration scaffold for support tickets (#14, creds-gated)

### DIFF
--- a/exceptions/src/main/java/com/oneday/exceptions/integration/JiraClient.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/integration/JiraClient.java
@@ -1,0 +1,80 @@
+package com.oneday.exceptions.integration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * REST implementation of {@link JiraPort} over the Jira Cloud v3 API. Off by default; when enabled +
+ * configured it POSTs {@code /rest/api/3/issue} with basic auth (email:apiToken). Best-effort — any
+ * failure is logged and swallowed so raising a support ticket never depends on Jira being reachable.
+ */
+@Component
+class JiraClient implements JiraPort {
+
+    private static final Logger log = LoggerFactory.getLogger(JiraClient.class);
+
+    private final JiraProperties props;
+    private final RestClient.Builder restClientBuilder;
+
+    JiraClient(JiraProperties props, RestClient.Builder restClientBuilder) {
+        this.props = props;
+        this.restClientBuilder = restClientBuilder;
+    }
+
+    @Override
+    public Optional<String> createIssue(String summary, String description) {
+        if (!props.isEnabled()) {
+            log.debug("[jira] disabled — skipping issue creation for '{}'", summary);
+            return Optional.empty();
+        }
+        if (!props.isConfigured()) {
+            log.warn("[jira] enabled but not fully configured (base-url/project-key/email/api-token) — skipping");
+            return Optional.empty();
+        }
+        try {
+            String basic = Base64.getEncoder().encodeToString(
+                    (props.getEmail() + ":" + props.getApiToken()).getBytes(StandardCharsets.UTF_8));
+            Map<?, ?> response = restClientBuilder.baseUrl(props.getBaseUrl()).build()
+                    .post()
+                    .uri("/rest/api/3/issue")
+                    .header(HttpHeaders.AUTHORIZATION, "Basic " + basic)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(issuePayload(summary, description))
+                    .retrieve()
+                    .body(Map.class);
+            Object key = response == null ? null : response.get("key");
+            if (key == null) {
+                log.warn("[jira] issue created but no key in response");
+                return Optional.empty();
+            }
+            log.info("[jira] created issue {} for '{}'", key, summary);
+            return Optional.of(key.toString());
+        } catch (Exception e) {
+            log.warn("[jira] issue creation failed: {}", e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    /** Jira Cloud v3 create-issue body (description in the minimal Atlassian Document Format). */
+    private Map<String, Object> issuePayload(String summary, String description) {
+        Map<String, Object> textNode = Map.of("type", "text", "text", description == null ? "" : description);
+        Map<String, Object> paragraph = Map.of("type", "paragraph", "content", List.of(textNode));
+        Map<String, Object> doc = Map.of("type", "doc", "version", 1, "content", List.of(paragraph));
+        Map<String, Object> fields = Map.of(
+                "project", Map.of("key", props.getProjectKey()),
+                "issuetype", Map.of("name", props.getIssueType()),
+                "summary", summary,
+                "description", doc);
+        return Map.of("fields", fields);
+    }
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/integration/JiraPort.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/integration/JiraPort.java
@@ -1,0 +1,18 @@
+package com.oneday.exceptions.integration;
+
+import java.util.Optional;
+
+/**
+ * Creates a Jira issue for a support ticket (roadmap #14). Fire-and-forget and best-effort: a failure
+ * (or a disabled integration) returns empty and never breaks the ticket flow.
+ */
+public interface JiraPort {
+
+    /**
+     * @param summary     the issue summary (one line)
+     * @param description plain-text body
+     * @return the created issue key (e.g. "OPS-123"), or empty if the integration is off / not
+     *         configured / the call failed
+     */
+    Optional<String> createIssue(String summary, String description);
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/integration/JiraProperties.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/integration/JiraProperties.java
@@ -1,0 +1,53 @@
+package com.oneday.exceptions.integration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Jira integration config (roadmap #14, chat→Jira). Disabled by default — the platform ships without
+ * Jira and flips it on when an ops team provides real credentials. NEVER commit secrets: set
+ * {@code apiToken} (and the rest) via environment variables only.
+ *
+ * <pre>{@code
+ * integrations:
+ *   jira:
+ *     enabled: true
+ *     base-url: https://your-org.atlassian.net
+ *     project-key: OPS
+ *     email: bot@your-org.com
+ *     api-token: ${JIRA_API_TOKEN}
+ *     issue-type: Task
+ * }</pre>
+ */
+@Component
+@ConfigurationProperties(prefix = "integrations.jira")
+public class JiraProperties {
+
+    /** Master switch — when false, JiraClient is a logged no-op. Default false. */
+    private boolean enabled = false;
+    private String baseUrl;
+    private String projectKey;
+    private String email;
+    private String apiToken;
+    private String issueType = "Task";
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+    public String getBaseUrl() { return baseUrl; }
+    public void setBaseUrl(String baseUrl) { this.baseUrl = baseUrl; }
+    public String getProjectKey() { return projectKey; }
+    public void setProjectKey(String projectKey) { this.projectKey = projectKey; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getApiToken() { return apiToken; }
+    public void setApiToken(String apiToken) { this.apiToken = apiToken; }
+    public String getIssueType() { return issueType; }
+    public void setIssueType(String issueType) { this.issueType = issueType; }
+
+    /** True only when enabled AND all required connection fields are present. */
+    public boolean isConfigured() {
+        return enabled && notBlank(baseUrl) && notBlank(projectKey) && notBlank(email) && notBlank(apiToken);
+    }
+
+    private static boolean notBlank(String s) { return s != null && !s.isBlank(); }
+}

--- a/exceptions/src/main/java/com/oneday/exceptions/service/impl/SupportTicketServiceImpl.java
+++ b/exceptions/src/main/java/com/oneday/exceptions/service/impl/SupportTicketServiceImpl.java
@@ -31,9 +31,12 @@ class SupportTicketServiceImpl implements SupportTicketService {
     private final SupportTicketRepository repository;
     private final SupportTicketMessageRepository messages;
     private final ShipmentLookupService shipmentLookup;
+    private final com.oneday.exceptions.integration.JiraPort jira;
 
     SupportTicketServiceImpl(SupportTicketRepository repository, SupportTicketMessageRepository messages,
-                             ShipmentLookupService shipmentLookup) {
+                             ShipmentLookupService shipmentLookup,
+                             com.oneday.exceptions.integration.JiraPort jira) {
+        this.jira = jira;
         this.repository = repository;
         this.messages = messages;
         this.shipmentLookup = shipmentLookup;
@@ -74,7 +77,16 @@ class SupportTicketServiceImpl implements SupportTicketService {
         t.setBody(body);
         t.setContactPhone(contactPhone);
         t.setStatus(TicketStatus.OPEN);
-        return SupportTicketResponse.from(repository.save(t));
+        SupportTicket saved = repository.save(t);
+
+        // Best-effort mirror to Jira (off unless configured) — a real ticket becomes an ops issue.
+        // Never breaks ticket creation: the client swallows failures and returns empty when disabled.
+        if (saved.getChannel() == TicketChannel.TICKET) {
+            jira.createIssue(
+                    subject != null ? subject : "Support ticket " + saved.getId(),
+                    (body != null ? body : "") + (shipmentRef != null ? "\n\nShipment: " + shipmentRef : ""));
+        }
+        return SupportTicketResponse.from(saved);
     }
 
     @Override

--- a/exceptions/src/test/java/com/oneday/exceptions/integration/JiraClientTest.java
+++ b/exceptions/src/test/java/com/oneday/exceptions/integration/JiraClientTest.java
@@ -1,0 +1,80 @@
+package com.oneday.exceptions.integration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class JiraClientTest {
+
+    private static JiraProperties props(boolean enabled, boolean configured) {
+        JiraProperties p = new JiraProperties();
+        p.setEnabled(enabled);
+        if (configured) {
+            p.setBaseUrl("https://jira.example");
+            p.setProjectKey("OPS");
+            p.setEmail("bot@x.com");
+            p.setApiToken("tok");
+        }
+        return p;
+    }
+
+    @Test
+    void disabled_isANoOp_andMakesNoHttpCall() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        // No expectations set → any HTTP call would fail verification.
+        JiraClient client = new JiraClient(props(false, false), builder);
+
+        assertThat(client.createIssue("Damaged box", "It arrived crushed")).isEmpty();
+        server.verify(); // no calls made
+    }
+
+    @Test
+    void enabledButNotConfigured_isANoOp() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer.bindTo(builder).build();
+        JiraClient client = new JiraClient(props(true, false), builder);
+        assertThat(client.createIssue("x", "y")).isEmpty();
+    }
+
+    @Test
+    void configured_postsTheIssue_andReturnsTheKey() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        server.expect(requestTo("https://jira.example/rest/api/3/issue"))
+                .andExpect(method(POST))
+                .andExpect(header("Authorization", org.hamcrest.Matchers.startsWith("Basic ")))
+                .andExpect(jsonPath("$.fields.project.key").value("OPS"))
+                .andExpect(jsonPath("$.fields.summary").value("Damaged box"))
+                .andRespond(withSuccess("{\"key\":\"OPS-42\"}", APPLICATION_JSON));
+
+        JiraClient client = new JiraClient(props(true, true), builder);
+        Optional<String> key = client.createIssue("Damaged box", "It arrived crushed");
+
+        assertThat(key).contains("OPS-42");
+        server.verify();
+    }
+
+    @Test
+    void httpFailure_isSwallowed_returnsEmpty() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        server.expect(requestTo("https://jira.example/rest/api/3/issue"))
+                .andRespond(org.springframework.test.web.client.response.MockRestResponseCreators
+                        .withServerError());
+
+        JiraClient client = new JiraClient(props(true, true), builder);
+        assertThat(client.createIssue("x", "y")).isEmpty();
+    }
+}

--- a/exceptions/src/test/java/com/oneday/exceptions/service/impl/SupportTicketServiceImplTest.java
+++ b/exceptions/src/test/java/com/oneday/exceptions/service/impl/SupportTicketServiceImplTest.java
@@ -34,8 +34,10 @@ class SupportTicketServiceImplTest {
     private final SupportTicketRepository repo = mock(SupportTicketRepository.class);
     private final SupportTicketMessageRepository messages = mock(SupportTicketMessageRepository.class);
     private final ShipmentLookupService shipmentLookup = mock(ShipmentLookupService.class);
+    private final com.oneday.exceptions.integration.JiraPort jira =
+            mock(com.oneday.exceptions.integration.JiraPort.class);
     private final SupportTicketServiceImpl service =
-            new SupportTicketServiceImpl(repo, messages, shipmentLookup);
+            new SupportTicketServiceImpl(repo, messages, shipmentLookup, jira);
 
     private static final UUID USER = UUID.randomUUID();
 


### PR DESCRIPTION
## What
The buildable half of roadmap **#14**'s Jira piece. A support **TICKET** now best-effort mirrors to Jira as an ops issue. **Off by default** — no behaviour change until an ops team supplies real Jira credentials.

## How
- `JiraPort` + config-gated `JiraClient` (Jira Cloud **v3** `POST /rest/api/3/issue` over Spring `RestClient`, basic auth `email:apiToken`, ADF description body).
- `JiraProperties` (`integrations.jira.*`): `enabled` (default **false**), `base-url`, `project-key`, `email`, `api-token`, `issue-type`. **Secrets via env only — never committed.**
- Best-effort: disabled / misconfigured / failed calls return empty and **never break ticket creation** (verified live — a ticket still creates with the hook, Jira off).
- Wired into `SupportTicketService.create` (TICKET channel).

## Verified
- `JiraClientTest` (MockRestServiceServer): disabled → no HTTP; enabled → POSTs the issue + returns the key; server error → swallowed. `SupportTicketServiceImplTest` still green. 16 exceptions tests pass; app boots with the beans wired.

## ⚠️ Limitation (the external blocker)
Real posting needs **live Jira credentials**, which aren't available — so the HTTP path is verified against a **mock**, not a real Jira. To turn it on: set `integrations.jira.enabled=true` + the connection env vars. This PR makes #14's Jira half **code-complete and ready to flip on**; it does not (and can't, without creds) prove a real round-trip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support tickets from the `TICKET` channel can now be mirrored to Jira Cloud.
  * Jira issue creation supports configurable project, issue type, account, and API settings.
  * Jira integration is disabled by default and handles incomplete or unsuccessful requests without interrupting ticket creation.

* **Tests**
  * Added coverage for successful Jira issue creation, disabled or incomplete configuration, and request failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->