### PR TITLE
fix(orders): resolve Flyway V4.45/V4.47 migration collisions (staging down)

### DIFF
--- a/orders/src/main/resources/db/migration/orders/V4_49__b2b_member_kyc.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_49__b2b_member_kyc.sql
@@ -1,7 +1,7 @@
 -- Per-user KYC (Discussion-2 xii): each team member can be KYC'd individually; skipping is allowed, so a
 -- member stays UNVERIFIED (a display label) until they verify. Distinct from account-level KYB
 -- (b2b_accounts.verification_status), which gates the whole account.
-ALTER TABLE b2b_account_member ADD COLUMN kyc_status VARCHAR(16) NOT NULL DEFAULT 'UNVERIFIED';
+ALTER TABLE b2b_account_member ADD COLUMN IF NOT EXISTS kyc_status VARCHAR(16) NOT NULL DEFAULT 'UNVERIFIED';
 
 -- Owners of an ACTIVE account passed KYB at onboarding, so carry that onto their per-member KYC (they'd
 -- otherwise show "unverified" on their own team page). Owners of accounts still in MANUAL_REVIEW / REJECTED

--- a/orders/src/main/resources/db/migration/orders/V4_50__da_cod_ledger.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_50__da_cod_ledger.sql
@@ -5,14 +5,14 @@
 
 -- Running balance = cash the DA is currently holding on the company's behalf. Lockable row that
 -- serialises concurrent postings, mirroring b2b_accounts.wallet_balance_paise.
-CREATE TABLE da_cod_balance (
+CREATE TABLE IF NOT EXISTS da_cod_balance (
     da_user_id         UUID PRIMARY KEY,
     cash_in_hand_paise BIGINT      NOT NULL DEFAULT 0,
     updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 -- Append-only history; the balance above is reconstructable from it. Never mutated after insert.
-CREATE TABLE da_cod_ledger (
+CREATE TABLE IF NOT EXISTS da_cod_ledger (
     id                  UUID        PRIMARY KEY,
     da_user_id          UUID        NOT NULL,
     -- COLLECTION (+ took cash at delivery), DEPOSIT (- handed cash in), ADJUSTMENT (± admin correction)
@@ -24,7 +24,7 @@ CREATE TABLE da_cod_ledger (
     created_by          UUID,
     created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-CREATE INDEX idx_da_cod_ledger_da ON da_cod_ledger (da_user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_da_cod_ledger_da ON da_cod_ledger (da_user_id, created_at DESC);
 
 -- NOTE: the ledger is authoritative for cash movements from here on. Existing cod_collection /
 -- cod_cash_deposit rows are NOT backfilled — the per-DA time-ordered reconstruction / cutover


### PR DESCRIPTION
## Incident
Staging is crash-looping on boot: `FlywayException: Found more than one migration with version 4.45`. Flyway refuses to start with a duplicate version, so the whole app context fails.

## Root cause
The `delivery-outcomes` feature and two Discussion-2 features independently grabbed the same migration numbers:

| Version | Applied on staging (delivery-outcomes) | Colliding newcomer |
|---|---|---|
| **4.45** | `create_delivery_confirmation` ✅ 2026-08-30 15:01 | `b2b_member_kyc` (#175), never applied |
| **4.47** | `add_return_shipment_links` ✅ 15:01 | `da_cod_ledger` (#184), never applied |

Staging's `flyway_schema_history` confirms the delivery-outcomes migrations (4.45/4.47/4.48) are committed and successful; the two newcomers were never applied. So the newcomers move.

## Fix
- `V4_45__b2b_member_kyc.sql` → `V4_49__b2b_member_kyc.sql`
- `V4_47__da_cod_ledger.sql` → `V4_50__da_cod_ledger.sql`
- Both made idempotent (`ADD COLUMN / CREATE TABLE / CREATE INDEX IF NOT EXISTS`) so they re-apply as no-ops on local/dev DBs where they already ran under the old numbers.

No SQL content change beyond the `IF NOT EXISTS` guards. After merge, staging applies 4.49/4.50 fresh and boots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration reliability by safely handling already-existing KYC fields and COD ledger structures.
  * Preserved existing defaults, account verification behavior, ledger schema, and cutover behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->