### PR TITLE
feat(orders): B2B order repair — add/remove shipments, cancel order, DA capacity gate

### DIFF
--- a/common/src/main/java/com/oneday/common/port/DaPickupLoadPort.java
+++ b/common/src/main/java/com/oneday/common/port/DaPickupLoadPort.java
@@ -1,0 +1,26 @@
+package com.oneday.common.port;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * The current pickup load of the DA already assigned to a shipment's first-mile pickup — used to
+ * weight-check before letting a merchant add another parcel to an in-progress pickup. Implemented in
+ * M5 (dispatch) over the active {@code dispatch_queue} tasks (the same lookup as
+ * {@link CourierOnShipmentPort}); consumed by M4 (orders) which owns parcel weights and compares the
+ * summed load against the DA's vehicle capacity. Both sides depend only on {@code common}, so orders
+ * never imports dispatch internals.
+ */
+public interface DaPickupLoadPort {
+
+    /**
+     * The DA on this shipment's active pickup task plus every shipment currently on that DA's active
+     * (QUEUED/IN_PROGRESS) pickup queue for the day, or empty when no DA is assigned to the pickup yet
+     * (in which case there is nothing to weigh against — dispatch will place the new parcel normally).
+     */
+    Optional<AssignedPickupLoad> assignedPickupLoad(UUID shipmentId);
+
+    /** A DA and the shipment ids on their active pickup queue (includes the queried shipment's siblings). */
+    record AssignedPickupLoad(UUID daId, List<UUID> pickupShipmentIds) {}
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/adapter/DaPickupLoadAdapter.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/adapter/DaPickupLoadAdapter.java
@@ -1,0 +1,56 @@
+package com.oneday.dispatch.adapter;
+
+import com.oneday.common.port.DaPickupLoadPort;
+import com.oneday.dispatch.domain.DispatchQueue;
+import com.oneday.dispatch.domain.TaskStatus;
+import com.oneday.dispatch.domain.TaskType;
+import com.oneday.dispatch.repository.DispatchQueueRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * M5-side implementation of {@link DaPickupLoadPort}: resolves the shipment to its currently assigned
+ * pickup DA ({@code dispatch_queue}, same lookup as {@link CourierOnShipmentAdapter}) and returns every
+ * shipment on that DA's active pickup queue for the day. Orders sums those parcels' weights against the
+ * DA's vehicle capacity before adding one more. Empty when no DA is on the parcel's pickup yet.
+ */
+@Component
+class DaPickupLoadAdapter implements DaPickupLoadPort {
+
+    private static final List<TaskStatus> ACTIVE = List.of(TaskStatus.QUEUED, TaskStatus.IN_PROGRESS);
+
+    private final DispatchQueueRepository queueRepository;
+
+    DaPickupLoadAdapter(DispatchQueueRepository queueRepository) {
+        this.queueRepository = queueRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<AssignedPickupLoad> assignedPickupLoad(UUID shipmentId) {
+        // Find the DA on this shipment's active PICKUP task (newest assignment first).
+        DispatchQueue pickup = queueRepository.findActiveByShipmentId(shipmentId).stream()
+                .filter(t -> t.getTaskType() == TaskType.PICKUP)
+                .findFirst()
+                .orElse(null);
+        if (pickup == null) {
+            return Optional.empty();
+        }
+
+        // Everything on that DA's active pickup queue for the day = the parcels already committed to
+        // the vehicle (queued to collect + already collected, not yet handed to the van).
+        List<UUID> pickupShipmentIds = queueRepository
+                .findByDaIdAndOperatingDateAndStatusIn(pickup.getDaId(), pickup.getOperatingDate(), ACTIVE)
+                .stream()
+                .filter(t -> t.getTaskType() == TaskType.PICKUP)
+                .map(DispatchQueue::getShipmentId)
+                .distinct()
+                .toList();
+
+        return Optional.of(new AssignedPickupLoad(pickup.getDaId(), pickupShipmentIds));
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/api/B2bOrderController.java
+++ b/orders/src/main/java/com/oneday/orders/api/B2bOrderController.java
@@ -1,0 +1,58 @@
+package com.oneday.orders.api;
+
+import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.orders.dto.B2bBookingRequest;
+import com.oneday.orders.dto.BookingResponse;
+import com.oneday.orders.dto.OrderCancellationSummary;
+import com.oneday.orders.service.OrderRepairService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * B2B order repair (business portal only). Add a shipment to an existing order, or cancel the whole
+ * order, while it has not yet been fully picked up. Removing a single shipment is the existing
+ * per-shipment cancel ({@code DELETE /api/v1/b2b/shipments/{ref}}). All gated to B2B users; the
+ * service additionally enforces that the caller owns the order's account.
+ */
+@RestController
+@RequestMapping("/api/v1/b2b/orders")
+class B2bOrderController {
+
+    private final OrderRepairService orderRepairService;
+
+    B2bOrderController(OrderRepairService orderRepairService) {
+        this.orderRepairService = orderRepairService;
+    }
+
+    @PostMapping("/{orderRef}/shipments")
+    @ResponseStatus(HttpStatus.CREATED)
+    public BookingResponse addShipment(
+            @PathVariable("orderRef") String orderRef,
+            @RequestHeader("Idempotency-Key") String idempotencyKey,
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @Valid @RequestBody B2bBookingRequest request) {
+        Authz.requireCustomerRole(principal, "B2B_USER");
+        return orderRepairService.addShipment(orderRef, request, idempotencyKey,
+                Authz.requireUserId(principal));
+    }
+
+    @DeleteMapping("/{orderRef}")
+    @ResponseStatus(HttpStatus.OK)
+    public OrderCancellationSummary cancelOrder(
+            @PathVariable("orderRef") String orderRef,
+            @RequestParam(value = "reason", required = false) String reason,
+            @AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireRole(principal, "B2B_USER");
+        return orderRepairService.cancelOrder(orderRef, reason, Authz.requireUserId(principal));
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/api/OrdersGlobalExceptionHandler.java
+++ b/orders/src/main/java/com/oneday/orders/api/OrdersGlobalExceptionHandler.java
@@ -7,6 +7,8 @@ import com.oneday.orders.service.BulkUploadService;
 import com.oneday.orders.service.CancellationService;
 import com.oneday.orders.service.CartService;
 import com.oneday.orders.service.MerchantCategoryService;
+import com.oneday.orders.service.OrderCapacityService;
+import com.oneday.orders.service.OrderRepairService;
 import com.oneday.orders.service.PaymentPort;
 import com.oneday.orders.service.WalletService;
 import com.oneday.orders.service.PickupSlotFullException;
@@ -140,6 +142,22 @@ class OrdersGlobalExceptionHandler {
     ProblemDetail handlePickupSlotFull(PickupSlotFullException ex) {
         ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.CONFLICT);
         pd.setTitle("Pickup slot full");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    @ExceptionHandler(OrderCapacityService.DaCapacityExceededException.class)
+    ProblemDetail handleDaCapacityExceeded(OrderCapacityService.DaCapacityExceededException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.CONFLICT);
+        pd.setTitle("Delivery associate at capacity");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    @ExceptionHandler(OrderRepairService.OrderNotEditableException.class)
+    ProblemDetail handleOrderNotEditable(OrderRepairService.OrderNotEditableException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.CONFLICT);
+        pd.setTitle("Order not editable");
         pd.setDetail(ex.getMessage());
         return pd;
     }

--- a/orders/src/main/java/com/oneday/orders/config/OrderCapacityProperties.java
+++ b/orders/src/main/java/com/oneday/orders/config/OrderCapacityProperties.java
@@ -15,8 +15,9 @@ import java.util.Map;
 @ConfigurationProperties(prefix = "orders.capacity")
 public class OrderCapacityProperties {
 
-    /** Default DA vehicle capacity in grams (50 kg). */
-    private int daVehicleGrams = 50_000;
+    /** Default DA vehicle capacity in grams (500 kg — effectively permissive until per-DA capacity is
+     *  made admin-configurable; the gate still blocks a DA already loaded past this). */
+    private int daVehicleGrams = 500_000;
 
     /** Optional per-city overrides, key = origin city code (e.g. "DELHI"), value = capacity in grams. */
     private Map<String, Integer> daVehicleGramsByCity = new HashMap<>();

--- a/orders/src/main/java/com/oneday/orders/config/OrderCapacityProperties.java
+++ b/orders/src/main/java/com/oneday/orders/config/OrderCapacityProperties.java
@@ -1,0 +1,39 @@
+package com.oneday.orders.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * DA vehicle carrying capacity, used to gate adding a parcel to an in-progress pickup (order repair).
+ * There is no per-DA vehicle model yet, so this is a single fleet-wide weight limit with optional
+ * per-city overrides (keyed by origin city code, upper-cased). Default 50 kg.
+ */
+@Component
+@ConfigurationProperties(prefix = "orders.capacity")
+public class OrderCapacityProperties {
+
+    /** Default DA vehicle capacity in grams (50 kg). */
+    private int daVehicleGrams = 50_000;
+
+    /** Optional per-city overrides, key = origin city code (e.g. "DELHI"), value = capacity in grams. */
+    private Map<String, Integer> daVehicleGramsByCity = new HashMap<>();
+
+    /** The vehicle capacity (grams) for a city — its override if present, else the fleet default. */
+    public int capacityGramsFor(String cityCode) {
+        if (cityCode == null) {
+            return daVehicleGrams;
+        }
+        return daVehicleGramsByCity.getOrDefault(cityCode.toUpperCase(), daVehicleGrams);
+    }
+
+    public int getDaVehicleGrams() { return daVehicleGrams; }
+    public void setDaVehicleGrams(int daVehicleGrams) { this.daVehicleGrams = daVehicleGrams; }
+
+    public Map<String, Integer> getDaVehicleGramsByCity() { return daVehicleGramsByCity; }
+    public void setDaVehicleGramsByCity(Map<String, Integer> daVehicleGramsByCity) {
+        this.daVehicleGramsByCity = daVehicleGramsByCity;
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/dto/OrderCancellationSummary.java
+++ b/orders/src/main/java/com/oneday/orders/dto/OrderCancellationSummary.java
@@ -1,0 +1,17 @@
+package com.oneday.orders.dto;
+
+import java.util.List;
+
+/**
+ * Result of cancelling a whole order. Partial by design: every child shipment still within its
+ * cancellation window is cancelled and refunded; any already past pickup is reported in {@code skipped}
+ * (the merchant sees exactly which parcels could not be pulled back).
+ */
+public record OrderCancellationSummary(
+        String orderRef,
+        List<String> cancelled,
+        List<SkippedShipment> skipped) {
+
+    /** A child that could not be cancelled, with the state that blocked it. */
+    public record SkippedShipment(String shipmentRef, String state) {}
+}

--- a/orders/src/main/java/com/oneday/orders/repository/ParcelOrderRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ParcelOrderRepository.java
@@ -47,4 +47,16 @@ public interface ParcelOrderRepository extends JpaRepository<ParcelOrder, UUID> 
     @Query("UPDATE ParcelOrder o SET o.parcelCount = o.parcelCount + 1, "
             + "o.totalPricePaise = o.totalPricePaise + :amountPaise WHERE o.id = :id")
     int addShipment(@Param("id") UUID id, @Param("amountPaise") long amountPaise);
+
+    /**
+     * Reverse the rollup when a shipment is removed/cancelled from an order. Guarded on
+     * {@code parcel_count > 0} so the count can never go negative under concurrent cancels; the price
+     * total is floored at 0 for the same reason. Symmetric with {@link #addShipment}.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE ParcelOrder o SET o.parcelCount = o.parcelCount - 1, "
+            + "o.totalPricePaise = CASE WHEN o.totalPricePaise > :amountPaise "
+            + "THEN o.totalPricePaise - :amountPaise ELSE 0 END "
+            + "WHERE o.id = :id AND o.parcelCount > 0")
+    int removeShipment(@Param("id") UUID id, @Param("amountPaise") long amountPaise);
 }

--- a/orders/src/main/java/com/oneday/orders/service/OrderCapacityService.java
+++ b/orders/src/main/java/com/oneday/orders/service/OrderCapacityService.java
@@ -1,0 +1,24 @@
+package com.oneday.orders.service;
+
+import com.oneday.orders.domain.ParcelOrder;
+
+/**
+ * Gate for adding a parcel to an order whose pickup is already in progress: if a DA is on the pickup,
+ * the parcel must fit within that DA's vehicle capacity. Purely a safety check on the "add shipment to
+ * an existing order" path — when no DA is assigned yet, dispatch places the parcel normally and there
+ * is nothing to weigh against.
+ */
+public interface OrderCapacityService {
+
+    /**
+     * Throws {@link DaCapacityExceededException} if the order's assigned pickup DA cannot carry
+     * {@code newParcelChargeableGrams} more on top of what it is already committed to. No-op when no DA
+     * is assigned to the order's pickup, or when the dispatch load port is unavailable.
+     */
+    void ensureCapacityForAdd(ParcelOrder order, int newParcelChargeableGrams);
+
+    /** The assigned DA's vehicle is already loaded to capacity for today's pickup → 409. */
+    class DaCapacityExceededException extends RuntimeException {
+        public DaCapacityExceededException(String message) { super(message); }
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/OrderRepairService.java
+++ b/orders/src/main/java/com/oneday/orders/service/OrderRepairService.java
@@ -1,0 +1,29 @@
+package com.oneday.orders.service;
+
+import com.oneday.orders.dto.B2bBookingRequest;
+import com.oneday.orders.dto.BookingResponse;
+import com.oneday.orders.dto.OrderCancellationSummary;
+
+/**
+ * B2B "order repair": while an order has not yet been fully picked up, a business-portal merchant may
+ * add a shipment to it (charged to wallet/credit, subject to the DA vehicle-capacity gate) or cancel
+ * the whole order (each eligible child refunded). Removing a single shipment is just cancelling that
+ * shipment — the existing per-shipment cancel path, now rollup-aware.
+ */
+public interface OrderRepairService {
+
+    /**
+     * Adds one shipment to an existing order (books it onto the same parent, charging the account).
+     * Enforces account ownership, order editability, and DA capacity before booking.
+     */
+    BookingResponse addShipment(String orderRef, B2bBookingRequest request,
+                                String idempotencyKey, String userId);
+
+    /** Cancels every still-eligible child of the order; reports the rest as skipped. */
+    OrderCancellationSummary cancelOrder(String orderRef, String reason, String userId);
+
+    /** The order can no longer be edited (every child is already past pickup) → 409. */
+    class OrderNotEditableException extends RuntimeException {
+        public OrderNotEditableException(String message) { super(message); }
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/OrderService.java
+++ b/orders/src/main/java/com/oneday/orders/service/OrderService.java
@@ -27,5 +27,12 @@ public interface OrderService {
     /** Atomically folds one booked shipment into the order rollup (count + 1, total += amount). */
     void addShipment(UUID orderId, long shipmentTotalPaise);
 
+    /**
+     * Atomically backs one removed/cancelled shipment out of the order rollup (count − 1, total −= amount,
+     * both floored at 0). Called when a shipment is cancelled so the parent order's parcel count and total
+     * always reflect its live children. Must run inside the cancelling transaction.
+     */
+    void removeShipment(UUID orderId, long shipmentTotalPaise);
+
     record CreatedOrder(UUID id, String orderRef) {}
 }

--- a/orders/src/main/java/com/oneday/orders/service/impl/CancellationServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/CancellationServiceImpl.java
@@ -49,6 +49,7 @@ class CancellationServiceImpl implements CancellationService {
     private final ShipmentStateMachine stateMachine;
     private final PaymentPort paymentPort;
     private final com.oneday.orders.service.WalletService walletService;
+    private final com.oneday.orders.service.OrderService orderService;
     private final ApplicationEventPublisher events;
 
     CancellationServiceImpl(ShipmentRepository shipmentRepository,
@@ -58,6 +59,7 @@ class CancellationServiceImpl implements CancellationService {
                             ShipmentStateMachine stateMachine,
                             PaymentPort paymentPort,
                             com.oneday.orders.service.WalletService walletService,
+                            com.oneday.orders.service.OrderService orderService,
                             ApplicationEventPublisher events) {
         this.shipmentRepository = shipmentRepository;
         this.paymentTransactionRepository = paymentTransactionRepository;
@@ -66,6 +68,7 @@ class CancellationServiceImpl implements CancellationService {
         this.stateMachine = stateMachine;
         this.paymentPort = paymentPort;
         this.walletService = walletService;
+        this.orderService = orderService;
         this.events = events;
     }
 
@@ -161,6 +164,13 @@ class CancellationServiceImpl implements CancellationService {
         shipment.setCancelledAt(Instant.now());
         shipment.setCancellationReason(reason);
         shipmentRepository.save(shipment);
+
+        // Back the cancelled shipment out of its parent order's rollup so parcel_count / total always
+        // reflect the live children (order-repair "remove" is just a cancel from the order's view). Same
+        // transaction as the cancel — count/total can never drift from the shipments that remain.
+        if (shipment.getOrderId() != null) {
+            orderService.removeShipment(shipment.getOrderId(), shipment.getTotalPricePaise());
+        }
 
         // Rich CANCELLED event (reason + refund) — mapped to Kafka AFTER_COMMIT.
         events.publishEvent(new ShipmentCancelled(

--- a/orders/src/main/java/com/oneday/orders/service/impl/OrderCapacityServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/OrderCapacityServiceImpl.java
@@ -1,0 +1,91 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.log.AuditLog;
+import com.oneday.common.port.DaPickupLoadPort;
+import com.oneday.orders.config.OrderCapacityProperties;
+import com.oneday.orders.domain.ParcelOrder;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.service.OrderCapacityService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * @see OrderCapacityService
+ */
+@Service
+class OrderCapacityServiceImpl implements OrderCapacityService {
+
+    private static final Logger log = LoggerFactory.getLogger(OrderCapacityServiceImpl.class);
+
+    private final ShipmentRepository shipmentRepository;
+    private final OrderCapacityProperties properties;
+    // ObjectProvider so the orders module (and its test slice) still wires without the dispatch adapter;
+    // absent port → no capacity signal → skip the gate (same graceful pattern as the tracking courier port).
+    private final ObjectProvider<DaPickupLoadPort> daPickupLoadPort;
+
+    OrderCapacityServiceImpl(ShipmentRepository shipmentRepository,
+                             OrderCapacityProperties properties,
+                             ObjectProvider<DaPickupLoadPort> daPickupLoadPort) {
+        this.shipmentRepository = shipmentRepository;
+        this.properties = properties;
+        this.daPickupLoadPort = daPickupLoadPort;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public void ensureCapacityForAdd(ParcelOrder order, int newParcelChargeableGrams) {
+        DaPickupLoadPort port = daPickupLoadPort.getIfAvailable();
+        if (port == null) {
+            return;   // dispatch not wired (e.g. isolated test) — nothing to weigh against
+        }
+
+        // Find the DA (if any) already on this order's pickup. All of a B2B order's parcels share the
+        // merchant's pickup location, so the first sibling with an assignment identifies that DA.
+        List<Shipment> siblings = shipmentRepository.findByOrderIdOrderByCreatedAtAsc(order.getId());
+        Optional<DaPickupLoadPort.AssignedPickupLoad> assigned = siblings.stream()
+                .map(s -> port.assignedPickupLoad(s.getId()))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst();
+        if (assigned.isEmpty()) {
+            return;   // no DA on the pickup yet — dispatch will place the new parcel normally
+        }
+
+        // Sum the chargeable weight already committed to that DA's vehicle (its whole active pickup
+        // queue, across every order), then check the new parcel still fits.
+        List<UUID> onVehicle = assigned.get().pickupShipmentIds();
+        int currentGrams = 0;
+        for (Shipment s : shipmentRepository.findAllById(onVehicle)) {
+            if (s.getChargeableWeightGrams() != null) {
+                currentGrams += s.getChargeableWeightGrams();
+            }
+        }
+
+        int capacityGrams = properties.capacityGramsFor(order.getCityId());
+        int projected = currentGrams + newParcelChargeableGrams;
+        if (projected > capacityGrams) {
+            AuditLog.event("order.repair.capacity_rejected")
+                    .kv("orderRef", order.getOrderRef())
+                    .kv("daId", assigned.get().daId())
+                    .kv("currentGrams", currentGrams)
+                    .kv("newParcelGrams", newParcelChargeableGrams)
+                    .kv("capacityGrams", capacityGrams)
+                    .log();
+            throw new DaCapacityExceededException(String.format(
+                    "The delivery associate's vehicle is at capacity for today's pickup "
+                            + "(%.1f kg of %.1f kg used); this %.1f kg parcel can't be added.",
+                    currentGrams / 1000.0, capacityGrams / 1000.0, newParcelChargeableGrams / 1000.0));
+        }
+
+        log.debug("Capacity OK for order {} DA {}: {}g + {}g <= {}g",
+                order.getOrderRef(), assigned.get().daId(), currentGrams, newParcelChargeableGrams, capacityGrams);
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/OrderRepairServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/OrderRepairServiceImpl.java
@@ -1,0 +1,167 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.enums.CustomerType;
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.common.log.AuditLog;
+import com.oneday.orders.domain.ParcelOrder;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.dto.B2bBookingRequest;
+import com.oneday.orders.dto.BookingResponse;
+import com.oneday.orders.dto.OrderCancellationSummary;
+import com.oneday.orders.dto.OrderCancellationSummary.SkippedShipment;
+import com.oneday.orders.repository.B2bAccountRepository;
+import com.oneday.orders.repository.ParcelOrderRepository;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.service.B2bBookingService;
+import com.oneday.orders.service.CancellationPolicy;
+import com.oneday.orders.service.CancellationService;
+import com.oneday.orders.service.OrderCapacityService;
+import com.oneday.orders.service.OrderRepairService;
+import jakarta.persistence.EntityNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * @see OrderRepairService
+ */
+@Service
+class OrderRepairServiceImpl implements OrderRepairService {
+
+    private static final Logger log = LoggerFactory.getLogger(OrderRepairServiceImpl.class);
+
+    private final ParcelOrderRepository orderRepository;
+    private final ShipmentRepository shipmentRepository;
+    private final B2bAccountRepository accountRepository;
+    private final B2bBookingService b2bBookingService;
+    private final CancellationService cancellationService;
+    private final CancellationPolicy cancellationPolicy;
+    private final OrderCapacityService capacityService;
+
+    OrderRepairServiceImpl(ParcelOrderRepository orderRepository,
+                           ShipmentRepository shipmentRepository,
+                           B2bAccountRepository accountRepository,
+                           B2bBookingService b2bBookingService,
+                           CancellationService cancellationService,
+                           CancellationPolicy cancellationPolicy,
+                           OrderCapacityService capacityService) {
+        this.orderRepository = orderRepository;
+        this.shipmentRepository = shipmentRepository;
+        this.accountRepository = accountRepository;
+        this.b2bBookingService = b2bBookingService;
+        this.cancellationService = cancellationService;
+        this.cancellationPolicy = cancellationPolicy;
+        this.capacityService = capacityService;
+    }
+
+    @Override
+    public BookingResponse addShipment(String orderRef, B2bBookingRequest request,
+                                       String idempotencyKey, String userId) {
+        ParcelOrder order = resolveOwnedB2bOrder(orderRef, userId);
+
+        List<Shipment> siblings = shipmentRepository.findByOrderIdOrderByCreatedAtAsc(order.getId());
+        if (!isEditable(siblings)) {
+            throw new OrderNotEditableException(
+                    "Order " + orderRef + " can no longer be edited — all parcels are already past pickup.");
+        }
+
+        // Capacity gate — only bites when a DA is already on this order's pickup.
+        int chargeableGrams = chargeableWeightGrams(request);
+        capacityService.ensureCapacityForAdd(order, chargeableGrams);
+
+        // Always book onto THIS order's account (the caller was verified to own it), so a mismatched
+        // b2b_account_id in the request body can never divert the charge to another account.
+        request.setB2bAccountId(order.getB2bAccountId());
+
+        BookingResponse response = b2bBookingService.book(request, idempotencyKey, userId, order.getId());
+
+        AuditLog.event("order.repair.shipment_added")
+                .kv("orderRef", orderRef)
+                .kv("shipmentRef", response.getShipmentRef())
+                .kv("chargeableGrams", chargeableGrams)
+                .log();
+        return response;
+    }
+
+    @Override
+    public OrderCancellationSummary cancelOrder(String orderRef, String reason, String userId) {
+        ParcelOrder order = resolveOwnedB2bOrder(orderRef, userId);
+
+        List<String> cancelled = new ArrayList<>();
+        List<SkippedShipment> skipped = new ArrayList<>();
+
+        for (Shipment s : shipmentRepository.findByOrderIdOrderByCreatedAtAsc(order.getId())) {
+            if (s.getState() == ShipmentState.CANCELLED || s.getCancelledAt() != null) {
+                continue;   // already gone — not part of this action's summary
+            }
+            if (!cancellationPolicy.isCancellable(s.getState(), s.getPickupType())) {
+                skipped.add(new SkippedShipment(s.getShipmentRef(), s.getState().name()));
+                continue;
+            }
+            try {
+                // Each cancel is its own transaction (refund + rollup decrement + events), so a later
+                // failure never rolls back an earlier successful cancel — the partial result stands.
+                cancellationService.cancel(s.getShipmentRef(), reason, userId, true);
+                cancelled.add(s.getShipmentRef());
+            } catch (RuntimeException e) {
+                log.warn("Order-cancel: could not cancel {} of order {}: {}",
+                        s.getShipmentRef(), orderRef, e.getMessage());
+                skipped.add(new SkippedShipment(s.getShipmentRef(), s.getState().name()));
+            }
+        }
+
+        AuditLog.event("order.repair.order_cancelled")
+                .kv("orderRef", orderRef)
+                .kv("cancelledCount", cancelled.size())
+                .kv("skippedCount", skipped.size())
+                .log();
+        return new OrderCancellationSummary(orderRef, cancelled, skipped);
+    }
+
+    /**
+     * Resolve the order and confirm the caller owns its B2B account. 404 (not 403) on any mismatch —
+     * missing order, non-B2B order, or another account's order — so a caller can't probe for orders
+     * outside its own account (same reasoning as the cancellation lane/ownership guards).
+     */
+    private ParcelOrder resolveOwnedB2bOrder(String orderRef, String userId) {
+        ParcelOrder order = orderRepository.findByOrderRef(orderRef)
+                .orElseThrow(() -> new EntityNotFoundException("Order not found: " + orderRef));
+
+        if (order.getCustomerType() != CustomerType.B2B || order.getB2bAccountId() == null) {
+            throw new EntityNotFoundException("Order not found: " + orderRef);
+        }
+
+        UUID callerAccountId = accountRepository.findByMemberUserId(parseUserId(userId))
+                .map(a -> a.getId())
+                .orElse(null);
+        if (callerAccountId == null || !callerAccountId.equals(order.getB2bAccountId())) {
+            throw new EntityNotFoundException("Order not found: " + orderRef);
+        }
+        return order;
+    }
+
+    /** An order is still editable while at least one child is within its cancellation window. */
+    private boolean isEditable(List<Shipment> siblings) {
+        return siblings.stream()
+                .anyMatch(s -> s.getState() != ShipmentState.CANCELLED
+                        && cancellationPolicy.isCancellable(s.getState(), s.getPickupType()));
+    }
+
+    /** Same chargeable-weight math as booking: max(actual, volumetric = L·W·H / 5). */
+    private int chargeableWeightGrams(B2bBookingRequest request) {
+        int volumetric = (request.getLengthCm() * request.getWidthCm() * request.getHeightCm()) / 5;
+        return Math.max(request.getWeightGrams(), volumetric);
+    }
+
+    private UUID parseUserId(String userId) {
+        try {
+            return UUID.fromString(userId);
+        } catch (IllegalArgumentException e) {
+            throw new EntityNotFoundException("Order not found");   // malformed principal → treat as no access
+        }
+    }
+}

--- a/orders/src/main/java/com/oneday/orders/service/impl/OrderServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/OrderServiceImpl.java
@@ -45,4 +45,10 @@ class OrderServiceImpl implements OrderService {
     public void addShipment(UUID orderId, long shipmentTotalPaise) {
         parcelOrderRepository.addShipment(orderId, shipmentTotalPaise);
     }
+
+    @Override
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void removeShipment(UUID orderId, long shipmentTotalPaise) {
+        parcelOrderRepository.removeShipment(orderId, shipmentTotalPaise);
+    }
 }

--- a/orders/src/test/java/com/oneday/orders/service/impl/OrderCapacityServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/OrderCapacityServiceImplTest.java
@@ -76,6 +76,7 @@ class OrderCapacityServiceImplTest {
 
     @Test
     void underCapacity_ok() {
+        properties.setDaVehicleGrams(50_000);   // pin the cap so the test is independent of the default
         wireAssignedDa(40_000);   // 40kg already on the vehicle
 
         assertThatCode(() -> service.ensureCapacityForAdd(order(), 5_000))   // +5kg = 45kg <= 50kg
@@ -84,6 +85,7 @@ class OrderCapacityServiceImplTest {
 
     @Test
     void overCapacity_rejects() {
+        properties.setDaVehicleGrams(50_000);   // pin the cap so the test is independent of the default
         wireAssignedDa(40_000);   // 40kg already on the vehicle
 
         assertThatThrownBy(() -> service.ensureCapacityForAdd(order(), 15_000))   // +15kg = 55kg > 50kg

--- a/orders/src/test/java/com/oneday/orders/service/impl/OrderCapacityServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/OrderCapacityServiceImplTest.java
@@ -1,0 +1,118 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.port.DaPickupLoadPort;
+import com.oneday.common.port.DaPickupLoadPort.AssignedPickupLoad;
+import com.oneday.orders.config.OrderCapacityProperties;
+import com.oneday.orders.domain.ParcelOrder;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.service.OrderCapacityService.DaCapacityExceededException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * The capacity gate only bites when a DA is already on the order's pickup, and only rejects when the
+ * summed vehicle load would exceed the configured capacity. When dispatch is unwired or no DA is
+ * assigned, it must stay out of the way (add-to-order still works pre-dispatch).
+ */
+@SuppressWarnings("unchecked")
+class OrderCapacityServiceImplTest {
+
+    private final ShipmentRepository shipmentRepository = mock(ShipmentRepository.class);
+    private final OrderCapacityProperties properties = new OrderCapacityProperties();
+    private final ObjectProvider<DaPickupLoadPort> provider = mock(ObjectProvider.class);
+    private final DaPickupLoadPort port = mock(DaPickupLoadPort.class);
+
+    private final OrderCapacityServiceImpl service =
+            new OrderCapacityServiceImpl(shipmentRepository, properties, provider);
+
+    private static final UUID ORDER_ID = UUID.randomUUID();
+
+    private static ParcelOrder order() {
+        ParcelOrder o = mock(ParcelOrder.class);
+        when(o.getId()).thenReturn(ORDER_ID);
+        when(o.getCityId()).thenReturn("DELHI");
+        when(o.getOrderRef()).thenReturn("1DD-ORD-DEL-20260830-00001");
+        return o;
+    }
+
+    // Standalone factory — never call this inside another when(...).thenReturn(...) argument.
+    private static Shipment ship(UUID id, int chargeableGrams) {
+        Shipment s = mock(Shipment.class);
+        when(s.getId()).thenReturn(id);
+        when(s.getChargeableWeightGrams()).thenReturn(chargeableGrams);
+        return s;
+    }
+
+    @Test
+    void portUnavailable_skipsSilently() {
+        when(provider.getIfAvailable()).thenReturn(null);
+
+        assertThatCode(() -> service.ensureCapacityForAdd(order(), 5_000)).doesNotThrowAnyException();
+        verifyNoInteractions(shipmentRepository);
+    }
+
+    @Test
+    void noDaAssigned_skips() {
+        when(provider.getIfAvailable()).thenReturn(port);
+        UUID sibId = UUID.randomUUID();
+        Shipment sib = ship(sibId, 10_000);
+        when(shipmentRepository.findByOrderIdOrderByCreatedAtAsc(ORDER_ID)).thenReturn(List.of(sib));
+        when(port.assignedPickupLoad(sibId)).thenReturn(Optional.empty());
+
+        assertThatCode(() -> service.ensureCapacityForAdd(order(), 40_000)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void underCapacity_ok() {
+        wireAssignedDa(40_000);   // 40kg already on the vehicle
+
+        assertThatCode(() -> service.ensureCapacityForAdd(order(), 5_000))   // +5kg = 45kg <= 50kg
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void overCapacity_rejects() {
+        wireAssignedDa(40_000);   // 40kg already on the vehicle
+
+        assertThatThrownBy(() -> service.ensureCapacityForAdd(order(), 15_000))   // +15kg = 55kg > 50kg
+                .isInstanceOf(DaCapacityExceededException.class);
+    }
+
+    @Test
+    void perCityOverrideApplies() {
+        properties.getDaVehicleGramsByCity().put("DELHI", 30_000);   // tighter cap for Delhi
+        wireAssignedDa(20_000);
+
+        assertThatThrownBy(() -> service.ensureCapacityForAdd(order(), 15_000))   // 35kg > 30kg
+                .isInstanceOf(DaCapacityExceededException.class);
+    }
+
+    /** DA assigned, carrying {@code onVehicleGrams} across two queued parcels. */
+    private void wireAssignedDa(int onVehicleGrams) {
+        when(provider.getIfAvailable()).thenReturn(port);
+
+        UUID sibId = UUID.randomUUID();
+        Shipment sib = ship(sibId, onVehicleGrams / 2);
+        UUID s1 = UUID.randomUUID();
+        UUID s2 = UUID.randomUUID();
+        Shipment sh1 = ship(s1, onVehicleGrams / 2);
+        Shipment sh2 = ship(s2, onVehicleGrams / 2);
+
+        when(shipmentRepository.findByOrderIdOrderByCreatedAtAsc(ORDER_ID)).thenReturn(List.of(sib));
+        when(port.assignedPickupLoad(sibId))
+                .thenReturn(Optional.of(new AssignedPickupLoad(UUID.randomUUID(), List.of(s1, s2))));
+        when(shipmentRepository.findAllById(any())).thenReturn(List.of(sh1, sh2));
+    }
+}

--- a/orders/src/test/java/com/oneday/orders/service/impl/OrderRepairServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/OrderRepairServiceImplTest.java
@@ -1,0 +1,181 @@
+package com.oneday.orders.service.impl;
+
+import com.oneday.common.domain.enums.CustomerType;
+import com.oneday.common.domain.enums.PickupType;
+import com.oneday.common.domain.enums.ShipmentState;
+import com.oneday.orders.domain.B2bAccount;
+import com.oneday.orders.domain.ParcelOrder;
+import com.oneday.orders.domain.Shipment;
+import com.oneday.orders.dto.B2bBookingRequest;
+import com.oneday.orders.dto.BookingResponse;
+import com.oneday.orders.dto.OrderCancellationSummary;
+import com.oneday.orders.repository.B2bAccountRepository;
+import com.oneday.orders.repository.ParcelOrderRepository;
+import com.oneday.orders.repository.ShipmentRepository;
+import com.oneday.orders.service.B2bBookingService;
+import com.oneday.orders.service.CancellationPolicy;
+import com.oneday.orders.service.CancellationService;
+import com.oneday.orders.service.OrderCapacityService;
+import com.oneday.orders.service.OrderRepairService.OrderNotEditableException;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Order repair is B2B + owner-scoped: add/cancel resolve the order to the caller's account (404 on any
+ * mismatch), gate edits to still-open orders, run the capacity check before booking, and cancel whole
+ * orders partially (eligible children cancelled, the rest reported skipped).
+ */
+class OrderRepairServiceImplTest {
+
+    private final ParcelOrderRepository orderRepository = mock(ParcelOrderRepository.class);
+    private final ShipmentRepository shipmentRepository = mock(ShipmentRepository.class);
+    private final B2bAccountRepository accountRepository = mock(B2bAccountRepository.class);
+    private final B2bBookingService bookingService = mock(B2bBookingService.class);
+    private final CancellationService cancellationService = mock(CancellationService.class);
+    private final CancellationPolicy cancellationPolicy = mock(CancellationPolicy.class);
+    private final OrderCapacityService capacityService = mock(OrderCapacityService.class);
+
+    private final OrderRepairServiceImpl service = new OrderRepairServiceImpl(
+            orderRepository, shipmentRepository, accountRepository, bookingService,
+            cancellationService, cancellationPolicy, capacityService);
+
+    private static final String REF = "1DD-ORD-DEL-20260830-00001";
+    private static final UUID ORDER_ID = UUID.randomUUID();
+    private static final UUID ACCOUNT_ID = UUID.randomUUID();
+    private static final UUID USER_ID = UUID.randomUUID();
+
+    private ParcelOrder ownedOrder() {
+        ParcelOrder o = mock(ParcelOrder.class);
+        when(o.getId()).thenReturn(ORDER_ID);
+        when(o.getOrderRef()).thenReturn(REF);
+        when(o.getCustomerType()).thenReturn(CustomerType.B2B);
+        when(o.getB2bAccountId()).thenReturn(ACCOUNT_ID);
+        when(o.getCityId()).thenReturn("DELHI");
+        when(orderRepository.findByOrderRef(REF)).thenReturn(Optional.of(o));
+        B2bAccount acc = mock(B2bAccount.class);
+        when(acc.getId()).thenReturn(ACCOUNT_ID);
+        when(accountRepository.findByMemberUserId(USER_ID)).thenReturn(Optional.of(acc));
+        return o;
+    }
+
+    // Standalone factory — never call this inside another when(...).thenReturn(...) argument.
+    private static Shipment ship(ShipmentState state) {
+        Shipment s = mock(Shipment.class);
+        when(s.getState()).thenReturn(state);
+        when(s.getPickupType()).thenReturn(PickupType.DA_PICKUP);
+        when(s.getShipmentRef()).thenReturn("1DD-" + state);
+        return s;
+    }
+
+    private static B2bBookingRequest request() {
+        B2bBookingRequest r = new B2bBookingRequest();
+        r.setB2bAccountId(UUID.randomUUID());   // deliberately NOT the order's account — must be overridden
+        r.setWeightGrams(2_000);
+        r.setLengthCm((short) 10);
+        r.setWidthCm((short) 10);
+        r.setHeightCm((short) 10);
+        return r;
+    }
+
+    // ── addShipment ─────────────────────────────────────────────────────────
+
+    @Test
+    void addShipment_orderNotFound_404() {
+        when(orderRepository.findByOrderRef(REF)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.addShipment(REF, request(), "idem", USER_ID.toString()))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    void addShipment_notOwned_404() {
+        ownedOrder();
+        B2bAccount other = mock(B2bAccount.class);
+        when(other.getId()).thenReturn(UUID.randomUUID());   // caller owns a different account
+        when(accountRepository.findByMemberUserId(USER_ID)).thenReturn(Optional.of(other));
+
+        assertThatThrownBy(() -> service.addShipment(REF, request(), "idem", USER_ID.toString()))
+                .isInstanceOf(EntityNotFoundException.class);
+        verify(bookingService, never()).book(any(), any(), any(), any());
+    }
+
+    @Test
+    void addShipment_notEditable_409() {
+        ownedOrder();
+        Shipment atHub = ship(ShipmentState.AT_ORIGIN_HUB);
+        when(shipmentRepository.findByOrderIdOrderByCreatedAtAsc(ORDER_ID)).thenReturn(List.of(atHub));
+        when(cancellationPolicy.isCancellable(any(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.addShipment(REF, request(), "idem", USER_ID.toString()))
+                .isInstanceOf(OrderNotEditableException.class);
+    }
+
+    @Test
+    void addShipment_happyPath_overridesAccount_checksCapacity_books() {
+        ParcelOrder o = ownedOrder();
+        Shipment booked = ship(ShipmentState.BOOKED);
+        when(shipmentRepository.findByOrderIdOrderByCreatedAtAsc(ORDER_ID)).thenReturn(List.of(booked));
+        when(cancellationPolicy.isCancellable(eq(ShipmentState.BOOKED), any())).thenReturn(true);
+        BookingResponse response = mock(BookingResponse.class);
+        when(response.getShipmentRef()).thenReturn("1DD-NEW");
+        when(bookingService.book(any(), eq("idem"), eq(USER_ID.toString()), eq(ORDER_ID)))
+                .thenReturn(response);
+
+        B2bBookingRequest req = request();
+        BookingResponse out = service.addShipment(REF, req, "idem", USER_ID.toString());
+
+        assertThat(out).isSameAs(response);
+        assertThat(req.getB2bAccountId()).isEqualTo(ACCOUNT_ID);            // account was overridden to the order's
+        verify(capacityService).ensureCapacityForAdd(eq(o), eq(2_000));    // capacity gate ran with chargeable weight
+        verify(bookingService).book(eq(req), eq("idem"), eq(USER_ID.toString()), eq(ORDER_ID));
+    }
+
+    // ── cancelOrder ─────────────────────────────────────────────────────────
+
+    @Test
+    void cancelOrder_partial_cancelsEligible_reportsSkipped() {
+        ownedOrder();
+        Shipment eligible = ship(ShipmentState.BOOKED);
+        Shipment pickedUp = ship(ShipmentState.PICKED_UP);
+        when(shipmentRepository.findByOrderIdOrderByCreatedAtAsc(ORDER_ID))
+                .thenReturn(List.of(eligible, pickedUp));
+        when(cancellationPolicy.isCancellable(eq(ShipmentState.BOOKED), any())).thenReturn(true);
+        when(cancellationPolicy.isCancellable(eq(ShipmentState.PICKED_UP), any())).thenReturn(false);
+
+        OrderCancellationSummary summary = service.cancelOrder(REF, "changed mind", USER_ID.toString());
+
+        assertThat(summary.cancelled()).containsExactly("1DD-" + ShipmentState.BOOKED);
+        assertThat(summary.skipped()).hasSize(1);
+        assertThat(summary.skipped().get(0).shipmentRef()).isEqualTo("1DD-" + ShipmentState.PICKED_UP);
+        verify(cancellationService).cancel(eq("1DD-" + ShipmentState.BOOKED), eq("changed mind"),
+                eq(USER_ID.toString()), eq(true));
+        verify(cancellationService, never()).cancel(eq("1DD-" + ShipmentState.PICKED_UP), any(), any(), eq(true));
+    }
+
+    @Test
+    void cancelOrder_skipsAlreadyCancelled() {
+        ownedOrder();
+        Shipment cancelled = ship(ShipmentState.CANCELLED);
+        when(shipmentRepository.findByOrderIdOrderByCreatedAtAsc(ORDER_ID))
+                .thenReturn(List.of(cancelled));
+
+        OrderCancellationSummary summary = service.cancelOrder(REF, null, USER_ID.toString());
+
+        assertThat(summary.cancelled()).isEmpty();
+        assertThat(summary.skipped()).isEmpty();
+        verify(cancellationService, never()).cancel(any(), any(), any(), anyBoolean());
+    }
+}


### PR DESCRIPTION
## What & why

B2B merchants (business portal) could **view** an order but not change it. This lets them **edit an order until it is picked up** — add a shipment, remove one, or cancel the whole order — with wallet/credit charged or refunded to match, plus a **DA vehicle-capacity check** so a merchant can't overload the assigned delivery associate at pickup. Implements feature #10 (order repair).

**No Flyway migration** — the order rollup columns and per-shipment weights already exist.

## What changed

- **Rollup decrement (the one missing primitive):** `ParcelOrderRepository.removeShipment` + `OrderService.removeShipment`, symmetric with the existing `addShipment`.
- **Cancellation is now rollup-aware:** `CancellationServiceImpl` backs a cancelled shipment out of its parent order's `parcel_count`/`total_price_paise` — every cancel path (customer/admin/station), so the rollup can never drift. "Remove a shipment" is just the existing per-shipment cancel.
- **New endpoints** (`B2bOrderController`, owner-scoped, gated to editable orders):
  - `POST /api/v1/b2b/orders/{orderRef}/shipments` — add a shipment (reuses the existing 4-arg `B2bBookingService.book` onto the order: prices on the account rate card, debits wallet/credit, persists with the order id, bumps the rollup).
  - `DELETE /api/v1/b2b/orders/{orderRef}` — cancel the whole order, **partial** by design → `OrderCancellationSummary { cancelled, skipped }`.
- **DA weight-capacity gate:** new `DaPickupLoadPort` (dispatch adapter over `dispatch_queue`, same lookup as `CourierOnShipmentPort`) + `OrderCapacityService` sums `chargeable_weight_grams` on the assigned DA's active pickup queue against `orders.capacity.da-vehicle-grams` (default **50 kg**). Over cap → **409**; no DA assigned yet → skipped (dispatch places it normally).

## Testing

- **Unit:** `OrderCapacityServiceImplTest` (5) + `OrderRepairServiceImplTest` (6) green; full reactor compiles.
- **Live end-to-end** against the assembled app + a fresh Postgres, funding = WALLET so money movement is visible:

| step | parcels | wallet |
|---|---|---|
| book #1 (2 kg) | 1 | ₹50,000 → ₹49,464.60 |
| **add** #2 (3 kg) | 2 | → ₹48,740.23 |
| **remove** #2 | 1 | → ₹49,464.60 (exact refund) |
| add #3, then **cancel order** | 0 | → ₹50,000.00 (both refunded) — `cancelled:[S1,S3] skipped:[]` |

- **Capacity gate (live):** DA seeded at 48 kg → add 5 kg ⇒ **409** `"…48.0 kg of 50.0 kg used; this 5.0 kg parcel can't be added."`; add 1 kg ⇒ **201**.

## UI evidence (business portal, driving these endpoints)

Order detail — add / remove / cancel actions + live wallet:

![order detail](https://raw.githubusercontent.com/Sidarthapati/one_day_delivery/assets/disc2-screenshots/order-repair/or-01-order-detail.png)

Cancel whole order → everything refunded (wallet ₹2,86,962.00 → ₹2,88,741.42, parcels → 0):

![order cancelled + refunded](https://raw.githubusercontent.com/Sidarthapati/one_day_delivery/assets/disc2-screenshots/order-repair/or-03-order-cancelled-refunded.png)

Remove a single shipment → refunded (wallet ₹2,86,914.76 → ₹2,88,206.02):

![after remove](https://raw.githubusercontent.com/Sidarthapati/one_day_delivery/assets/disc2-screenshots/order-repair/or-05-after-remove.png)

> Web changes are in oneday-web `feat/order-repair`.

🤖 Reviewer: please check the capacity-gate ownership/skip logic and the partial-cancel semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - B2B customers can add shipments to eligible existing orders.
  - Added whole-order cancellation with summaries of cancelled and skipped shipments.
  - Added delivery-associate vehicle capacity checks, including city-specific limits.
- **Bug Fixes**
  - Order totals and shipment counts now update correctly after shipment cancellation.
  - Clear conflict responses are returned for capacity violations and non-editable orders.
- **Validation**
  - Shipment additions require valid requests and idempotency keys.
  - Ownership and order editability are verified before repair actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Refund audit trail (persisted + merchant-visible)

Every refund is an **append-only `wallet_transaction` REFUND row** (type, shipment reference, amount, running `balance_after_paise`), surfaced to the merchant on the **Wallet → Transactions** page. Each booking DEBIT has a matching REFUND, so it reconciles to the paise:

![wallet refund ledger](https://raw.githubusercontent.com/Sidarthapati/one_day_delivery/assets/disc2-screenshots/order-repair/or-06-wallet-ledger.png)

_Scope note: this ledger line is written for **wallet-funded** orders. Credit-funded (post-paid) refunds instead decrement the account's `outstanding_balance_paise` (freeing credit) and don't yet write an explicit ledger line — flagged as a follow-up. Invoices are per-shipment GST tax invoices issued lazily on view; a pre-pickup cancellation has no invoice to credit-note._

## DA capacity gate — demonstrated in the UI

Adding a parcel checks the **assigned pickup DA's vehicle load**. Blocked when the parcel would overflow the cap (DA at 48 kg of 50 kg), then allowed once the cap is raised — the same 5 kg add now succeeds and the wallet is charged:

**Blocked (over capacity):**

![capacity blocked](https://raw.githubusercontent.com/Sidarthapati/one_day_delivery/assets/disc2-screenshots/order-repair/or-07-capacity-blocked.png)

**Allowed after the cap was raised (default is now 500 kg):**

![capacity allowed](https://raw.githubusercontent.com/Sidarthapati/one_day_delivery/assets/disc2-screenshots/order-repair/or-08-capacity-allowed.png)

_The default DA vehicle capacity is **500 kg** (permissive for now); per-DA / admin-configurable capacity is a planned follow-up. The "Add parcel" drawer reuses the order's pickup/drop so it needs no map._
