### PR TITLE
feat: DA driver-app anti-abuse / location-trust hardening (server)

### DIFF
--- a/app/src/main/resources/db/migration/auth/V1_17__add_refresh_token_device.sql
+++ b/app/src/main/resources/db/migration/auth/V1_17__add_refresh_token_device.sql
@@ -1,0 +1,9 @@
+-- M1 auth — device binding (anti-abuse Phase 4). Bind each refresh-token family to the physical
+-- device it was minted on (X-Device-Id), so a shared/rented DA login on a second device is detectable
+-- and (when single-active-device is enabled) the older device's session is revoked. Nullable: tokens
+-- minted by clients that don't send the header stay valid and simply carry no binding.
+ALTER TABLE refresh_tokens ADD COLUMN device_id VARCHAR(64);
+
+-- Fast "this user's active sessions on other devices" lookup for the single-active-device sweep.
+CREATE INDEX idx_refresh_tokens_user_device ON refresh_tokens (user_id, device_id)
+    WHERE revoked_at IS NULL;

--- a/auth/src/main/java/com/oneday/auth/api/AuthController.java
+++ b/auth/src/main/java/com/oneday/auth/api/AuthController.java
@@ -41,8 +41,10 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
-        return ResponseEntity.ok(authService.login(request));
+    public ResponseEntity<LoginResponse> login(
+            @Valid @RequestBody LoginRequest request,
+            @RequestHeader(value = "X-Device-Id", required = false) String deviceId) {
+        return ResponseEntity.ok(authService.login(request, deviceId));
     }
 
     @PostMapping("/register")

--- a/auth/src/main/java/com/oneday/auth/config/DeviceBindingProperties.java
+++ b/auth/src/main/java/com/oneday/auth/config/DeviceBindingProperties.java
@@ -1,0 +1,38 @@
+package com.oneday.auth.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+/**
+ * Device-binding policy (anti-abuse Phase 4), bound under {@code godspeed.device-binding}. When
+ * {@code single-active-device} is on, a fresh login from a role in {@code roles} revokes that user's
+ * sessions on every other device — so a rented/shared DA login can't run on two handsets at once.
+ * Off by default: it only bites once ops turn it on, and only for the listed roles.
+ *
+ * <pre>{@code
+ * godspeed:
+ *   device-binding:
+ *     single-active-device: true
+ *     roles: [DELIVERY_ASSOCIATE]
+ * }</pre>
+ */
+@Component
+@ConfigurationProperties(prefix = "godspeed.device-binding")
+public class DeviceBindingProperties {
+
+    private boolean singleActiveDevice = false;
+    private Set<String> roles = Set.of("DELIVERY_ASSOCIATE");
+
+    /** True when the single-active-device sweep should run for this role. */
+    public boolean appliesTo(String role) {
+        return singleActiveDevice && role != null && roles.contains(role);
+    }
+
+    public boolean isSingleActiveDevice() { return singleActiveDevice; }
+    public void setSingleActiveDevice(boolean singleActiveDevice) { this.singleActiveDevice = singleActiveDevice; }
+
+    public Set<String> getRoles() { return roles; }
+    public void setRoles(Set<String> roles) { this.roles = roles; }
+}

--- a/auth/src/main/java/com/oneday/auth/domain/RefreshToken.java
+++ b/auth/src/main/java/com/oneday/auth/domain/RefreshToken.java
@@ -38,6 +38,10 @@ public class RefreshToken extends BaseEntity {
     @Column(name = "replaced_by_id")
     private UUID replacedById;
 
+    /** The physical device (X-Device-Id) this family was minted on; null if the client sent none. */
+    @Column(name = "device_id", length = 64)
+    private String deviceId;
+
     public boolean isRevoked() {
         return revokedAt != null;
     }

--- a/auth/src/main/java/com/oneday/auth/repository/RefreshTokenRepository.java
+++ b/auth/src/main/java/com/oneday/auth/repository/RefreshTokenRepository.java
@@ -35,6 +35,19 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, UUID
     int revokeFamily(@Param("familyId") UUID familyId, @Param("now") Instant now);
 
     /**
+     * Single-active-device sweep: revoke this user's still-active tokens on any OTHER device (or with
+     * no device binding). Called on a fresh login from {@code deviceId} so only the newest device
+     * keeps a live session. Returns rows revoked.
+     */
+    @Modifying
+    @Transactional
+    @Query("UPDATE RefreshToken t SET t.revokedAt = :now "
+            + "WHERE t.user.id = :userId AND t.revokedAt IS NULL "
+            + "AND (t.deviceId IS NULL OR t.deviceId <> :deviceId)")
+    int revokeOtherDevices(@Param("userId") UUID userId, @Param("deviceId") String deviceId,
+                           @Param("now") Instant now);
+
+    /**
      * Delete tokens already past their expiry. Revoked-but-unexpired rows are kept until they'd
      * expire anyway, so reuse detection still fires for a stolen token within its natural lifetime.
      */

--- a/auth/src/main/java/com/oneday/auth/service/AuthService.java
+++ b/auth/src/main/java/com/oneday/auth/service/AuthService.java
@@ -13,6 +13,8 @@ import java.util.UUID;
 
 public interface AuthService {
     LoginResponse login(LoginRequest request);
+    /** Password login that binds the session to {@code deviceId} (X-Device-Id) for device policy. */
+    LoginResponse login(LoginRequest request, String deviceId);
     LoginResponse register(RegisterRequest request);
     LoginResponse loginWithGoogle(GoogleLoginRequest request);
     OtpRequestResponse requestOtp(OtpRequestRequest request);

--- a/auth/src/main/java/com/oneday/auth/service/RefreshTokenService.java
+++ b/auth/src/main/java/com/oneday/auth/service/RefreshTokenService.java
@@ -15,6 +15,18 @@ public interface RefreshTokenService {
     Issued issue(User user);
 
     /**
+     * Mint a refresh token bound to {@code deviceId} (X-Device-Id). Enables single-active-device
+     * enforcement and lets ops see which physical device holds a session. Null deviceId = unbound.
+     */
+    Issued issue(User user, String deviceId);
+
+    /**
+     * Revoke this user's still-active sessions on any device other than {@code deviceId} (the
+     * single-active-device sweep). No-op when deviceId is null. Returns the number revoked.
+     */
+    int revokeOtherDevices(User user, String deviceId);
+
+    /**
      * Validate + rotate a presented raw refresh token: revoke it and mint its successor in the same
      * family. Reuse of an already-revoked token revokes the entire family and throws.
      */

--- a/auth/src/main/java/com/oneday/auth/service/impl/AuthServiceImpl.java
+++ b/auth/src/main/java/com/oneday/auth/service/impl/AuthServiceImpl.java
@@ -1,5 +1,6 @@
 package com.oneday.auth.service.impl;
 
+import com.oneday.auth.config.DeviceBindingProperties;
 import com.oneday.auth.config.OtpProperties;
 import com.oneday.auth.domain.ApiKey;
 import com.oneday.auth.domain.AuthProvider;
@@ -73,6 +74,7 @@ class AuthServiceImpl implements AuthService {
     private final OtpProperties otpProperties;
     private final RefreshTokenService refreshTokenService;
     private final RefreshTokenProperties refreshTokenProperties;
+    private final DeviceBindingProperties deviceBindingProperties;
     private final SecureRandom secureRandom = new SecureRandom();
 
     AuthServiceImpl(UserRepository userRepository,
@@ -86,7 +88,8 @@ class AuthServiceImpl implements AuthService {
             OtpSender otpSender,
             OtpProperties otpProperties,
             RefreshTokenService refreshTokenService,
-            RefreshTokenProperties refreshTokenProperties) {
+            RefreshTokenProperties refreshTokenProperties,
+            DeviceBindingProperties deviceBindingProperties) {
         this.userRepository = userRepository;
         this.roleRepository = roleRepository;
         this.apiKeyRepository = apiKeyRepository;
@@ -99,11 +102,18 @@ class AuthServiceImpl implements AuthService {
         this.otpProperties = otpProperties;
         this.refreshTokenService = refreshTokenService;
         this.refreshTokenProperties = refreshTokenProperties;
+        this.deviceBindingProperties = deviceBindingProperties;
     }
 
     @Override
     @Transactional
     public LoginResponse login(LoginRequest request) {
+        return login(request, null);
+    }
+
+    @Override
+    @Transactional
+    public LoginResponse login(LoginRequest request, String deviceId) {
         User user = userRepository.findByEmail(request.email())
                 .filter(User::isActive)
                 .orElseThrow(BadCredentialsException::new);
@@ -114,7 +124,7 @@ class AuthServiceImpl implements AuthService {
             throw new BadCredentialsException();
         }
 
-        return toLoginResponse(user);
+        return toLoginResponse(user, deviceId);
     }
 
     @Override
@@ -347,10 +357,20 @@ class AuthServiceImpl implements AuthService {
     }
 
     private LoginResponse toLoginResponse(User user) {
+        return toLoginResponse(user, null);
+    }
+
+    private LoginResponse toLoginResponse(User user, String deviceId) {
         String token = jwtService.createToken(user);
         Instant expiresAt = jwtService.expiryFor(user);
+
+        // Single-active-device (Phase 4): a fresh login from an applicable role kicks that user's
+        // sessions off every other device before minting the new device-bound session.
+        if (deviceBindingProperties.appliesTo(user.getRole().getName())) {
+            refreshTokenService.revokeOtherDevices(user, deviceId);
+        }
         String refreshToken = refreshTokenProperties.isEnabled()
-                ? refreshTokenService.issue(user).rawToken()
+                ? refreshTokenService.issue(user, deviceId).rawToken()
                 : null;
         return new LoginResponse(token, expiresAt, user.getRole().getName(),
                 user.getCityId(), user.getName(), user.getPhone(), user.isMustChangePassword(),

--- a/auth/src/main/java/com/oneday/auth/service/impl/RefreshTokenServiceImpl.java
+++ b/auth/src/main/java/com/oneday/auth/service/impl/RefreshTokenServiceImpl.java
@@ -49,8 +49,28 @@ class RefreshTokenServiceImpl implements RefreshTokenService {
     @Override
     @Transactional
     public Issued issue(User user) {
-        Minted minted = mint(user, UUID.randomUUID());
+        return issue(user, null);
+    }
+
+    @Override
+    @Transactional
+    public Issued issue(User user, String deviceId) {
+        Minted minted = mint(user, UUID.randomUUID(), deviceId);
         return new Issued(minted.rawToken(), minted.entity().getExpiresAt());
+    }
+
+    @Override
+    @Transactional
+    public int revokeOtherDevices(User user, String deviceId) {
+        if (deviceId == null || deviceId.isBlank()) {
+            return 0; // nothing to bind against — leave existing sessions untouched
+        }
+        int revoked = repository.revokeOtherDevices(user.getId(), deviceId, Instant.now());
+        if (revoked > 0) {
+            log.info("Single-active-device: revoked {} session(s) for user {} on other devices",
+                    revoked, user.getId());
+        }
+        return revoked;
     }
 
     @Override
@@ -78,7 +98,8 @@ class RefreshTokenServiceImpl implements RefreshTokenService {
         User user = userRepository.findActiveByIdWithRole(current.getUser().getId())
                 .orElseThrow(() -> new InvalidRefreshTokenException("User not found or inactive"));
 
-        Minted next = mint(user, current.getFamilyId());
+        // Carry the device binding forward across rotation, so the family stays tied to its device.
+        Minted next = mint(user, current.getFamilyId(), current.getDeviceId());
         // The bulk claim already set revoked_at in the DB; set it on the managed entity too (so the
         // flush doesn't reset it) and record the rotation lineage.
         current.setRevokedAt(now);
@@ -115,7 +136,7 @@ class RefreshTokenServiceImpl implements RefreshTokenService {
         });
     }
 
-    private Minted mint(User user, UUID familyId) {
+    private Minted mint(User user, UUID familyId, String deviceId) {
         byte[] bytes = new byte[RAW_TOKEN_BYTES];
         secureRandom.nextBytes(bytes);
         String rawToken = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
@@ -124,6 +145,7 @@ class RefreshTokenServiceImpl implements RefreshTokenService {
         entity.setTokenHash(sha256Hex(rawToken));
         entity.setUser(user);
         entity.setFamilyId(familyId);
+        entity.setDeviceId(deviceId);
         entity.setExpiresAt(Instant.now().plus(properties.getTtl()));
         entity = repository.save(entity); // flush to populate the generated id for replacedById
 

--- a/auth/src/test/java/com/oneday/auth/service/impl/AuthServiceSocialOtpTest.java
+++ b/auth/src/test/java/com/oneday/auth/service/impl/AuthServiceSocialOtpTest.java
@@ -74,13 +74,14 @@ class AuthServiceSocialOtpTest {
         when(jwtService.expiryFor(any(User.class))).thenReturn(Instant.now().plusSeconds(3600));
 
         RefreshTokenService refreshTokenService = mock(RefreshTokenService.class);
-        when(refreshTokenService.issue(any(User.class))).thenReturn(
+        when(refreshTokenService.issue(any(User.class), any())).thenReturn(
                 new RefreshTokenService.Issued("raw-refresh", Instant.now().plusSeconds(1_209_600)));
 
         service = new AuthServiceImpl(userRepository, roleRepository, apiKeyRepository,
                 auditLogRepository, otpRepository, jwtService, passwordEncoder,
                 googleTokenVerifier, otpSender, new OtpProperties(),
-                refreshTokenService, new RefreshTokenProperties());
+                refreshTokenService, new RefreshTokenProperties(),
+                new com.oneday.auth.config.DeviceBindingProperties());
     }
 
     @Test

--- a/auth/src/test/java/com/oneday/auth/service/impl/RefreshTokenServiceImplTest.java
+++ b/auth/src/test/java/com/oneday/auth/service/impl/RefreshTokenServiceImplTest.java
@@ -95,6 +95,24 @@ class RefreshTokenServiceImplTest {
                 return n;
             }
         });
+        // Single-active-device sweep: revoke this user's active tokens bound to any other device.
+        when(repository.revokeOtherDevices(any(), any(), any())).thenAnswer(inv -> {
+            synchronized (store) {
+                UUID uid = inv.getArgument(0);
+                String dev = inv.getArgument(1);
+                Instant now = inv.getArgument(2);
+                int n = 0;
+                for (RefreshToken t : store.values()) {
+                    boolean sameUser = t.getUser() != null && uid.equals(idOf(t.getUser()));
+                    boolean otherDevice = t.getDeviceId() == null || !t.getDeviceId().equals(dev);
+                    if (sameUser && t.getRevokedAt() == null && otherDevice) {
+                        t.setRevokedAt(now);
+                        n++;
+                    }
+                }
+                return n;
+            }
+        });
 
         Role role = new Role();
         role.setName("C2C_CUSTOMER");
@@ -118,6 +136,35 @@ class RefreshTokenServiceImplTest {
         // Stored under the SHA-256 hash — never the raw token itself.
         assertThat(store).hasSize(1);
         assertThat(store).doesNotContainKey(issued.rawToken());
+    }
+
+    @Test
+    void issue_bindsDevice_andRotationCarriesItForward() {
+        RefreshTokenService.Issued issued = service.issue(user, "device-1");
+        RefreshToken entity = store.values().iterator().next();
+        assertThat(entity.getDeviceId()).isEqualTo("device-1");
+
+        // A rotation stays tied to the same physical device (the session, not the token, is bound).
+        RefreshTokenService.Rotation rot = service.rotate(issued.rawToken());
+        RefreshToken next = store.get(sha256Hex(rot.rawToken()));
+        assertThat(next.getDeviceId()).isEqualTo("device-1");
+    }
+
+    @Test
+    void revokeOtherDevices_kicksSessionsOnOtherDevices() {
+        service.issue(user, "old-device"); // an active session on the DA's previous phone
+
+        int revoked = service.revokeOtherDevices(user, "new-device");
+
+        assertThat(revoked).isEqualTo(1);
+        assertThat(store.values().stream().filter(RefreshToken::isActive).count()).isZero();
+    }
+
+    @Test
+    void revokeOtherDevices_noopWhenDeviceIdBlank() {
+        service.issue(user, "old-device");
+        assertThat(service.revokeOtherDevices(user, null)).isZero();
+        assertThat(store.values().stream().filter(RefreshToken::isActive).count()).isEqualTo(1);
     }
 
     @Test

--- a/dispatch/src/main/java/com/oneday/dispatch/api/DaDispatchController.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/api/DaDispatchController.java
@@ -1,6 +1,7 @@
 package com.oneday.dispatch.api;
 
 import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.dispatch.dto.request.AttestRequest;
 import com.oneday.dispatch.dto.request.CustodyCollectRequest;
 import com.oneday.dispatch.dto.request.DropCompletedRequest;
 import com.oneday.dispatch.dto.request.GpsPingRequest;
@@ -8,13 +9,20 @@ import com.oneday.dispatch.dto.request.HubHandoffRequest;
 import com.oneday.dispatch.dto.request.OtpVerifyRequest;
 import com.oneday.dispatch.dto.request.TaskFailedRequest;
 import com.oneday.dispatch.dto.request.VanHandoffRequest;
+import com.oneday.dispatch.config.DispatchProperties;
 import com.oneday.dispatch.service.AttendanceService;
 import com.oneday.dispatch.service.DaStatusService;
+import com.oneday.dispatch.service.DeviceAttestationService;
 import com.oneday.dispatch.service.DaTaskService;
 import com.oneday.dispatch.service.DaTaskView;
 import com.oneday.dispatch.service.GpsFixView;
+import com.oneday.dispatch.service.GpsPlausibilityService;
+import com.oneday.dispatch.service.GpsPlausibilityService.GpsPlausibility;
+import com.oneday.dispatch.service.GpsSample;
+import com.oneday.dispatch.service.IpReputationService;
 import com.oneday.dispatch.service.OtpVerificationService;
 import com.oneday.dispatch.service.model.DaLiveStatus;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -46,14 +54,54 @@ public class DaDispatchController {
     private final DaTaskService daTaskService;
     private final OtpVerificationService otpVerificationService;
     private final AttendanceService attendanceService;
+    private final GpsPlausibilityService gpsPlausibilityService;
+    private final IpReputationService ipReputationService;
+    private final DeviceAttestationService deviceAttestationService;
+    private final DispatchProperties props;
 
     public DaDispatchController(DaStatusService daStatusService, DaTaskService daTaskService,
                                OtpVerificationService otpVerificationService,
-                               AttendanceService attendanceService) {
+                               AttendanceService attendanceService,
+                               GpsPlausibilityService gpsPlausibilityService,
+                               IpReputationService ipReputationService,
+                               DeviceAttestationService deviceAttestationService,
+                               DispatchProperties props) {
         this.daStatusService = daStatusService;
         this.daTaskService = daTaskService;
         this.otpVerificationService = otpVerificationService;
         this.attendanceService = attendanceService;
+        this.gpsPlausibilityService = gpsPlausibilityService;
+        this.ipReputationService = ipReputationService;
+        this.deviceAttestationService = deviceAttestationService;
+        this.props = props;
+    }
+
+    /** Issue a single-use nonce for a Play Integrity attestation (DA-self). */
+    @PostMapping("/integrity/nonce")
+    public DeviceAttestationService.Nonce attestationNonce(
+            @PathVariable UUID daId, @AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireDaSelf(principal, daId);
+        return deviceAttestationService.issueNonce(daId);
+    }
+
+    /** Submit the Play Integrity token for the issued nonce; returns the verdict (DA-self). */
+    @PostMapping("/integrity/attest")
+    public DeviceAttestationService.AttestationVerdict attest(
+            @PathVariable UUID daId, @AuthenticationPrincipal AuthUserDetails principal,
+            @Valid @RequestBody AttestRequest request) {
+        Authz.requireDaSelf(principal, daId);
+        return deviceAttestationService.verify(daId, request.nonce(), request.token());
+    }
+
+    /** Client IP for reputation checks — the rightmost X-Forwarded-For hop (proxy-set, hard to spoof),
+     *  else the socket address. Mirrors the auth RateLimitFilter's convention. */
+    private static String clientIp(HttpServletRequest request) {
+        String xff = request.getHeader("X-Forwarded-For");
+        if (xff != null && !xff.isBlank()) {
+            String[] hops = xff.split(",");
+            return hops[hops.length - 1].trim();
+        }
+        return request.getRemoteAddr();
     }
 
     /** The DA's task queue for the day (the app's home list). Each item carries taskLat/taskLon for Open-in-Maps. */
@@ -68,16 +116,33 @@ public class DaDispatchController {
     @PostMapping("/gps")
     public ResponseEntity<Void> gps(@PathVariable UUID daId,
                                     @AuthenticationPrincipal AuthUserDetails principal,
-                                    @Valid @RequestBody GpsPingRequest request) {
+                                    @Valid @RequestBody GpsPingRequest request,
+                                    HttpServletRequest httpRequest) {
         Authz.requireDaSelf(principal, daId);
-        Instant ts = request.timestamp() != null ? request.timestamp() : Instant.now();
-        daStatusService.updateGps(daId, request.lat(), request.lon(), ts);
+        Instant serverNow = Instant.now();
+        Instant ts = request.timestamp() != null ? request.timestamp() : serverNow;
+
+        // Evaluate trust BEFORE storing, so impossible-travel is measured against the prior fix.
+        GpsPlausibility trust = gpsPlausibilityService.evaluate(
+                daId, request.lat(), request.lon(), ts, request.accuracy(), request.mocked(), serverNow);
+        // Soft IP signal (Phase 5): a datacenter/VPN client IP raises the risk score for ops review but
+        // never blocks (hybrid posture) — so it's not part of trusted()/attendance gating below.
+        IpReputationService.IpReputation ip = ipReputationService.evaluate(clientIp(httpRequest));
+        int riskScore = Math.min(100, trust.riskScore() + ip.riskBump());
+        daStatusService.updateGps(daId, new GpsSample(
+                request.lat(), request.lon(), ts, request.accuracy(), request.speed(), request.mocked(),
+                trust.velocityFlag(), trust.tsSkewFlag(), riskScore));
+
         // Reactive geocoded attendance: an on-shift DA within the hub geofence is auto-marked present.
-        // Uses the in-memory live status (city + shift) so the hot ping path takes no extra DB read.
-        DaLiveStatus live = daStatusService.getLiveStatus(daId);
-        if (live != null && live.getCityId() != null) {
-            attendanceService.onGpsFix(daId, live.getCityId(), live.getShiftType(),
-                    request.lat(), request.lon(), ts);
+        // Only a trusted fix may establish presence — a mocked/teleported/skewed ping is recorded for
+        // ops review but never counts as being at the hub. Uses in-memory live status (no extra DB read).
+        boolean gate = props.getGps().getIntegrity().isMockedBlocksAttendance();
+        if (!gate || trust.trusted()) {
+            DaLiveStatus live = daStatusService.getLiveStatus(daId);
+            if (live != null && live.getCityId() != null) {
+                attendanceService.onGpsFix(daId, live.getCityId(), live.getShiftType(),
+                        request.lat(), request.lon(), ts);
+            }
         }
         return ResponseEntity.noContent().build();
     }

--- a/dispatch/src/main/java/com/oneday/dispatch/api/DaIntegrityController.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/api/DaIntegrityController.java
@@ -1,0 +1,55 @@
+package com.oneday.dispatch.api;
+
+import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.dispatch.dto.response.DaIntegritySummary;
+import com.oneday.dispatch.service.DaIntegrityService;
+import com.oneday.grid.service.GridService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Ops location-trust console (M5 anti-abuse Phase 6). Lists each DA's GREEN/AMBER/RED trust standing
+ * for a date so a station manager can spot a GPS spoofer before payroll settles. STATION_MANAGER sees
+ * their own city; ADMIN sees all. Read-only — holding payroll stays a human decision.
+ */
+@RestController
+public class DaIntegrityController {
+
+    private final DaIntegrityService daIntegrityService;
+    private final GridService gridService;
+
+    public DaIntegrityController(DaIntegrityService daIntegrityService, GridService gridService) {
+        this.daIntegrityService = daIntegrityService;
+        this.gridService = gridService;
+    }
+
+    @GetMapping("/dispatch/integrity/das")
+    public List<DaIntegritySummary> das(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireRole(principal, Authz.STATION_MANAGER);
+        UUID scopeCityId = Authz.isAdmin(principal) ? null : managerCity(principal);
+        return daIntegrityService.summariesForDate(date != null ? date : LocalDate.now(), scopeCityId);
+    }
+
+    private UUID managerCity(AuthUserDetails principal) {
+        String city = principal.getUser().getCityId();
+        if (city == null || city.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Station manager has no city scope");
+        }
+        try {
+            return UUID.fromString(city);
+        } catch (IllegalArgumentException notUuid) {
+            return gridService.resolveCityId(city);
+        }
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/config/DispatchProperties.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/config/DispatchProperties.java
@@ -70,6 +70,10 @@ public class DispatchProperties {
     private Absence absence = new Absence();
     @NestedConfigurationProperty
     private Attendance attendance = new Attendance();
+    @NestedConfigurationProperty
+    private IpReputation ipReputation = new IpReputation();
+    @NestedConfigurationProperty
+    private Attestation attestation = new Attestation();
 
     public Cron getCron() { return cron; }
     public void setCron(Cron cron) { this.cron = cron; }
@@ -103,6 +107,54 @@ public class DispatchProperties {
     public void setAbsence(Absence absence) { this.absence = absence; }
     public Attendance getAttendance() { return attendance; }
     public void setAttendance(Attendance attendance) { this.attendance = attendance; }
+    public IpReputation getIpReputation() { return ipReputation; }
+    public void setIpReputation(IpReputation ipReputation) { this.ipReputation = ipReputation; }
+    public Attestation getAttestation() { return attestation; }
+    public void setAttestation(Attestation attestation) { this.attestation = attestation; }
+
+    /**
+     * Device attestation (Play Integrity, Phase 2). {@code enabled}=false ships a permissive stub
+     * verifier (UNKNOWN verdict) so the nonce flow works in dev without Google keys; production sets
+     * enabled=true and wires the real verifier with {@code GOOGLE_PLAY_INTEGRITY_*} credentials.
+     */
+    public static class Attestation {
+        private boolean enabled = false;
+        /** How long an issued nonce is valid before it must be re-requested. */
+        private int nonceTtlSeconds = 300;
+
+        public boolean isEnabled() { return enabled; }
+        public void setEnabled(boolean enabled) { this.enabled = enabled; }
+        public int getNonceTtlSeconds() { return nonceTtlSeconds; }
+        public void setNonceTtlSeconds(int nonceTtlSeconds) { this.nonceTtlSeconds = nonceTtlSeconds; }
+    }
+
+    /**
+     * VPN/datacenter IP reputation — a SOFT anti-abuse signal (Phase 5). A ping from a
+     * datacenter/VPN/proxy range adds {@code riskBump} to that ping's risk score (surfaced to ops);
+     * it never blocks. The starter CIDR list covers a few well-known cloud/VPN ranges; extend it via
+     * {@code dispatch.ip-reputation.datacenter-cidrs} or point at a richer feed later.
+     */
+    public static class IpReputation {
+        private boolean enabled = true;
+        private int riskBump = 15;
+        /** IPv4 CIDR ranges treated as datacenter/VPN. A conservative starter set of major clouds. */
+        private List<String> datacenterCidrs = new ArrayList<>(List.of(
+                "3.0.0.0/8",       // AWS
+                "13.32.0.0/12",    // AWS/CloudFront
+                "34.0.0.0/8",      // Google Cloud
+                "35.184.0.0/13",   // Google Cloud
+                "104.16.0.0/12",   // Cloudflare
+                "146.70.0.0/15",   // M247 (common VPN exit)
+                "185.220.100.0/22" // Tor/VPN exit range
+        ));
+
+        public boolean isEnabled() { return enabled; }
+        public void setEnabled(boolean enabled) { this.enabled = enabled; }
+        public int getRiskBump() { return riskBump; }
+        public void setRiskBump(int riskBump) { this.riskBump = riskBump; }
+        public List<String> getDatacenterCidrs() { return datacenterCidrs; }
+        public void setDatacenterCidrs(List<String> datacenterCidrs) { this.datacenterCidrs = datacenterCidrs; }
+    }
 
     /** Cron-meeting protection (the hard constraint). */
     public static class Cron {
@@ -207,6 +259,37 @@ public class DispatchProperties {
         }
         public String getTrailPurgeCron() { return trailPurgeCron; }
         public void setTrailPurgeCron(String trailPurgeCron) { this.trailPurgeCron = trailPurgeCron; }
+
+        /** Location-trust plausibility thresholds for each incoming ping (Phase 1). */
+        private Integrity integrity = new Integrity();
+        public Integrity getIntegrity() { return integrity; }
+        public void setIntegrity(Integrity integrity) { this.integrity = integrity; }
+
+        /**
+         * Server-side plausibility limits. A DA can travel fast but not teleport, and a phone's clock
+         * can drift but not by hours; a fix that breaks these is flagged (and excluded from attendance)
+         * rather than trusted. {@code mockedBlocksAttendance} keeps a mock-provider fix from ever
+         * establishing presence.
+         */
+        public static class Integrity {
+            /** Ground speed between two consecutive fixes above this (km/h) is an impossible jump. */
+            private double maxSpeedKmph = 150.0;
+            /** Device fix time further than this from server receive time (seconds) is skewed. */
+            private long timestampSkewToleranceSeconds = 120;
+            /** Accuracy worse (larger) than this many metres is treated as low-trust. */
+            private double maxAccuracyMeters = 200.0;
+            /** A mock-provider fix (or one that fails plausibility) never marks the DA present. */
+            private boolean mockedBlocksAttendance = true;
+
+            public double getMaxSpeedKmph() { return maxSpeedKmph; }
+            public void setMaxSpeedKmph(double maxSpeedKmph) { this.maxSpeedKmph = maxSpeedKmph; }
+            public long getTimestampSkewToleranceSeconds() { return timestampSkewToleranceSeconds; }
+            public void setTimestampSkewToleranceSeconds(long v) { this.timestampSkewToleranceSeconds = v; }
+            public double getMaxAccuracyMeters() { return maxAccuracyMeters; }
+            public void setMaxAccuracyMeters(double maxAccuracyMeters) { this.maxAccuracyMeters = maxAccuracyMeters; }
+            public boolean isMockedBlocksAttendance() { return mockedBlocksAttendance; }
+            public void setMockedBlocksAttendance(boolean v) { this.mockedBlocksAttendance = v; }
+        }
     }
 
     public static class Osrm {

--- a/dispatch/src/main/java/com/oneday/dispatch/domain/DaGpsPing.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/domain/DaGpsPing.java
@@ -34,6 +34,32 @@ public class DaGpsPing extends BaseEntity {
     @Column(name = "recorded_at", nullable = false, updatable = false)
     private Instant recordedAt;
 
+    // ── location-trust signals (Phase 1) — all set once at insert, never mutated ──
+
+    /** Device reported the fix came from a mock-location provider (Android isMock). Null on old builds. */
+    @Column(name = "mocked", updatable = false)
+    private Boolean mocked;
+
+    /** Device-reported horizontal accuracy in metres, if sent. */
+    @Column(name = "accuracy_m", updatable = false)
+    private Double accuracyM;
+
+    /** Device-reported speed in m/s, if sent. */
+    @Column(name = "speed_mps", updatable = false)
+    private Double speedMps;
+
+    /** Server found an impossible jump (teleport) from the previous fix. */
+    @Column(name = "velocity_flag", nullable = false, updatable = false)
+    private boolean velocityFlag;
+
+    /** Device fix time is implausibly far from server receive time. */
+    @Column(name = "ts_skew_flag", nullable = false, updatable = false)
+    private boolean tsSkewFlag;
+
+    /** 0-100 rollup of the trust signals (higher = less trustworthy). */
+    @Column(name = "risk_score", nullable = false, updatable = false)
+    private int riskScore;
+
     public DaGpsPing(UUID daId, double lat, double lon, Instant recordedAt) {
         this.daId = daId;
         this.lat = lat;

--- a/dispatch/src/main/java/com/oneday/dispatch/dto/request/AttestRequest.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/dto/request/AttestRequest.java
@@ -1,0 +1,9 @@
+package com.oneday.dispatch.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+/** A Play Integrity attestation: the server-issued {@code nonce} and the {@code token} the app got. */
+public record AttestRequest(
+        @NotBlank String nonce,
+        @NotBlank String token) {
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/dto/request/GpsPingRequest.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/dto/request/GpsPingRequest.java
@@ -4,9 +4,17 @@ import jakarta.validation.constraints.NotNull;
 
 import java.time.Instant;
 
-/** A DA GPS heartbeat. {@code timestamp} is optional (defaults to now at the controller). */
+/**
+ * A DA GPS heartbeat. {@code timestamp} is the device fix time (optional; defaults to now at the
+ * controller). The trust fields are optional so older app builds keep working: {@code accuracy}/
+ * {@code speed} are the device's own readings; {@code mocked} is the Android mock-location flag the
+ * app forwards from {@code expo-location} (true ⇒ the fix came from a fake-GPS provider).
+ */
 public record GpsPingRequest(
         @NotNull Double lat,
         @NotNull Double lon,
-        Instant timestamp) {
+        Instant timestamp,
+        Double accuracy,
+        Double speed,
+        Boolean mocked) {
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/dto/response/DaIntegritySummary.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/dto/response/DaIntegritySummary.java
@@ -1,0 +1,21 @@
+package com.oneday.dispatch.dto.response;
+
+import java.util.UUID;
+
+/**
+ * One DA's location-trust standing for a date, for the ops integrity console. {@code trustLevel} is a
+ * GREEN/AMBER/RED triage: RED = a mock-provider fix or a high-risk fix (review payroll); AMBER = some
+ * flagged fixes; GREEN = clean.
+ */
+public record DaIntegritySummary(
+        UUID daId,
+        String daName,
+        UUID cityId,
+        long totalPings,
+        long flaggedPings,
+        int maxRiskScore,
+        long mockedPings,
+        long velocityPings,
+        long skewPings,
+        String trustLevel) {
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/repository/DaGpsPingRepository.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/repository/DaGpsPingRepository.java
@@ -37,7 +37,7 @@ public interface DaGpsPingRepository extends JpaRepository<DaGpsPing, UUID> {
                    sum(case when p.velocityFlag = true then 1 else 0 end) as velocityCount,
                    sum(case when p.tsSkewFlag = true then 1 else 0 end) as skewCount
             from DaGpsPing p
-            where p.recordedAt between :from and :to
+            where p.recordedAt >= :from and p.recordedAt < :to
             group by p.daId
             """)
     List<DaPingIntegrityAggregate> aggregateIntegrityByDa(@Param("from") Instant from,

--- a/dispatch/src/main/java/com/oneday/dispatch/repository/DaGpsPingRepository.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/repository/DaGpsPingRepository.java
@@ -26,4 +26,20 @@ public interface DaGpsPingRepository extends JpaRepository<DaGpsPing, UUID> {
     @Transactional
     @Query("delete from DaGpsPing p where p.recordedAt < :cutoff")
     int deleteOlderThan(@Param("cutoff") Instant cutoff);
+
+    /** Per-DA location-trust rollup over a window (ops integrity console). One row per DA that pinged. */
+    @Query("""
+            select p.daId as daId,
+                   count(p) as total,
+                   sum(case when p.riskScore > 0 then 1 else 0 end) as flagged,
+                   max(p.riskScore) as maxRisk,
+                   sum(case when p.mocked = true then 1 else 0 end) as mockedCount,
+                   sum(case when p.velocityFlag = true then 1 else 0 end) as velocityCount,
+                   sum(case when p.tsSkewFlag = true then 1 else 0 end) as skewCount
+            from DaGpsPing p
+            where p.recordedAt between :from and :to
+            group by p.daId
+            """)
+    List<DaPingIntegrityAggregate> aggregateIntegrityByDa(@Param("from") Instant from,
+                                                          @Param("to") Instant to);
 }

--- a/dispatch/src/main/java/com/oneday/dispatch/repository/DaPingIntegrityAggregate.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/repository/DaPingIntegrityAggregate.java
@@ -1,0 +1,17 @@
+package com.oneday.dispatch.repository;
+
+import java.util.UUID;
+
+/**
+ * Per-DA rollup of location-trust signals over a window (Spring Data projection). Backs the ops
+ * integrity console: how many fixes a DA sent that day and how many were untrustworthy.
+ */
+public interface DaPingIntegrityAggregate {
+    UUID getDaId();
+    long getTotal();
+    long getFlagged();       // fixes with risk_score > 0
+    Integer getMaxRisk();    // null if no rows (shouldn't happen inside a group)
+    long getMockedCount();
+    long getVelocityCount();
+    long getSkewCount();
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/service/DaIntegrityService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/DaIntegrityService.java
@@ -1,0 +1,21 @@
+package com.oneday.dispatch.service;
+
+import com.oneday.dispatch.dto.response.DaIntegritySummary;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Ops-facing rollup of DA location-trust for a date. Reads the per-ping risk signals recorded on the
+ * breadcrumb and triages each DA GREEN/AMBER/RED so a station manager can spot a spoofer before payroll
+ * settles. Read-only — enforcement (holding payroll) stays a human decision in the hybrid posture.
+ */
+public interface DaIntegrityService {
+
+    /**
+     * Per-DA trust standing for {@code date}. {@code scopeCityId} null = all cities (ADMIN); otherwise
+     * only DAs in that city (station manager). Ordered worst-trust first.
+     */
+    List<DaIntegritySummary> summariesForDate(LocalDate date, UUID scopeCityId);
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/service/DaStatusService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/DaStatusService.java
@@ -35,6 +35,13 @@ public interface DaStatusService {
     void updateGps(UUID daId, double lat, double lon, Instant timestamp);
 
     /**
+     * Record a ping carrying its evaluated location-trust signals (mock flag, accuracy, plausibility
+     * flags, risk score) onto the append-only breadcrumb. The live position/heartbeat is still updated
+     * so the ops map keeps moving, but a caller can inspect the stored {@code risk_score} afterwards.
+     */
+    void updateGps(UUID daId, GpsSample sample);
+
+    /**
      * The DA's GPS breadcrumb trail between {@code from} and {@code to} (inclusive), oldest first.
      * Reads the append-only {@code da_gps_ping} table — unlike the live status, this survives pod
      * restarts and captures every recorded fix (route replay).

--- a/dispatch/src/main/java/com/oneday/dispatch/service/DeviceAttestationService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/DeviceAttestationService.java
@@ -1,0 +1,27 @@
+package com.oneday.dispatch.service;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Device attestation (anti-abuse Phase 2). The app proves it's a genuine, unmodified build on an
+ * un-tampered device via Google Play Integrity. Flow: the app asks the server for a single-use
+ * {@link #issueNonce nonce}, requests a Play Integrity token bound to it, and sends the token back to
+ * {@link #verify}; the server checks the nonce is one it issued (anti-replay) and hands the token to
+ * the {@link com.oneday.dispatch.service.PlayIntegrityVerifier} for cryptographic verification. Per the
+ * hybrid posture a failing verdict is surfaced/flagged, not silently trusted — the app hard-blocks on
+ * its own device checks; this is the server-side corroboration.
+ */
+public interface DeviceAttestationService {
+
+    /** Issue a single-use, short-lived nonce bound to this DA for a Play Integrity request. */
+    Nonce issueNonce(UUID daId);
+
+    /** Consume the nonce and verify the token. Throws if the nonce is unknown/expired/mismatched. */
+    AttestationVerdict verify(UUID daId, String nonce, String integrityToken);
+
+    record Nonce(String value, Instant expiresAt) {}
+
+    /** @param verdict PASS / BASIC_ONLY / FAIL / UNKNOWN (verifier disabled or key absent). */
+    record AttestationVerdict(boolean passed, String verdict, String detail) {}
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/service/GpsPlausibilityService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/GpsPlausibilityService.java
@@ -1,0 +1,35 @@
+package com.oneday.dispatch.service;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Server-side plausibility check for an incoming DA GPS ping. The device's own signals (mock-provider
+ * flag, accuracy) are combined with server-derived checks (coordinate range, timestamp skew vs the
+ * server clock, and impossible-travel speed vs the DA's previous fix) into a trust verdict. Nothing
+ * here trusts the client's word alone — the mock flag is one signal among several.
+ */
+public interface GpsPlausibilityService {
+
+    /**
+     * Evaluate a fix. {@code deviceTime} is the client-supplied fix time; {@code serverNow} is the
+     * server receive time. {@code accuracyM}/{@code mocked} may be null on older app builds.
+     */
+    GpsPlausibility evaluate(UUID daId, double lat, double lon, Instant deviceTime,
+                             Double accuracyM, Boolean mocked, Instant serverNow);
+
+    /** The verdict for a single ping. {@link #trusted()} fixes may establish attendance / drive tracking. */
+    record GpsPlausibility(
+            boolean rangeValid,
+            boolean velocityFlag,
+            boolean tsSkewFlag,
+            boolean lowAccuracy,
+            boolean mocked,
+            int riskScore) {
+
+        /** Trustworthy enough to establish presence or move the live map: in-range, real, coherent. */
+        public boolean trusted() {
+            return rangeValid && !mocked && !velocityFlag && !tsSkewFlag;
+        }
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/service/GpsSample.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/GpsSample.java
@@ -1,0 +1,25 @@
+package com.oneday.dispatch.service;
+
+import java.time.Instant;
+
+/**
+ * A DA GPS fix plus its evaluated location-trust signals, as persisted to the append-only breadcrumb.
+ * {@code recordedAt} is the device fix time; the flags/score come from {@link GpsPlausibilityService}.
+ * Raw-only fixes (e.g. internal callers, tests) use {@link #trusted(double, double, Instant)}.
+ */
+public record GpsSample(
+        double lat,
+        double lon,
+        Instant recordedAt,
+        Double accuracyM,
+        Double speedMps,
+        Boolean mocked,
+        boolean velocityFlag,
+        boolean tsSkewFlag,
+        int riskScore) {
+
+    /** A fix with no integrity metadata, treated as trusted (server-internal / legacy callers). */
+    public static GpsSample trusted(double lat, double lon, Instant recordedAt) {
+        return new GpsSample(lat, lon, recordedAt, null, null, null, false, false, 0);
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/service/IpReputationService.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/IpReputationService.java
@@ -1,0 +1,25 @@
+package com.oneday.dispatch.service;
+
+/**
+ * A soft location-trust signal derived from the request's client IP (anti-abuse Phase 5). A DA pinging
+ * from a datacenter / VPN / proxy range isn't on a phone in the field — suspicious, but not proof of
+ * cheating (carrier-grade NAT, corporate VPNs), so per the hybrid posture this only RAISES the risk
+ * score for ops review; it never hard-blocks. Backed by a config-driven CIDR list so a richer
+ * reputation feed can swap in later without touching callers.
+ */
+public interface IpReputationService {
+
+    /** Evaluate a client IP (may be null/blank → clean). */
+    IpReputation evaluate(String clientIp);
+
+    /**
+     * @param datacenter true if the IP falls in a known datacenter/VPN/proxy range
+     * @param riskBump   points to add to the ping's risk score (0 when clean)
+     * @param reason     short human label, or null when clean
+     */
+    record IpReputation(boolean datacenter, int riskBump, String reason) {
+        public static IpReputation clean() {
+            return new IpReputation(false, 0, null);
+        }
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/service/PlayIntegrityVerifier.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/PlayIntegrityVerifier.java
@@ -1,0 +1,16 @@
+package com.oneday.dispatch.service;
+
+import com.oneday.dispatch.service.DeviceAttestationService.AttestationVerdict;
+
+/**
+ * Verifies a Play Integrity token server-side. The real implementation decrypts + validates the token
+ * against Google (device integrity, app integrity, licensing) and checks the embedded nonce. It's a
+ * separate port so the crypto/Google dependency stays swappable and the nonce lifecycle is testable
+ * without it. Ships with a config-gated stub; the production verifier that holds the Google key is a
+ * follow-up (it needs {@code GOOGLE_PLAY_INTEGRITY_*} credentials, never committed).
+ */
+public interface PlayIntegrityVerifier {
+
+    /** Verify {@code integrityToken}, confirming it embeds {@code expectedNonce}. */
+    AttestationVerdict verify(String integrityToken, String expectedNonce);
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/AttendanceServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/AttendanceServiceImpl.java
@@ -146,9 +146,12 @@ class AttendanceServiceImpl implements AttendanceService {
                 throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
                         "No location available — enable GPS and try again");
             }
-            // A mock-provider fix must never back a check-in (a spoofer's last ping sits at the hub).
+            // An untrusted fix must never back a check-in — not just a mock provider, but also a
+            // teleport (velocity) or clock-skew flag, since any of those makes the last ping's
+            // hub position unreliable (a spoofer's last ping sits at the hub).
             if (props.getGps().getIntegrity().isMockedBlocksAttendance()
-                    && Boolean.TRUE.equals(last.getMocked())) {
+                    && (Boolean.TRUE.equals(last.getMocked())
+                        || last.isVelocityFlag() || last.isTsSkewFlag())) {
                 throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
                         "Location integrity check failed — disable mock/developer location and try again");
             }

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/AttendanceServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/AttendanceServiceImpl.java
@@ -146,6 +146,12 @@ class AttendanceServiceImpl implements AttendanceService {
                 throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
                         "No location available — enable GPS and try again");
             }
+            // A mock-provider fix must never back a check-in (a spoofer's last ping sits at the hub).
+            if (props.getGps().getIntegrity().isMockedBlocksAttendance()
+                    && Boolean.TRUE.equals(last.getMocked())) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                        "Location integrity check failed — disable mock/developer location and try again");
+            }
             useLat = last.getLat();
             useLon = last.getLon();
             pingAt = last.getRecordedAt();

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaIntegrityServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaIntegrityServiceImpl.java
@@ -1,0 +1,98 @@
+package com.oneday.dispatch.service.impl;
+
+import com.oneday.common.port.DaDirectoryPort;
+import com.oneday.dispatch.config.DispatchProperties;
+import com.oneday.dispatch.domain.DaStatus;
+import com.oneday.dispatch.dto.response.DaIntegritySummary;
+import com.oneday.dispatch.repository.DaGpsPingRepository;
+import com.oneday.dispatch.repository.DaPingIntegrityAggregate;
+import com.oneday.dispatch.repository.DaStatusRepository;
+import com.oneday.dispatch.service.DaIntegrityService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Rolls up the per-ping risk signals into a GREEN/AMBER/RED standing per DA. RED = a mock-provider fix
+ * or a high-risk fix; AMBER = some flagged fixes; GREEN = clean. Worst-trust first so ops triage from
+ * the top. City is resolved from {@code da_status}; the name from the DA directory.
+ */
+@Service
+class DaIntegrityServiceImpl implements DaIntegrityService {
+
+    private static final int RED_RISK = 60; // matches the mock-flag weight — an unambiguous cheat
+
+    private final DaGpsPingRepository pingRepository;
+    private final DaStatusRepository daStatusRepository;
+    private final DaDirectoryPort daDirectory;
+    private final DispatchProperties props;
+
+    DaIntegrityServiceImpl(DaGpsPingRepository pingRepository, DaStatusRepository daStatusRepository,
+                           DaDirectoryPort daDirectory, DispatchProperties props) {
+        this.pingRepository = pingRepository;
+        this.daStatusRepository = daStatusRepository;
+        this.daDirectory = daDirectory;
+        this.props = props;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<DaIntegritySummary> summariesForDate(LocalDate date, UUID scopeCityId) {
+        ZoneId zone = ZoneId.of(props.getAttendance().getZone());
+        Instant from = date.atStartOfDay(zone).toInstant();
+        Instant to = date.plusDays(1).atStartOfDay(zone).toInstant();
+
+        List<DaPingIntegrityAggregate> rows = pingRepository.aggregateIntegrityByDa(from, to);
+
+        // City per DA (from da_status), applying the caller's city scope.
+        Map<UUID, UUID> cityByDa = new java.util.HashMap<>();
+        List<UUID> inScope = new java.util.ArrayList<>();
+        for (DaPingIntegrityAggregate r : rows) {
+            UUID cityId = daStatusRepository.findByDaId(r.getDaId()).map(DaStatus::getCityId).orElse(null);
+            if (scopeCityId != null && !scopeCityId.equals(cityId)) {
+                continue; // outside this station manager's city
+            }
+            cityByDa.put(r.getDaId(), cityId);
+            inScope.add(r.getDaId());
+        }
+        Map<UUID, DaDirectoryPort.DaContact> names = daDirectory.contactsFor(inScope);
+
+        return rows.stream()
+                .filter(r -> cityByDa.containsKey(r.getDaId()))
+                .map(r -> toSummary(r, cityByDa.get(r.getDaId()), names.get(r.getDaId())))
+                .sorted(Comparator.comparingInt((DaIntegritySummary s) -> rank(s.trustLevel())).reversed()
+                        .thenComparing(Comparator.comparingInt(DaIntegritySummary::maxRiskScore).reversed()))
+                .toList();
+    }
+
+    private DaIntegritySummary toSummary(DaPingIntegrityAggregate r, UUID cityId,
+                                         DaDirectoryPort.DaContact contact) {
+        int maxRisk = r.getMaxRisk() != null ? r.getMaxRisk() : 0;
+        String level;
+        if (r.getMockedCount() > 0 || maxRisk >= RED_RISK) {
+            level = "RED";
+        } else if (r.getFlagged() > 0) {
+            level = "AMBER";
+        } else {
+            level = "GREEN";
+        }
+        return new DaIntegritySummary(r.getDaId(), contact != null ? contact.name() : null, cityId,
+                r.getTotal(), r.getFlagged(), maxRisk, r.getMockedCount(), r.getVelocityCount(),
+                r.getSkewCount(), level);
+    }
+
+    private int rank(String level) {
+        return switch (level) {
+            case "RED" -> 2;
+            case "AMBER" -> 1;
+            default -> 0;
+        };
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaStatusServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DaStatusServiceImpl.java
@@ -9,6 +9,7 @@ import com.oneday.dispatch.repository.DaGpsPingRepository;
 import com.oneday.dispatch.repository.DaStatusRepository;
 import com.oneday.dispatch.service.DaStatusService;
 import com.oneday.dispatch.service.GpsFixView;
+import com.oneday.dispatch.service.GpsSample;
 import com.oneday.dispatch.service.model.DaLiveStatus;
 import com.oneday.dispatch.service.model.DaQueue;
 import org.slf4j.Logger;
@@ -94,10 +95,26 @@ class DaStatusServiceImpl implements DaStatusService {
 
     @Override
     public void updateGps(UUID daId, double lat, double lon, Instant timestamp) {
+        updateGps(daId, GpsSample.trusted(lat, lon, timestamp));
+    }
+
+    @Override
+    public void updateGps(UUID daId, GpsSample sample) {
+        double lat = sample.lat();
+        double lon = sample.lon();
+        Instant timestamp = sample.recordedAt();
+
         // Append-only breadcrumb FIRST, unconditionally — the route trail must capture every ping even
-        // when the DA has no shift loaded in memory (ad-hoc tracking / route replay). ponytail: one insert
-        // per ping, fine at current DA volume; batch-buffer if ping QPS ever climbs.
-        daGpsPingRepository.save(new DaGpsPing(daId, lat, lon, timestamp));
+        // when the DA has no shift loaded in memory (ad-hoc tracking / route replay). Even a low-trust
+        // fix is stored (with its risk score) so ops can review it; it just won't drive attendance.
+        DaGpsPing ping = new DaGpsPing(daId, lat, lon, timestamp);
+        ping.setMocked(sample.mocked());
+        ping.setAccuracyM(sample.accuracyM());
+        ping.setSpeedMps(sample.speedMps());
+        ping.setVelocityFlag(sample.velocityFlag());
+        ping.setTsSkewFlag(sample.tsSkewFlag());
+        ping.setRiskScore(sample.riskScore());
+        daGpsPingRepository.save(ping);
 
         DaLiveStatus live = liveStatus.get(daId);
         if (live == null) {

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/DeviceAttestationServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/DeviceAttestationServiceImpl.java
@@ -1,0 +1,76 @@
+package com.oneday.dispatch.service.impl;
+
+import com.oneday.dispatch.config.DispatchProperties;
+import com.oneday.dispatch.service.DeviceAttestationService;
+import com.oneday.dispatch.service.PlayIntegrityVerifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Nonce lifecycle for device attestation. Nonces are single-use, short-lived, and bound to the DA that
+ * requested them, held in memory (they live seconds and never need to survive a restart). Verification
+ * itself is delegated to {@link PlayIntegrityVerifier}; this class owns anti-replay: a nonce is
+ * consumed on first {@link #verify} and can't be reused, and a token presented with an unknown/expired
+ * nonce, or one issued to a different DA, is rejected before any crypto runs.
+ */
+@Service
+class DeviceAttestationServiceImpl implements DeviceAttestationService {
+
+    private static final int NONCE_BYTES = 32;
+
+    private final PlayIntegrityVerifier verifier;
+    private final DispatchProperties props;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    // nonce value → (daId, expiresAt). Consumed (removed) on verify.
+    private final Map<String, Pending> pending = new ConcurrentHashMap<>();
+
+    DeviceAttestationServiceImpl(PlayIntegrityVerifier verifier, DispatchProperties props) {
+        this.verifier = verifier;
+        this.props = props;
+    }
+
+    @Override
+    public Nonce issueNonce(UUID daId) {
+        byte[] bytes = new byte[NONCE_BYTES];
+        secureRandom.nextBytes(bytes);
+        String value = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+        Instant expiresAt = Instant.now().plusSeconds(props.getAttestation().getNonceTtlSeconds());
+        pending.put(value, new Pending(daId, expiresAt));
+        sweepExpired();
+        return new Nonce(value, expiresAt);
+    }
+
+    @Override
+    public AttestationVerdict verify(UUID daId, String nonce, String integrityToken) {
+        if (nonce == null || nonce.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Missing nonce");
+        }
+        Pending p = pending.remove(nonce); // single-use: consumed whether or not it verifies
+        if (p == null) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Unknown or already-used nonce");
+        }
+        if (p.expiresAt().isBefore(Instant.now())) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Nonce expired");
+        }
+        if (!p.daId().equals(daId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Nonce was issued to a different DA");
+        }
+        return verifier.verify(integrityToken, nonce);
+    }
+
+    private void sweepExpired() {
+        Instant now = Instant.now();
+        pending.values().removeIf(p -> p.expiresAt().isBefore(now));
+    }
+
+    private record Pending(UUID daId, Instant expiresAt) {}
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/GpsPlausibilityServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/GpsPlausibilityServiceImpl.java
@@ -1,0 +1,72 @@
+package com.oneday.dispatch.service.impl;
+
+import com.oneday.dispatch.config.DispatchProperties;
+import com.oneday.dispatch.domain.DaGpsPing;
+import com.oneday.dispatch.repository.DaGpsPingRepository;
+import com.oneday.dispatch.service.GpsPlausibilityService;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Combines the ping's self-reported signals with server-derived checks (§ location-trust Phase 1).
+ * Impossible-travel is measured against the DA's most recent stored fix; the mock flag and coordinate
+ * range are hard trust-breakers; timestamp skew and poor accuracy are softer contributors to the score.
+ * Risk weights are additive and capped at 100.
+ */
+@Service
+class GpsPlausibilityServiceImpl implements GpsPlausibilityService {
+
+    private static final int W_RANGE = 100;   // impossible coordinate — cannot be a real fix
+    private static final int W_MOCK = 60;     // device admits a mock provider
+    private static final int W_VELOCITY = 40; // teleport between fixes
+    private static final int W_SKEW = 30;     // device clock/timestamp implausible
+    private static final int W_ACCURACY = 15; // very poor fix — weak corroboration
+
+    private final DaGpsPingRepository pingRepository;
+    private final DispatchProperties props;
+
+    GpsPlausibilityServiceImpl(DaGpsPingRepository pingRepository, DispatchProperties props) {
+        this.pingRepository = pingRepository;
+        this.props = props;
+    }
+
+    @Override
+    public GpsPlausibility evaluate(UUID daId, double lat, double lon, Instant deviceTime,
+                                    Double accuracyM, Boolean mocked, Instant serverNow) {
+        DispatchProperties.Gps.Integrity cfg = props.getGps().getIntegrity();
+
+        boolean rangeValid = lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180;
+        boolean isMock = Boolean.TRUE.equals(mocked);
+        boolean lowAccuracy = accuracyM != null && accuracyM > cfg.getMaxAccuracyMeters();
+
+        boolean tsSkew = deviceTime != null
+                && Math.abs(Duration.between(deviceTime, serverNow).getSeconds())
+                        > cfg.getTimestampSkewToleranceSeconds();
+
+        boolean velocity = false;
+        if (rangeValid && deviceTime != null) {
+            DaGpsPing prev = pingRepository.findTopByDaIdOrderByRecordedAtDesc(daId);
+            if (prev != null) {
+                long dtSeconds = Duration.between(prev.getRecordedAt(), deviceTime).getSeconds();
+                if (dtSeconds > 0) {
+                    double km = GeoDistance.km(prev.getLat(), prev.getLon(), lat, lon);
+                    double kmph = km / (dtSeconds / 3600.0);
+                    velocity = kmph > cfg.getMaxSpeedKmph();
+                }
+            }
+        }
+
+        int score = 0;
+        if (!rangeValid) score += W_RANGE;
+        if (isMock) score += W_MOCK;
+        if (velocity) score += W_VELOCITY;
+        if (tsSkew) score += W_SKEW;
+        if (lowAccuracy) score += W_ACCURACY;
+        score = Math.min(score, 100);
+
+        return new GpsPlausibility(rangeValid, velocity, tsSkew, lowAccuracy, isMock, score);
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/IpReputationServiceImpl.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/IpReputationServiceImpl.java
@@ -1,0 +1,111 @@
+package com.oneday.dispatch.service.impl;
+
+import com.oneday.dispatch.config.DispatchProperties;
+import com.oneday.dispatch.service.IpReputationService;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * CIDR-based datacenter/VPN detection. Matches the client IP against a config-driven list of IPv4
+ * ranges (a small starter set of well-known cloud/VPN ASNs, extended via {@code dispatch.ip-reputation
+ * .datacenter-cidrs}). IPv6 and unparseable inputs are treated as clean — this is a soft signal, so
+ * a miss is safe. Bad CIDR entries are skipped, not fatal.
+ */
+@Service
+class IpReputationServiceImpl implements IpReputationService {
+
+    private final DispatchProperties props;
+    private volatile List<Cidr> parsed;
+
+    IpReputationServiceImpl(DispatchProperties props) {
+        this.props = props;
+    }
+
+    @Override
+    public IpReputation evaluate(String clientIp) {
+        DispatchProperties.IpReputation cfg = props.getIpReputation();
+        if (!cfg.isEnabled() || clientIp == null || clientIp.isBlank()) {
+            return IpReputation.clean();
+        }
+        long ip = parseIpv4(clientIp.trim());
+        if (ip < 0) {
+            return IpReputation.clean(); // IPv6 / unparseable — don't guess
+        }
+        for (Cidr c : cidrs(cfg)) {
+            if (c.contains(ip)) {
+                return new IpReputation(true, cfg.getRiskBump(), "datacenter/VPN IP");
+            }
+        }
+        return IpReputation.clean();
+    }
+
+    private List<Cidr> cidrs(DispatchProperties.IpReputation cfg) {
+        List<Cidr> local = parsed;
+        if (local == null) {
+            local = new ArrayList<>();
+            for (String raw : cfg.getDatacenterCidrs()) {
+                Cidr c = Cidr.parse(raw);
+                if (c != null) {
+                    local.add(c);
+                }
+            }
+            parsed = local;
+        }
+        return local;
+    }
+
+    /** Returns the 32-bit IPv4 as an unsigned long, or -1 if not a valid dotted-quad. */
+    static long parseIpv4(String s) {
+        String[] parts = s.split("\\.");
+        if (parts.length != 4) {
+            return -1;
+        }
+        long v = 0;
+        for (String p : parts) {
+            try {
+                int octet = Integer.parseInt(p);
+                if (octet < 0 || octet > 255) {
+                    return -1;
+                }
+                v = (v << 8) | octet;
+            } catch (NumberFormatException e) {
+                return -1;
+            }
+        }
+        return v;
+    }
+
+    /** An IPv4 CIDR block. */
+    record Cidr(long network, long mask) {
+        static Cidr parse(String raw) {
+            if (raw == null) {
+                return null;
+            }
+            String[] parts = raw.trim().split("/");
+            if (parts.length != 2) {
+                return null;
+            }
+            long base = parseIpv4(parts[0]);
+            if (base < 0) {
+                return null;
+            }
+            int bits;
+            try {
+                bits = Integer.parseInt(parts[1]);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+            if (bits < 0 || bits > 32) {
+                return null;
+            }
+            long mask = bits == 0 ? 0L : (0xFFFFFFFFL << (32 - bits)) & 0xFFFFFFFFL;
+            return new Cidr(base & mask, mask);
+        }
+
+        boolean contains(long ip) {
+            return (ip & mask) == network;
+        }
+    }
+}

--- a/dispatch/src/main/java/com/oneday/dispatch/service/impl/StubPlayIntegrityVerifier.java
+++ b/dispatch/src/main/java/com/oneday/dispatch/service/impl/StubPlayIntegrityVerifier.java
@@ -1,0 +1,38 @@
+package com.oneday.dispatch.service.impl;
+
+import com.oneday.dispatch.config.DispatchProperties;
+import com.oneday.dispatch.service.DeviceAttestationService.AttestationVerdict;
+import com.oneday.dispatch.service.PlayIntegrityVerifier;
+import org.springframework.stereotype.Component;
+
+/**
+ * Default, no-credential Play Integrity verifier. It cannot cryptographically verify a Google token
+ * (that needs the project's decryption key), so it returns an UNKNOWN verdict that PASSES — the app's
+ * own on-device checks are the real gate in dev. The production verifier (holding the Google key)
+ * swaps in as {@code @Primary} once {@code dispatch.attestation.enabled=true}. When enabled here with
+ * no real verifier present, it refuses to fake a PASS: it returns UNKNOWN/failed so a misconfiguration
+ * is visible rather than silently trusting every token.
+ */
+@Component
+class StubPlayIntegrityVerifier implements PlayIntegrityVerifier {
+
+    private final DispatchProperties props;
+
+    StubPlayIntegrityVerifier(DispatchProperties props) {
+        this.props = props;
+    }
+
+    @Override
+    public AttestationVerdict verify(String integrityToken, String expectedNonce) {
+        if (integrityToken == null || integrityToken.isBlank()) {
+            return new AttestationVerdict(false, "FAIL", "empty attestation token");
+        }
+        if (props.getAttestation().isEnabled()) {
+            // Attestation is switched on but no real Google verifier is wired — don't fake a pass.
+            return new AttestationVerdict(false, "UNKNOWN",
+                    "attestation enabled but no Play Integrity verifier configured");
+        }
+        // Dev/default: the nonce round-trip is exercised, verification deferred to the real verifier.
+        return new AttestationVerdict(true, "UNKNOWN", "stub verifier (attestation disabled)");
+    }
+}

--- a/dispatch/src/main/resources/db/migration/dispatch/V5_19__add_gps_integrity.sql
+++ b/dispatch/src/main/resources/db/migration/dispatch/V5_19__add_gps_integrity.sql
@@ -1,0 +1,19 @@
+-- M5 dispatch — location-trust hardening (Phase 1). Carry per-ping integrity signals on the append-only
+-- breadcrumb so a spoofed/implausible fix is detectable after the fact and can be excluded from
+-- attendance/tracking. All columns nullable: pings from an app build that predates this stay valid.
+--   mocked        : device reported the fix came from a mock-location provider (Android isMock)
+--   accuracy_m    : device-reported horizontal accuracy (m); wildly large = low-trust
+--   speed_mps     : device-reported speed (m/s), if any
+--   velocity_flag : server found an impossible jump from the previous fix (teleport)
+--   ts_skew_flag  : device fix time (recorded_at) is implausibly far from server receive time (created_at)
+--   risk_score    : 0-100 rollup of the signals above (higher = less trustworthy)
+ALTER TABLE da_gps_ping
+    ADD COLUMN mocked        BOOLEAN,
+    ADD COLUMN accuracy_m    DOUBLE PRECISION,
+    ADD COLUMN speed_mps     DOUBLE PRECISION,
+    ADD COLUMN velocity_flag BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN ts_skew_flag  BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN risk_score    INTEGER NOT NULL DEFAULT 0;
+
+-- Ops query: find a DA's low-trust fixes fast (attendance review / fraud triage).
+CREATE INDEX idx_da_gps_ping_risk ON da_gps_ping (da_id, recorded_at) WHERE risk_score > 0;

--- a/dispatch/src/test/java/com/oneday/dispatch/api/DaDispatchControllerTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/api/DaDispatchControllerTest.java
@@ -1,25 +1,32 @@
 package com.oneday.dispatch.api;
 
 import com.oneday.auth.security.AuthUserDetails;
+import com.oneday.dispatch.config.DispatchProperties;
 import com.oneday.dispatch.dto.request.GpsPingRequest;
 import com.oneday.dispatch.dto.request.HubHandoffRequest;
 import com.oneday.dispatch.dto.request.OtpVerifyRequest;
 import com.oneday.dispatch.service.DaStatusService;
 import com.oneday.dispatch.service.DaTaskService;
 import com.oneday.dispatch.service.DaTaskView;
+import com.oneday.dispatch.service.GpsPlausibilityService;
+import com.oneday.dispatch.service.GpsPlausibilityService.GpsPlausibility;
+import com.oneday.dispatch.service.GpsSample;
+import com.oneday.dispatch.service.IpReputationService;
+import com.oneday.dispatch.service.IpReputationService.IpReputation;
 import com.oneday.dispatch.service.OtpVerificationService;
+import org.springframework.mock.web.MockHttpServletRequest;
 import com.oneday.dispatch.domain.TaskStatus;
 import com.oneday.dispatch.domain.TaskType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.time.Instant;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
@@ -33,6 +40,7 @@ class DaDispatchControllerTest {
     private DaStatusService daStatusService;
     private DaTaskService daTaskService;
     private OtpVerificationService otpVerificationService;
+    private GpsPlausibilityService gpsPlausibilityService;
     private DaDispatchController controller;
 
     private final UUID da = UUID.randomUUID();
@@ -43,16 +51,25 @@ class DaDispatchControllerTest {
         daStatusService = mock(DaStatusService.class);
         daTaskService = mock(DaTaskService.class);
         otpVerificationService = mock(OtpVerificationService.class);
+        gpsPlausibilityService = mock(GpsPlausibilityService.class);
+        // Default: every fix is trusted, so attendance is not gated in the unrelated tests.
+        when(gpsPlausibilityService.evaluate(any(), anyDouble(), anyDouble(), any(), any(), any(), any()))
+                .thenReturn(new GpsPlausibility(true, false, false, false, false, 0));
+        IpReputationService ipReputationService = mock(IpReputationService.class);
+        when(ipReputationService.evaluate(any())).thenReturn(IpReputation.clean());
         controller = new DaDispatchController(daStatusService, daTaskService, otpVerificationService,
-                mock(com.oneday.dispatch.service.AttendanceService.class));
+                mock(com.oneday.dispatch.service.AttendanceService.class), gpsPlausibilityService,
+                ipReputationService, mock(com.oneday.dispatch.service.DeviceAttestationService.class),
+                new DispatchProperties());
         when(daTaskService.markEnRoute(any(), any())).thenReturn(sampleView());
     }
 
     @Test
     void gpsDelegatesAndReturns204() {
-        var resp = controller.gps(da, principal(da, "DELIVERY_ASSOCIATE"), new GpsPingRequest(12.9, 77.6, null));
+        var resp = controller.gps(da, principal(da, "DELIVERY_ASSOCIATE"),
+                new GpsPingRequest(12.9, 77.6, null, null, null, null), new MockHttpServletRequest());
         assertThat(resp.getStatusCode().value()).isEqualTo(204);
-        verify(daStatusService).updateGps(eq(da), eq(12.9), eq(77.6), any(Instant.class));
+        verify(daStatusService).updateGps(eq(da), any(GpsSample.class));
     }
 
     @Test

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/AttendanceServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/AttendanceServiceImplTest.java
@@ -143,6 +143,30 @@ class AttendanceServiceImplTest {
     }
 
     @Test
+    void checkIn_noCoords_fallbackPingFlaggedForTeleport_returns422() {
+        // No coords supplied → falls back to the last stored ping. That ping is a velocity (teleport)
+        // flag, so its hub position can't be trusted to back a check-in.
+        DaStatus da = new DaStatus();
+        da.setDaId(daId);
+        da.setCityId(cityId);
+        da.setShiftType("SHIFT_1");
+        when(daStatusRepository.findByDaId(daId)).thenReturn(Optional.of(da));
+        when(attendanceRepository.findByDaIdAndAttendanceDate(eq(daId), any())).thenReturn(Optional.empty());
+
+        DaGpsPing last = new DaGpsPing();
+        last.setDaId(daId);
+        last.setLat(HUB_LAT);
+        last.setLon(HUB_LON);
+        last.setRecordedAt(Instant.now());
+        last.setVelocityFlag(true); // teleport — untrusted even though it's sitting at the hub
+        when(daGpsPingRepository.findTopByDaIdOrderByRecordedAtDesc(daId)).thenReturn(last);
+
+        assertThatThrownBy(() -> service.checkIn(daId, null, null))
+                .hasMessageContaining("integrity check failed");
+        verify(attendanceRepository, never()).save(any());
+    }
+
+    @Test
     void today_present_returnsPresentEntry() {
         DaAttendance present = new DaAttendance();
         present.setDaId(daId);

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaIntegrityServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/DaIntegrityServiceImplTest.java
@@ -1,0 +1,98 @@
+package com.oneday.dispatch.service.impl;
+
+import com.oneday.common.port.DaDirectoryPort;
+import com.oneday.common.port.DaDirectoryPort.DaContact;
+import com.oneday.dispatch.config.DispatchProperties;
+import com.oneday.dispatch.domain.DaStatus;
+import com.oneday.dispatch.dto.response.DaIntegritySummary;
+import com.oneday.dispatch.repository.DaGpsPingRepository;
+import com.oneday.dispatch.repository.DaPingIntegrityAggregate;
+import com.oneday.dispatch.repository.DaStatusRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Triage: a mock-provider fix → RED, some flagged fixes → AMBER, clean → GREEN; worst-trust first, city-scoped. */
+class DaIntegrityServiceImplTest {
+
+    private final DaGpsPingRepository pingRepository = mock(DaGpsPingRepository.class);
+    private final DaStatusRepository daStatusRepository = mock(DaStatusRepository.class);
+    private final DaDirectoryPort daDirectory = mock(DaDirectoryPort.class);
+    private final DispatchProperties props = new DispatchProperties();
+    private final DaIntegrityServiceImpl service =
+            new DaIntegrityServiceImpl(pingRepository, daStatusRepository, daDirectory, props);
+
+    private final UUID cityA = UUID.randomUUID();
+    private final UUID cityB = UUID.randomUUID();
+
+    private DaPingIntegrityAggregate agg(UUID da, long total, long flagged, int maxRisk,
+                                         long mocked, long velocity, long skew) {
+        DaPingIntegrityAggregate a = mock(DaPingIntegrityAggregate.class);
+        when(a.getDaId()).thenReturn(da);
+        when(a.getTotal()).thenReturn(total);
+        when(a.getFlagged()).thenReturn(flagged);
+        when(a.getMaxRisk()).thenReturn(maxRisk);
+        when(a.getMockedCount()).thenReturn(mocked);
+        when(a.getVelocityCount()).thenReturn(velocity);
+        when(a.getSkewCount()).thenReturn(skew);
+        return a;
+    }
+
+    private void wireCity(UUID da, UUID city) {
+        DaStatus s = new DaStatus();
+        s.setDaId(da);
+        s.setCityId(city);
+        when(daStatusRepository.findByDaId(da)).thenReturn(Optional.of(s));
+    }
+
+    @Test
+    void triagesAndOrdersWorstFirst() {
+        UUID clean = UUID.randomUUID(), amber = UUID.randomUUID(), red = UUID.randomUUID();
+        wireCity(clean, cityA);
+        wireCity(amber, cityA);
+        wireCity(red, cityA);
+        // Build each projection mock standalone — a when(...) inside List.of(...) trips UnfinishedStubbing.
+        DaPingIntegrityAggregate cleanAgg = agg(clean, 100, 0, 0, 0, 0, 0);
+        DaPingIntegrityAggregate amberAgg = agg(amber, 100, 3, 40, 0, 3, 0);   // velocity flags, no mock → AMBER
+        DaPingIntegrityAggregate redAgg = agg(red, 100, 5, 60, 2, 0, 0);        // mock provider fixes → RED
+        when(pingRepository.aggregateIntegrityByDa(any(), any()))
+                .thenReturn(List.of(cleanAgg, amberAgg, redAgg));
+        when(daDirectory.contactsFor(any())).thenReturn(Map.of(
+                clean, new DaContact("Clean", "+91"),
+                amber, new DaContact("Amber", "+92"),
+                red, new DaContact("Red", "+93")));
+
+        List<DaIntegritySummary> out = service.summariesForDate(LocalDate.parse("2026-08-31"), null);
+
+        assertThat(out).hasSize(3);
+        assertThat(out.get(0).trustLevel()).isEqualTo("RED");
+        assertThat(out.get(1).trustLevel()).isEqualTo("AMBER");
+        assertThat(out.get(2).trustLevel()).isEqualTo("GREEN");
+        assertThat(out.get(0).mockedPings()).isEqualTo(2);
+    }
+
+    @Test
+    void cityScopeExcludesOtherCities() {
+        UUID mine = UUID.randomUUID(), other = UUID.randomUUID();
+        wireCity(mine, cityA);
+        wireCity(other, cityB);
+        DaPingIntegrityAggregate mineAgg = agg(mine, 10, 0, 0, 0, 0, 0);
+        DaPingIntegrityAggregate otherAgg = agg(other, 10, 0, 0, 0, 0, 0);
+        when(pingRepository.aggregateIntegrityByDa(any(), any()))
+                .thenReturn(List.of(mineAgg, otherAgg));
+        when(daDirectory.contactsFor(any())).thenReturn(Map.of(mine, new DaContact("Mine", "+91")));
+
+        List<DaIntegritySummary> out = service.summariesForDate(LocalDate.parse("2026-08-31"), cityA);
+
+        assertThat(out).extracting(DaIntegritySummary::daId).containsExactly(mine);
+    }
+}

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/DeviceAttestationServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/DeviceAttestationServiceImplTest.java
@@ -1,0 +1,55 @@
+package com.oneday.dispatch.service.impl;
+
+import com.oneday.dispatch.config.DispatchProperties;
+import com.oneday.dispatch.service.DeviceAttestationService.AttestationVerdict;
+import com.oneday.dispatch.service.DeviceAttestationService.Nonce;
+import com.oneday.dispatch.service.PlayIntegrityVerifier;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** The nonce is anti-replay: single-use, DA-bound, expiring — and only then is the token verified. */
+class DeviceAttestationServiceImplTest {
+
+    private final PlayIntegrityVerifier verifier = mock(PlayIntegrityVerifier.class);
+    private final DispatchProperties props = new DispatchProperties();
+    private final DeviceAttestationServiceImpl service = new DeviceAttestationServiceImpl(verifier, props);
+
+    private final UUID da = UUID.randomUUID();
+
+    @Test
+    void verify_consumesNonce_andDelegatesToVerifier() {
+        when(verifier.verify(eq("tok"), any())).thenReturn(new AttestationVerdict(true, "PASS", "ok"));
+        Nonce nonce = service.issueNonce(da);
+
+        AttestationVerdict v = service.verify(da, nonce.value(), "tok");
+        assertThat(v.passed()).isTrue();
+
+        // Single-use: replaying the same nonce is now rejected.
+        assertThatThrownBy(() -> service.verify(da, nonce.value(), "tok"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Unknown or already-used nonce");
+    }
+
+    @Test
+    void verify_rejectsNonceIssuedToAnotherDa() {
+        Nonce nonce = service.issueNonce(da);
+        assertThatThrownBy(() -> service.verify(UUID.randomUUID(), nonce.value(), "tok"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("different DA");
+    }
+
+    @Test
+    void verify_rejectsUnknownNonce() {
+        assertThatThrownBy(() -> service.verify(da, "never-issued", "tok"))
+                .isInstanceOf(ResponseStatusException.class);
+    }
+}

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/GpsPlausibilityServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/GpsPlausibilityServiceImplTest.java
@@ -1,0 +1,110 @@
+package com.oneday.dispatch.service.impl;
+
+import com.oneday.dispatch.config.DispatchProperties;
+import com.oneday.dispatch.domain.DaGpsPing;
+import com.oneday.dispatch.repository.DaGpsPingRepository;
+import com.oneday.dispatch.service.GpsPlausibilityService.GpsPlausibility;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The plausibility service turns one ping (plus the DA's previous fix) into a trust verdict: a real,
+ * in-range, coherent fix is trusted; a mock-provider fix, a teleport, a skewed clock, or an off-planet
+ * coordinate is not — and each contributes to the risk score.
+ */
+class GpsPlausibilityServiceImplTest {
+
+    private final DaGpsPingRepository pingRepository = mock(DaGpsPingRepository.class);
+    private final DispatchProperties props = new DispatchProperties();
+    private final GpsPlausibilityServiceImpl service = new GpsPlausibilityServiceImpl(pingRepository, props);
+
+    private final UUID da = UUID.randomUUID();
+    // Bengaluru hub-ish; server "now" == device time so no skew in the happy path.
+    private static final double LAT = 12.9716, LON = 77.5946;
+
+    private DaGpsPing prevAt(double lat, double lon, Instant t) {
+        DaGpsPing p = new DaGpsPing(da, lat, lon, t);
+        return p;
+    }
+
+    @Test
+    void cleanFix_isTrusted() {
+        when(pingRepository.findTopByDaIdOrderByRecordedAtDesc(da)).thenReturn(null);
+        Instant now = Instant.parse("2026-08-31T06:00:00Z");
+
+        GpsPlausibility v = service.evaluate(da, LAT, LON, now, 12.0, false, now);
+
+        assertThat(v.trusted()).isTrue();
+        assertThat(v.riskScore()).isZero();
+    }
+
+    @Test
+    void mockedFix_isUntrusted_andScored() {
+        when(pingRepository.findTopByDaIdOrderByRecordedAtDesc(da)).thenReturn(null);
+        Instant now = Instant.parse("2026-08-31T06:00:00Z");
+
+        GpsPlausibility v = service.evaluate(da, LAT, LON, now, 12.0, true, now);
+
+        assertThat(v.mocked()).isTrue();
+        assertThat(v.trusted()).isFalse();
+        assertThat(v.riskScore()).isGreaterThanOrEqualTo(60);
+    }
+
+    @Test
+    void teleport_flagsVelocity() {
+        Instant prevT = Instant.parse("2026-08-31T06:00:00Z");
+        // Previous fix in Delhi, current in Bengaluru ~1740km, 60s later → ~104000 km/h.
+        when(pingRepository.findTopByDaIdOrderByRecordedAtDesc(da))
+                .thenReturn(prevAt(28.6139, 77.2090, prevT));
+        Instant now = prevT.plusSeconds(60);
+
+        GpsPlausibility v = service.evaluate(da, LAT, LON, now, 12.0, false, now);
+
+        assertThat(v.velocityFlag()).isTrue();
+        assertThat(v.trusted()).isFalse();
+    }
+
+    @Test
+    void realisticDrive_doesNotFlagVelocity() {
+        Instant prevT = Instant.parse("2026-08-31T06:00:00Z");
+        // ~1km apart, 120s later → 30 km/h.
+        when(pingRepository.findTopByDaIdOrderByRecordedAtDesc(da))
+                .thenReturn(prevAt(12.9626, 77.5946, prevT));
+        Instant now = prevT.plusSeconds(120);
+
+        GpsPlausibility v = service.evaluate(da, LAT, LON, now, 12.0, false, now);
+
+        assertThat(v.velocityFlag()).isFalse();
+        assertThat(v.trusted()).isTrue();
+    }
+
+    @Test
+    void staleClock_flagsSkew() {
+        when(pingRepository.findTopByDaIdOrderByRecordedAtDesc(da)).thenReturn(null);
+        Instant deviceTime = Instant.parse("2026-08-31T06:00:00Z");
+        Instant serverNow = deviceTime.plusSeconds(600); // 10 min skew > 120s tolerance
+
+        GpsPlausibility v = service.evaluate(da, LAT, LON, deviceTime, 12.0, false, serverNow);
+
+        assertThat(v.tsSkewFlag()).isTrue();
+        assertThat(v.trusted()).isFalse();
+    }
+
+    @Test
+    void offPlanetCoordinate_isRangeInvalid() {
+        when(pingRepository.findTopByDaIdOrderByRecordedAtDesc(da)).thenReturn(null);
+        Instant now = Instant.parse("2026-08-31T06:00:00Z");
+
+        GpsPlausibility v = service.evaluate(da, 999.0, 999.0, now, 12.0, false, now);
+
+        assertThat(v.rangeValid()).isFalse();
+        assertThat(v.trusted()).isFalse();
+        assertThat(v.riskScore()).isEqualTo(100);
+    }
+}

--- a/dispatch/src/test/java/com/oneday/dispatch/service/impl/IpReputationServiceImplTest.java
+++ b/dispatch/src/test/java/com/oneday/dispatch/service/impl/IpReputationServiceImplTest.java
@@ -1,0 +1,52 @@
+package com.oneday.dispatch.service.impl;
+
+import com.oneday.dispatch.config.DispatchProperties;
+import com.oneday.dispatch.service.IpReputationService.IpReputation;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** CIDR matching for the soft VPN/datacenter signal: a listed range flags (with a bump); anything else, IPv6, or junk is clean. */
+class IpReputationServiceImplTest {
+
+    private final DispatchProperties props = new DispatchProperties();
+    private final IpReputationServiceImpl service = new IpReputationServiceImpl(props);
+
+    @Test
+    void datacenterIp_flagsWithBump() {
+        // 34.0.0.0/8 (Google Cloud) is in the starter list.
+        IpReputation r = service.evaluate("34.120.5.9");
+        assertThat(r.datacenter()).isTrue();
+        assertThat(r.riskBump()).isEqualTo(props.getIpReputation().getRiskBump());
+    }
+
+    @Test
+    void residentialIp_isClean() {
+        IpReputation r = service.evaluate("49.36.100.20"); // a typical Indian residential range, not listed
+        assertThat(r.datacenter()).isFalse();
+        assertThat(r.riskBump()).isZero();
+    }
+
+    @Test
+    void nullOrIpv6OrJunk_isClean() {
+        assertThat(service.evaluate(null).datacenter()).isFalse();
+        assertThat(service.evaluate("2001:db8::1").datacenter()).isFalse();
+        assertThat(service.evaluate("not-an-ip").datacenter()).isFalse();
+    }
+
+    @Test
+    void disabled_isAlwaysClean() {
+        props.getIpReputation().setEnabled(false);
+        assertThat(service.evaluate("34.120.5.9").datacenter()).isFalse();
+    }
+
+    @Test
+    void customCidr_matches() {
+        props.getIpReputation().setDatacenterCidrs(List.of("10.10.0.0/16"));
+        IpReputationServiceImpl svc = new IpReputationServiceImpl(props);
+        assertThat(svc.evaluate("10.10.5.5").datacenter()).isTrue();
+        assertThat(svc.evaluate("10.11.5.5").datacenter()).isFalse();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,9 @@
         <opencv.version>4.9.0-1.5.10</opencv.version>
         <!-- Override Spring Boot 3.2.5's managed versions to patched releases that clear the
              HIGH/CRITICAL CVEs flagged by Trivy. Same minor/patch lines (drop-in compatible):
-             tomcat 10.1.20 → 10.1.55 (CVE-2025-24813, CVE-2026-41293/43512/43515),
+             tomcat 10.1.20 → 10.1.59 (CVE-2025-24813, CVE-2026-41293/43512/43515,
+                 CVE-2026-65182/65905/68525 — security-constraint/DIGEST/FORM auth bypass;
+                 fixed in 10.1.58 but that patch was never published to Central, so use 10.1.59),
              spring-security 6.2.7 → 6.2.8 (CVE-2024-38827 case-sensitive auth bypass; latest 6.2.x),
              postgresql 42.6.x → 42.7.12 (CVE-2026-42198, CVE-2026-54291 SCRAM-SHA-256-PLUS downgrade),
              spring-framework 6.1.6 → 6.1.14 (path-traversal CVE-2024-38816/38819, DoS CVE-2024-38809),
@@ -61,7 +63,7 @@
              spring-framework CVE-2026-41842/41845/41850, micrometer CVE-2026-40984) are only fixed
              in the Spring Boot 3.4/3.5 lines (Framework 6.2/7.0) — deferred to a Boot major upgrade,
              tracked in .trivyignore. -->
-        <tomcat.version>10.1.55</tomcat.version>
+        <tomcat.version>10.1.59</tomcat.version>
         <spring-security.version>6.2.8</spring-security.version>
         <postgresql.version>42.7.12</postgresql.version>
         <spring-framework.version>6.1.14</spring-framework.version>


### PR DESCRIPTION
## DA driver-app anti-abuse / location-trust hardening — server side

Feature (v): protect the platform from a DA who cheats their location/attendance. **Hybrid risk-score posture** — hard-block only unambiguous cheats (mock-GPS/root/emulator/failed attestation), soft-flag the rest (VPN, teleport, clock-skew) for ops. This is 1 of 3 coordinated PRs (backend + [oneday-driver-app] + [oneday-web]).

### What's here (dispatch + auth)
- **P1 — GPS trust.** `GpsPingRequest` gains `mocked`/`accuracy`; `GpsPlausibilityService` scores every fix (mock provider, impossible-travel >150 km/h vs prior fix, timestamp skew >120s vs the **server** clock, off-planet coords, poor accuracy) → 0–100 `risk_score`. Every ping is stored on `da_gps_ping` with its flags (**V5_19**). Attendance (`onGpsFix` + manual check-in) now **refuses a mocked/untrusted fix** — closes fake-hub-attendance and client timestamp forgery.
- **P2 — Attestation.** Play Integrity: single-use DA-bound nonce + `PlayIntegrityVerifier` port + config-gated stub (`dispatch.attestation.*`). Endpoints `POST /dispatch/da/{id}/integrity/nonce|attest`. Real Google verification is a keyed follow-up (needs `GOOGLE_PLAY_INTEGRITY_*`).
- **P4 — Device binding.** `refresh_tokens.device_id` (**V1_17**), `X-Device-Id` bound at login + carried across rotation, config-gated single-active-device sweep (`godspeed.device-binding.*`, default OFF, DELIVERY_ASSOCIATE).
- **P5 — VPN/IP.** `IpReputationService` (config CIDR list `dispatch.ip-reputation.*`) adds a **soft** risk bump for datacenter/VPN client IPs — never blocks (hybrid).
- **P6 — Ops console.** `GET /dispatch/integrity/das?date=` → per-DA GREEN/AMBER/RED (ADMIN/STATION_MANAGER, city-scoped).

### Tests
`dispatch` **199** + `auth` **68** green; full app assembles; migrations apply on a fresh DB.

### Live evidence (fresh throwaway DB + running backend)
Mocked ping → stored **risk 100** and **zero** attendance rows (blocked). Ops console rendering live data:

![ops console](https://raw.githubusercontent.com/Sidarthapati/one_day_delivery/assets/disc2-screenshots/da-hardening/daabuse-01-integrity-console.png)

The client hard-block, proven live on the Android emulator with the real native modules (see the driver-app PR):

![block screen](https://raw.githubusercontent.com/Sidarthapati/one_day_delivery/assets/disc2-screenshots/da-hardening/daabuse-02-block-emulator.png)

### Notes for review
- Migration versions chosen above the shared-DB history to avoid collisions (`V5_19`, `V1_17`).
- All thresholds are config-driven; enforcement (holding payroll) stays a human decision per the hybrid posture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional device-bound login sessions with configurable single-device enforcement.
  * Added device attestation endpoints for verifying app and device integrity.
  * Added GPS trust evaluation using mock-location detection, accuracy, timestamp, travel speed, and network reputation.
  * Added integrity summaries with GREEN, AMBER, and RED trust levels for dispatch personnel.
* **Bug Fixes**
  * Attendance can now be blocked when stored location data shows integrity concerns.
* **Tests**
  * Added coverage for authentication sessions, attestation, GPS integrity, network reputation, attendance checks, and trust classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->