### PR TITLE
feat(b2b): per-member spend budget + membership-based booking (D3-vi)

### DIFF
--- a/docs/B2B/MEMBER-BUDGET-SCOPE.md
+++ b/docs/B2B/MEMBER-BUDGET-SCOPE.md
@@ -1,0 +1,85 @@
+# Discussion-3 (vi) — Per-user RBAC + per-member budget: scope
+
+_Branch `feat/b2b-member-budget`. Scopes the **budget check** first (the concrete, enforceable half); role expansion is a lighter companion, noted at the end._
+
+## The decisive finding: members can't book today
+
+All B2B bookings funnel through **one** method — `B2bBookingServiceImpl.book()` — from every entry point:
+- single shipment: `B2bShipmentController:63`
+- cart checkout: `CartServiceImpl:234` (one `book()` per item, caller = `cart.userId`)
+- order repair: `OrderRepairServiceImpl:80`
+
+And that method enforces **owner-only** access:
+
+```java
+// B2bBookingServiceImpl:141-146
+if (account.getOwnerUserId() == null || !account.getOwnerUserId().toString().equals(userId)) {
+    throw new AccountAccessException("Caller is not authorized for B2B account: " + ...);
+}
+```
+
+The membership table (`b2b_account_member`, `V4_44`, built in Discussion-2 xii) **is never consulted in the booking path** — booking checks `b2b_accounts.owner_user_id` only. So a MEMBER cannot book at all today. The split doc's "any member draws the account credit" is aspirational; the code blocks non-owners.
+
+**Consequence:** a per-member budget is meaningless until members can book. So (vi) is two parts, in order.
+
+---
+
+## Part A — precondition: membership-based booking authorization
+
+Replace the owner-only guard in `book()` with a membership check (the single chokepoint covers all three entry points):
+
+- Resolve the caller's membership: `B2bAccountMemberRepository.findByB2bAccountIdAndUserId(accountId, userId)` (already exists).
+- **Allow** if the caller is an OWNER **or** MEMBER of the account; **fail closed** (`AccountAccessException`, 403) otherwise. The owner still works — the `V4_44` backfill made every owner an `OWNER` member row.
+- Keep the null-safety of the current guard (no membership row → reject).
+
+This is a behaviour change (members gain booking) — call it out in the PR; it's what makes budgets enforceable.
+
+## Part B — per-member budget (the check itself)
+
+### Data
+`V4_51__b2b_member_spend_limit.sql` — one nullable column on `b2b_account_member`:
+
+```sql
+ALTER TABLE b2b_account_member ADD COLUMN spend_limit_paise BIGINT;  -- NULL = unlimited
+```
+Mirror it on `B2bAccountMember` (a `Long spendLimitPaise`, same style as the existing `kycStatus` field).
+
+**No running-counter column.** Spend is summed on demand (below) — that avoids a period-reset job and cancel/refund reversal bookkeeping. Add a counter only if the sum query ever measures as a hotspot (it won't at pilot volume). `// ponytail: sum-on-check, add a counter if booking QPS ever makes the SELECT-sum hurt`.
+
+### The check (inside the existing booking TX)
+In `persistB2b`, right beside the credit check (`:239-248`), after the account is locked `findByIdForUpdate`:
+
+1. Load the caller's member row **`FOR UPDATE`** (new `B2bAccountMemberRepository.findByAccountAndUserForUpdate`) so a member's concurrent bookings serialize on the budget — mirrors the account-row lock pattern already used for credit.
+2. If `spendLimitPaise == null` → no cap, skip (OWNER, or a member with no limit set).
+3. Else compute this-period spend + this booking and gate:
+   ```java
+   long spent = shipmentRepository.sumMemberSpendSince(userId, periodStart); // non-cancelled totals
+   if (spent + quote.totalPricePaise() > member.getSpendLimitPaise())
+       throw new MemberBudgetExceededException(...); // new, maps to 402
+   ```
+4. New repo query: `sumMemberSpendSince(UUID bookedByUserId, Instant since)` → `SUM(total_price_paise)` over shipments where `booked_by_user_id = ?` and `created_at >= ?` and `state <> 'CANCELLED'`. `bookedByUserId` is already persisted on every shipment (`:300`); no new write.
+
+### Basis, exemptions, semantics (decisions baked in)
+- **Basis** = `quote.totalPricePaise()` — the shipping charge, same basis as the credit check. **COD amount is not counted** (it's buyer→vendor money, not the member's spend).
+- **Budget is independent of account credit** — both must pass: a member can be blocked by their own limit while the account still has credit (this is the whole point). Order: member-budget check, then the existing account-credit check.
+- **Exempt:** OWNER and any member with `spend_limit_paise = NULL` (unlimited). Budget bites only when a limit is set.
+- **Period = calendar month** (see open question — the one real decision).
+
+### Admin + web
+- `MembersController` / `B2bMemberService`: set/clear a member's `spend_limit_paise` (owner-only, existing owner guard on member admin).
+- `MemberResponse`: surface `spendLimitPaise` + `spentThisPeriodPaise` + `remainingPaise`.
+- `oneday-web` business **team** page: a budget field per member + "₹X of ₹Y used" surface. Typecheck `@oneday/business`.
+
+---
+
+## Decisions (resolved)
+- **Budget period = calendar month.** The limit is per calendar month; sum-on-check enforces it with `created_at >= start-of-month` (IST) — no reset job. A `spend_period` column can generalise later if the business ever wants lifetime/billing-cycle windows.
+- **Scope of this branch = budget only.** The RBAC/roles expansion is a **separate follow-up PR**, not this one. This keeps the diff focused and lands the enforceable budget sooner. (When built, the role gate sits at the same `book()` chokepoint — e.g. a view-only member blocked from booking.)
+
+## Verification (end-to-end)
+A member with `spend_limit_paise` set is **blocked past it while the account still has credit**; a member with no limit, and the owner, book freely; role (if built) gates who can book at all. (`mvn test -pl orders` + `pnpm --filter @oneday/business typecheck` green before push.)
+
+## Status
+- **Backend done** (branch `feat/b2b-member-budget`): Part A (membership-based booking) + Part B (V4_51 migration, `spendLimitPaise` on `B2bAccountMember`, `FOR UPDATE` member lock + monthly sum-on-check in `B2bBookingServiceImpl`, `MemberBudgetExceededException` → 402, `PUT /api/v1/b2b/members/{userId}/budget`, `MemberResponse` spend fields). Orders unit tests **198 green** (5 new/rewritten in `B2bBookingServiceImplTest`, member test updated).
+- **Pre-existing red (not this change):** the `orders` **e2e** suite fails to load its Spring context — `CodCashServiceImpl` needs an `auth.UserService` bean the e2e `OrdersTestApplication` doesn't provide (merged with the DA-cod-ledger on main; identical failure with this branch stashed). Flagged, out of scope here.
+- **Web pending:** business **team** page — per-member budget field + "₹X of ₹Y used"; wire `PUT …/budget` into `@oneday/api`.

--- a/orders/src/main/java/com/oneday/orders/api/MembersController.java
+++ b/orders/src/main/java/com/oneday/orders/api/MembersController.java
@@ -2,6 +2,7 @@ package com.oneday.orders.api;
 
 import com.oneday.auth.security.AuthUserDetails;
 import com.oneday.orders.dto.AddMemberRequest;
+import com.oneday.orders.dto.MemberBudgetRequest;
 import com.oneday.orders.dto.MemberKycRequest;
 import com.oneday.orders.dto.MemberResponse;
 import com.oneday.orders.repository.B2bAccountRepository;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -67,6 +69,15 @@ class MembersController {
                                       @Valid @RequestBody MemberKycRequest request) {
         UUID caller = UUID.fromString(Authz.requireUserId(principal));
         return members.verifyMyKyc(ownedAccountId(principal), caller, request.pan(), request.name());
+    }
+
+    /** Set or clear a member's monthly spend budget (null clears it). OWNER-only; the owner isn't cappable. */
+    @PutMapping("/{userId}/budget")
+    public MemberResponse setBudget(@AuthenticationPrincipal AuthUserDetails principal,
+                                    @PathVariable UUID userId,
+                                    @Valid @RequestBody MemberBudgetRequest request) {
+        UUID caller = UUID.fromString(Authz.requireUserId(principal));
+        return members.setSpendLimit(ownedAccountId(principal), caller, userId, request.spendLimitPaise());
     }
 
     /** Remove a member from the caller's account. OWNER-only; the owner can't be removed. */

--- a/orders/src/main/java/com/oneday/orders/api/OrdersGlobalExceptionHandler.java
+++ b/orders/src/main/java/com/oneday/orders/api/OrdersGlobalExceptionHandler.java
@@ -255,6 +255,14 @@ class OrdersGlobalExceptionHandler {
         return pd;
     }
 
+    @ExceptionHandler(B2bBookingService.MemberBudgetExceededException.class)
+    ProblemDetail handleMemberBudgetExceeded(B2bBookingService.MemberBudgetExceededException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.PAYMENT_REQUIRED);
+        pd.setTitle("Member spend budget exceeded");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
     /**
      * Authz gates ({@link Authz}) throw {@link ResponseStatusException} (401/403). Handle it here so
      * the chosen status + reason are written as a ProblemDetail in-process. Otherwise the framework

--- a/orders/src/main/java/com/oneday/orders/domain/B2bAccountMember.java
+++ b/orders/src/main/java/com/oneday/orders/domain/B2bAccountMember.java
@@ -45,4 +45,13 @@ public class B2bAccountMember extends MutableBaseEntity {
 
     @Column(name = "name", length = 200)
     private String name;
+
+    /**
+     * Per-member spend cap in paise for the current calendar month, or {@code null} for no limit
+     * (owners, and members the account owner hasn't capped). Enforced at booking alongside the
+     * account-level credit check — a member can be blocked by their own budget while the account
+     * still has credit.
+     */
+    @Column(name = "spend_limit_paise")
+    private Long spendLimitPaise;
 }

--- a/orders/src/main/java/com/oneday/orders/dto/MemberBudgetRequest.java
+++ b/orders/src/main/java/com/oneday/orders/dto/MemberBudgetRequest.java
@@ -1,0 +1,11 @@
+package com.oneday.orders.dto;
+
+import jakarta.validation.constraints.PositiveOrZero;
+
+/**
+ * The owner sets (or clears) a member's monthly spend budget. A null {@code spendLimitPaise} clears the
+ * cap (unlimited); a value caps the member's bookings for the current calendar month.
+ */
+public record MemberBudgetRequest(
+        @PositiveOrZero Long spendLimitPaise) {
+}

--- a/orders/src/main/java/com/oneday/orders/dto/MemberResponse.java
+++ b/orders/src/main/java/com/oneday/orders/dto/MemberResponse.java
@@ -1,14 +1,31 @@
 package com.oneday.orders.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.oneday.orders.domain.B2bAccountMember;
 
 import java.util.UUID;
 
-/** A row in the account's team list. {@code role} is OWNER or MEMBER; {@code kycStatus} UNVERIFIED or VERIFIED. */
-public record MemberResponse(UUID userId, String email, String name, String role, String kycStatus) {
+/**
+ * A row in the account's team list. {@code role} is OWNER or MEMBER; {@code kycStatus} UNVERIFIED or
+ * VERIFIED. {@code spendLimitPaise} is the member's monthly budget (null = unlimited). {@code
+ * spentThisMonthPaise} / {@code remainingPaise} are populated only where computed (team list, /me);
+ * they are omitted from the JSON otherwise.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record MemberResponse(UUID userId, String email, String name, String role, String kycStatus,
+                             Long spendLimitPaise, Long spentThisMonthPaise, Long remainingPaise) {
 
+    /** Row fields only — no spend computed (used by add/remove/kyc results). */
     public static MemberResponse from(B2bAccountMember m) {
         return new MemberResponse(m.getUserId(), m.getEmail(), m.getName(), m.getRole().name(),
-                m.getKycStatus().name());
+                m.getKycStatus().name(), m.getSpendLimitPaise(), null, null);
+    }
+
+    /** Row fields + this-month spend and remaining budget (null remaining when the member is uncapped). */
+    public static MemberResponse withSpend(B2bAccountMember m, long spentThisMonthPaise) {
+        Long limit = m.getSpendLimitPaise();
+        Long remaining = limit == null ? null : Math.max(0L, limit - spentThisMonthPaise);
+        return new MemberResponse(m.getUserId(), m.getEmail(), m.getName(), m.getRole().name(),
+                m.getKycStatus().name(), limit, spentThisMonthPaise, remaining);
     }
 }

--- a/orders/src/main/java/com/oneday/orders/repository/B2bAccountMemberRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/B2bAccountMemberRepository.java
@@ -1,7 +1,11 @@
 package com.oneday.orders.repository;
 
 import com.oneday.orders.domain.B2bAccountMember;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,6 +18,15 @@ public interface B2bAccountMemberRepository extends JpaRepository<B2bAccountMemb
 
     /** The caller's membership in a specific account (for the owner-only guard). */
     Optional<B2bAccountMember> findByB2bAccountIdAndUserId(UUID b2bAccountId, UUID userId);
+
+    /**
+     * The caller's membership, locked FOR UPDATE — so a member's concurrent bookings serialize on the
+     * per-member spend check (mirrors {@code B2bAccountRepository.findByIdForUpdate} for account credit).
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT m FROM B2bAccountMember m WHERE m.b2bAccountId = :accountId AND m.userId = :userId")
+    Optional<B2bAccountMember> findByAccountAndUserForUpdate(@Param("accountId") UUID accountId,
+                                                            @Param("userId") UUID userId);
 
     /** True if this user already belongs to any account (a user is on at most one account in v1). */
     boolean existsByUserId(UUID userId);

--- a/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
+++ b/orders/src/main/java/com/oneday/orders/repository/ShipmentRepository.java
@@ -144,6 +144,14 @@ public interface ShipmentRepository extends JpaRepository<Shipment, UUID> {
             + "AND s.createdAt >= :since")
     AccountTotals sumTotalsForAccount(@Param("accountId") UUID accountId, @Param("since") Instant since);
 
+    // Per-member spend for the budget check: shipping charge (totalPricePaise, same basis as the credit
+    // check) booked by one member since the period start, excluding CANCELLED bookings. COALESCE keeps
+    // it 0 for a member with none. COD is buyer→vendor money, not the member's spend, so it's excluded.
+    @Query("SELECT COALESCE(SUM(s.totalPricePaise), 0) FROM Shipment s "
+            + "WHERE s.bookedByUserId = :bookedByUserId AND s.createdAt >= :since "
+            + "AND s.state <> com.oneday.common.domain.enums.ShipmentState.CANCELLED")
+    long sumMemberSpendSince(@Param("bookedByUserId") UUID bookedByUserId, @Param("since") Instant since);
+
     // Destination-city split (only 5 serviceable cities, so a tiny result set), busiest first.
     @Query("SELECT s.destCity AS city, COUNT(s) AS count FROM Shipment s "
             + "WHERE s.b2bAccountId = :accountId AND s.createdAt >= :since "

--- a/orders/src/main/java/com/oneday/orders/service/B2bBookingService.java
+++ b/orders/src/main/java/com/oneday/orders/service/B2bBookingService.java
@@ -27,8 +27,13 @@ public interface B2bBookingService {
         public CreditLimitExceededException(String message) { super(message); }
     }
 
-    /** Caller is authenticated but does not own the requested B2B account → 403. */
+    /** Caller is authenticated but is not a member of the requested B2B account → 403. */
     class AccountAccessException extends RuntimeException {
         public AccountAccessException(String message) { super(message); }
+    }
+
+    /** The booking member has a per-member spend limit and this booking would exceed it → 402. */
+    class MemberBudgetExceededException extends RuntimeException {
+        public MemberBudgetExceededException(String message) { super(message); }
     }
 }

--- a/orders/src/main/java/com/oneday/orders/service/B2bMemberService.java
+++ b/orders/src/main/java/com/oneday/orders/service/B2bMemberService.java
@@ -28,6 +28,13 @@ public interface B2bMemberService {
     void remove(UUID accountId, UUID callerUserId, UUID targetUserId);
 
     /**
+     * Set (or clear, when {@code spendLimitPaise} is null) a member's monthly spend budget. OWNER-only;
+     * the owner is exempt from budgets and cannot be capped. Returns the target's updated row with the
+     * new limit and this-month spend.
+     */
+    MemberResponse setSpendLimit(UUID accountId, UUID callerUserId, UUID targetUserId, Long spendLimitPaise);
+
+    /**
      * The caller verifies their own KYC by PAN (Discussion-2 xii). On a verified PAN whose name matches,
      * the caller's membership flips to VERIFIED. 404 if the caller isn't a member; 422 if the PAN fails
      * or the name doesn't match. Returns the caller's updated member row.

--- a/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/B2bBookingServiceImpl.java
@@ -22,6 +22,8 @@ import com.oneday.orders.domain.Shipment;
 import com.oneday.orders.domain.ShipmentStateHistory;
 import com.oneday.orders.dto.B2bBookingRequest;
 import com.oneday.orders.dto.BookingResponse;
+import com.oneday.orders.domain.B2bAccountMember;
+import com.oneday.orders.repository.B2bAccountMemberRepository;
 import com.oneday.orders.repository.B2bAccountRepository;
 import com.oneday.orders.repository.CodCollectionRepository;
 import com.oneday.orders.repository.MerchantCategoryRepository;
@@ -59,6 +61,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
     private static final Logger log = LoggerFactory.getLogger(B2bBookingServiceImpl.class);
 
     private final B2bAccountRepository b2bAccountRepository;
+    private final B2bAccountMemberRepository b2bAccountMemberRepository;
     private final ServiceabilityPort serviceabilityPort;
     private final PricingPort pricingPort;
     private final EtaPort etaPort;
@@ -83,6 +86,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
     private final ScheduledExecutorService scheduler;
 
     B2bBookingServiceImpl(B2bAccountRepository b2bAccountRepository,
+                          B2bAccountMemberRepository b2bAccountMemberRepository,
                           ServiceabilityPort serviceabilityPort,
                           PricingPort pricingPort,
                           EtaPort etaPort,
@@ -101,6 +105,7 @@ class B2bBookingServiceImpl implements B2bBookingService {
                           TimeLimiterRegistry timeLimiterRegistry,
                           @Qualifier("resilienceScheduler") ScheduledExecutorService resilienceScheduler) {
         this.b2bAccountRepository = b2bAccountRepository;
+        this.b2bAccountMemberRepository = b2bAccountMemberRepository;
         this.serviceabilityPort   = serviceabilityPort;
         this.pricingPort          = pricingPort;
         this.etaPort              = etaPort;
@@ -138,11 +143,15 @@ class B2bBookingServiceImpl implements B2bBookingService {
             throw new AccountInactiveException(
                     "B2B account is inactive: " + req.getB2bAccountId());
         }
-        // Ownership: the caller must own the account. Fail CLOSED — a null ownerUserId must NOT
-        // let any B2B user draw down this account's credit/wallet. ADMIN-on-behalf is not modelled yet.
-        if (account.getOwnerUserId() == null || !account.getOwnerUserId().toString().equals(userId)) {
+        // Access: the caller must be a MEMBER (or OWNER) of the account — owners are members too,
+        // backfilled by V4_44. Fail CLOSED — a non-member (or an unparseable user id) must NOT draw
+        // down this account's credit/wallet. ADMIN-on-behalf is not modelled yet.
+        java.util.UUID callerId = UserIds.parse(userId);
+        if (callerId == null
+                || b2bAccountMemberRepository
+                        .findByB2bAccountIdAndUserId(req.getB2bAccountId(), callerId).isEmpty()) {
             throw new AccountAccessException(
-                    "Caller is not authorized for B2B account: " + req.getB2bAccountId());
+                    "Caller is not a member of B2B account: " + req.getB2bAccountId());
         }
         // Category (optional) must be one of THIS merchant's own LIVE categories — never another
         // account's, and never an archived (soft-deleted) one.
@@ -228,6 +237,27 @@ class B2bBookingServiceImpl implements B2bBookingService {
         B2bAccount account = b2bAccountRepository.findByIdForUpdate(req.getB2bAccountId())
                 .orElseThrow(() -> new AccountNotFoundException(
                         "B2B account not found inside transaction: " + req.getB2bAccountId()));
+
+        // ── 5a-budget. Per-member spend cap (independent of account credit) ────
+        // A member with a spend_limit_paise can be blocked by their own monthly budget even while the
+        // account still has credit. Owners and uncapped members (null limit) are exempt. The member row
+        // is locked FOR UPDATE so a member's concurrent bookings serialize on this check.
+        java.util.UUID bookerId = UserIds.parse(userId);
+        if (bookerId != null) {
+            B2bAccountMember member = b2bAccountMemberRepository
+                    .findByAccountAndUserForUpdate(req.getB2bAccountId(), bookerId)
+                    .orElse(null);
+            if (member != null && member.getSpendLimitPaise() != null) {
+                Instant monthStart = MonthWindow.startOfCurrentMonth();
+                long spent = shipmentRepository.sumMemberSpendSince(bookerId, monthStart);
+                if (spent + quote.totalPricePaise() > member.getSpendLimitPaise()) {
+                    throw new B2bBookingService.MemberBudgetExceededException(
+                            "Monthly spend budget exceeded for member " + bookerId + " on account "
+                            + req.getB2bAccountId() + ": spent " + spent + " + booking "
+                            + quote.totalPricePaise() + " > limit " + member.getSpendLimitPaise());
+                }
+            }
+        }
 
         // ── 5b. Funding: WALLET debit or CREDIT check ──────────────────────────
         // Default: an account with a credit line ships on credit; otherwise it must recharge first.

--- a/orders/src/main/java/com/oneday/orders/service/impl/B2bMemberServiceImpl.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/B2bMemberServiceImpl.java
@@ -12,6 +12,7 @@ import com.oneday.orders.domain.MemberRole;
 import com.oneday.orders.dto.MemberResponse;
 import com.oneday.orders.repository.B2bAccountMemberRepository;
 import com.oneday.orders.repository.B2bAccountRepository;
+import com.oneday.orders.repository.ShipmentRepository;
 import com.oneday.orders.service.B2bMemberService;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
@@ -29,22 +30,35 @@ class B2bMemberServiceImpl implements B2bMemberService {
 
     private final B2bAccountMemberRepository members;
     private final B2bAccountRepository accounts;
+    private final ShipmentRepository shipments;
     private final UserService userService;
     private final KycPort kycPort;
 
     B2bMemberServiceImpl(B2bAccountMemberRepository members, B2bAccountRepository accounts,
-                         UserService userService, KycPort kycPort) {
+                         ShipmentRepository shipments, UserService userService, KycPort kycPort) {
         this.members = members;
         this.accounts = accounts;
+        this.shipments = shipments;
         this.userService = userService;
         this.kycPort = kycPort;
+    }
+
+    /** This calendar month's spend for a member (0 when uncapped — no need to query if there's no limit). */
+    private long spentThisMonth(B2bAccountMember m) {
+        if (m.getSpendLimitPaise() == null) {
+            return 0L;
+        }
+        return shipments.sumMemberSpendSince(m.getUserId(), MonthWindow.startOfCurrentMonth());
     }
 
     @Override
     @Transactional(readOnly = true)
     public List<MemberResponse> list(UUID accountId) {
+        // Spend is queried only for capped members (spentThisMonth short-circuits uncapped to 0), so a
+        // team of mostly-uncapped members costs no extra queries. ponytail: per-capped-member sum, fine
+        // at pilot team sizes; fold into one grouped query if teams ever get large.
         return members.findByB2bAccountIdOrderByCreatedAtAsc(accountId).stream()
-                .map(MemberResponse::from)
+                .map(m -> MemberResponse.withSpend(m, spentThisMonth(m)))
                 .toList();
     }
 
@@ -101,8 +115,26 @@ class B2bMemberServiceImpl implements B2bMemberService {
     @Transactional(readOnly = true)
     public MemberResponse me(UUID accountId, UUID callerUserId) {
         return members.findByB2bAccountIdAndUserId(accountId, callerUserId)
-                .map(MemberResponse::from)
+                .map(m -> MemberResponse.withSpend(m, spentThisMonth(m)))
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Not a member of this account"));
+    }
+
+    @Override
+    @Transactional
+    public MemberResponse setSpendLimit(UUID accountId, UUID callerUserId, UUID targetUserId,
+                                        Long spendLimitPaise) {
+        requireOwner(accountId, callerUserId);
+        B2bAccountMember target = members.findByB2bAccountIdAndUserId(accountId, targetUserId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Not a member of this account"));
+        // The owner is exempt from budgets — capping the account owner is meaningless (they manage the
+        // account and the shared credit line), so reject it rather than storing a limit that never bites.
+        if (target.getRole() == MemberRole.OWNER) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "The account owner isn't subject to a member budget.");
+        }
+        target.setSpendLimitPaise(spendLimitPaise);   // null clears the cap
+        B2bAccountMember saved = members.save(target);
+        return MemberResponse.withSpend(saved, spentThisMonth(saved));
     }
 
     @Override

--- a/orders/src/main/java/com/oneday/orders/service/impl/MonthWindow.java
+++ b/orders/src/main/java/com/oneday/orders/service/impl/MonthWindow.java
@@ -1,0 +1,28 @@
+package com.oneday.orders.service.impl;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+/**
+ * The current calendar-month window in IST — the period a per-member spend budget resets on. Month
+ * boundaries follow Indian wall-clock time (the platform's convention, {@code Asia/Kolkata}), so a
+ * budget rolls over at IST midnight on the 1st, not UTC.
+ */
+final class MonthWindow {
+
+    private static final ZoneId IST = ZoneId.of("Asia/Kolkata");
+
+    private MonthWindow() {}
+
+    /** The instant of 00:00 IST on the first day of the current month. */
+    static Instant startOfCurrentMonth() {
+        return startOfMonthFor(Instant.now());
+    }
+
+    /** The instant of 00:00 IST on the first day of the IST month containing {@code at}. */
+    static Instant startOfMonthFor(Instant at) {
+        LocalDate firstOfMonth = at.atZone(IST).toLocalDate().withDayOfMonth(1);
+        return firstOfMonth.atStartOfDay(IST).toInstant();
+    }
+}

--- a/orders/src/main/resources/db/migration/orders/V4_51__b2b_member_spend_limit.sql
+++ b/orders/src/main/resources/db/migration/orders/V4_51__b2b_member_spend_limit.sql
@@ -1,0 +1,8 @@
+-- Discussion-3 (vi): per-member spend budget. A B2B account owner can cap how much an individual
+-- member spends per calendar month, independent of the shared account credit limit. NULL = no cap
+-- (owners, and members left uncapped). Enforced at booking beside the account-credit check; spend is
+-- summed on demand from shipments.booked_by_user_id, so there is no counter to reset each month.
+ALTER TABLE b2b_account_member ADD COLUMN spend_limit_paise BIGINT;
+
+COMMENT ON COLUMN b2b_account_member.spend_limit_paise IS
+    'Per-member spend cap in paise for the current calendar month; NULL = unlimited.';

--- a/orders/src/test/java/com/oneday/orders/service/impl/B2bBookingServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/B2bBookingServiceImplTest.java
@@ -51,6 +51,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -60,6 +61,7 @@ import static org.mockito.Mockito.when;
 class B2bBookingServiceImplTest {
 
     @Mock private B2bAccountRepository b2bAccountRepository;
+    @Mock private com.oneday.orders.repository.B2bAccountMemberRepository b2bAccountMemberRepository;
     @Mock private ServiceabilityPort serviceabilityPort;
     @Mock private PricingPort pricingPort;
     @Mock private EtaPort etaPort;
@@ -85,6 +87,7 @@ class B2bBookingServiceImplTest {
 
     private static final String IDEMPOTENCY_KEY = "idem-b2b-123";
     private static final UUID   OWNER_ID        = UUID.randomUUID();
+    private static final UUID   MEMBER_ID       = UUID.randomUUID();
     private static final String USER_ID         = OWNER_ID.toString();
     private static final String SHIPMENT_REF    = "1DD-BLR-20260530-00001";
     private static final UUID   SHIPMENT_ID     = UUID.randomUUID();
@@ -100,7 +103,7 @@ class B2bBookingServiceImplTest {
         lenient().when(orderService.createOrder(any(), any(), anyString(), anyString(), any()))
                 .thenReturn(new OrderService.CreatedOrder(UUID.randomUUID(), "1DD-ORD-BLR-20260530-00001"));
         service = new B2bBookingServiceImpl(
-                b2bAccountRepository, serviceabilityPort, pricingPort, etaPort,
+                b2bAccountRepository, b2bAccountMemberRepository, serviceabilityPort, pricingPort, etaPort,
                 shipmentRefService, orderService, shipmentRepository, historyRepository,
                 codCollectionRepository, org.mockito.Mockito.mock(com.oneday.orders.repository.MerchantCategoryRepository.class),
                 stateMapper, walletService, org.mockito.Mockito.mock(PickupSlotCapacity.class), new TransactionTemplate(NO_OP_TX),
@@ -193,13 +196,15 @@ class B2bBookingServiceImplTest {
         verify(shipmentRepository, never()).save(any());
     }
 
-    // ── ownership (fail closed) ──────────────────────────────────────────────
+    // ── membership access (fail closed) ──────────────────────────────────────
 
     @Test
-    void book_callerDoesNotOwnAccount_throwsAccountAccessException() {
-        B2bAccount ownedByOther = activeAccount(0L, 1_000_000L);
-        ownedByOther.setOwnerUserId(UUID.randomUUID()); // a different user owns it
-        when(b2bAccountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(ownedByOther));
+    void book_callerNotAMember_throwsAccountAccessException() {
+        B2bAccount account = activeAccount(0L, 1_000_000L);
+        when(b2bAccountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(account));
+        // No membership stub: the caller is not on the account → fail closed before serviceability.
+        when(b2bAccountMemberRepository.findByB2bAccountIdAndUserId(ACCOUNT_ID, OWNER_ID))
+                .thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.book(bookingRequest(), IDEMPOTENCY_KEY, USER_ID))
                 .isInstanceOf(B2bBookingService.AccountAccessException.class);
@@ -209,15 +214,74 @@ class B2bBookingServiceImplTest {
     }
 
     @Test
-    void book_accountHasNoOwner_throwsAccountAccessException() {
-        B2bAccount noOwner = activeAccount(0L, 1_000_000L);
-        noOwner.setOwnerUserId(null); // fail closed: an ownerless account is not drawable
-        when(b2bAccountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(noOwner));
+    void book_memberOfAccount_isAllowedToBook() {
+        // A non-owner MEMBER (uncapped) can book — the guard is membership, not ownership.
+        String memberId = MEMBER_ID.toString();
+        B2bAccount account = activeAccount(0L, 1_000_000L);
+        when(b2bAccountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(account));
+        when(b2bAccountRepository.findByIdForUpdate(ACCOUNT_ID)).thenReturn(Optional.of(account));
+        stubMember(member(MEMBER_ID, com.oneday.orders.domain.MemberRole.MEMBER, null));
+        stubServiceability(true, DeliveryType.INTERCITY);
+        stubPricing(4000L, 720L, 4720L);
+        when(shipmentRefService.generateRef(anyString())).thenReturn(SHIPMENT_REF);
+        when(shipmentRepository.save(any())).thenAnswer(inv -> {
+            Shipment s = inv.getArgument(0);
+            ReflectionTestUtils.setField(s, "id", SHIPMENT_ID);
+            return s;
+        });
+        when(b2bAccountRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(historyRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
-        assertThatThrownBy(() -> service.book(bookingRequest(), IDEMPOTENCY_KEY, USER_ID))
-                .isInstanceOf(B2bBookingService.AccountAccessException.class);
+        BookingResponse resp = service.book(bookingRequest(), IDEMPOTENCY_KEY, memberId);
+
+        assertThat(resp.getShipmentRef()).isEqualTo(SHIPMENT_REF);
+        verify(shipmentRepository).save(any());
+    }
+
+    // ── per-member budget (independent of account credit) ────────────────────
+
+    @Test
+    void book_memberBudgetExceeded_throwsEvenWhenAccountHasCredit() {
+        String memberId = MEMBER_ID.toString();
+        B2bAccount account = activeAccount(0L, 1_000_000L); // account has plenty of credit
+        when(b2bAccountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(account));
+        when(b2bAccountRepository.findByIdForUpdate(ACCOUNT_ID)).thenReturn(Optional.of(account));
+        // Member capped at ₹50; already spent ₹48 this month; this booking (₹47.20) tips them over.
+        stubMember(member(MEMBER_ID, com.oneday.orders.domain.MemberRole.MEMBER, 5_000L));
+        when(shipmentRepository.sumMemberSpendSince(eq(MEMBER_ID), any())).thenReturn(4_800L);
+        stubServiceability(true, DeliveryType.INTERCITY);
+        stubPricing(4000L, 720L, 4720L);
+        // generateRef is NOT stubbed — the budget check throws before a shipment ref is minted.
+
+        assertThatThrownBy(() -> service.book(bookingRequest(), IDEMPOTENCY_KEY, memberId))
+                .isInstanceOf(B2bBookingService.MemberBudgetExceededException.class);
 
         verify(shipmentRepository, never()).save(any());
+    }
+
+    @Test
+    void book_memberWithinBudget_isAllowed() {
+        String memberId = MEMBER_ID.toString();
+        B2bAccount account = activeAccount(0L, 1_000_000L);
+        when(b2bAccountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(account));
+        when(b2bAccountRepository.findByIdForUpdate(ACCOUNT_ID)).thenReturn(Optional.of(account));
+        // Capped at ₹100, spent ₹10, booking ₹47.20 → well within.
+        stubMember(member(MEMBER_ID, com.oneday.orders.domain.MemberRole.MEMBER, 10_000L));
+        when(shipmentRepository.sumMemberSpendSince(eq(MEMBER_ID), any())).thenReturn(1_000L);
+        stubServiceability(true, DeliveryType.INTERCITY);
+        stubPricing(4000L, 720L, 4720L);
+        when(shipmentRefService.generateRef(anyString())).thenReturn(SHIPMENT_REF);
+        when(shipmentRepository.save(any())).thenAnswer(inv -> {
+            Shipment s = inv.getArgument(0);
+            ReflectionTestUtils.setField(s, "id", SHIPMENT_ID);
+            return s;
+        });
+        when(b2bAccountRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(historyRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        BookingResponse resp = service.book(bookingRequest(), IDEMPOTENCY_KEY, memberId);
+
+        assertThat(resp.getShipmentRef()).isEqualTo(SHIPMENT_REF);
     }
 
     // ── credit limit exceeded ──────────────────────────────────────────────
@@ -314,6 +378,26 @@ class B2bBookingServiceImplTest {
     private void stubAccount(B2bAccount account) {
         when(b2bAccountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(account));
         when(b2bAccountRepository.findByIdForUpdate(ACCOUNT_ID)).thenReturn(Optional.of(account));
+        // Caller (OWNER_ID) is a member of the account; owner has no spend cap, so the budget check skips.
+        stubMember(member(OWNER_ID, com.oneday.orders.domain.MemberRole.OWNER, null));
+    }
+
+    /** Both the access lookup and the FOR-UPDATE budget lookup resolve the caller to this member row. */
+    private void stubMember(com.oneday.orders.domain.B2bAccountMember m) {
+        lenient().when(b2bAccountMemberRepository.findByB2bAccountIdAndUserId(ACCOUNT_ID, m.getUserId()))
+                .thenReturn(Optional.of(m));
+        lenient().when(b2bAccountMemberRepository.findByAccountAndUserForUpdate(ACCOUNT_ID, m.getUserId()))
+                .thenReturn(Optional.of(m));
+    }
+
+    private static com.oneday.orders.domain.B2bAccountMember member(
+            UUID userId, com.oneday.orders.domain.MemberRole role, Long spendLimitPaise) {
+        com.oneday.orders.domain.B2bAccountMember m = new com.oneday.orders.domain.B2bAccountMember();
+        m.setB2bAccountId(ACCOUNT_ID);
+        m.setUserId(userId);
+        m.setRole(role);
+        m.setSpendLimitPaise(spendLimitPaise);
+        return m;
     }
 
     private void stubServiceability(boolean serviceable, DeliveryType deliveryType) {

--- a/orders/src/test/java/com/oneday/orders/service/impl/B2bMemberServiceImplTest.java
+++ b/orders/src/test/java/com/oneday/orders/service/impl/B2bMemberServiceImplTest.java
@@ -34,6 +34,7 @@ class B2bMemberServiceImplTest {
 
     @Mock private B2bAccountMemberRepository members;
     @Mock private B2bAccountRepository accounts;
+    @Mock private com.oneday.orders.repository.ShipmentRepository shipments;
     @Mock private UserService userService;
     @Mock private KycPort kycPort;
 
@@ -41,7 +42,7 @@ class B2bMemberServiceImplTest {
     private final UUID owner = UUID.randomUUID();
 
     private B2bMemberServiceImpl service() {
-        return new B2bMemberServiceImpl(members, accounts, userService, kycPort);
+        return new B2bMemberServiceImpl(members, accounts, shipments, userService, kycPort);
     }
 
     private void accountPan(String pan) {


### PR DESCRIPTION
## What & why
Discussion-3 **(vi)** — per-user RBAC + budget under a B2B account. This PR ships the **budget half** (the RBAC/roles expansion is a separate follow-up per the split). Scope/design: `docs/B2B/MEMBER-BUDGET-SCOPE.md`.

Two parts, both at the single `B2bBookingServiceImpl.book()` chokepoint all B2B bookings (single / cart / repair) funnel through.

### Part A — members can actually book
The booking guard checked `owner_user_id` only, so a non-owner **MEMBER could never book** — the membership table (from D2-xii) was never consulted in the booking path. Swapped the owner-only guard for a **membership check** (OWNER or MEMBER; fail closed for non-members / unparseable user id). This is what makes a per-member budget meaningful.

### Part B — per-member monthly budget (independent of account credit)
- **`V4_51`** adds nullable `spend_limit_paise` to `b2b_account_member` (NULL = unlimited).
- The booking TX locks the member row **`FOR UPDATE`** (mirrors the account-credit lock) and, if a limit is set, sums the member's **non-CANCELLED** bookings **this calendar month** (IST, `MonthWindow`) + this booking; over the cap → **`MemberBudgetExceededException` (402)**. A member can be blocked by their own budget **while the account still has credit** — the whole point.
- **COD excluded** (buyer→vendor money, not the member's spend). Basis = shipping charge, same as the credit check.
- **Sum-on-check** (`ShipmentRepository.sumMemberSpendSince`) — no running counter, so no month-reset job and no cancel/refund reversal bookkeeping.
- Owner sets/clears a cap: **`PUT /api/v1/b2b/members/{userId}/budget`** (owner-only; the owner isn't cappable). `MemberResponse` now carries `spendLimitPaise` + `spentThisMonthPaise` + `remainingPaise`.

## Tests
Orders unit tests **198 green**. New/changed: member-allowed-to-book, budget-exceeded-past-cap-while-account-has-credit, within-budget-allowed; the old ownership tests rewritten as membership tests; `B2bMemberServiceImplTest` updated for the new dependency.

## Notes
- The `orders` **e2e** suite fails to load its Spring context (`CodCashServiceImpl` needs an `auth.UserService` bean the e2e app doesn't provide) — **pre-existing on main**, identical with this branch stashed. Not addressed here.
- **Web pending** (separate PR): business team page budget field + "₹X of ₹Y used", wiring `PUT …/budget` into `@oneday/api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Web PR:** https://github.com/Sidarthapati/oneday-web/pull/67

---

### 📘 Walkthrough — business scenarios + code, end to end
Diagrammatic explainer (the two-gate flow, all booking scenarios, and the diffs): https://claude.ai/code/artifact/fa9407a0-cfdc-4d76-ac6c-c001357e9e68
