### PR TITLE
feat(cod): per-DA COD cash-in-hand ledger

### DIFF
--- a/orders/src/main/java/com/oneday/orders/api/DaCodController.java
+++ b/orders/src/main/java/com/oneday/orders/api/DaCodController.java
@@ -7,12 +7,14 @@ import com.oneday.orders.dto.DaCodLedgerEntryResponse;
 import com.oneday.orders.dto.RecordCodDepositRequest;
 import com.oneday.orders.service.CodCashService;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -48,10 +50,14 @@ class DaCodController {
         return codCash.daSummary(callerDaId(principal));
     }
 
-    /** The DA's own cash-in-hand ledger (collections + deposits with a running balance), newest first. */
+    /** A page of the DA's own cash-in-hand ledger (collections + deposits, running balance), newest first. */
     @GetMapping("/ledger")
-    public List<DaCodLedgerEntryResponse> ledger(@AuthenticationPrincipal AuthUserDetails principal) {
-        return codCash.daLedger(callerDaId(principal));
+    public List<DaCodLedgerEntryResponse> ledger(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "50") int size) {
+        int capped = Math.min(Math.max(1, size), 200);
+        return codCash.daLedger(callerDaId(principal), PageRequest.of(Math.max(0, page), capped));
     }
 
     /** The calling delivery associate's own user id (also gates the endpoint to that role). */

--- a/orders/src/main/java/com/oneday/orders/api/DaCodController.java
+++ b/orders/src/main/java/com/oneday/orders/api/DaCodController.java
@@ -3,6 +3,7 @@ package com.oneday.orders.api;
 import com.oneday.auth.security.AuthUserDetails;
 import com.oneday.orders.dto.CodCashDepositResponse;
 import com.oneday.orders.dto.DaCodCashSummaryResponse;
+import com.oneday.orders.dto.DaCodLedgerEntryResponse;
 import com.oneday.orders.dto.RecordCodDepositRequest;
 import com.oneday.orders.service.CodCashService;
 import jakarta.validation.Valid;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -44,6 +46,12 @@ class DaCodController {
     @GetMapping("/summary")
     public DaCodCashSummaryResponse summary(@AuthenticationPrincipal AuthUserDetails principal) {
         return codCash.daSummary(callerDaId(principal));
+    }
+
+    /** The DA's own cash-in-hand ledger (collections + deposits with a running balance), newest first. */
+    @GetMapping("/ledger")
+    public List<DaCodLedgerEntryResponse> ledger(@AuthenticationPrincipal AuthUserDetails principal) {
+        return codCash.daLedger(callerDaId(principal));
     }
 
     /** The calling delivery associate's own user id (also gates the endpoint to that role). */

--- a/orders/src/main/java/com/oneday/orders/domain/DaCodBalance.java
+++ b/orders/src/main/java/com/oneday/orders/domain/DaCodBalance.java
@@ -1,0 +1,38 @@
+package com.oneday.orders.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * A delivery associate's running COD cash-in-hand — the cash they've collected on delivery but not yet
+ * deposited. The lockable balance row (PK = the DA's user id) that serialises concurrent ledger
+ * postings, mirroring {@code b2b_accounts.wallet_balance_paise} for the wallet. The
+ * {@link DaCodLedgerEntry} history makes it fully reconstructable.
+ */
+@Entity
+@Table(name = "da_cod_balance")
+@Getter
+@Setter
+@NoArgsConstructor
+public class DaCodBalance {
+
+    @Id
+    @Column(name = "da_user_id", nullable = false, updatable = false)
+    private UUID daUserId;
+
+    @Column(name = "cash_in_hand_paise", nullable = false)
+    private long cashInHandPaise;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/orders/src/main/java/com/oneday/orders/domain/DaCodLedgerEntry.java
+++ b/orders/src/main/java/com/oneday/orders/domain/DaCodLedgerEntry.java
@@ -1,0 +1,63 @@
+package com.oneday.orders.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * One append-only movement on a delivery associate's COD cash-in-hand ledger. The running balance is
+ * stored on {@link DaCodBalance} for cheap gating; this ledger makes it fully reconstructable. Never
+ * mutated after insert, so it does not extend {@code MutableBaseEntity}. Mirrors {@code WalletTransaction}.
+ */
+@Entity
+@Table(name = "da_cod_ledger")
+@Getter
+@Setter
+@NoArgsConstructor
+public class DaCodLedgerEntry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "da_user_id", nullable = false, updatable = false)
+    private UUID daUserId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", length = 20, nullable = false, updatable = false)
+    private DaCodLedgerType type;
+
+    /** Signed: positive increases cash-in-hand (a collection), negative decreases it (a deposit). */
+    @Column(name = "amount_paise", nullable = false, updatable = false)
+    private long amountPaise;
+
+    @Column(name = "balance_after_paise", nullable = false, updatable = false)
+    private long balanceAfterPaise;
+
+    /** Shipment ref / deposit ref, for reconciliation. */
+    @Column(name = "reference", length = 80, updatable = false)
+    private String reference;
+
+    @Column(name = "description", length = 300, updatable = false)
+    private String description;
+
+    @Column(name = "created_by", updatable = false)
+    private UUID createdBy;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private Instant createdAt;
+}

--- a/orders/src/main/java/com/oneday/orders/domain/DaCodLedgerType.java
+++ b/orders/src/main/java/com/oneday/orders/domain/DaCodLedgerType.java
@@ -1,0 +1,11 @@
+package com.oneday.orders.domain;
+
+/** A movement on a delivery associate's COD cash-in-hand ledger. */
+public enum DaCodLedgerType {
+    /** DA took cash from the buyer on delivery (+ increases cash-in-hand owed to the company). */
+    COLLECTION,
+    /** DA handed cash in (bank/hub) (− decreases cash-in-hand). */
+    DEPOSIT,
+    /** Admin correction / shortfall write-off (± either direction). */
+    ADJUSTMENT
+}

--- a/orders/src/main/java/com/oneday/orders/dto/DaCodCashSummaryResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/DaCodCashSummaryResponse.java
@@ -5,7 +5,8 @@ import java.util.UUID;
 
 /**
  * A delivery associate's own COD cash position: what they collected vs what they've deposited.
- * A positive {@code outstandingPaise} means the DA is still holding cash they owe the company.
+ * {@code cashInHandPaise} is the authoritative running balance from the ledger (cash the DA is still
+ * holding); {@code outstandingPaise} is the on-the-fly collected−deposited figure kept for continuity.
  */
 public record DaCodCashSummaryResponse(
         UUID daUserId,
@@ -13,5 +14,6 @@ public record DaCodCashSummaryResponse(
         long collectedPaise,
         long depositedPaise,
         long outstandingPaise,
+        long cashInHandPaise,
         List<CodCashDepositResponse> deposits) {
 }

--- a/orders/src/main/java/com/oneday/orders/dto/DaCodLedgerEntryResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/DaCodLedgerEntryResponse.java
@@ -1,0 +1,22 @@
+package com.oneday.orders.dto;
+
+import com.oneday.orders.domain.DaCodLedgerEntry;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/** One row of a DA's COD cash-in-hand ledger. Snake_case on the wire (project-wide Jackson strategy). */
+public record DaCodLedgerEntryResponse(
+        UUID id,
+        String type,
+        long amountPaise,
+        long balanceAfterPaise,
+        String reference,
+        String description,
+        Instant createdAt) {
+
+    public static DaCodLedgerEntryResponse from(DaCodLedgerEntry e) {
+        return new DaCodLedgerEntryResponse(e.getId(), e.getType().name(), e.getAmountPaise(),
+                e.getBalanceAfterPaise(), e.getReference(), e.getDescription(), e.getCreatedAt());
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/dto/RecordCodDepositRequest.java
+++ b/orders/src/main/java/com/oneday/orders/dto/RecordCodDepositRequest.java
@@ -1,11 +1,16 @@
 package com.oneday.orders.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
-/** A delivery associate records a COD cash deposit (bank/hub). */
+/**
+ * A delivery associate records a COD cash deposit (bank/hub). {@code depositRef} is required — it is the
+ * idempotency key for the deposit (and the ledger movement it posts), so a retried submit can't
+ * double-count cash.
+ */
 public record RecordCodDepositRequest(
         @Positive Long amountPaise,
-        @Size(max = 80) String depositRef,
+        @NotBlank @Size(max = 80) String depositRef,
         @Size(max = 300) String note) {
 }

--- a/orders/src/main/java/com/oneday/orders/repository/DaCodBalanceRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/DaCodBalanceRepository.java
@@ -1,0 +1,29 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.DaCodBalance;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface DaCodBalanceRepository extends JpaRepository<DaCodBalance, UUID> {
+
+    /**
+     * Idempotently create the DA's balance row (zero) if it doesn't exist. Called before the locking
+     * read so the row is always present to lock; safe under concurrent first-postings (ON CONFLICT).
+     */
+    @Modifying
+    @Query(value = "INSERT INTO da_cod_balance (da_user_id, cash_in_hand_paise) VALUES (:daId, 0) "
+            + "ON CONFLICT (da_user_id) DO NOTHING", nativeQuery = true)
+    void ensureRow(@Param("daId") UUID daId);
+
+    /** Pessimistic-write lock (SELECT … FOR UPDATE) — serialises concurrent postings for one DA. */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT b FROM DaCodBalance b WHERE b.daUserId = :daId")
+    Optional<DaCodBalance> findByIdForUpdate(@Param("daId") UUID daId);
+}

--- a/orders/src/main/java/com/oneday/orders/repository/DaCodLedgerRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/DaCodLedgerRepository.java
@@ -1,0 +1,13 @@
+package com.oneday.orders.repository;
+
+import com.oneday.orders.domain.DaCodLedgerEntry;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface DaCodLedgerRepository extends JpaRepository<DaCodLedgerEntry, UUID> {
+
+    /** A DA's ledger history, newest first. */
+    List<DaCodLedgerEntry> findByDaUserIdOrderByCreatedAtDesc(UUID daUserId);
+}

--- a/orders/src/main/java/com/oneday/orders/repository/DaCodLedgerRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/DaCodLedgerRepository.java
@@ -1,6 +1,7 @@
 package com.oneday.orders.repository;
 
 import com.oneday.orders.domain.DaCodLedgerEntry;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -8,6 +9,6 @@ import java.util.UUID;
 
 public interface DaCodLedgerRepository extends JpaRepository<DaCodLedgerEntry, UUID> {
 
-    /** A DA's ledger history, newest first. */
-    List<DaCodLedgerEntry> findByDaUserIdOrderByCreatedAtDesc(UUID daUserId);
+    /** A page of a DA's ledger history, newest first (the ledger is append-only and unbounded). */
+    List<DaCodLedgerEntry> findByDaUserIdOrderByCreatedAtDesc(UUID daUserId, Pageable pageable);
 }

--- a/orders/src/main/java/com/oneday/orders/service/CodCashService.java
+++ b/orders/src/main/java/com/oneday/orders/service/CodCashService.java
@@ -5,6 +5,7 @@ import com.oneday.orders.dto.CodCashDepositResponse;
 import com.oneday.orders.dto.DaCodCashSummaryResponse;
 import com.oneday.orders.dto.DaCodLedgerEntryResponse;
 import com.oneday.orders.dto.RecordCodDepositRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.UUID;
@@ -25,8 +26,8 @@ public interface CodCashService {
     /** The DA's own position: collected vs deposited + authoritative cash-in-hand, with deposit history. */
     DaCodCashSummaryResponse daSummary(UUID daUserId);
 
-    /** The DA's cash-in-hand ledger (append-only movement history), newest first. */
-    List<DaCodLedgerEntryResponse> daLedger(UUID daUserId);
+    /** A page of the DA's cash-in-hand ledger (append-only movement history), newest first. */
+    List<DaCodLedgerEntryResponse> daLedger(UUID daUserId, Pageable pageable);
 
     // ── Admin ─────────────────────────────────────────────────────────────────
 

--- a/orders/src/main/java/com/oneday/orders/service/CodCashService.java
+++ b/orders/src/main/java/com/oneday/orders/service/CodCashService.java
@@ -3,6 +3,7 @@ package com.oneday.orders.service;
 import com.oneday.orders.dto.AdminCodReconciliationRow;
 import com.oneday.orders.dto.CodCashDepositResponse;
 import com.oneday.orders.dto.DaCodCashSummaryResponse;
+import com.oneday.orders.dto.DaCodLedgerEntryResponse;
 import com.oneday.orders.dto.RecordCodDepositRequest;
 
 import java.util.List;
@@ -21,8 +22,11 @@ public interface CodCashService {
     /** Record a cash deposit the DA has handed in. */
     CodCashDepositResponse recordDeposit(UUID daUserId, RecordCodDepositRequest request);
 
-    /** The DA's own position: collected vs deposited, with their deposit history. */
+    /** The DA's own position: collected vs deposited + authoritative cash-in-hand, with deposit history. */
     DaCodCashSummaryResponse daSummary(UUID daUserId);
+
+    /** The DA's cash-in-hand ledger (append-only movement history), newest first. */
+    List<DaCodLedgerEntryResponse> daLedger(UUID daUserId);
 
     // ── Admin ─────────────────────────────────────────────────────────────────
 

--- a/orders/src/main/java/com/oneday/orders/service/CodLedgerService.java
+++ b/orders/src/main/java/com/oneday/orders/service/CodLedgerService.java
@@ -1,0 +1,29 @@
+package com.oneday.orders.service;
+
+import com.oneday.orders.domain.DaCodLedgerType;
+import com.oneday.orders.dto.DaCodLedgerEntryResponse;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * The per-DA COD cash-in-hand ledger — an append-only record of the cash a delivery associate has
+ * collected (and not yet deposited), with a running balance. Mirrors the merchant wallet ledger.
+ * Separate concern from {@link CodRemittanceService} (money owed to merchants).
+ */
+public interface CodLedgerService {
+
+    /**
+     * Post one movement atomically: lock the DA's balance, apply {@code signedAmountPaise}
+     * (+ collection, − deposit), write the ledger entry with the resulting balance, and update the
+     * running balance. Returns the balance after this entry.
+     */
+    long post(UUID daUserId, DaCodLedgerType type, long signedAmountPaise, String reference,
+              String description, UUID createdBy);
+
+    /** The DA's current cash-in-hand (0 if they have no ledger yet). */
+    long cashInHand(UUID daUserId);
+
+    /** The DA's ledger history, newest first. */
+    List<DaCodLedgerEntryResponse> history(UUID daUserId);
+}

--- a/orders/src/main/java/com/oneday/orders/service/CodLedgerService.java
+++ b/orders/src/main/java/com/oneday/orders/service/CodLedgerService.java
@@ -2,6 +2,7 @@ package com.oneday.orders.service;
 
 import com.oneday.orders.domain.DaCodLedgerType;
 import com.oneday.orders.dto.DaCodLedgerEntryResponse;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.UUID;
@@ -24,6 +25,6 @@ public interface CodLedgerService {
     /** The DA's current cash-in-hand (0 if they have no ledger yet). */
     long cashInHand(UUID daUserId);
 
-    /** The DA's ledger history, newest first. */
-    List<DaCodLedgerEntryResponse> history(UUID daUserId);
+    /** A page of the DA's ledger history, newest first. */
+    List<DaCodLedgerEntryResponse> history(UUID daUserId, Pageable pageable);
 }

--- a/orders/src/main/java/com/oneday/orders/service/impl/CodCashServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/CodCashServiceImpl.java
@@ -12,6 +12,7 @@ import com.oneday.orders.repository.CodCashDepositRepository;
 import com.oneday.orders.repository.CodCollectionRepository;
 import com.oneday.orders.service.CodCashService;
 import com.oneday.orders.service.CodLedgerService;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,14 +45,12 @@ class CodCashServiceImpl implements CodCashService {
     @Override
     @Transactional
     public CodCashDepositResponse recordDeposit(UUID daUserId, RecordCodDepositRequest request) {
-        String ref = request.depositRef() == null ? null : request.depositRef().trim();
-        // Idempotent on (DA, deposit_ref): a repeated submission returns the existing deposit instead
-        // of double-counting cash. A concurrent duplicate is caught by the DB unique index (V4_36).
-        if (ref != null && !ref.isBlank()) {
-            var existing = deposits.findByDaUserIdAndDepositRef(daUserId, ref);
-            if (existing.isPresent()) {
-                return CodCashDepositResponse.from(existing.get());
-            }
+        // depositRef is the required idempotency key (@NotBlank on the request). Every deposit is
+        // pre-checked, so a retry returns the existing row and never double-posts a ledger movement.
+        String ref = request.depositRef().trim();
+        var existing = deposits.findByDaUserIdAndDepositRef(daUserId, ref);
+        if (existing.isPresent()) {
+            return CodCashDepositResponse.from(existing.get());
         }
         CodCashDeposit d = new CodCashDeposit();
         d.setDaUserId(daUserId);
@@ -63,9 +62,11 @@ class CodCashServiceImpl implements CodCashService {
         try {
             saved = deposits.saveAndFlush(d);
         } catch (org.springframework.dao.DataIntegrityViolationException race) {
-            // Lost the race to a concurrent identical submit — return the winner, don't double-post.
-            return CodCashDepositResponse.from(
-                    deposits.findByDaUserIdAndDepositRef(daUserId, ref).orElseThrow(() -> race));
+            // A concurrent identical submit won the unique-index race. Don't recover-read here — the
+            // transaction is already rollback-only — surface a 409 so the client retries and the
+            // pre-check above returns the winning row (200). No double-post.
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "A deposit with this reference is already being recorded — retry.");
         }
         // A genuinely new deposit reduces the DA's cash-in-hand (they handed the cash over).
         codLedger.post(daUserId, DaCodLedgerType.DEPOSIT, -saved.getAmountPaise(),
@@ -88,8 +89,8 @@ class CodCashServiceImpl implements CodCashService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<DaCodLedgerEntryResponse> daLedger(UUID daUserId) {
-        return codLedger.history(daUserId);
+    public List<DaCodLedgerEntryResponse> daLedger(UUID daUserId, Pageable pageable) {
+        return codLedger.history(daUserId, pageable);
     }
 
     @Override

--- a/orders/src/main/java/com/oneday/orders/service/impl/CodCashServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/CodCashServiceImpl.java
@@ -2,13 +2,16 @@ package com.oneday.orders.service.impl;
 
 import com.oneday.orders.domain.CodCashDeposit;
 import com.oneday.orders.domain.CodCashDepositState;
+import com.oneday.orders.domain.DaCodLedgerType;
 import com.oneday.orders.dto.AdminCodReconciliationRow;
 import com.oneday.orders.dto.CodCashDepositResponse;
 import com.oneday.orders.dto.DaCodCashSummaryResponse;
+import com.oneday.orders.dto.DaCodLedgerEntryResponse;
 import com.oneday.orders.dto.RecordCodDepositRequest;
 import com.oneday.orders.repository.CodCashDepositRepository;
 import com.oneday.orders.repository.CodCollectionRepository;
 import com.oneday.orders.service.CodCashService;
+import com.oneday.orders.service.CodLedgerService;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,10 +32,13 @@ class CodCashServiceImpl implements CodCashService {
 
     private final CodCashDepositRepository deposits;
     private final CodCollectionRepository collections;
+    private final CodLedgerService codLedger;
 
-    CodCashServiceImpl(CodCashDepositRepository deposits, CodCollectionRepository collections) {
+    CodCashServiceImpl(CodCashDepositRepository deposits, CodCollectionRepository collections,
+                       CodLedgerService codLedger) {
         this.deposits = deposits;
         this.collections = collections;
+        this.codLedger = codLedger;
     }
 
     @Override
@@ -53,13 +59,18 @@ class CodCashServiceImpl implements CodCashService {
         d.setDepositRef(ref);
         d.setNote(request.note());
         d.setStatus(CodCashDepositState.DEPOSITED);
+        CodCashDeposit saved;
         try {
-            return CodCashDepositResponse.from(deposits.saveAndFlush(d));
+            saved = deposits.saveAndFlush(d);
         } catch (org.springframework.dao.DataIntegrityViolationException race) {
-            // Lost the race to a concurrent identical submit — return the winner.
+            // Lost the race to a concurrent identical submit — return the winner, don't double-post.
             return CodCashDepositResponse.from(
                     deposits.findByDaUserIdAndDepositRef(daUserId, ref).orElseThrow(() -> race));
         }
+        // A genuinely new deposit reduces the DA's cash-in-hand (they handed the cash over).
+        codLedger.post(daUserId, DaCodLedgerType.DEPOSIT, -saved.getAmountPaise(),
+                saved.getDepositRef(), "Cash deposited", daUserId);
+        return CodCashDepositResponse.from(saved);
     }
 
     @Override
@@ -68,9 +79,17 @@ class CodCashServiceImpl implements CodCashService {
         long collected = collections.sumCollectedByDa(daUserId);
         long count = collections.countCollectedByDa(daUserId);
         long deposited = deposits.sumDepositedByDa(daUserId);
+        long cashInHand = codLedger.cashInHand(daUserId);
         List<CodCashDepositResponse> rows = deposits.findByDaUserIdOrderByCreatedAtDesc(daUserId)
                 .stream().map(CodCashDepositResponse::from).toList();
-        return new DaCodCashSummaryResponse(daUserId, count, collected, deposited, collected - deposited, rows);
+        return new DaCodCashSummaryResponse(
+                daUserId, count, collected, deposited, collected - deposited, cashInHand, rows);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<DaCodLedgerEntryResponse> daLedger(UUID daUserId) {
+        return codLedger.history(daUserId);
     }
 
     @Override

--- a/orders/src/main/java/com/oneday/orders/service/impl/CodLedgerServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/CodLedgerServiceImpl.java
@@ -7,6 +7,7 @@ import com.oneday.orders.dto.DaCodLedgerEntryResponse;
 import com.oneday.orders.repository.DaCodBalanceRepository;
 import com.oneday.orders.repository.DaCodLedgerRepository;
 import com.oneday.orders.service.CodLedgerService;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,8 +57,8 @@ class CodLedgerServiceImpl implements CodLedgerService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<DaCodLedgerEntryResponse> history(UUID daUserId) {
-        return ledger.findByDaUserIdOrderByCreatedAtDesc(daUserId).stream()
+    public List<DaCodLedgerEntryResponse> history(UUID daUserId, Pageable pageable) {
+        return ledger.findByDaUserIdOrderByCreatedAtDesc(daUserId, pageable).stream()
                 .map(DaCodLedgerEntryResponse::from)
                 .toList();
     }

--- a/orders/src/main/java/com/oneday/orders/service/impl/CodLedgerServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/CodLedgerServiceImpl.java
@@ -1,0 +1,64 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.domain.DaCodBalance;
+import com.oneday.orders.domain.DaCodLedgerEntry;
+import com.oneday.orders.domain.DaCodLedgerType;
+import com.oneday.orders.dto.DaCodLedgerEntryResponse;
+import com.oneday.orders.repository.DaCodBalanceRepository;
+import com.oneday.orders.repository.DaCodLedgerRepository;
+import com.oneday.orders.service.CodLedgerService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+class CodLedgerServiceImpl implements CodLedgerService {
+
+    private final DaCodBalanceRepository balances;
+    private final DaCodLedgerRepository ledger;
+
+    CodLedgerServiceImpl(DaCodBalanceRepository balances, DaCodLedgerRepository ledger) {
+        this.balances = balances;
+        this.ledger = ledger;
+    }
+
+    @Override
+    @Transactional
+    public long post(UUID daUserId, DaCodLedgerType type, long signedAmountPaise, String reference,
+                     String description, UUID createdBy) {
+        // Ensure the balance row exists, then lock it so concurrent postings for this DA serialise and the
+        // running balance can't race (mirrors the wallet's lock on b2b_accounts.wallet_balance_paise).
+        balances.ensureRow(daUserId);
+        DaCodBalance balance = balances.findByIdForUpdate(daUserId).orElseThrow();
+        long newBalance = balance.getCashInHandPaise() + signedAmountPaise;
+        balance.setCashInHandPaise(newBalance);
+        balances.save(balance);
+
+        DaCodLedgerEntry entry = new DaCodLedgerEntry();
+        entry.setDaUserId(daUserId);
+        entry.setType(type);
+        entry.setAmountPaise(signedAmountPaise);
+        entry.setBalanceAfterPaise(newBalance);
+        entry.setReference(reference);
+        entry.setDescription(description);
+        entry.setCreatedBy(createdBy);
+        ledger.save(entry);
+        return newBalance;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public long cashInHand(UUID daUserId) {
+        return balances.findById(daUserId).map(DaCodBalance::getCashInHandPaise).orElse(0L);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<DaCodLedgerEntryResponse> history(UUID daUserId) {
+        return ledger.findByDaUserIdOrderByCreatedAtDesc(daUserId).stream()
+                .map(DaCodLedgerEntryResponse::from)
+                .toList();
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/CodRemittanceServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/CodRemittanceServiceImpl.java
@@ -14,6 +14,8 @@ import com.oneday.orders.dto.CodSummaryResponse;
 import com.oneday.orders.repository.B2bAccountRepository;
 import com.oneday.orders.repository.CodCollectionRepository;
 import com.oneday.orders.repository.CodRemittanceRepository;
+import com.oneday.orders.domain.DaCodLedgerType;
+import com.oneday.orders.service.CodLedgerService;
 import com.oneday.orders.service.CodRemittanceService;
 import com.oneday.orders.service.Notifier;
 import org.slf4j.Logger;
@@ -43,19 +45,22 @@ class CodRemittanceServiceImpl implements CodRemittanceService {
     private final CodProperties props;
     private final PayoutPort payouts;
     private final Notifier notifier;
+    private final CodLedgerService codLedger;
 
     CodRemittanceServiceImpl(CodCollectionRepository collections,
                              CodRemittanceRepository remittances,
                              B2bAccountRepository accounts,
                              CodProperties props,
                              PayoutPort payouts,
-                             Notifier notifier) {
+                             Notifier notifier,
+                             CodLedgerService codLedger) {
         this.collections = collections;
         this.remittances = remittances;
         this.accounts = accounts;
         this.props = props;
         this.payouts = payouts;
         this.notifier = notifier;
+        this.codLedger = codLedger;
     }
 
     // ── Lifecycle hooks — run in their own transaction (called AFTER_COMMIT) ────
@@ -69,6 +74,12 @@ class CodRemittanceServiceImpl implements CodRemittanceService {
                 c.setCollectedAt(Instant.now());
                 c.setCollectedByDaId(collectedByDaId);
                 collections.save(c);
+                // A doorstep DA now holds the buyer's cash → post it to their cash-in-hand ledger. Skip
+                // hub self-collect (collectedByDaId null) — no rider is carrying that cash.
+                if (collectedByDaId != null) {
+                    codLedger.post(collectedByDaId, DaCodLedgerType.COLLECTION, c.getAmountPaise(),
+                            c.getShipmentRef(), "COD collected on delivery", collectedByDaId);
+                }
                 log.info("COD collection {} for shipment {} → COLLECTED ({} paise)",
                         c.getId(), c.getShipmentRef(), c.getAmountPaise());
             }

--- a/orders/src/main/resources/db/migration/orders/V4_47__da_cod_ledger.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_47__da_cod_ledger.sql
@@ -1,0 +1,31 @@
+-- vii: per-DA COD cash ledger. The company is owed the cash its riders collect on delivery until they
+-- deposit it. Until now a DA's position was recomputed on the fly (Σ collected − Σ deposited) with no
+-- audit trail; this makes it an append-only ledger with a running balance, exactly like the merchant
+-- wallet (wallet_transaction + b2b_accounts.wallet_balance_paise).
+
+-- Running balance = cash the DA is currently holding on the company's behalf. Lockable row that
+-- serialises concurrent postings, mirroring b2b_accounts.wallet_balance_paise.
+CREATE TABLE da_cod_balance (
+    da_user_id         UUID PRIMARY KEY,
+    cash_in_hand_paise BIGINT      NOT NULL DEFAULT 0,
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Append-only history; the balance above is reconstructable from it. Never mutated after insert.
+CREATE TABLE da_cod_ledger (
+    id                  UUID        PRIMARY KEY,
+    da_user_id          UUID        NOT NULL,
+    -- COLLECTION (+ took cash at delivery), DEPOSIT (- handed cash in), ADJUSTMENT (± admin correction)
+    type                VARCHAR(20) NOT NULL,
+    amount_paise        BIGINT      NOT NULL,   -- signed: + increases cash-in-hand, - decreases it
+    balance_after_paise BIGINT      NOT NULL,
+    reference           VARCHAR(80),            -- shipment_ref / deposit_ref, for reconciliation
+    description         VARCHAR(300),
+    created_by          UUID,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_da_cod_ledger_da ON da_cod_ledger (da_user_id, created_at DESC);
+
+-- NOTE: the ledger is authoritative for cash movements from here on. Existing cod_collection /
+-- cod_cash_deposit rows are NOT backfilled (a per-DA time-ordered reconstruction is deferred — see the
+-- COD-ledger follow-up issue); the on-the-fly collected/deposited sums remain for historical continuity.

--- a/orders/src/main/resources/db/migration/orders/V4_47__da_cod_ledger.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_47__da_cod_ledger.sql
@@ -27,5 +27,8 @@ CREATE TABLE da_cod_ledger (
 CREATE INDEX idx_da_cod_ledger_da ON da_cod_ledger (da_user_id, created_at DESC);
 
 -- NOTE: the ledger is authoritative for cash movements from here on. Existing cod_collection /
--- cod_cash_deposit rows are NOT backfilled (a per-DA time-ordered reconstruction is deferred — see the
--- COD-ledger follow-up issue); the on-the-fly collected/deposited sums remain for historical continuity.
+-- cod_cash_deposit rows are NOT backfilled — the per-DA time-ordered reconstruction / cutover
+-- opening-balance seed is deferred to issue #185. Until then a DA depositing pre-cutover cash can drive
+-- the ledger balance negative; that's expected (the ledger simply doesn't yet know their pre-cutover
+-- collections), and it's why we do NOT clamp deposits to a non-negative balance. The on-the-fly
+-- collected/deposited sums remain for historical continuity.

--- a/orders/src/test/java/com/oneday/orders/service/impl/CodCashServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/CodCashServiceImplTest.java
@@ -4,8 +4,10 @@ import com.oneday.orders.domain.CodCashDeposit;
 import com.oneday.orders.domain.CodCashDepositState;
 import com.oneday.orders.dto.CodCashDepositResponse;
 import com.oneday.orders.dto.RecordCodDepositRequest;
+import com.oneday.orders.domain.DaCodLedgerType;
 import com.oneday.orders.repository.CodCashDepositRepository;
 import com.oneday.orders.repository.CodCollectionRepository;
+import com.oneday.orders.service.CodLedgerService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -17,6 +19,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,9 +30,10 @@ class CodCashServiceImplTest {
 
     @Mock private CodCashDepositRepository deposits;
     @Mock private CodCollectionRepository collections;
+    @Mock private CodLedgerService codLedger;
 
     private CodCashServiceImpl service() {
-        return new CodCashServiceImpl(deposits, collections);
+        return new CodCashServiceImpl(deposits, collections, codLedger);
     }
 
     @Test
@@ -49,6 +53,9 @@ class CodCashServiceImplTest {
         assertThat(resp.id()).isEqualTo(existing.getId());
         verify(deposits, never()).save(any());
         verify(deposits, never()).saveAndFlush(any());
+        // An idempotent repeat must NOT post to the ledger again (no double debit of cash-in-hand).
+        verify(codLedger, never()).post(any(), any(), org.mockito.ArgumentMatchers.anyLong(),
+                any(), any(), any());
     }
 
     @Test
@@ -62,5 +69,7 @@ class CodCashServiceImplTest {
 
         assertThat(resp.amountPaise()).isEqualTo(700L);
         verify(deposits).saveAndFlush(any(CodCashDeposit.class));
+        // A new deposit posts a negative (DEPOSIT) movement to the DA's cash-in-hand ledger.
+        verify(codLedger).post(eq(da), eq(DaCodLedgerType.DEPOSIT), eq(-700L), eq("REF-2"), any(), eq(da));
     }
 }

--- a/orders/src/test/java/com/oneday/orders/service/impl/CodLedgerServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/CodLedgerServiceImplTest.java
@@ -1,0 +1,73 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.orders.domain.DaCodBalance;
+import com.oneday.orders.domain.DaCodLedgerEntry;
+import com.oneday.orders.domain.DaCodLedgerType;
+import com.oneday.orders.repository.DaCodBalanceRepository;
+import com.oneday.orders.repository.DaCodLedgerRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The ledger's one load-bearing guarantee: each posting locks the DA's balance, applies the signed
+ * amount, and stamps the resulting running balance on the entry. A collection then a deposit must land
+ * at the right cash-in-hand.
+ */
+@ExtendWith(MockitoExtension.class)
+class CodLedgerServiceImplTest {
+
+    @Mock private DaCodBalanceRepository balances;
+    @Mock private DaCodLedgerRepository ledger;
+
+    private final UUID da = UUID.randomUUID();
+
+    /** A tiny in-memory balance row keyed by DA, so post() reads back what it wrote (like the DB would). */
+    private void wireBalanceStore() {
+        Map<UUID, DaCodBalance> store = new HashMap<>();
+        when(balances.findByIdForUpdate(any())).thenAnswer(inv -> {
+            UUID id = inv.getArgument(0);
+            return Optional.of(store.computeIfAbsent(id, k -> {
+                DaCodBalance b = new DaCodBalance();
+                b.setDaUserId(k);
+                return b;
+            }));
+        });
+        when(balances.save(any(DaCodBalance.class))).thenAnswer(inv -> {
+            DaCodBalance b = inv.getArgument(0);
+            store.put(b.getDaUserId(), b);
+            return b;
+        });
+    }
+
+    @Test
+    void collectionThenDeposit_runningBalanceIsCorrect() {
+        wireBalanceStore();
+        CodLedgerServiceImpl svc = new CodLedgerServiceImpl(balances, ledger);
+
+        long afterCollect = svc.post(da, DaCodLedgerType.COLLECTION, 1_000L, "1DD-1", "collected", da);
+        long afterDeposit = svc.post(da, DaCodLedgerType.DEPOSIT, -400L, "DEP-1", "deposited", da);
+
+        assertThat(afterCollect).isEqualTo(1_000L);   // holds ₹10
+        assertThat(afterDeposit).isEqualTo(600L);      // handed ₹4 back → ₹6 left in hand
+        verify(balances, org.mockito.Mockito.times(2)).ensureRow(da);
+
+        ArgumentCaptor<DaCodLedgerEntry> entries = ArgumentCaptor.forClass(DaCodLedgerEntry.class);
+        verify(ledger, org.mockito.Mockito.times(2)).save(entries.capture());
+        assertThat(entries.getAllValues().get(0).getBalanceAfterPaise()).isEqualTo(1_000L);
+        assertThat(entries.getAllValues().get(1).getBalanceAfterPaise()).isEqualTo(600L);
+        assertThat(entries.getAllValues().get(1).getAmountPaise()).isEqualTo(-400L);
+    }
+}


### PR DESCRIPTION
https://claude.ai/code/artifact/b5257104-a631-4133-9886-e0de80412042?via=auto_preview

<img width="2872" height="834" alt="image" src="https://github.com/user-attachments/assets/10fee475-047c-4ce1-a905-381d030cf63d" />

<img width="2922" height="1414" alt="image" src="https://github.com/user-attachments/assets/309e4cbc-52db-4756-b112-31a19aea2a67" />

<img width="1586" height="1340" alt="image" src="https://github.com/user-attachments/assets/13b1b589-9991-4267-a7c3-79fbc03484a0" />

## What this is for

When a customer pays cash on delivery, the rider is holding **the company's money** until they hand it in. This is the first piece of the COD cash-reconciliation pathway (vii): a proper **running ledger of each rider's cash-in-hand**, so at any moment we know exactly how much cash a delivery associate is carrying on our behalf — and can reconcile it against what they deposit.

## The problem it solves

**"How much cash is this rider holding right now?"** Until now that number was recomputed on the fly by subtracting total deposits from total collections, with no history and nothing to audit. This makes it a real, append-only ledger with a running balance — exactly like the merchant wallet:

- Every COD collection on delivery **adds** to the rider's cash-in-hand.
- Every deposit they hand in **subtracts** from it.
- Each movement is recorded with the balance after it, so the position is always reconstructable and auditable, and a repeated deposit submission can't double-count.

A rider (and the ops team) can see their cash-in-hand and the full movement history.

## Live now
- Ledger + running balance, wired into delivery (collection) and deposit.
- The rider's own cash-in-hand and ledger history are exposed to the driver app.

## Follow-ups (tracked separately)
This is the foundation. Still to come on the COD pathway: netting the admin reconcile verdict into the ledger (shortfall / write-off entries), the DA→hub cash-custody hand-off as a tracked step, and surfacing COD fees/remittance on the merchant side. Captured in the COD-ledger follow-up issue.

## Checked
Ledger posting computes the running balance correctly (a collection then a deposit lands at the right cash-in-hand); a repeated deposit doesn't post twice. COD tests green; the app assembles. Existing collections aren't backfilled — the ledger is authoritative from here on (noted in the migration).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cash-in-hand tracking for delivery associates through collections, deposits, and adjustments.
  * Added a COD ledger with transaction history, running balances, and newest-first viewing.
  * Added pagination controls for ledger history.
  * COD summaries now include the authoritative cash-in-hand balance.
* **Bug Fixes**
  * Prevented duplicate deposits from creating duplicate ledger entries.
  * Ensured doorstep COD collections update the responsible associate’s balance while hub collections are excluded.
  * Deposit references are now required for reliable processing.
* **Tests**
  * Added coverage for balance updates, persistence, pagination, and duplicate deposits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->