### PR TITLE
feat(analytics): merchant RTO rate

### DIFF
--- a/orders/src/main/java/com/oneday/orders/dto/MerchantAnalyticsResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/MerchantAnalyticsResponse.java
@@ -15,6 +15,7 @@ import java.util.List;
  * @param cancelled         cancelled shipments
  * @param rto               returned-to-origin (initiated, in transit, or completed)
  * @param deliveryRatePct   delivered ÷ (total − cancelled), or null if nothing to rate
+ * @param rtoRatePct        returned-to-origin ÷ (total − cancelled), or null if nothing to rate
  * @param onTimePct         delivered on/before promised ETA ÷ delivered-with-ETA, or null if none
  * @param gmvPaise          total shipping charged, in paise
  * @param codValuePaise     total COD goods-value handled, in paise
@@ -30,6 +31,7 @@ public record MerchantAnalyticsResponse(
         long cancelled,
         long rto,
         Integer deliveryRatePct,
+        Integer rtoRatePct,
         Integer onTimePct,
         long gmvPaise,
         long codValuePaise,

--- a/orders/src/main/java/com/oneday/orders/service/impl/MerchantAnalyticsServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/MerchantAnalyticsServiceImpl.java
@@ -74,6 +74,8 @@ class MerchantAnalyticsServiceImpl implements MerchantAnalyticsService {
 
         long rateable = total - cancelled; // a cancelled parcel was never a delivery attempt
         Integer deliveryRatePct = rateable > 0 ? Math.round(delivered * 100f / rateable) : null;
+        // RTO rate over the same base: of the parcels we actually attempted, what share came back.
+        Integer rtoRatePct = rateable > 0 ? Math.round(rto * 100f / rateable) : null;
 
         AccountTotals totals = shipments.sumTotalsForAccount(accountId, since);
         long gmv = totals == null ? 0 : totals.getGmvPaise();
@@ -92,7 +94,7 @@ class MerchantAnalyticsServiceImpl implements MerchantAnalyticsService {
         List<CategoryCount> categorySplit = categorySplit(accountId, since);
 
         return new MerchantAnalyticsResponse(windowDays, total, delivered, inTransit, cancelled, rto,
-                deliveryRatePct, onTimePct, gmv, cod, avg, dests, categorySplit);
+                deliveryRatePct, rtoRatePct, onTimePct, gmv, cod, avg, dests, categorySplit);
     }
 
     /**

--- a/orders/src/test/java/com/oneday/orders/service/impl/MerchantAnalyticsServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/MerchantAnalyticsServiceImplTest.java
@@ -120,6 +120,8 @@ class MerchantAnalyticsServiceImplTest {
         assertThat(r.rto()).isEqualTo(1);
         // delivery rate = delivered / (total - cancelled) = 10/14 = 71%
         assertThat(r.deliveryRatePct()).isEqualTo(71);
+        // RTO rate = rto / (total - cancelled) = 1/14 = 7%
+        assertThat(r.rtoRatePct()).isEqualTo(7);
         // on-time = 9/10 = 90%
         assertThat(r.onTimePct()).isEqualTo(90);
         assertThat(r.gmvPaise()).isEqualTo(1_600_000);
@@ -160,6 +162,7 @@ class MerchantAnalyticsServiceImplTest {
         assertThat(r.totalShipments()).isEqualTo(4);
         assertThat(r.cancelled()).isEqualTo(4);
         assertThat(r.deliveryRatePct()).isNull(); // total - cancelled = 0 → not rateable
+        assertThat(r.rtoRatePct()).isNull();
     }
 
     @Test


### PR DESCRIPTION
## What this is for

A merchant's dashboard already shows how many parcels came back (RTO), but a raw count doesn't tell them whether that's a little or a lot. This adds an **RTO rate** — the share of the parcels they actually shipped that came back — so they can see at a glance how much of their volume is being returned, over whatever window they pick.

## The problem it solves

**"Is my return rate a problem?"** "12 RTOs" means nothing without a denominator; "8% of shipments returned" is immediately actionable. The rate is measured on the same basis as the delivery rate (out of the parcels actually attempted, setting aside ones that were cancelled before they ever moved), so the two read consistently side by side.

## Checked
Reconciles against the shipment book; covered by tests (a normal case and the nothing-to-rate case).

## Follow-ups (not in this PR)
- **RTO trend over time** and **RTO reasons** are the natural next step for a fuller RTO view. Reasons depend on the returns/exceptions module; trend needs a time-series view. Flagged as separate work.
- **RTO fees** (charging a fee on a return, and showing it in invoices/remittances) is the other half of this feature and is tracked separately.

## Web half
Sidarthapati/oneday-web#57 (the RTO-rate tile on the dashboard).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Merchant analytics now include the return-to-origin (RTO) rate percentage.
  - The rate is calculated from eligible, non-cancelled shipments.

- **Bug Fixes**
  - RTO rate is correctly left blank when there are no eligible shipments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->