### PR TITLE
feat(dispatch): global auto-present admin toggle (M5 attendance)

### DIFF
--- a/dispatch/src/main/java/com/oneday/dispatch/api/AttendanceConfigController.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/api/AttendanceConfigController.java
@@ -1,0 +1,53 @@
+package com.oneday.dispatch.api;
+
+import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.dispatch.domain.AttendanceConfig;
+import com.oneday.dispatch.dto.request.AttendanceConfigUpdateRequest;
+import com.oneday.dispatch.dto.response.AttendanceConfigResponse;
+import com.oneday.dispatch.service.AttendanceConfigService;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.UUID;
+
+/**
+ * Global attendance config, ADMIN-only. v1 exposes the single {@code auto_present_enabled} switch that
+ * gates geofence auto-present (manual "I've arrived" check-in is unaffected). Surfaced in the admin
+ * console's Settings page.
+ */
+@RestController
+public class AttendanceConfigController {
+
+    private final AttendanceConfigService configService;
+
+    public AttendanceConfigController(AttendanceConfigService configService) {
+        this.configService = configService;
+    }
+
+    @GetMapping("/dispatch/admin/attendance-config")
+    public AttendanceConfigResponse get(@AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireRole(principal, Authz.ADMIN);
+        return toResponse(configService.get());
+    }
+
+    @PutMapping("/dispatch/admin/attendance-config")
+    public AttendanceConfigResponse update(@RequestBody(required = false) AttendanceConfigUpdateRequest request,
+                                           @AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireRole(principal, Authz.ADMIN);
+        UUID actor = Authz.requireUserId(principal);
+        if (request == null || request.autoPresentEnabled() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "auto_present_enabled is required");
+        }
+        return toResponse(configService.setAutoPresentEnabled(request.autoPresentEnabled(), actor));
+    }
+
+    private AttendanceConfigResponse toResponse(AttendanceConfig config) {
+        return new AttendanceConfigResponse(
+                config.isAutoPresentEnabled(), config.getUpdatedAt(), config.getUpdatedByUserId());
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/domain/AttendanceConfig.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/domain/AttendanceConfig.java
@@ -1,0 +1,30 @@
+package com.oneday.dispatch.domain;
+
+import com.oneday.common.domain.MutableBaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+/**
+ * Global attendance config — a single row (the earliest by created_at). Currently just the
+ * {@code autoPresentEnabled} master switch for geofence auto-present. Ops-tunable at runtime via the
+ * admin toggle, unlike the static yaml knobs in {@code DispatchProperties.Attendance}.
+ */
+@Entity
+@Table(name = "attendance_config")
+@Getter
+@Setter
+@NoArgsConstructor
+public class AttendanceConfig extends MutableBaseEntity {
+
+    @Column(name = "auto_present_enabled", nullable = false)
+    private boolean autoPresentEnabled = true;
+
+    @Column(name = "updated_by_user_id")
+    private UUID updatedByUserId;
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/dto/request/AttendanceConfigUpdateRequest.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/dto/request/AttendanceConfigUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.oneday.dispatch.dto.request;
+
+/**
+ * Admin update to the global attendance config. {@code autoPresentEnabled} (json
+ * {@code auto_present_enabled}) is required — the master switch for geofence auto-present.
+ */
+public record AttendanceConfigUpdateRequest(Boolean autoPresentEnabled) {
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/dto/response/AttendanceConfigResponse.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/dto/response/AttendanceConfigResponse.java
@@ -1,0 +1,11 @@
+package com.oneday.dispatch.dto.response;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * The global attendance config as returned to the admin console. Serialised snake_case
+ * ({@code auto_present_enabled}, {@code updated_at}, {@code updated_by}).
+ */
+public record AttendanceConfigResponse(boolean autoPresentEnabled, Instant updatedAt, UUID updatedBy) {
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/repository/AttendanceConfigRepository.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/repository/AttendanceConfigRepository.java
@@ -1,0 +1,13 @@
+package com.oneday.dispatch.repository;
+
+import com.oneday.dispatch.domain.AttendanceConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface AttendanceConfigRepository extends JpaRepository<AttendanceConfig, UUID> {
+
+    /** The singleton config row (earliest by created_at, in case duplicates ever slip in). */
+    Optional<AttendanceConfig> findFirstByOrderByCreatedAtAsc();
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/service/AttendanceConfigService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/AttendanceConfigService.java
@@ -1,0 +1,21 @@
+package com.oneday.dispatch.service;
+
+import com.oneday.dispatch.domain.AttendanceConfig;
+
+import java.util.UUID;
+
+/**
+ * Reads and writes the global attendance config (a single row). {@link #isAutoPresentEnabled()} is on
+ * the hot GPS-ping path, so it is served from an in-memory cache refreshed on write.
+ */
+public interface AttendanceConfigService {
+
+    /** Whether geofence auto-present is currently enabled (cached; cheap to call per ping). */
+    boolean isAutoPresentEnabled();
+
+    /** The current config row (for the admin read). */
+    AttendanceConfig get();
+
+    /** Flip the auto-present switch; returns the persisted row and refreshes the cache. */
+    AttendanceConfig setAutoPresentEnabled(boolean enabled, UUID actorUserId);
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/AttendanceConfigServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/AttendanceConfigServiceImpl.java
@@ -1,0 +1,64 @@
+package com.oneday.dispatch.service.impl;
+
+import com.oneday.dispatch.domain.AttendanceConfig;
+import com.oneday.dispatch.repository.AttendanceConfigRepository;
+import com.oneday.dispatch.service.AttendanceConfigService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * Default {@link AttendanceConfigService}. The single config row is seeded by Flyway (V5_18); the
+ * {@code auto_present_enabled} flag is cached in memory so {@link #isAutoPresentEnabled()} stays cheap
+ * on the per-ping path and is refreshed whenever an admin writes.
+ */
+@Service
+class AttendanceConfigServiceImpl implements AttendanceConfigService {
+
+    private final AttendanceConfigRepository repository;
+
+    /** Cached flag; null until first load. Volatile — written by the admin thread, read by ping threads. */
+    private volatile Boolean cachedAutoPresent;
+
+    AttendanceConfigServiceImpl(AttendanceConfigRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public boolean isAutoPresentEnabled() {
+        Boolean cached = cachedAutoPresent;
+        if (cached != null) {
+            return cached;
+        }
+        boolean value = load().isAutoPresentEnabled();
+        cachedAutoPresent = value;
+        return value;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AttendanceConfig get() {
+        return load();
+    }
+
+    @Override
+    @Transactional
+    public AttendanceConfig setAutoPresentEnabled(boolean enabled, UUID actorUserId) {
+        AttendanceConfig config = load();
+        config.setAutoPresentEnabled(enabled);
+        config.setUpdatedByUserId(actorUserId);
+        AttendanceConfig saved = repository.save(config);
+        cachedAutoPresent = enabled;
+        return saved;
+    }
+
+    /** The singleton row; defensively creates it if a DB somehow lacks the seed. */
+    private AttendanceConfig load() {
+        return repository.findFirstByOrderByCreatedAtAsc().orElseGet(() -> {
+            AttendanceConfig config = new AttendanceConfig();
+            config.setAutoPresentEnabled(true);
+            return repository.save(config);
+        });
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/AttendanceServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/AttendanceServiceImpl.java
@@ -15,6 +15,7 @@ import com.oneday.dispatch.repository.DaAttendanceRepository;
 import com.oneday.dispatch.repository.DaGpsPingRepository;
 import com.oneday.dispatch.repository.DaStatusRepository;
 import com.oneday.dispatch.service.AbsenceReassignmentService;
+import com.oneday.dispatch.service.AttendanceConfigService;
 import com.oneday.dispatch.service.AttendanceService;
 import com.oneday.grid.service.GridService;
 import org.slf4j.Logger;
@@ -54,6 +55,7 @@ class AttendanceServiceImpl implements AttendanceService {
     private final DaEventProducer eventProducer;
     private final GridService gridService;
     private final DispatchProperties props;
+    private final AttendanceConfigService attendanceConfigService;
 
     /** daId → date it was already marked present, so repeat pings short-circuit before any DB read. */
     private final Map<UUID, LocalDate> markedPresentOn = new ConcurrentHashMap<>();
@@ -61,7 +63,8 @@ class AttendanceServiceImpl implements AttendanceService {
     AttendanceServiceImpl(DaAttendanceRepository attendanceRepository, DaStatusRepository daStatusRepository,
                           DaGpsPingRepository daGpsPingRepository, DaDirectoryPort daDirectory,
                           AbsenceReassignmentService absenceService, DaEventProducer eventProducer,
-                          GridService gridService, DispatchProperties props) {
+                          GridService gridService, DispatchProperties props,
+                          AttendanceConfigService attendanceConfigService) {
         this.attendanceRepository = attendanceRepository;
         this.daStatusRepository = daStatusRepository;
         this.daGpsPingRepository = daGpsPingRepository;
@@ -70,6 +73,7 @@ class AttendanceServiceImpl implements AttendanceService {
         this.eventProducer = eventProducer;
         this.gridService = gridService;
         this.props = props;
+        this.attendanceConfigService = attendanceConfigService;
     }
 
     private ZoneId zone() {
@@ -79,6 +83,9 @@ class AttendanceServiceImpl implements AttendanceService {
     @Override
     @Transactional
     public void onGpsFix(UUID daId, UUID cityId, String shiftType, double lat, double lon, Instant pingAt) {
+        if (!attendanceConfigService.isAutoPresentEnabled()) {
+            return; // geofence auto-present globally disabled (admin toggle); manual check-in still works
+        }
         // Date of the fix, not of processing — a ping delayed across midnight IST still lands on the
         // day the DA was actually at the hub, so it settles the right shift's cutoff.
         LocalDate today = LocalDate.ofInstant(pingAt, zone());

--- a/dispatch/src/main/resources/db/migration/dispatch/V5_18__create_attendance_config.sql
+++ b/dispatch/src/main/resources/db/migration/dispatch/V5_18__create_attendance_config.sql
@@ -1,0 +1,28 @@
+-- Global, ops-tunable attendance config (a single row). v1 holds one flag: auto_present_enabled —
+-- the master switch for geofence auto-present in AttendanceServiceImpl.onGpsFix. When OFF, a GPS fix
+-- inside the hub geofence no longer auto-marks a DA present; the manual "I've arrived" check-in still
+-- works. Distinct from the yaml knobs in DispatchProperties.Attendance (radius/zone) which are static.
+-- (V5_17 is reserved by the concurrent delivery-outcomes branch — this lands at V5_18 to avoid a clash.)
+CREATE TABLE attendance_config (
+    id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    auto_present_enabled  BOOLEAN NOT NULL DEFAULT TRUE,
+    updated_by_user_id    UUID,                                   -- the ADMIN who last flipped it; null for the seed
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Seed the singleton row (enabled — preserves today's behaviour until an admin turns it off).
+INSERT INTO attendance_config (auto_present_enabled) VALUES (TRUE);
+
+-- Shared trigger fn (created by earlier migrations). CREATE OR REPLACE keeps this self-contained.
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER attendance_config_updated_at
+    BEFORE UPDATE ON attendance_config
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/AttendanceServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/AttendanceServiceImplTest.java
@@ -13,6 +13,7 @@ import com.oneday.dispatch.repository.DaAttendanceRepository;
 import com.oneday.dispatch.repository.DaGpsPingRepository;
 import com.oneday.dispatch.repository.DaStatusRepository;
 import com.oneday.dispatch.service.AbsenceReassignmentService;
+import com.oneday.dispatch.service.AttendanceConfigService;
 import com.oneday.grid.service.GridService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,6 +50,7 @@ class AttendanceServiceImplTest {
     @Mock AbsenceReassignmentService absenceService;
     @Mock DaEventProducer eventProducer;
     @Mock GridService gridService;
+    @Mock AttendanceConfigService attendanceConfigService;
 
     private DispatchProperties props;
     private AttendanceServiceImpl service;
@@ -66,11 +68,12 @@ class AttendanceServiceImplTest {
         props.getAttendance().getHubLocations().put(cityId.toString(), hub);
 
         service = new AttendanceServiceImpl(attendanceRepository, daStatusRepository, daGpsPingRepository,
-                daDirectory, absenceService, eventProducer, gridService, props);
+                daDirectory, absenceService, eventProducer, gridService, props, attendanceConfigService);
     }
 
     @Test
     void onGpsFix_withinRadius_marksPresentOnce() {
+        when(attendanceConfigService.isAutoPresentEnabled()).thenReturn(true);
         when(attendanceRepository.findByDaIdAndAttendanceDate(eq(daId), any())).thenReturn(Optional.empty());
 
         // First ping at the hub → present.
@@ -88,8 +91,20 @@ class AttendanceServiceImplTest {
 
     @Test
     void onGpsFix_outsideRadius_doesNothing() {
+        when(attendanceConfigService.isAutoPresentEnabled()).thenReturn(true);
         // ~1.5 km south of the hub — well outside 500 m.
         service.onGpsFix(daId, cityId, "SHIFT_1", HUB_LAT - 0.0135, HUB_LON, Instant.now());
+        verify(attendanceRepository, never()).save(any());
+        verify(attendanceRepository, never()).findByDaIdAndAttendanceDate(any(), any());
+    }
+
+    @Test
+    void onGpsFix_autoPresentDisabled_doesNothing_evenAtHub() {
+        // Global toggle off: a fix right at the hub must NOT auto-mark present, and must do no DB work.
+        when(attendanceConfigService.isAutoPresentEnabled()).thenReturn(false);
+
+        service.onGpsFix(daId, cityId, "SHIFT_1", HUB_LAT, HUB_LON, Instant.now());
+
         verify(attendanceRepository, never()).save(any());
         verify(attendanceRepository, never()).findByDaIdAndAttendanceDate(any(), any());
     }


### PR DESCRIPTION
## What
A global, admin-tunable switch that gates **geofence auto-present** for DAs — Discussion-2 item (xv).

- New DB singleton `attendance_config` (Flyway **V5_18**, seeded `true`) — numbered V5_18 to avoid a clash with the concurrent delivery-outcomes branch's V5_17.
- `AttendanceServiceImpl.onGpsFix` returns early when disabled — a GPS fix inside the hub geofence no longer auto-marks present. **Manual "I've arrived" check-in is untouched.**
- `AttendanceConfigService` caches the flag on the hot ping path, refreshed on write.
- `GET`/`PUT /dispatch/admin/attendance-config` (ADMIN-only), snake_case `auto_present_enabled`.

Pairs with the admin Settings page in oneday-web (`feat/auto-present-toggle`).

## Testing (local)
- Dispatch suite **184 green**, incl. new `onGpsFix_autoPresentDisabled_doesNothing_evenAtHub`.
- Fresh-DB boot: GET/PUT round-trip verified (updated_by recorded, 400 on missing field, DB persistence); toggle flipped live from the admin Settings UI.

## Do not merge
awaiting CodeRabbit + Claude review + CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an admin-only setting to view and update automatic attendance.
  - Automatic geofence-based presence is enabled by default and can be switched off at runtime.
  - Configuration changes record the update time and the administrator who made the change.
- **Bug Fixes**
  - GPS-based attendance no longer creates attendance records when automatic presence is disabled.
  - Manual check-ins continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Test evidence

Admin **Settings** driving `PUT /dispatch/admin/attendance-config` — On → Off (persisted, verified in DB):

| Auto-present **On** | Auto-present **Off** |
|---|---|
| ![on](https://raw.githubusercontent.com/Sidarthapati/one_day_delivery/assets/disc2-screenshots/evidence/auto-present-settings-on.png) | ![off](https://raw.githubusercontent.com/Sidarthapati/one_day_delivery/assets/disc2-screenshots/evidence/auto-present-settings-off.png) |
