### PR TITLE
feat(notify): WhatsApp as an outbound notification channel

### DIFF
--- a/orders/src/main/java/com/oneday/orders/config/NotifyProperties.java
+++ b/orders/src/main/java/com/oneday/orders/config/NotifyProperties.java
@@ -15,12 +15,14 @@ public class NotifyProperties {
 
     private final Sms sms = new Sms();
     private final Email email = new Email();
+    private final WhatsApp whatsapp = new WhatsApp();
 
     /** How many delivery attempts the outbox drain makes before leaving a row FAILED. */
     private int maxAttempts = 3;
 
     public Sms getSms() { return sms; }
     public Email getEmail() { return email; }
+    public WhatsApp getWhatsapp() { return whatsapp; }
     public int getMaxAttempts() { return maxAttempts; }
     // Clamp to >= 1: a zero/negative cap would make the drain query (attempts < max) exclude every
     // new row, stranding notifications PENDING forever.
@@ -42,6 +44,30 @@ public class NotifyProperties {
         public void setMsg91SenderId(String v) { this.msg91SenderId = v; }
         public String getMsg91TemplateId() { return msg91TemplateId; }
         public void setMsg91TemplateId(String v) { this.msg91TemplateId = v; }
+    }
+
+    public static class WhatsApp {
+        /** log | meta */
+        private String provider = "log";
+        /** Meta WhatsApp Cloud API phone-number id (the sending number). */
+        private String phoneNumberId = "";
+        /** Meta system-user / app access token. Env only — never committed. */
+        private String accessToken = "";
+        /** Token Meta echoes back on the webhook verify (GET) handshake — used by the inbound seam. */
+        private String verifyToken = "";
+        /** App secret for verifying inbound webhook signatures (X-Hub-Signature-256). */
+        private String appSecret = "";
+
+        public String getProvider() { return provider; }
+        public void setProvider(String v) { this.provider = v; }
+        public String getPhoneNumberId() { return phoneNumberId; }
+        public void setPhoneNumberId(String v) { this.phoneNumberId = v; }
+        public String getAccessToken() { return accessToken; }
+        public void setAccessToken(String v) { this.accessToken = v; }
+        public String getVerifyToken() { return verifyToken; }
+        public void setVerifyToken(String v) { this.verifyToken = v; }
+        public String getAppSecret() { return appSecret; }
+        public void setAppSecret(String v) { this.appSecret = v; }
     }
 
     public static class Email {

--- a/orders/src/main/java/com/oneday/orders/domain/NotificationChannel.java
+++ b/orders/src/main/java/com/oneday/orders/domain/NotificationChannel.java
@@ -1,7 +1,8 @@
 package com.oneday.orders.domain;
 
-/** Delivery channel for a notification. */
+/** Delivery channel for a notification. (WHATSAPP is 8 chars — fits notification_log.channel VARCHAR(8).) */
 public enum NotificationChannel {
     EMAIL,
-    SMS
+    SMS,
+    WHATSAPP
 }

--- a/orders/src/main/java/com/oneday/orders/service/WhatsAppSender.java
+++ b/orders/src/main/java/com/oneday/orders/service/WhatsAppSender.java
@@ -1,0 +1,11 @@
+package com.oneday.orders.service;
+
+/**
+ * Sends a WhatsApp message. The default {@code LoggingWhatsAppSender} logs it so notifications work
+ * end-to-end before a BSP/Meta account lands; a real provider swaps in via
+ * {@code notify.whatsapp.provider=meta}, mirroring {@link SmsSender} / {@link EmailSender}.
+ * Implementations must be best-effort — never throw into the caller of the notification port.
+ */
+public interface WhatsAppSender {
+    void send(String phone, String message);
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/LoggingWhatsAppSender.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/LoggingWhatsAppSender.java
@@ -1,0 +1,29 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.service.WhatsAppSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/**
+ * Default WhatsApp sender — no provider. Logs the message so notifications work end-to-end on
+ * dev/staging (read them from the app log). A real provider replaces this via
+ * {@code notify.whatsapp.provider=meta}. Logged at WARN precisely because it must NOT be the sender
+ * in production.
+ */
+@Component
+@ConditionalOnProperty(name = "notify.whatsapp.provider", havingValue = "log", matchIfMissing = true)
+class LoggingWhatsAppSender implements WhatsAppSender {
+
+    private static final Logger log = LoggerFactory.getLogger(LoggingWhatsAppSender.class);
+
+    LoggingWhatsAppSender() {
+        log.info("[notify] whatsapp provider=log — messages are logged, not sent (dev/staging only)");
+    }
+
+    @Override
+    public void send(String phone, String message) {
+        log.warn("[notify:whatsapp] → {} : {}", phone, message);
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/MetaWhatsAppSender.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/MetaWhatsAppSender.java
@@ -1,5 +1,6 @@
 package com.oneday.orders.service.impl;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.oneday.orders.config.NotifyProperties;
 import com.oneday.orders.service.NotificationDeliveryException;
 import com.oneday.orders.service.WhatsAppSender;
@@ -13,6 +14,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.Map;
 
 /**
  * Meta WhatsApp Cloud API adapter. Gated by {@code notify.whatsapp.provider=meta} — off by default,
@@ -34,10 +36,12 @@ class MetaWhatsAppSender implements WhatsAppSender {
     private static final String GRAPH_BASE = "https://graph.facebook.com/v21.0/";
 
     private final NotifyProperties props;
+    private final ObjectMapper mapper;
     private final HttpClient http = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(4)).build();
 
-    MetaWhatsAppSender(NotifyProperties props) {
+    MetaWhatsAppSender(NotifyProperties props, ObjectMapper mapper) {
         this.props = props;
+        this.mapper = mapper;
         log.info("[notify] whatsapp provider=meta (phoneNumberId={})", props.getWhatsapp().getPhoneNumberId());
     }
 
@@ -45,9 +49,13 @@ class MetaWhatsAppSender implements WhatsAppSender {
     public void send(String phone, String message) {
         try {
             String to = phone.startsWith("+") ? phone.substring(1) : phone;   // Meta wants no leading +
-            String body = "{\"messaging_product\":\"whatsapp\",\"to\":\"" + to + "\","
-                    + "\"type\":\"text\",\"text\":{\"body\":\""
-                    + message.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n") + "\"}}";
+            // Serialize with Jackson so both `to` and the message body are correctly escaped (no hand-rolled
+            // JSON, no injection). ponytail: plain-text body — swap to a "template" object at go-live.
+            String body = mapper.writeValueAsString(Map.of(
+                    "messaging_product", "whatsapp",
+                    "to", to,
+                    "type", "text",
+                    "text", Map.of("body", message)));
             URI url = URI.create(GRAPH_BASE + props.getWhatsapp().getPhoneNumberId() + "/messages");
             HttpRequest req = HttpRequest.newBuilder(url)
                     .timeout(Duration.ofSeconds(6))

--- a/orders/src/main/java/com/oneday/orders/service/impl/MetaWhatsAppSender.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/MetaWhatsAppSender.java
@@ -1,0 +1,72 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.config.NotifyProperties;
+import com.oneday.orders.service.NotificationDeliveryException;
+import com.oneday.orders.service.WhatsAppSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+/**
+ * Meta WhatsApp Cloud API adapter. Gated by {@code notify.whatsapp.provider=meta} — off by default,
+ * like {@link Msg91SmsSender}. Sends a plain-text message via the Graph API using the account's phone
+ * number id + access token. Credentials come from {@link NotifyProperties} (env only, never committed).
+ * Best-effort: any failure is turned into a {@link NotificationDeliveryException} the outbox retries.
+ *
+ * <p><b>STUB — untested against the live Meta API (no BSP/WABA account yet).</b> This is the seam, not
+ * a validated integration. Production WhatsApp requires pre-approved <i>message templates</i> for
+ * business-initiated messages outside the 24-hour customer-service window; this sends a plain text body
+ * (fine inside the window / for testing). Swap the payload to a {@code template} object, and verify the
+ * phone-number-id / token wiring, before go-live.
+ */
+@Component
+@ConditionalOnProperty(name = "notify.whatsapp.provider", havingValue = "meta")
+class MetaWhatsAppSender implements WhatsAppSender {
+
+    private static final Logger log = LoggerFactory.getLogger(MetaWhatsAppSender.class);
+    private static final String GRAPH_BASE = "https://graph.facebook.com/v21.0/";
+
+    private final NotifyProperties props;
+    private final HttpClient http = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(4)).build();
+
+    MetaWhatsAppSender(NotifyProperties props) {
+        this.props = props;
+        log.info("[notify] whatsapp provider=meta (phoneNumberId={})", props.getWhatsapp().getPhoneNumberId());
+    }
+
+    @Override
+    public void send(String phone, String message) {
+        try {
+            String to = phone.startsWith("+") ? phone.substring(1) : phone;   // Meta wants no leading +
+            String body = "{\"messaging_product\":\"whatsapp\",\"to\":\"" + to + "\","
+                    + "\"type\":\"text\",\"text\":{\"body\":\""
+                    + message.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n") + "\"}}";
+            URI url = URI.create(GRAPH_BASE + props.getWhatsapp().getPhoneNumberId() + "/messages");
+            HttpRequest req = HttpRequest.newBuilder(url)
+                    .timeout(Duration.ofSeconds(6))
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + props.getWhatsapp().getAccessToken())
+                    .POST(HttpRequest.BodyPublishers.ofString(body))
+                    .build();
+            HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+            if (resp.statusCode() / 100 != 2) {
+                throw new NotificationDeliveryException(
+                        "meta whatsapp " + resp.statusCode() + " for " + to + ": " + resp.body());
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new NotificationDeliveryException("interrupted sending whatsapp to " + phone, e);
+        } catch (NotificationDeliveryException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new NotificationDeliveryException("meta whatsapp send to " + phone + " failed: " + e, e);
+        }
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/NotificationDispatchJob.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/NotificationDispatchJob.java
@@ -7,6 +7,7 @@ import com.oneday.orders.domain.NotificationStatus;
 import com.oneday.orders.repository.NotificationLogRepository;
 import com.oneday.orders.service.EmailSender;
 import com.oneday.orders.service.SmsSender;
+import com.oneday.orders.service.WhatsAppSender;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -33,13 +34,15 @@ class NotificationDispatchJob {
     private final NotificationLogRepository repository;
     private final EmailSender emailSender;
     private final SmsSender smsSender;
+    private final WhatsAppSender whatsAppSender;
     private final NotifyProperties props;
 
     NotificationDispatchJob(NotificationLogRepository repository, EmailSender emailSender,
-                            SmsSender smsSender, NotifyProperties props) {
+                            SmsSender smsSender, WhatsAppSender whatsAppSender, NotifyProperties props) {
         this.repository = repository;
         this.emailSender = emailSender;
         this.smsSender = smsSender;
+        this.whatsAppSender = whatsAppSender;
         this.props = props;
     }
 
@@ -54,10 +57,10 @@ class NotificationDispatchJob {
         for (NotificationLog row : batch) {
             row.setAttempts(row.getAttempts() + 1);
             try {
-                if (row.getChannel() == NotificationChannel.EMAIL) {
-                    emailSender.send(row.getRecipient(), row.getSubject(), row.getBody());
-                } else {
-                    smsSender.send(row.getRecipient(), row.getBody());
+                switch (row.getChannel()) {
+                    case EMAIL -> emailSender.send(row.getRecipient(), row.getSubject(), row.getBody());
+                    case SMS -> smsSender.send(row.getRecipient(), row.getBody());
+                    case WHATSAPP -> whatsAppSender.send(row.getRecipient(), row.getBody());
                 }
                 row.setStatus(NotificationStatus.SENT);
                 row.setSentAt(Instant.now());

--- a/orders/src/main/java/com/oneday/orders/service/impl/NotificationTemplateResolverImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/NotificationTemplateResolverImpl.java
@@ -48,8 +48,9 @@ class NotificationTemplateResolverImpl implements NotificationTemplateResolver {
                 "Your Godspeed wallet is running low",
                 "Your Godspeed wallet balance is now ₹{balance}. Top up to keep shipping without interruption."));
 
+        // Delay comms also go out on WhatsApp — the channel is stubbed (logs) until a BSP account lands.
         TEMPLATES.put(NotificationEventType.SHIPMENT_DELAYED, new Template(
-                EnumSet.of(NotificationChannel.EMAIL, NotificationChannel.SMS),
+                EnumSet.of(NotificationChannel.EMAIL, NotificationChannel.SMS, NotificationChannel.WHATSAPP),
                 "Your Godspeed delivery {shipment_ref} is running late",
                 "Your shipment {shipment_ref} is now expected by {new_eta} (was {original_eta}). "
                         + "No action is needed to keep it — or cancel for a full refund if the new time doesn't work."));

--- a/orders/src/test/java/com/oneday/orders/service/impl/NotificationDispatchJobTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/NotificationDispatchJobTest.java
@@ -8,6 +8,7 @@ import com.oneday.orders.repository.NotificationLogRepository;
 import com.oneday.orders.service.EmailSender;
 import com.oneday.orders.service.NotificationDeliveryException;
 import com.oneday.orders.service.SmsSender;
+import com.oneday.orders.service.WhatsAppSender;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -29,8 +30,9 @@ class NotificationDispatchJobTest {
     private final NotificationLogRepository repo = mock(NotificationLogRepository.class);
     private final EmailSender email = mock(EmailSender.class);
     private final SmsSender sms = mock(SmsSender.class);
+    private final WhatsAppSender whatsApp = mock(WhatsAppSender.class);
     private final NotifyProperties props = new NotifyProperties();
-    private final NotificationDispatchJob job = new NotificationDispatchJob(repo, email, sms, props);
+    private final NotificationDispatchJob job = new NotificationDispatchJob(repo, email, sms, whatsApp, props);
 
     private static NotificationLog emailRow() {
         NotificationLog r = new NotificationLog();
@@ -56,6 +58,23 @@ class NotificationDispatchJobTest {
         assertThat(row.getAttempts()).isEqualTo(1);
         assertThat(row.getSentAt()).isNotNull();
         verify(repo).save(row);
+    }
+
+    @Test
+    void whatsAppRowIsDeliveredViaTheWhatsAppSender() {
+        NotificationLog row = new NotificationLog();
+        row.setEventType("SHIPMENT_DELAYED");
+        row.setChannel(NotificationChannel.WHATSAPP);
+        row.setRecipient("+919000000009");
+        row.setBody("Your delivery is running late");
+        row.setStatus(NotificationStatus.PENDING);
+        when(repo.findTop200ByStatusInAndAttemptsLessThanOrderByCreatedAtAsc(any(), anyInt()))
+                .thenReturn(List.of(row));
+
+        job.drain();
+
+        verify(whatsApp).send("+919000000009", "Your delivery is running late");
+        assertThat(row.getStatus()).isEqualTo(NotificationStatus.SENT);
     }
 
     @Test


### PR DESCRIPTION
## What this is for

Godspeed talks to customers and merchants over email and SMS today. This adds **WhatsApp as a third channel**, so the platform can reach people where they actually read messages — starting with the "your delivery is running late" notice, and available for every other notification we choose to send there.

It's the shared foundation the field side is waiting on: the same channel will carry delivery-delay updates, and later the pre-ship "accept or reject your parcel" outreach and the return (RTO) follow-ups.

## The problem it solves

**"An email about a late delivery often goes unseen; a WhatsApp doesn't."** Adding WhatsApp to the delay notice means the customer gets told on the channel they're most likely to see, alongside the existing email/SMS.

## Live now vs. later

- The channel is **wired end to end** and already carries the delay notice. Until we connect a WhatsApp Business account, messages are recorded (and visible in the app log on dev/staging) rather than actually sent — exactly how email and SMS behaved before their providers were connected.
- **Going live is a config switch**, no code change: point it at a WhatsApp Business (Meta) account with its credentials. Note that WhatsApp requires pre-approved message templates for business-initiated messages, which we'll finalise at that point.

## Checked
Covered by tests (a WhatsApp message is delivered via the WhatsApp channel and marked sent); the app assembles.

## Follow-up (separate PR)
The **inbound** side — a customer replying on WhatsApp and having it show up in their support conversation (the "chat mirror") — comes next.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WhatsApp as a notification delivery channel.
  * Added support for sending notifications through Meta’s WhatsApp Cloud API.
  * Added a logging mode for WhatsApp messages when external delivery is not configured.
  * Shipment delay notifications can now be delivered via WhatsApp.

* **Bug Fixes**
  * Improved notification routing and delivery status handling across email, SMS, and WhatsApp.
  * Improved WhatsApp message payload handling for more reliable delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->