### PR TITLE
feat(analytics): per-category shipment split

### DIFF
--- a/orders/src/main/java/com/oneday/orders/domain/MerchantCategory.java
+++ b/orders/src/main/java/com/oneday/orders/domain/MerchantCategory.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.Instant;
 import java.util.UUID;
 
 /**
@@ -26,4 +27,9 @@ public class MerchantCategory extends MutableBaseEntity {
 
     @Column(name = "name", length = 60, nullable = false)
     private String name;
+
+    /** When the merchant archived (soft-deleted) this category. Null = live. Archived rows stay so
+     *  reports still resolve the name of parcels tagged with them, but drop out of the pick list. */
+    @Column(name = "archived_at")
+    private Instant archivedAt;
 }

--- a/orders/src/main/java/com/oneday/orders/dto/MerchantAnalyticsResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/MerchantAnalyticsResponse.java
@@ -20,6 +20,7 @@ import java.util.List;
  * @param codValuePaise     total COD goods-value handled, in paise
  * @param avgShipmentPaise  gmvPaise ÷ totalShipments (0 when no shipments)
  * @param topDestinations   busiest destination cities first
+ * @param categorySplit     shipment count per merchant category, busiest first (untagged → "Uncategorised")
  */
 public record MerchantAnalyticsResponse(
         Integer windowDays,
@@ -33,8 +34,12 @@ public record MerchantAnalyticsResponse(
         long gmvPaise,
         long codValuePaise,
         long avgShipmentPaise,
-        List<DestinationCount> topDestinations) {
+        List<DestinationCount> topDestinations,
+        List<CategoryCount> categorySplit) {
 
     /** One destination city with its shipment count. */
     public record DestinationCount(String city, long count) {}
+
+    /** One merchant category with its shipment count. */
+    public record CategoryCount(String category, long count) {}
 }

--- a/orders/src/main/java/com/oneday/orders/repository/CategoryCount.java
+++ b/orders/src/main/java/com/oneday/orders/repository/CategoryCount.java
@@ -1,0 +1,13 @@
+package com.oneday.orders.repository;
+
+import java.util.UUID;
+
+/**
+ * Projection for the merchant-analytics category split — one row per {@code category_id} with the
+ * shipment count ({@code categoryId} is null for untagged parcels). Alias names in the JPQL
+ * ({@code AS categoryId}, {@code AS count}) must match these getters. Names are resolved in the service.
+ */
+public interface CategoryCount {
+    UUID getCategoryId();
+    long getCount();
+}

--- a/orders/src/main/java/com/oneday/orders/repository/MerchantCategoryRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/MerchantCategoryRepository.java
@@ -9,10 +9,17 @@ import java.util.UUID;
 
 public interface MerchantCategoryRepository extends JpaRepository<MerchantCategory, UUID> {
 
+    /** All of a merchant's categories incl. archived — for resolving names on already-tagged shipments
+     *  (analytics). Never use for the pick list, which must show live categories only. */
     List<MerchantCategory> findByB2bAccountIdOrderByName(UUID b2bAccountId);
 
-    /** Account-scoped fetch so one merchant can never read/edit/tag-with another's category by id. */
-    Optional<MerchantCategory> findByIdAndB2bAccountId(UUID id, UUID b2bAccountId);
+    /** The merchant's live (non-archived) categories — the pick list / console list. */
+    List<MerchantCategory> findByB2bAccountIdAndArchivedAtIsNullOrderByName(UUID b2bAccountId);
 
-    boolean existsByB2bAccountIdAndNameIgnoreCase(UUID b2bAccountId, String name);
+    /** Account-scoped live fetch so one merchant can never read/edit/tag-with another's (or an archived)
+     *  category by id. Rename/delete/booking-tag all go through this. */
+    Optional<MerchantCategory> findByIdAndB2bAccountIdAndArchivedAtIsNull(UUID id, UUID b2bAccountId);
+
+    /** Uniqueness is enforced only among live categories (an archived name can be reused). */
+    boolean existsByB2bAccountIdAndNameIgnoreCaseAndArchivedAtIsNull(UUID b2bAccountId, String name);
 }

--- a/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
@@ -147,6 +147,12 @@ public interface ShipmentRepository extends JpaRepository<Shipment, UUID> {
             + "GROUP BY s.destCity ORDER BY COUNT(s) DESC")
     List<CityCount> destinationSplitForAccount(@Param("accountId") UUID accountId, @Param("since") Instant since);
 
+    // Category split — one row per category_id (null = untagged), busiest first. Names resolved in the service.
+    @Query("SELECT s.categoryId AS categoryId, COUNT(s) AS count FROM Shipment s "
+            + "WHERE s.b2bAccountId = :accountId AND s.createdAt >= :since "
+            + "GROUP BY s.categoryId ORDER BY COUNT(s) DESC")
+    List<CategoryCount> categorySplitForAccount(@Param("accountId") UUID accountId, @Param("since") Instant since);
+
     // On-time delivery: joins each parcel's actual delivered time (the history row's occurred_at for a
     // delivered terminal state) against its promised ETA. Theta-join because shipment↔history is a bare
     // UUID reference, not a mapped association. Only parcels with a promised ETA are rated.

--- a/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
@@ -144,9 +144,12 @@ class B2bBookingServiceImpl implements B2bBookingService {
             throw new AccountAccessException(
                     "Caller is not authorized for B2B account: " + req.getB2bAccountId());
         }
-        // Category (optional) must be one of THIS merchant's own — never another account's category.
+        // Category (optional) must be one of THIS merchant's own LIVE categories — never another
+        // account's, and never an archived (soft-deleted) one.
         if (req.getCategoryId() != null
-                && merchantCategoryRepository.findByIdAndB2bAccountId(req.getCategoryId(), req.getB2bAccountId()).isEmpty()) {
+                && merchantCategoryRepository
+                        .findByIdAndB2bAccountIdAndArchivedAtIsNull(req.getCategoryId(), req.getB2bAccountId())
+                        .isEmpty()) {
             throw new BookingService.InvalidBookingRequestException(
                     "Unknown category for this account: " + req.getCategoryId());
         }

--- a/orders/src/main/java/com/oneday/orders/service/impl/MerchantAnalyticsServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/MerchantAnalyticsServiceImpl.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -37,6 +38,10 @@ class MerchantAnalyticsServiceImpl implements MerchantAnalyticsService {
     private static final int TOP_DESTINATIONS = 6;
 
     private static final String UNCATEGORISED = "Uncategorised";
+    private static final String OTHER = "Other";
+    /** Cap the named-category rows so a merchant who (ab)uses categories as per-order tags can't blow up the
+     *  payload or the chart; everything past the busiest few folds into "Other". */
+    private static final int TOP_CATEGORIES = 10;
 
     private final ShipmentRepository shipments;
     private final MerchantCategoryRepository categories;
@@ -99,15 +104,41 @@ class MerchantAnalyticsServiceImpl implements MerchantAnalyticsService {
         for (MerchantCategory c : categories.findByB2bAccountIdOrderByName(accountId)) {
             names.put(c.getId(), c.getName());
         }
-        Map<String, Long> byName = new LinkedHashMap<>();
-        shipments.categorySplitForAccount(accountId, since).forEach(row -> {
-            String name = row.getCategoryId() == null ? UNCATEGORISED
-                    : names.getOrDefault(row.getCategoryId(), UNCATEGORISED);
-            byName.merge(name, row.getCount(), Long::sum);
-        });
-        return byName.entrySet().stream()
+        // Named-category totals (archived categories still resolve to their real name), plus the untagged
+        // bucket kept aside — "Uncategorised" is meaningful and always shown, never folded into "Other".
+        Map<String, Long> named = new LinkedHashMap<>();
+        long uncategorised = 0;
+        for (var row : shipments.categorySplitForAccount(accountId, since)) {
+            if (row.getCategoryId() == null) {
+                uncategorised += row.getCount();
+                continue;
+            }
+            named.merge(names.getOrDefault(row.getCategoryId(), UNCATEGORISED), row.getCount(), Long::sum);
+        }
+        // A resolved name may itself be "Uncategorised" (a since-deleted id we couldn't resolve) — treat it
+        // the same as untagged rather than as a named category.
+        uncategorised += named.getOrDefault(UNCATEGORISED, 0L);
+        named.remove(UNCATEGORISED);
+
+        List<Map.Entry<String, Long>> sorted = named.entrySet().stream()
                 .sorted(Comparator.comparingLong(Map.Entry<String, Long>::getValue).reversed())
-                .map(e -> new CategoryCount(e.getKey(), e.getValue()))
                 .toList();
+
+        List<CategoryCount> out = new ArrayList<>();
+        long other = 0;
+        for (int i = 0; i < sorted.size(); i++) {
+            if (i < TOP_CATEGORIES) {
+                out.add(new CategoryCount(sorted.get(i).getKey(), sorted.get(i).getValue()));
+            } else {
+                other += sorted.get(i).getValue();   // everything past the busiest few
+            }
+        }
+        if (other > 0) {
+            out.add(new CategoryCount(OTHER, other));
+        }
+        if (uncategorised > 0) {
+            out.add(new CategoryCount(UNCATEGORISED, uncategorised));
+        }
+        return out;
     }
 }

--- a/orders/src/main/java/com/oneday/orders/service/impl/MerchantAnalyticsServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/MerchantAnalyticsServiceImpl.java
@@ -1,9 +1,12 @@
 package com.oneday.orders.service.impl;
 
 import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.domain.MerchantCategory;
 import com.oneday.orders.dto.MerchantAnalyticsResponse;
+import com.oneday.orders.dto.MerchantAnalyticsResponse.CategoryCount;
 import com.oneday.orders.dto.MerchantAnalyticsResponse.DestinationCount;
 import com.oneday.orders.repository.AccountTotals;
+import com.oneday.orders.repository.MerchantCategoryRepository;
 import com.oneday.orders.repository.OnTimeStat;
 import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.repository.StateCount;
@@ -13,8 +16,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
 import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -29,10 +36,14 @@ class MerchantAnalyticsServiceImpl implements MerchantAnalyticsService {
     /** Busiest few destinations are enough for the dashboard; there are only 5 serviceable cities today. */
     private static final int TOP_DESTINATIONS = 6;
 
-    private final ShipmentRepository shipments;
+    private static final String UNCATEGORISED = "Uncategorised";
 
-    MerchantAnalyticsServiceImpl(ShipmentRepository shipments) {
+    private final ShipmentRepository shipments;
+    private final MerchantCategoryRepository categories;
+
+    MerchantAnalyticsServiceImpl(ShipmentRepository shipments, MerchantCategoryRepository categories) {
         this.shipments = shipments;
+        this.categories = categories;
     }
 
     @Override
@@ -73,7 +84,30 @@ class MerchantAnalyticsServiceImpl implements MerchantAnalyticsService {
                 .map(cc -> new DestinationCount(cc.getCity(), cc.getCount()))
                 .toList();
 
+        List<CategoryCount> categorySplit = categorySplit(accountId, since);
+
         return new MerchantAnalyticsResponse(windowDays, total, delivered, inTransit, cancelled, rto,
-                deliveryRatePct, onTimePct, gmv, cod, avg, dests);
+                deliveryRatePct, onTimePct, gmv, cod, avg, dests, categorySplit);
+    }
+
+    /**
+     * Shipments per merchant category, busiest first. The split query groups by {@code category_id}; here
+     * we resolve ids to names, folding untagged parcels and any since-deleted category into "Uncategorised".
+     */
+    private List<CategoryCount> categorySplit(UUID accountId, Instant since) {
+        Map<UUID, String> names = new HashMap<>();
+        for (MerchantCategory c : categories.findByB2bAccountIdOrderByName(accountId)) {
+            names.put(c.getId(), c.getName());
+        }
+        Map<String, Long> byName = new LinkedHashMap<>();
+        shipments.categorySplitForAccount(accountId, since).forEach(row -> {
+            String name = row.getCategoryId() == null ? UNCATEGORISED
+                    : names.getOrDefault(row.getCategoryId(), UNCATEGORISED);
+            byName.merge(name, row.getCount(), Long::sum);
+        });
+        return byName.entrySet().stream()
+                .sorted(Comparator.comparingLong(Map.Entry<String, Long>::getValue).reversed())
+                .map(e -> new CategoryCount(e.getKey(), e.getValue()))
+                .toList();
     }
 }

--- a/orders/src/main/java/com/oneday/orders/service/impl/MerchantCategoryServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/MerchantCategoryServiceImpl.java
@@ -8,6 +8,7 @@ import com.oneday.orders.service.MerchantCategoryService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -23,7 +24,7 @@ class MerchantCategoryServiceImpl implements MerchantCategoryService {
     @Override
     @Transactional(readOnly = true)
     public List<MerchantCategoryResponse> list(UUID accountId) {
-        return repository.findByB2bAccountIdOrderByName(accountId).stream()
+        return repository.findByB2bAccountIdAndArchivedAtIsNullOrderByName(accountId).stream()
                 .map(MerchantCategoryResponse::from)
                 .toList();
     }
@@ -42,7 +43,7 @@ class MerchantCategoryServiceImpl implements MerchantCategoryService {
     @Override
     @Transactional
     public MerchantCategoryResponse rename(UUID accountId, UUID categoryId, MerchantCategoryRequest request) {
-        MerchantCategory entity = repository.findByIdAndB2bAccountId(categoryId, accountId)
+        MerchantCategory entity = repository.findByIdAndB2bAccountIdAndArchivedAtIsNull(categoryId, accountId)
                 .orElseThrow(() -> new CategoryNotFoundException("Category not found: " + categoryId));
         String name = request.getName().trim();
         if (!name.equalsIgnoreCase(entity.getName())) {
@@ -55,15 +56,16 @@ class MerchantCategoryServiceImpl implements MerchantCategoryService {
     @Override
     @Transactional
     public void delete(UUID accountId, UUID categoryId) {
-        MerchantCategory entity = repository.findByIdAndB2bAccountId(categoryId, accountId)
+        MerchantCategory entity = repository.findByIdAndB2bAccountIdAndArchivedAtIsNull(categoryId, accountId)
                 .orElseThrow(() -> new CategoryNotFoundException("Category not found: " + categoryId));
-        // Existing shipments keep their category_id (a snapshot of the tag at booking); deleting the
-        // definition just removes it from the pick list. No cascade needed.
-        repository.delete(entity);
+        // Soft-delete: existing shipments keep their category_id, and the archived row stays so reports
+        // still resolve the name. It just drops out of the pick list. No cascade, no history lost.
+        entity.setArchivedAt(Instant.now());
+        repository.save(entity);
     }
 
     private void requireUnique(UUID accountId, String name) {
-        if (repository.existsByB2bAccountIdAndNameIgnoreCase(accountId, name)) {
+        if (repository.existsByB2bAccountIdAndNameIgnoreCaseAndArchivedAtIsNull(accountId, name)) {
             throw new DuplicateCategoryException("Category already exists: " + name);
         }
     }

--- a/orders/src/main/resources/db/migration/orders/V4_46__merchant_category_soft_delete.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_46__merchant_category_soft_delete.sql
@@ -1,0 +1,10 @@
+-- Soft-delete for merchant categories. Deleting a category shouldn't erase the history of the parcels
+-- already tagged with it: an archived category keeps its row (so reports still show the real name), but
+-- disappears from the pick list. archived_at NULL = live.
+ALTER TABLE merchant_category ADD COLUMN archived_at TIMESTAMPTZ;
+
+-- The name-uniqueness rule now applies only among live categories, so a merchant can reuse the name of a
+-- category they've archived (e.g. re-run a seasonal "Diwali Sale" next year).
+DROP INDEX ux_merchant_category_account_name;
+CREATE UNIQUE INDEX ux_merchant_category_account_name
+  ON merchant_category (b2b_account_id, lower(name)) WHERE archived_at IS NULL;

--- a/orders/src/test/java/com/oneday/orders/service/impl/MerchantAnalyticsServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/MerchantAnalyticsServiceImplTest.java
@@ -174,10 +174,34 @@ class MerchantAnalyticsServiceImplTest {
 
         MerchantAnalyticsResponse r = service().forAccount(acct, 30);
 
-        // Untagged (null) + the since-deleted id both fold into "Uncategorised" (3 + 1 = 4), busiest first.
+        // Named categories busiest-first, then Uncategorised pinned last (untagged 3 + since-deleted id 1 = 4).
         assertThat(r.categorySplit()).extracting("category", "count").containsExactly(
                 tuple("Electronics", 5L),
-                tuple("Uncategorised", 4L),
-                tuple("Apparel", 2L));
+                tuple("Apparel", 2L),
+                tuple("Uncategorised", 4L));
+    }
+
+    @Test
+    void categorySplitCapsNamedCategoriesAtTopTenPlusOther() {
+        // 12 named categories with descending counts 12..1, plus some untagged parcels.
+        List<MerchantCategory> defs = new java.util.ArrayList<>();
+        List<CategoryCount> counts = new java.util.ArrayList<>();
+        for (int i = 0; i < 12; i++) {
+            UUID id = UUID.randomUUID();
+            defs.add(mcat(id, "Cat" + i));
+            counts.add(cat(id, 12 - i)); // Cat0=12, Cat1=11, … Cat11=1
+        }
+        counts.add(cat(null, 100)); // untagged
+        when(categories.findByB2bAccountIdOrderByName(acct)).thenReturn(defs);
+        when(shipments.categorySplitForAccount(eq(acct), any())).thenReturn(counts);
+
+        MerchantAnalyticsResponse r = service().forAccount(acct, 30);
+
+        // Top 10 named (Cat0..Cat9), then "Other" = the tail (Cat10=2 + Cat11=1 = 3), then Uncategorised.
+        assertThat(r.categorySplit()).hasSize(12); // 10 + Other + Uncategorised
+        assertThat(r.categorySplit()).element(0).extracting("category", "count").containsExactly("Cat0", 12L);
+        assertThat(r.categorySplit()).element(9).extracting("category", "count").containsExactly("Cat9", 3L);
+        assertThat(r.categorySplit()).element(10).extracting("category", "count").containsExactly("Other", 3L);
+        assertThat(r.categorySplit()).element(11).extracting("category", "count").containsExactly("Uncategorised", 100L);
     }
 }

--- a/orders/src/test/java/com/oneday/orders/service/impl/MerchantAnalyticsServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/MerchantAnalyticsServiceImplTest.java
@@ -1,9 +1,12 @@
 package com.oneday.orders.service.impl;
 
 import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.domain.MerchantCategory;
 import com.oneday.orders.dto.MerchantAnalyticsResponse;
 import com.oneday.orders.repository.AccountTotals;
+import com.oneday.orders.repository.CategoryCount;
 import com.oneday.orders.repository.CityCount;
+import com.oneday.orders.repository.MerchantCategoryRepository;
 import com.oneday.orders.repository.OnTimeStat;
 import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.repository.StateCount;
@@ -17,6 +20,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -25,8 +29,36 @@ import static org.mockito.Mockito.when;
 class MerchantAnalyticsServiceImplTest {
 
     @Mock private ShipmentRepository shipments;
+    @Mock private MerchantCategoryRepository categories;
 
     private final UUID acct = UUID.randomUUID();
+
+    private MerchantAnalyticsServiceImpl service() {
+        return new MerchantAnalyticsServiceImpl(shipments, categories);
+    }
+
+    private static CategoryCount cat(UUID id, long n) {
+        return new CategoryCount() {
+            @Override
+            public UUID getCategoryId() { return id; }
+            @Override
+            public long getCount() { return n; }
+        };
+    }
+
+    /** A real MerchantCategory with a set id + name (id has no setter, so reflect it in). */
+    private static MerchantCategory mcat(UUID id, String name) {
+        MerchantCategory c = new MerchantCategory();
+        c.setName(name);
+        try {
+            var idField = com.oneday.common.domain.BaseEntity.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(c, id);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+        return c;
+    }
 
     private static StateCount state(ShipmentState s, long c) {
         return new StateCount() {
@@ -78,7 +110,7 @@ class MerchantAnalyticsServiceImplTest {
         when(shipments.destinationSplitForAccount(eq(acct), any())).thenReturn(List.of(
                 city("DEL", 9), city("BLR", 7)));
 
-        MerchantAnalyticsServiceImpl svc = new MerchantAnalyticsServiceImpl(shipments);
+        MerchantAnalyticsServiceImpl svc = service();
         MerchantAnalyticsResponse r = svc.forAccount(acct, 30);
 
         assertThat(r.totalShipments()).isEqualTo(16);
@@ -106,7 +138,7 @@ class MerchantAnalyticsServiceImplTest {
         when(shipments.onTimeForAccount(eq(acct), any(), any())).thenReturn(onTime(0, 0));
         when(shipments.destinationSplitForAccount(eq(acct), any())).thenReturn(List.of());
 
-        MerchantAnalyticsResponse r = new MerchantAnalyticsServiceImpl(shipments).forAccount(acct, null);
+        MerchantAnalyticsResponse r = service().forAccount(acct, null);
 
         assertThat(r.totalShipments()).isZero();
         assertThat(r.deliveryRatePct()).isNull();  // nothing rateable
@@ -123,10 +155,29 @@ class MerchantAnalyticsServiceImplTest {
         when(shipments.onTimeForAccount(eq(acct), any(), any())).thenReturn(onTime(0, 0));
         when(shipments.destinationSplitForAccount(eq(acct), any())).thenReturn(List.of());
 
-        MerchantAnalyticsResponse r = new MerchantAnalyticsServiceImpl(shipments).forAccount(acct, 7);
+        MerchantAnalyticsResponse r = service().forAccount(acct, 7);
 
         assertThat(r.totalShipments()).isEqualTo(4);
         assertThat(r.cancelled()).isEqualTo(4);
         assertThat(r.deliveryRatePct()).isNull(); // total - cancelled = 0 → not rateable
+    }
+
+    @Test
+    void categorySplitResolvesNamesAndFoldsUntagged() {
+        UUID electronics = UUID.randomUUID();
+        UUID apparel = UUID.randomUUID();
+        UUID deleted = UUID.randomUUID(); // a category id no longer in the account's list
+        when(categories.findByB2bAccountIdOrderByName(acct)).thenReturn(List.of(
+                mcat(electronics, "Electronics"), mcat(apparel, "Apparel")));
+        when(shipments.categorySplitForAccount(eq(acct), any())).thenReturn(List.of(
+                cat(electronics, 5), cat(null, 3), cat(apparel, 2), cat(deleted, 1)));
+
+        MerchantAnalyticsResponse r = service().forAccount(acct, 30);
+
+        // Untagged (null) + the since-deleted id both fold into "Uncategorised" (3 + 1 = 4), busiest first.
+        assertThat(r.categorySplit()).extracting("category", "count").containsExactly(
+                tuple("Electronics", 5L),
+                tuple("Uncategorised", 4L),
+                tuple("Apparel", 2L));
     }
 }

--- a/orders/src/test/java/com/oneday/orders/service/impl/MerchantCategoryServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/MerchantCategoryServiceImplTest.java
@@ -40,7 +40,7 @@ class MerchantCategoryServiceImplTest {
 
     @Test
     void createTrimsNameAndStampsTheCallersAccount() {
-        when(repo.existsByB2bAccountIdAndNameIgnoreCase(ACCOUNT, "Electronics")).thenReturn(false);
+        when(repo.existsByB2bAccountIdAndNameIgnoreCaseAndArchivedAtIsNull(ACCOUNT, "Electronics")).thenReturn(false);
         when(repo.save(any(MerchantCategory.class))).thenAnswer(inv -> inv.getArgument(0));
 
         MerchantCategoryResponse resp = service.create(ACCOUNT, req("  Electronics  "));
@@ -54,7 +54,7 @@ class MerchantCategoryServiceImplTest {
 
     @Test
     void createRejectsADuplicateName() {
-        when(repo.existsByB2bAccountIdAndNameIgnoreCase(ACCOUNT, "Apparel")).thenReturn(true);
+        when(repo.existsByB2bAccountIdAndNameIgnoreCaseAndArchivedAtIsNull(ACCOUNT, "Apparel")).thenReturn(true);
 
         assertThatThrownBy(() -> service.create(ACCOUNT, req("Apparel")))
                 .isInstanceOf(MerchantCategoryService.DuplicateCategoryException.class);
@@ -64,7 +64,7 @@ class MerchantCategoryServiceImplTest {
     @Test
     void renameOfAnotherMerchantsCategoryIsNotFound() {
         UUID foreignId = UUID.randomUUID();
-        when(repo.findByIdAndB2bAccountId(foreignId, ACCOUNT)).thenReturn(Optional.empty());
+        when(repo.findByIdAndB2bAccountIdAndArchivedAtIsNull(foreignId, ACCOUNT)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.rename(ACCOUNT, foreignId, req("Hijack")))
                 .isInstanceOf(MerchantCategoryService.CategoryNotFoundException.class);
@@ -73,12 +73,29 @@ class MerchantCategoryServiceImplTest {
     @Test
     void deleteIsScopedToTheCallersAccount() {
         UUID id = UUID.randomUUID();
-        when(repo.findByIdAndB2bAccountId(id, ACCOUNT)).thenReturn(Optional.empty());
+        when(repo.findByIdAndB2bAccountIdAndArchivedAtIsNull(id, ACCOUNT)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.delete(ACCOUNT, id))
                 .isInstanceOf(MerchantCategoryService.CategoryNotFoundException.class);
-        // Looked up strictly within the caller's account — never a bare findById.
-        verify(repo).findByIdAndB2bAccountId(eq(id), eq(ACCOUNT));
+        // Looked up strictly within the caller's account (live only) — never a bare findById.
+        verify(repo).findByIdAndB2bAccountIdAndArchivedAtIsNull(eq(id), eq(ACCOUNT));
+        verify(repo, never()).delete(any());
+    }
+
+    @Test
+    void deleteArchivesRatherThanHardDeleting() {
+        UUID id = UUID.randomUUID();
+        MerchantCategory live = new MerchantCategory();
+        live.setB2bAccountId(ACCOUNT);
+        live.setName("Diwali Sale");
+        when(repo.findByIdAndB2bAccountIdAndArchivedAtIsNull(id, ACCOUNT)).thenReturn(Optional.of(live));
+        when(repo.save(any(MerchantCategory.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        service.delete(ACCOUNT, id);
+
+        var saved = forClass(MerchantCategory.class);
+        verify(repo).save(saved.capture());
+        assertThat(saved.getValue().getArchivedAt()).isNotNull(); // soft-deleted, history preserved
         verify(repo, never()).delete(any());
     }
 }


### PR DESCRIPTION
## What this is for

Merchants tag their parcels by category (Electronics, Apparel, "Diwali Sale", …). Until now they could tag and filter, but couldn't see the shape of their shipping at a glance. This adds a **"By category" breakdown** to their analytics dashboard, so a merchant can instantly see which parts of their business drive volume over the window they pick.

## The problems it solves

**"Which categories am I actually shipping?"** The dashboard now shows a per-category count, busiest first — the same numbers they can already filter their shipment list by, rolled up into one view.

**Deleting a category shouldn't rewrite history.** If a merchant ran a "Diwali Sale" category in October and later removes it, those October parcels still show under **"Diwali Sale"** in their reports — the history of what they shipped and why stays intact. Removing a category just takes it off the pick list going forward, and the name can be reused next year.

**A messy account can't break the dashboard.** A merchant who uses categories loosely (a new one per purchase order, hundreds of them) still gets a clean chart: the busiest 10 categories are shown, everything else rolls up into a single **"Other"** line, and parcels with no category sit in **"Uncategorised"**.

## How it was checked
The category counts reconcile against the raw shipment book; the breakdown, the "Other" roll-up, and the archived-name behaviour are covered by tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Merchant analytics now include shipment counts broken down by category.
  * Categories are displayed in descending order by shipment volume.
  * Shipments without a matching category are grouped under “Uncategorised.”
  * Results show the top 10 categories, with remaining categories combined under “Other.”
  * Deleted categories are archived rather than permanently removed, preserving historical analytics while excluding them from active category lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->