### PR TITLE
feat(cod): station DA-cash view + city-scoped reconcile (#191)

### DIFF
--- a/orders/src/main/java/com/oneday/orders/api/AdminCodController.java
+++ b/orders/src/main/java/com/oneday/orders/api/AdminCodController.java
@@ -2,17 +2,20 @@ package com.oneday.orders.api;
 
 import com.oneday.auth.security.AuthUserDetails;
 import com.oneday.orders.dto.AdminCodReconciliationRow;
+import com.oneday.orders.dto.AdminDaCashRow;
 import com.oneday.orders.dto.CodAccountBalanceResponse;
 import com.oneday.orders.dto.CodCashDepositResponse;
 import com.oneday.orders.dto.CodCollectionResponse;
 import com.oneday.orders.dto.CodRemittanceResponse;
 import com.oneday.orders.dto.CreateRemittanceRequest;
+import com.oneday.orders.dto.DaCodLedgerEntryResponse;
 import com.oneday.orders.dto.MarkRemittancePaidRequest;
 import com.oneday.orders.dto.ReconcileDepositRequest;
 import com.oneday.orders.domain.CodCollectionState;
 import com.oneday.orders.service.CodCashService;
 import com.oneday.orders.service.CodRemittanceService;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -36,12 +39,24 @@ import java.util.UUID;
 @RequestMapping("/api/v1/admin/cod")
 class AdminCodController {
 
+    private static final String STATION_MANAGER = "STATION_MANAGER";
+    private static final String ADMIN = "ADMIN";
+
     private final CodRemittanceService cod;
     private final CodCashService codCash;
 
     AdminCodController(CodRemittanceService cod, CodCashService codCash) {
         this.cod = cod;
         this.codCash = codCash;
+    }
+
+    /**
+     * The city a station manager is scoped to, or null for an ADMIN (who sees every city). The DA-cash
+     * endpoints below pass this to the service, which filters/enforces access by it.
+     */
+    private static String cityFilter(AuthUserDetails principal) {
+        return ADMIN.equals(principal.getUser().getRole().getName())
+                ? null : principal.getUser().getCityId();
     }
 
     /** Vendors that currently have a payout-available balance, largest first. */
@@ -100,30 +115,49 @@ class AdminCodController {
         return cod.payout(id);
     }
 
-    // ── DA cash reconciliation ───────────────────────────────────────────────────
+    // ── DA cash (station manager + admin) ─────────────────────────────────────────
 
-    /** Per-DA collected-vs-deposited cash, riders with the largest outstanding first. */
+    /** Every DA's live cash-in-hand, most-holding first. Station managers see their own city; admin, all. */
+    @GetMapping("/cash/da-balances")
+    public List<AdminDaCashRow> daBalances(@AuthenticationPrincipal AuthUserDetails principal) {
+        Authz.requireRole(principal, STATION_MANAGER);
+        return codCash.daCashBalances(cityFilter(principal));
+    }
+
+    /** One DA's cash-in-hand passbook (append-only, running balance), newest first. City-gated. */
+    @GetMapping("/cash/da/{daUserId}/ledger")
+    public List<DaCodLedgerEntryResponse> daLedger(
+            @AuthenticationPrincipal AuthUserDetails principal,
+            @PathVariable("daUserId") UUID daUserId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "50") int size) {
+        Authz.requireRole(principal, STATION_MANAGER);
+        int capped = Math.min(Math.max(1, size), 200);
+        return codCash.managerDaLedger(daUserId, PageRequest.of(Math.max(0, page), capped), cityFilter(principal));
+    }
+
+    /** Per-DA collected-vs-deposited cash + ledger balance, riders with the largest outstanding first. */
     @GetMapping("/cash/reconciliation")
     public List<AdminCodReconciliationRow> reconciliation(@AuthenticationPrincipal AuthUserDetails principal) {
-        Authz.requireRole(principal, "ADMIN");
+        Authz.requireRole(principal, STATION_MANAGER);
         return codCash.reconciliation();
     }
 
     /** Every declared cash deposit, newest first. */
     @GetMapping("/cash/deposits")
     public List<CodCashDepositResponse> deposits(@AuthenticationPrincipal AuthUserDetails principal) {
-        Authz.requireRole(principal, "ADMIN");
+        Authz.requireRole(principal, STATION_MANAGER);
         return codCash.allDeposits();
     }
 
-    /** Verify a deposit: matched → RECONCILED, else DISCREPANCY. PATCH (not idempotency-gated). */
+    /** Verify a deposit: matched → RECONCILED, else DISCREPANCY. PATCH (not idempotency-gated). City-gated. */
     @PatchMapping("/cash/deposits/{id}")
     public CodCashDepositResponse reconcile(
             @AuthenticationPrincipal AuthUserDetails principal,
             @PathVariable("id") UUID id,
             @Valid @RequestBody ReconcileDepositRequest request) {
-        Authz.requireRole(principal, "ADMIN");
-        UUID adminId = UUID.fromString(Authz.requireUserId(principal));
-        return codCash.reconcile(id, adminId, request.reconciled(), request.note());
+        Authz.requireRole(principal, STATION_MANAGER);
+        UUID actorId = UUID.fromString(Authz.requireUserId(principal));
+        return codCash.reconcile(id, actorId, request.reconciled(), request.note(), cityFilter(principal));
     }
 }

--- a/orders/src/main/java/com/oneday/orders/api/AdminCodController.java
+++ b/orders/src/main/java/com/oneday/orders/api/AdminCodController.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.UUID;
@@ -55,8 +56,16 @@ class AdminCodController {
      * endpoints below pass this to the service, which filters/enforces access by it.
      */
     private static String cityFilter(AuthUserDetails principal) {
-        return ADMIN.equals(principal.getUser().getRole().getName())
-                ? null : principal.getUser().getCityId();
+        if (ADMIN.equals(principal.getUser().getRole().getName())) {
+            return null; // admin sees every city
+        }
+        String cityId = principal.getUser().getCityId();
+        if (cityId == null) {
+            // Fail closed: a non-admin with no city assignment must not fall through to the null
+            // (= admin, unscoped) branch and read every city's cash.
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "No city is assigned to your account.");
+        }
+        return cityId;
     }
 
     /** Vendors that currently have a payout-available balance, largest first. */
@@ -140,14 +149,14 @@ class AdminCodController {
     @GetMapping("/cash/reconciliation")
     public List<AdminCodReconciliationRow> reconciliation(@AuthenticationPrincipal AuthUserDetails principal) {
         Authz.requireRole(principal, STATION_MANAGER);
-        return codCash.reconciliation();
+        return codCash.reconciliation(cityFilter(principal));
     }
 
     /** Every declared cash deposit, newest first. */
     @GetMapping("/cash/deposits")
     public List<CodCashDepositResponse> deposits(@AuthenticationPrincipal AuthUserDetails principal) {
         Authz.requireRole(principal, STATION_MANAGER);
-        return codCash.allDeposits();
+        return codCash.allDeposits(cityFilter(principal));
     }
 
     /** Verify a deposit: matched → RECONCILED, else DISCREPANCY. PATCH (not idempotency-gated). City-gated. */

--- a/orders/src/main/java/com/oneday/orders/dto/AdminCodReconciliationRow.java
+++ b/orders/src/main/java/com/oneday/orders/dto/AdminCodReconciliationRow.java
@@ -5,12 +5,18 @@ import java.util.UUID;
 /**
  * One row of the admin cash-reconciliation view: per delivery associate, the COD cash they were
  * expected to collect vs what they've handed in. {@code variancePaise} = collected − deposited
- * (positive ⇒ the DA still owes cash; negative ⇒ over-deposited, needs a look).
+ * (positive ⇒ the DA still owes cash; negative ⇒ over-deposited, needs a look). {@code cashInHandPaise}
+ * is the authoritative running balance from the append-only ledger (issue #191 — the variance view and
+ * the ledger read the same source; the two agree once opening balances are backfilled, see #185). Name
+ * / email are best-effort (null if the user record can't be resolved). Snake_case on the wire.
  */
 public record AdminCodReconciliationRow(
         UUID daUserId,
+        String daName,
+        String daEmail,
         long collectedCount,
         long collectedPaise,
         long depositedPaise,
-        long variancePaise) {
+        long variancePaise,
+        long cashInHandPaise) {
 }

--- a/orders/src/main/java/com/oneday/orders/dto/AdminDaCashRow.java
+++ b/orders/src/main/java/com/oneday/orders/dto/AdminDaCashRow.java
@@ -1,0 +1,19 @@
+package com.oneday.orders.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * One row of the station/admin "DA Cash" view: a delivery associate's live COD cash-in-hand (from the
+ * append-only ledger) plus who they are and when they last deposited. {@code cashInHandPaise} is the
+ * authoritative running balance; {@code lastDepositAt} is null if the DA has never deposited. Name /
+ * email / city are best-effort (null if the user record can't be resolved). Snake_case on the wire.
+ */
+public record AdminDaCashRow(
+        UUID daUserId,
+        String daName,
+        String daEmail,
+        String cityId,
+        long cashInHandPaise,
+        Instant lastDepositAt) {
+}

--- a/orders/src/main/java/com/oneday/orders/repository/CodCashDepositRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/CodCashDepositRepository.java
@@ -25,4 +25,8 @@ public interface CodCashDepositRepository extends JpaRepository<CodCashDeposit, 
     /** Distinct DAs that have declared at least one deposit. */
     @Query("SELECT DISTINCT d.daUserId FROM CodCashDeposit d")
     List<UUID> findDistinctDaIds();
+
+    /** When the DA last handed cash in — null if never (for the station DA-cash worklist, #191). */
+    @Query("SELECT MAX(d.createdAt) FROM CodCashDeposit d WHERE d.daUserId = :daUserId")
+    java.time.Instant lastDepositAt(@Param("daUserId") UUID daUserId);
 }

--- a/orders/src/main/java/com/oneday/orders/repository/DaCodBalanceRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/DaCodBalanceRepository.java
@@ -8,10 +8,14 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface DaCodBalanceRepository extends JpaRepository<DaCodBalance, UUID> {
+
+    /** Every DA's cash-in-hand, most-holding first — powers the station/admin DA-cash worklist (#191). */
+    List<DaCodBalance> findAllByOrderByCashInHandPaiseDesc();
 
     /**
      * Idempotently create the DA's balance row (zero) if it doesn't exist. Called before the locking

--- a/orders/src/main/java/com/oneday/orders/service/CodCashService.java
+++ b/orders/src/main/java/com/oneday/orders/service/CodCashService.java
@@ -45,11 +45,19 @@ public interface CodCashService {
      */
     List<DaCodLedgerEntryResponse> managerDaLedger(UUID daUserId, Pageable pageable, String cityFilter);
 
-    /** Per-DA collected-vs-deposited + authoritative ledger balance, riders with the largest outstanding first. */
-    List<AdminCodReconciliationRow> reconciliation();
+    /**
+     * Per-DA collected-vs-deposited + authoritative ledger balance, riders with the largest outstanding
+     * first. {@code cityFilter} scopes the list to one city (a station manager sees their own city);
+     * null = every city (admin). A DA whose city can't be resolved is hidden from a scoped manager.
+     */
+    List<AdminCodReconciliationRow> reconciliation(String cityFilter);
 
-    /** Every declared deposit, newest first. */
-    List<CodCashDepositResponse> allDeposits();
+    /**
+     * Every declared deposit, newest first. {@code cityFilter} scopes the list to one city (a station
+     * manager sees their own city); null = every city (admin). A deposit whose DA's city can't be
+     * resolved is hidden from a scoped manager.
+     */
+    List<CodCashDepositResponse> allDeposits(String cityFilter);
 
     /**
      * Manager/admin verdict on a deposit: matched → RECONCILED, else DISCREPANCY. {@code cityFilter}

--- a/orders/src/main/java/com/oneday/orders/service/CodCashService.java
+++ b/orders/src/main/java/com/oneday/orders/service/CodCashService.java
@@ -1,6 +1,7 @@
 package com.oneday.orders.service;
 
 import com.oneday.orders.dto.AdminCodReconciliationRow;
+import com.oneday.orders.dto.AdminDaCashRow;
 import com.oneday.orders.dto.CodCashDepositResponse;
 import com.oneday.orders.dto.DaCodCashSummaryResponse;
 import com.oneday.orders.dto.DaCodLedgerEntryResponse;
@@ -29,14 +30,31 @@ public interface CodCashService {
     /** A page of the DA's cash-in-hand ledger (append-only movement history), newest first. */
     List<DaCodLedgerEntryResponse> daLedger(UUID daUserId, Pageable pageable);
 
-    // ── Admin ─────────────────────────────────────────────────────────────────
+    // ── Station / Admin ─────────────────────────────────────────────────────────
 
-    /** Per-DA collected-vs-deposited, riders with the largest outstanding cash first. */
+    /**
+     * Every DA's live cash-in-hand for the station/admin worklist (#191), most-holding first.
+     * {@code cityFilter} scopes the list to one city (a station manager sees their own city); null =
+     * every city (admin).
+     */
+    List<AdminDaCashRow> daCashBalances(String cityFilter);
+
+    /**
+     * A page of one DA's cash-in-hand ledger for a manager/admin (#191). {@code cityFilter} enforces
+     * access — a manager scoped to a city can't read a DA in another city (403); null = admin, no gate.
+     */
+    List<DaCodLedgerEntryResponse> managerDaLedger(UUID daUserId, Pageable pageable, String cityFilter);
+
+    /** Per-DA collected-vs-deposited + authoritative ledger balance, riders with the largest outstanding first. */
     List<AdminCodReconciliationRow> reconciliation();
 
     /** Every declared deposit, newest first. */
     List<CodCashDepositResponse> allDeposits();
 
-    /** Admin verdict on a deposit: matched → RECONCILED, else DISCREPANCY. */
-    CodCashDepositResponse reconcile(UUID depositId, UUID adminId, boolean reconciled, String note);
+    /**
+     * Manager/admin verdict on a deposit: matched → RECONCILED, else DISCREPANCY. {@code cityFilter}
+     * enforces access — a manager can only reconcile a deposit whose DA is in their city (403); null =
+     * admin, no gate.
+     */
+    CodCashDepositResponse reconcile(UUID depositId, UUID actorId, boolean reconciled, String note, String cityFilter);
 }

--- a/orders/src/main/java/com/oneday/orders/service/impl/CodCashServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/CodCashServiceImpl.java
@@ -133,30 +133,44 @@ class CodCashServiceImpl implements CodCashService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<AdminCodReconciliationRow> reconciliation() {
+    public List<AdminCodReconciliationRow> reconciliation(String cityFilter) {
         // Union of DAs that collected cash and DAs that declared deposits.
         Set<UUID> das = new LinkedHashSet<>(collections.findDasWithCollectedCash());
         das.addAll(deposits.findDistinctDaIds());
         return das.stream()
                 .map(da -> {
+                    UserResponse u = tryGetUser(da);
+                    // A city-scoped manager only sees their own city's riders; a DA whose city can't be
+                    // resolved is hidden from a scoped manager (fail-closed) but shown to admin.
+                    if (cityFilter != null && (u == null || !cityFilter.equals(u.cityId()))) {
+                        return null;
+                    }
                     long collected = collections.sumCollectedByDa(da);
                     long count = collections.countCollectedByDa(da);
                     long deposited = deposits.sumDepositedByDa(da);
-                    UserResponse u = tryGetUser(da);
                     return new AdminCodReconciliationRow(da,
                             u == null ? null : u.name(),
                             u == null ? null : u.email(),
                             count, collected, deposited, collected - deposited,
                             codLedger.cashInHand(da));
                 })
+                .filter(java.util.Objects::nonNull)
                 .sorted(Comparator.comparingLong(AdminCodReconciliationRow::variancePaise).reversed())
                 .toList();
     }
 
     @Override
     @Transactional(readOnly = true)
-    public List<CodCashDepositResponse> allDeposits() {
+    public List<CodCashDepositResponse> allDeposits(String cityFilter) {
+        // Resolve each DA's city at most once; a deposit whose DA isn't in the manager's city (or
+        // can't be resolved) is hidden from a scoped manager but shown to admin (null filter).
+        java.util.Map<UUID, Boolean> inCity = new java.util.HashMap<>();
         return deposits.findAllByOrderByCreatedAtDesc().stream()
+                .filter(d -> cityFilter == null
+                        || inCity.computeIfAbsent(d.getDaUserId(), id -> {
+                            UserResponse u = tryGetUser(id);
+                            return u != null && cityFilter.equals(u.cityId());
+                        }))
                 .map(CodCashDepositResponse::from).toList();
     }
 

--- a/orders/src/main/java/com/oneday/orders/service/impl/CodCashServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/CodCashServiceImpl.java
@@ -1,15 +1,21 @@
 package com.oneday.orders.service.impl;
 
+import com.oneday.auth.dto.response.UserResponse;
+import com.oneday.auth.exception.UserNotFoundException;
+import com.oneday.auth.service.UserService;
 import com.oneday.orders.domain.CodCashDeposit;
 import com.oneday.orders.domain.CodCashDepositState;
+import com.oneday.orders.domain.DaCodBalance;
 import com.oneday.orders.domain.DaCodLedgerType;
 import com.oneday.orders.dto.AdminCodReconciliationRow;
+import com.oneday.orders.dto.AdminDaCashRow;
 import com.oneday.orders.dto.CodCashDepositResponse;
 import com.oneday.orders.dto.DaCodCashSummaryResponse;
 import com.oneday.orders.dto.DaCodLedgerEntryResponse;
 import com.oneday.orders.dto.RecordCodDepositRequest;
 import com.oneday.orders.repository.CodCashDepositRepository;
 import com.oneday.orders.repository.CodCollectionRepository;
+import com.oneday.orders.repository.DaCodBalanceRepository;
 import com.oneday.orders.service.CodCashService;
 import com.oneday.orders.service.CodLedgerService;
 import org.springframework.data.domain.Pageable;
@@ -34,12 +40,17 @@ class CodCashServiceImpl implements CodCashService {
     private final CodCashDepositRepository deposits;
     private final CodCollectionRepository collections;
     private final CodLedgerService codLedger;
+    private final DaCodBalanceRepository balances;
+    private final UserService userService;
 
     CodCashServiceImpl(CodCashDepositRepository deposits, CodCollectionRepository collections,
-                       CodLedgerService codLedger) {
+                       CodLedgerService codLedger, DaCodBalanceRepository balances,
+                       UserService userService) {
         this.deposits = deposits;
         this.collections = collections;
         this.codLedger = codLedger;
+        this.balances = balances;
+        this.userService = userService;
     }
 
     @Override
@@ -95,6 +106,33 @@ class CodCashServiceImpl implements CodCashService {
 
     @Override
     @Transactional(readOnly = true)
+    public List<AdminDaCashRow> daCashBalances(String cityFilter) {
+        return balances.findAllByOrderByCashInHandPaiseDesc().stream()
+                .map(b -> {
+                    UserResponse u = tryGetUser(b.getDaUserId());
+                    return new AdminDaCashRow(
+                            b.getDaUserId(),
+                            u == null ? null : u.name(),
+                            u == null ? null : u.email(),
+                            u == null ? null : u.cityId(),
+                            b.getCashInHandPaise(),
+                            deposits.lastDepositAt(b.getDaUserId()));
+                })
+                // A city-scoped manager only sees their own city's riders; a DA whose city can't be
+                // resolved is hidden from a scoped manager (can't confirm they belong) but shown to admin.
+                .filter(row -> cityFilter == null || cityFilter.equals(row.cityId()))
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<DaCodLedgerEntryResponse> managerDaLedger(UUID daUserId, Pageable pageable, String cityFilter) {
+        assertCityAccess(daUserId, cityFilter);
+        return codLedger.history(daUserId, pageable);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public List<AdminCodReconciliationRow> reconciliation() {
         // Union of DAs that collected cash and DAs that declared deposits.
         Set<UUID> das = new LinkedHashSet<>(collections.findDasWithCollectedCash());
@@ -104,7 +142,12 @@ class CodCashServiceImpl implements CodCashService {
                     long collected = collections.sumCollectedByDa(da);
                     long count = collections.countCollectedByDa(da);
                     long deposited = deposits.sumDepositedByDa(da);
-                    return new AdminCodReconciliationRow(da, count, collected, deposited, collected - deposited);
+                    UserResponse u = tryGetUser(da);
+                    return new AdminCodReconciliationRow(da,
+                            u == null ? null : u.name(),
+                            u == null ? null : u.email(),
+                            count, collected, deposited, collected - deposited,
+                            codLedger.cashInHand(da));
                 })
                 .sorted(Comparator.comparingLong(AdminCodReconciliationRow::variancePaise).reversed())
                 .toList();
@@ -119,15 +162,40 @@ class CodCashServiceImpl implements CodCashService {
 
     @Override
     @Transactional
-    public CodCashDepositResponse reconcile(UUID depositId, UUID adminId, boolean reconciled, String note) {
+    public CodCashDepositResponse reconcile(UUID depositId, UUID actorId, boolean reconciled, String note,
+                                            String cityFilter) {
         CodCashDeposit d = deposits.findById(depositId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Deposit not found"));
+        assertCityAccess(d.getDaUserId(), cityFilter);
         d.setStatus(reconciled ? CodCashDepositState.RECONCILED : CodCashDepositState.DISCREPANCY);
-        d.setReconciledBy(adminId);
+        d.setReconciledBy(actorId);
         d.setReconciledAt(Instant.now());
         if (note != null && !note.isBlank()) {
             d.setNote(note.trim());
         }
         return CodCashDepositResponse.from(deposits.save(d));
+    }
+
+    /** Resolve a user to name/email/city, or null if the record isn't found. Best-effort enrichment. */
+    private UserResponse tryGetUser(UUID userId) {
+        try {
+            return userService.getUser(userId);
+        } catch (UserNotFoundException e) {
+            return null;
+        }
+    }
+
+    /**
+     * A city-scoped manager may only act on a DA in their own city. {@code cityFilter} null ⇒ admin,
+     * no gate. A DA whose city can't be resolved is refused to a scoped manager (fail-closed).
+     */
+    private void assertCityAccess(UUID daUserId, String cityFilter) {
+        if (cityFilter == null) {
+            return;
+        }
+        UserResponse u = tryGetUser(daUserId);
+        if (u == null || !cityFilter.equals(u.cityId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "This delivery associate isn't in your city.");
+        }
     }
 }

--- a/orders/src/test/java/com/oneday/orders/service/impl/CodCashServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/CodCashServiceImplTest.java
@@ -180,11 +180,46 @@ class CodCashServiceImplTest {
         when(codLedger.cashInHand(da)).thenReturn(300L);
         when(userService.getUser(da)).thenReturn(user(da, "BLR"));
 
-        var rows = service().reconciliation();
+        var rows = service().reconciliation(null); // admin: every city
         assertThat(rows).singleElement().satisfies(r -> {
             assertThat(r.variancePaise()).isEqualTo(300L);       // collected − deposited
             assertThat(r.cashInHandPaise()).isEqualTo(300L);     // authoritative ledger balance
             assertThat(r.daName()).isEqualTo("DA BLR");
         });
+    }
+
+    @Test
+    void reconciliation_scopedManager_hidesOtherCities() {
+        UUID blr = UUID.randomUUID();
+        UUID del = UUID.randomUUID();
+        when(collections.findDasWithCollectedCash()).thenReturn(List.of(blr, del));
+        when(deposits.findDistinctDaIds()).thenReturn(List.of());
+        when(collections.sumCollectedByDa(any())).thenReturn(1000L);
+        when(collections.countCollectedByDa(any())).thenReturn(1L);
+        when(deposits.sumDepositedByDa(any())).thenReturn(0L);
+        when(codLedger.cashInHand(any())).thenReturn(1000L);
+        when(userService.getUser(blr)).thenReturn(user(blr, "BLR"));
+        when(userService.getUser(del)).thenReturn(user(del, "DEL"));
+
+        var rows = service().reconciliation("BLR"); // manager scoped to BLR sees only BLR's rider
+        assertThat(rows).singleElement()
+                .satisfies(r -> assertThat(r.daUserId()).isEqualTo(blr));
+    }
+
+    @Test
+    void allDeposits_scopedManager_hidesOtherCities() {
+        UUID blr = UUID.randomUUID();
+        UUID del = UUID.randomUUID();
+        CodCashDeposit inCity = new CodCashDeposit();
+        inCity.setDaUserId(blr);
+        CodCashDeposit otherCity = new CodCashDeposit();
+        otherCity.setDaUserId(del);
+        when(deposits.findAllByOrderByCreatedAtDesc()).thenReturn(List.of(inCity, otherCity));
+        when(userService.getUser(blr)).thenReturn(user(blr, "BLR"));
+        when(userService.getUser(del)).thenReturn(user(del, "DEL"));
+
+        var rows = service().allDeposits("BLR"); // manager scoped to BLR
+        assertThat(rows).singleElement()
+                .satisfies(r -> assertThat(r.daUserId()).isEqualTo(blr));
     }
 }

--- a/orders/src/test/java/com/oneday/orders/service/impl/CodCashServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/CodCashServiceImplTest.java
@@ -1,39 +1,66 @@
 package com.oneday.orders.service.impl;
 
+import com.oneday.auth.dto.response.UserResponse;
+import com.oneday.auth.exception.UserNotFoundException;
+import com.oneday.auth.service.UserService;
 import com.oneday.orders.domain.CodCashDeposit;
 import com.oneday.orders.domain.CodCashDepositState;
+import com.oneday.orders.domain.DaCodBalance;
+import com.oneday.orders.dto.AdminDaCashRow;
 import com.oneday.orders.dto.CodCashDepositResponse;
 import com.oneday.orders.dto.RecordCodDepositRequest;
 import com.oneday.orders.domain.DaCodLedgerType;
 import com.oneday.orders.repository.CodCashDepositRepository;
 import com.oneday.orders.repository.CodCollectionRepository;
+import com.oneday.orders.repository.DaCodBalanceRepository;
 import com.oneday.orders.service.CodLedgerService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-/** Guards the COD deposit dedup fix (vuln-0012): a repeated (DA, deposit_ref) submit is idempotent. */
+/**
+ * Guards the COD deposit dedup fix (vuln-0012 — a repeated (DA, deposit_ref) submit is idempotent) and
+ * the station DA-cash view + city-scoping (#191).
+ */
 @ExtendWith(MockitoExtension.class)
 class CodCashServiceImplTest {
 
     @Mock private CodCashDepositRepository deposits;
     @Mock private CodCollectionRepository collections;
     @Mock private CodLedgerService codLedger;
+    @Mock private DaCodBalanceRepository balances;
+    @Mock private UserService userService;
 
     private CodCashServiceImpl service() {
-        return new CodCashServiceImpl(deposits, collections, codLedger);
+        return new CodCashServiceImpl(deposits, collections, codLedger, balances, userService);
+    }
+
+    private static DaCodBalance balance(UUID da, long paise) {
+        DaCodBalance b = new DaCodBalance();
+        b.setDaUserId(da);
+        b.setCashInHandPaise(paise);
+        return b;
+    }
+
+    private static UserResponse user(UUID id, String city) {
+        return new UserResponse(id, id + "@1dd.in", "DA " + city, "DELIVERY_ASSOCIATE", city, true);
     }
 
     @Test
@@ -71,5 +98,93 @@ class CodCashServiceImplTest {
         verify(deposits).saveAndFlush(any(CodCashDeposit.class));
         // A new deposit posts a negative (DEPOSIT) movement to the DA's cash-in-hand ledger.
         verify(codLedger).post(eq(da), eq(DaCodLedgerType.DEPOSIT), eq(-700L), eq("REF-2"), any(), eq(da));
+    }
+
+    // ── #191 station DA-cash view + city scoping ──────────────────────────────────
+
+    @Test
+    void daCashBalances_enrichesAndHonoursCityFilter() {
+        UUID blrDa = UUID.randomUUID();
+        UUID delDa = UUID.randomUUID();
+        // Repo already returns most-holding-first; the service preserves that order.
+        when(balances.findAllByOrderByCashInHandPaiseDesc())
+                .thenReturn(List.of(balance(blrDa, 50000L), balance(delDa, 30000L)));
+        when(userService.getUser(blrDa)).thenReturn(user(blrDa, "BLR"));
+        lenient().when(userService.getUser(delDa)).thenReturn(user(delDa, "DEL"));
+        lenient().when(deposits.lastDepositAt(any())).thenReturn(null);
+
+        // A BLR-scoped manager sees only the BLR rider.
+        List<AdminDaCashRow> scoped = service().daCashBalances("BLR");
+        assertThat(scoped).extracting(AdminDaCashRow::daUserId).containsExactly(blrDa);
+        assertThat(scoped.get(0).cashInHandPaise()).isEqualTo(50000L);
+        assertThat(scoped.get(0).daEmail()).isEqualTo(blrDa + "@1dd.in");
+
+        // Admin (null filter) sees both, still ordered by cash desc.
+        List<AdminDaCashRow> all = service().daCashBalances(null);
+        assertThat(all).extracting(AdminDaCashRow::daUserId).containsExactly(blrDa, delDa);
+    }
+
+    @Test
+    void daCashBalances_scopedManager_doesNotSeeUnresolvableDa() {
+        UUID ghostDa = UUID.randomUUID();
+        when(balances.findAllByOrderByCashInHandPaiseDesc()).thenReturn(List.of(balance(ghostDa, 10000L)));
+        when(userService.getUser(ghostDa)).thenThrow(new UserNotFoundException("gone"));
+
+        // Fail-closed: a rider whose city can't be resolved is hidden from a city-scoped manager…
+        assertThat(service().daCashBalances("BLR")).isEmpty();
+    }
+
+    @Test
+    void managerDaLedger_crossCity_forbidden_butAdminAndSameCityPass() {
+        UUID da = UUID.randomUUID();
+        when(userService.getUser(da)).thenReturn(user(da, "BLR"));
+        lenient().when(codLedger.history(eq(da), any())).thenReturn(List.of());
+        var page = PageRequest.of(0, 50);
+
+        // A DEL manager reading a BLR rider → 403.
+        assertThatThrownBy(() -> service().managerDaLedger(da, page, "DEL"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("your city");
+
+        // Same-city manager and admin (null filter) both pass through to the ledger.
+        service().managerDaLedger(da, page, "BLR");
+        service().managerDaLedger(da, page, null);
+        verify(codLedger, org.mockito.Mockito.times(2)).history(eq(da), any());
+    }
+
+    @Test
+    void reconcile_crossCityManager_forbidden() {
+        UUID da = UUID.randomUUID();
+        UUID depositId = UUID.randomUUID();
+        CodCashDeposit d = new CodCashDeposit();
+        d.setDaUserId(da);
+        when(deposits.findById(depositId)).thenReturn(Optional.of(d));
+        when(userService.getUser(da)).thenReturn(user(da, "BLR"));
+
+        assertThatThrownBy(() -> service().reconcile(depositId, UUID.randomUUID(), true, null, "DEL"))
+                .isInstanceOf(ResponseStatusException.class);
+        // The reconcile must be rejected BEFORE the verdict is applied — status stays DEPOSITED, not
+        // flipped to RECONCILED/DISCREPANCY, and nothing is persisted.
+        assertThat(d.getStatus()).isEqualTo(CodCashDepositState.DEPOSITED);
+        verify(deposits, never()).save(any());
+    }
+
+    @Test
+    void reconciliation_rowCarriesLedgerCashInHand() {
+        UUID da = UUID.randomUUID();
+        when(collections.findDasWithCollectedCash()).thenReturn(List.of(da));
+        when(deposits.findDistinctDaIds()).thenReturn(List.of());
+        when(collections.sumCollectedByDa(da)).thenReturn(4300L);
+        when(collections.countCollectedByDa(da)).thenReturn(2L);
+        when(deposits.sumDepositedByDa(da)).thenReturn(4000L);
+        when(codLedger.cashInHand(da)).thenReturn(300L);
+        when(userService.getUser(da)).thenReturn(user(da, "BLR"));
+
+        var rows = service().reconciliation();
+        assertThat(rows).singleElement().satisfies(r -> {
+            assertThat(r.variancePaise()).isEqualTo(300L);       // collected − deposited
+            assertThat(r.cashInHandPaise()).isEqualTo(300L);     // authoritative ledger balance
+            assertThat(r.daName()).isEqualTo("DA BLR");
+        });
     }
 }


### PR DESCRIPTION
Implements #191 (backend). Surfaces the per-DA COD cash-in-hand ledger (#184, DA-app-facing only) to **station managers and admins**.

## What a manager can now do
See every rider's live cash-in-hand and drill into any rider's passbook — the daily "who's holding how much, and does it reconcile" view.

## New endpoints (STATION_MANAGER + ADMIN)
- `GET /api/v1/admin/cod/cash/da-balances` — every DA's cash-in-hand (from the ledger balance row), most-holding first, enriched with name / email / last-deposit-at.
- `GET /api/v1/admin/cod/cash/da/{daUserId}/ledger` — one DA's append-only passbook, paginated (size capped 200).

## City scoping
A station manager only sees / acts on DAs in **their own city** (resolved via `UserService.getUser(daUserId).cityId()`); an **ADMIN** sees all cities. Cross-city read/reconcile → **403**; a DA whose city can't be resolved is **fail-closed** for a scoped manager.

## Also
- Widened the existing reconcile `PATCH` + reconciliation/deposits `GET`s from ADMIN-only to **STATION_MANAGER + ADMIN** (managers do the daily cash close — confirmed with product).
- `reconciliation()` now carries the authoritative ledger `cash_in_hand_paise` (issue acceptance: variance view and ledger read the **same source**) and enriches rows with DA name/email (were bare UUIDs).

## No migration
Reuses #184's `da_cod_balance` / `da_cod_ledger` tables.

## Verified
`CodCashServiceImplTest` (7 green) + live: SMblr (BLR) sees DAblr ₹500 & its passbook; a DEL manager gets 0 rows + 403 on DAblr's ledger; admin sees all.

Web PR (station "DA Cash" page): PENDING#PENDING

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cash-balance views for delivery associates, including identity, city, cash-in-hand amount, and latest deposit time.
  * Added paginated cash-ledger access for station managers.
  * Enabled station managers to reconcile and verify deposits within their permitted city.
  * Reconciliation details now include delivery associate names, email addresses, and ledger-based cash balances.
* **Bug Fixes**
  * Improved access controls to prevent cross-city ledger, reconciliation, and deposit access.
  * Users without an assigned city are denied access.
  * Unknown delivery associates are safely excluded from city-scoped results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### 📘 Walkthrough — business example + technical implementation
A visual explainer (Bangalore-vs-Delhi cash story, before/after leak diagram, and the JWT→cityFilter→service request path): https://claude.ai/code/artifact/7e2ac6dc-2e69-448d-8b91-20775e956752
