### PR TITLE
feat(eta): notify only when a delay exceeds a day

### DIFF
--- a/orders/src/main/java/com/oneday/orders/service/impl/ShipmentEtaServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/ShipmentEtaServiceImpl.java
@@ -46,6 +46,10 @@ class ShipmentEtaServiceImpl implements ShipmentEtaService {
     ShipmentEtaServiceImpl(ShipmentRepository shipments, B2bAccountRepository accounts,
                            NotificationPort notificationPort,
                            @Value("${orders.eta.delay-threshold-minutes:1440}") long delayThresholdMinutes) {
+        if (delayThresholdMinutes < 0) {
+            throw new IllegalArgumentException(
+                    "orders.eta.delay-threshold-minutes must be >= 0, was " + delayThresholdMinutes);
+        }
         this.shipments = shipments;
         this.accounts = accounts;
         this.notificationPort = notificationPort;

--- a/orders/src/main/java/com/oneday/orders/service/impl/ShipmentEtaServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/ShipmentEtaServiceImpl.java
@@ -36,16 +36,20 @@ class ShipmentEtaServiceImpl implements ShipmentEtaService {
     private final B2bAccountRepository accounts;
     private final NotificationPort notificationPort;
 
-    /** ponytail: a small grace so a tiny slip doesn't spam the customer. Tune per SLA sensitivity. */
-    private final long graceMinutes;
+    /**
+     * Dynamic-ETA rule (Discussion-2 xiii): only tell the customer when the delivery will slip more than
+     * a materiality threshold past the promise — a day, by default. Below it, a revision is silent (the
+     * ETA is still recorded). Configurable via {@code orders.eta.delay-threshold-minutes} (1440 = 24h).
+     */
+    private final long delayThresholdMinutes;
 
     ShipmentEtaServiceImpl(ShipmentRepository shipments, B2bAccountRepository accounts,
                            NotificationPort notificationPort,
-                           @Value("${orders.eta.delay-grace-minutes:15}") long graceMinutes) {
+                           @Value("${orders.eta.delay-threshold-minutes:1440}") long delayThresholdMinutes) {
         this.shipments = shipments;
         this.accounts = accounts;
         this.notificationPort = notificationPort;
-        this.graceMinutes = graceMinutes;
+        this.delayThresholdMinutes = delayThresholdMinutes;
     }
 
     @Override
@@ -66,7 +70,9 @@ class ShipmentEtaServiceImpl implements ShipmentEtaService {
         s.setEtaUpdated(newEta);
         // Dirty-checking persists the change; no explicit save needed inside the transaction.
 
-        boolean delayed = promised != null && newEta.isAfter(promised.plus(Duration.ofMinutes(graceMinutes)));
+        // Only a slip past the materiality threshold (default 24h) is a delay worth telling the customer.
+        boolean delayed = promised != null
+                && newEta.isAfter(promised.plus(Duration.ofMinutes(delayThresholdMinutes)));
         boolean notified = false;
         if (delayed) {
             notified = notifyCustomer(s, promised, newEta);

--- a/orders/src/test/java/com/oneday/orders/service/impl/ShipmentEtaServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/ShipmentEtaServiceImplTest.java
@@ -36,10 +36,10 @@ class ShipmentEtaServiceImplTest {
     @Mock private B2bAccountRepository accounts;
     @Mock private NotificationPort notificationPort;
 
-    private static final long GRACE = 15;
+    private static final long THRESHOLD_MINUTES = 24 * 60; // 24h — the dynamic-ETA materiality rule
 
     private ShipmentEtaServiceImpl service() {
-        return new ShipmentEtaServiceImpl(shipments, accounts, notificationPort, GRACE);
+        return new ShipmentEtaServiceImpl(shipments, accounts, notificationPort, THRESHOLD_MINUTES);
     }
 
     private Shipment b2cShipment(Instant promised) {
@@ -54,10 +54,10 @@ class ShipmentEtaServiceImplTest {
     }
 
     @Test
-    void slipBeyondGrace_notifiesTheSender_andRecordsNewEta() {
+    void slipBeyondADay_notifiesTheSender_andRecordsNewEta() {
         Instant promised = Instant.parse("2026-08-27T10:00:00Z");
         Shipment s = b2cShipment(promised);
-        Instant newEta = promised.plus(Duration.ofHours(3)); // clearly late
+        Instant newEta = promised.plus(Duration.ofHours(30)); // more than a day late
 
         ReviseEtaResponse r = service().reviseEta("1DD-DEL-1", newEta, "flight delayed", "ops-1", null);
 
@@ -76,10 +76,10 @@ class ShipmentEtaServiceImplTest {
     }
 
     @Test
-    void earlierOrWithinGrace_isNotADelay_andDoesNotNotify() {
+    void lateButWithinADay_isNotADelay_andDoesNotNotify() {
         Instant promised = Instant.parse("2026-08-27T10:00:00Z");
         b2cShipment(promised);
-        Instant newEta = promised.plus(Duration.ofMinutes(5)); // within the 15-min grace
+        Instant newEta = promised.plus(Duration.ofHours(6)); // late, but under the 24h threshold
 
         ReviseEtaResponse r = service().reviseEta("1DD-DEL-1", newEta, null, "ops-1", null);
 
@@ -91,7 +91,7 @@ class ShipmentEtaServiceImplTest {
     @Test
     void noPromisedEta_cannotBeADelay() {
         b2cShipment(null); // never got an ETA at booking
-        ReviseEtaResponse r = service().reviseEta("1DD-DEL-1", Instant.parse("2026-08-27T20:00:00Z"), null, "ops-1", null);
+        ReviseEtaResponse r = service().reviseEta("1DD-DEL-1", Instant.parse("2026-08-28T20:00:00Z"), null, "ops-1", null);
         assertThat(r.delayed()).isFalse();
         verify(notificationPort, never()).send(any());
     }
@@ -107,12 +107,12 @@ class ShipmentEtaServiceImplTest {
         when(shipments.findByShipmentRef("1DD-DEL-7")).thenReturn(Optional.of(s));
 
         // A MAA manager (scope "MAA") touches neither origin nor dest → 404, nothing notified.
-        assertThatThrownBy(() -> service().reviseEta("1DD-DEL-7", Instant.parse("2026-08-27T20:00:00Z"), null, "sm-maa", "MAA"))
+        assertThatThrownBy(() -> service().reviseEta("1DD-DEL-7", Instant.parse("2026-08-28T20:00:00Z"), null, "sm-maa", "MAA"))
                 .isInstanceOf(ResponseStatusException.class);
         verify(notificationPort, never()).send(any());
 
         // The destination-city manager (scope "BLR") is in scope → allowed, and it's a delay.
-        assertThat(service().reviseEta("1DD-DEL-7", Instant.parse("2026-08-27T20:00:00Z"), null, "sm-blr", "BLR").delayed())
+        assertThat(service().reviseEta("1DD-DEL-7", Instant.parse("2026-08-28T20:00:00Z"), null, "sm-blr", "BLR").delayed())
                 .isTrue();
     }
 
@@ -134,7 +134,7 @@ class ShipmentEtaServiceImplTest {
         acc.setSupportPhone("+919111111111");
         when(accounts.findById(accountId)).thenReturn(Optional.of(acc));
 
-        ReviseEtaResponse r = service().reviseEta("1DD-BLR-9", promised.plus(Duration.ofHours(4)), null, "ops-1", null);
+        ReviseEtaResponse r = service().reviseEta("1DD-BLR-9", promised.plus(Duration.ofHours(30)), null, "ops-1", null);
 
         assertThat(r.customerNotified()).isTrue();
         ArgumentCaptor<NotificationRequest> req = ArgumentCaptor.forClass(NotificationRequest.class);


### PR DESCRIPTION
## What
Dynamic-ETA notify rule (Discussion-2 item xiii, backend half).

- The delay notice now fires only when the revised ETA slips **more than 24h** past the promise (was a 15-minute grace). A smaller slip is still recorded on the shipment, silently.
- Threshold is configurable: `orders.eta.delay-threshold-minutes` (default **1440** = 24h).

## Why
"Only inform the customer when we'll exceed 24h." Below a day, a revised ETA shouldn't ping the customer — it just updates "Arriving by".

## Test
- `ShipmentEtaServiceImplTest` **5 green** — adds a "late but within a day → not a delay, no notify" case; the notify cases now use >24h slips.

## Scope note
Part (b) of xiii — **auto-recompute ETA from live tracking** — is deferred: the orders→routing consumer (`CronEventsConsumer`) is dormant (M6 doesn't emit route-deviation events yet, no broker). Revision stays ops-triggered for now; this PR lands the 24h rule + the customer surface (web #55).

## Web half
Sidarthapati/oneday-web#55 (customer "running more than a day late" notice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMHFVQqNBSJdsxgasHqpny


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - ETA-delay notifications now trigger only when a revised arrival time exceeds the promised ETA by more than 24 hours.
  - Smaller delays, such as six hours, no longer generate notifications.

- **Tests**
  - Updated coverage verifies the new 24-hour threshold across customer, station-manager, and B2B notification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->